### PR TITLE
release: v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-24
+
 ### Fixed
 - Port-check status in the menu header now refreshes after running any
   battlegroup CLI command (`1. status`, `2. start`, `3. restart`, `4. stop`).
@@ -83,7 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened the post-reboot readiness check to verify webhook Service endpoints
   are populated (not just pods Running) before calling battlegroup start.
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/releases/tag/v1.0.0

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -5,7 +5,7 @@
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "1.1.0"
+$script:ToolVersion = "1.1.1"
 
 # Resize console window so the full menu is visible
 try {


### PR DESCRIPTION
## v1.1.1

PATCH bump.

### Fixed
- Port-check status in the menu header now refreshes after running any battlegroup CLI command (#6).

See [CHANGELOG.md](./CHANGELOG.md) for full details.