### PR TITLE
fix: refresh port-check after battlegroup CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Port-check status in the menu header now refreshes after running any
+  battlegroup CLI command (`1. status`, `2. start`, `3. restart`, `4. stop`).
+  Previously the cached results were keyed only by public IP with no TTL, so
+  the `[OPEN]` / `[CLOSED]` indicators would stick at their first observed
+  values for the entire session even when the server's actual port state
+  changed.
+
 ## [1.1.0] - 2026-05-24
 
 ### Added

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1174,6 +1174,11 @@ while ($true) {
     # --- Fallback: delegate to battlegroup CLI on VM ---
     ssh -t -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" "$bgBinPath $cmd"
 
+    # Battlegroup commands (status/start/restart/stop) can change observable
+    # port state, so invalidate the cached external port-check results to
+    # force a fresh check on the next menu render.
+    $script:portCheckCache = $null
+
     # After start/restart, resolve director port
     if ($cmd -eq "start" -or $cmd -eq "restart") {
         $elapsed = 0; $timeout = 60


### PR DESCRIPTION
## Bug

The menu-header port-check status (`[OPEN]` / `[CLOSED]` / `[UNKNOWN]`) was caching results keyed solely on public IP, with no TTL. Once first computed, the cache never refreshed for the rest of the session even when the server's actual port state changed (e.g., after `2. start` or `4. stop`). Pressing `1. status` did not refresh either.

## Fix

Invalidate `` after the SSH-fallback `battlegroup` command runs (covers `status`, `start`, `restart`, `stop`). Next menu render re-queries the port checker.

Mirrors the same one-liner already used by the `graceful-shutdown` handler.

## Scope note

Intentionally not adding a generic TTL in this PR — pressing option 1 (or any state-changing battlegroup command) is now the explicit refresh action, which keeps behavior predictable and avoids unsolicited HTTP requests to yougetsignal.com on every menu render.

## Changelog

- [x] Added `Fixed` entry under `[Unreleased]`.