### PR TITLE
fix: disable dune-admin menu option (21) when VM is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Menu option `21. dune-admin` is now correctly disabled (greyed out with a reason)
+  when the Hyper-V VM does not exist or is not running, matching the behavior of
+  every other VM-dependent menu item. Previously it was always shown as available.
+
 ## [1.0.0] - 2026-05-24
 
 ### Added

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -475,6 +475,8 @@ function Get-ToolCmdAvailability {
             return @{ Available = $true; Reason = $null }
         }
         "dune-admin" {
+            if (-not $info.Exists)  { return @{ Available = $false; Reason = "VM '$vmName' does not exist." } }
+            if (-not $info.Running) { return @{ Available = $false; Reason = "VM '$vmName' is not running." } }
             return @{ Available = $true; Reason = $null }
         }
         default { return @{ Available = $true; Reason = $null } }


### PR DESCRIPTION
## Summary

Option `21. dune-admin` was the only VM-dependent menu item that returned `Available = $true` unconditionally. It should be gated on `info.Exists` and `info.Running` like every other VM-dependent option (`ssh`, all battlegroup commands, graceful-reboot, graceful-shutdown, etc.) — otherwise the menu shows it as actionable when the VM is down, and launching it produces SSH tunnel errors.

## Testing

- [x] Parse-validated both copies of the script
- [x] PSScriptAnalyzer runs in CI (lint workflow)
- [ ] End-to-end smoke test against a live VM (will do after merge)

## Changelog

- [x] Added entry to `CHANGELOG.md` under `[Unreleased]` > Fixed