### PR TITLE
release: v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-05-24
+
 ### Fixed
 - Menu option `21. dune-admin` is now correctly disabled (greyed out with a reason)
   when the Hyper-V VM does not exist or is not running, matching the behavior of
@@ -46,5 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened the post-reboot readiness check to verify webhook Service endpoints
   are populated (not just pods Running) before calling battlegroup start.
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/releases/tag/v1.0.0

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -5,7 +5,7 @@
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "1.0.0"
+$script:ToolVersion = "1.0.1"
 
 # Resize console window so the full menu is visible
 try {


### PR DESCRIPTION
## Summary

Cut release v1.0.1 (PATCH).

- Bump `\$script:ToolVersion` to `1.0.1`.
- Move the `[Unreleased] > Fixed` block into `[1.0.1] - 2026-05-24`.
- Add the v1.0.1 compare link to CHANGELOG.

## What's in this release

**Fixed**
- Menu option `21. dune-admin` is now disabled when the VM is down (#1).

## After merge

- Tag `v1.0.1` and push.
- Create GitHub Release pointing at `v1.0.1`.