### PR TITLE
feat: web UI + dune-admin download offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-24
+
+### Added
+- **Localhost web UI** (`b. web` menu option). Spins up a [Pode](https://github.com/Badgerati/Pode)
+  server on `http://127.0.0.1:8765` and opens your default browser to a
+  button panel that mirrors the console menu. Each click POSTs to
+  `/api/exec/{name}`, which spawns `dune-server.ps1 -Cmd <name>` in a new
+  console window so interactive prompts (battlegroup picker, password entry,
+  confirmations) keep working. Status panel polls every 5 seconds.
+  Confirmation dialog on `graceful-reboot` and `graceful-shutdown`.
+  Lives under `web/` &mdash; `Start-DuneWeb.ps1` + `public/{index.html,app.js,styles.css}`.
+- **`-Cmd <name>` parameter** on `dune-server.ps1` for non-interactive
+  dispatch. Skips the menu, looks up the command by name, runs the handler
+  once, and exits. Used by the web UI; also handy for shortcuts and scripts.
+- **`dune-admin` install offer during setup** (step 3). Prompts to either
+  download the latest release from
+  [`Icehunter/dune-admin`](https://github.com/Icehunter/dune-admin)
+  to a directory you choose (default `%USERPROFILE%\dune-admin`), use an
+  existing local install, or skip. The chosen `dune-admin.exe` path is stored
+  in `dune-server.config` exactly as before; this repo does not bundle the
+  binary.
+
+### Changed
+- VM section re-lettered sequentially so the section ends cleanly at
+  `g. change-password` before the numbered Battlegroup commands begin:
+  - `a. initial-setup`
+  - `b. web` *(new)*
+  - `c. startup` *(was `h`)*
+  - `d. graceful-reboot` *(was `f`)*
+  - `e. graceful-shutdown` *(was `g`)*
+  - `f. rotate-ssh-key` *(was `d`)*
+  - `g. change-password` *(was `e`)*
+- Post-menu hint when the VM isn't running now reads "Press 'c' to run
+  'startup'" instead of the removed "Press 'b' to start it".
+
+### Removed
+- `b. start-vm` and `c. stop-vm` menu entries. The graceful counterparts
+  (`c. startup` cold-starts the full stack; `e. graceful-shutdown` stops
+  battlegroup and powers off) cover everything they did without leaving
+  pods in inconsistent state. The underlying handlers remain in the script
+  so existing automation calling them by name still works.
+
 ## [1.1.1] - 2026-05-24
 
 ### Fixed
@@ -85,7 +127,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened the post-reboot readiness check to verify webhook Service endpoints
   are populated (not just pods Running) before calling battlegroup start.
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.0.0...v1.0.1

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1,11 +1,19 @@
 #Requires -RunAsAdministrator
 
+[CmdletBinding()]
+param(
+    # When set, skip the interactive menu and dispatch directly to the named
+    # command. Used by the web UI (web/Start-DuneWeb.ps1) to invoke commands
+    # in a fresh console window per click.
+    [string]$Cmd
+)
+
 # ============================================================
 # Dune Awakening Server Management — Extended Menu
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "1.1.1"
+$script:ToolVersion = "1.2.0"
 
 # Resize console window so the full menu is visible
 try {
@@ -102,21 +110,48 @@ function Run-Setup {
 
     # ── 3. dune-admin.exe ──
     Write-Host "3. Dune Admin Tool (optional)" -ForegroundColor Yellow
-    Write-Host "   Path to dune-admin.exe. Leave blank to skip." -ForegroundColor Gray
+    Write-Host "   The dune-admin tool (by Icehunter) provides extra utilities for managing" -ForegroundColor Gray
+    Write-Host "   your battlegroup. Repo: https://github.com/Icehunter/dune-admin" -ForegroundColor Gray
     Write-Host ""
-    $defaultAdmin = $null
-    $adminCandidates = @(
-        "$env:USERPROFILE\Desktop\dune-admin-main\dune-admin.exe",
-        "$env:USERPROFILE\Desktop\dune-admin\dune-admin.exe",
-        "$scriptDir\dune-admin\dune-admin.exe"
-    )
-    foreach ($a in $adminCandidates) {
-        if (Test-Path $a) { $defaultAdmin = $a; break }
-    }
-    if ($existing.DuneAdminExe) { $defaultAdmin = $existing.DuneAdminExe }
-    $adminExe = Ask -Label "dune-admin.exe path" -Default $defaultAdmin
-    if ($adminExe -and -not (Test-Path $adminExe)) {
-        Write-Warning "File not found — dune-admin option will be hidden until the file exists."
+    Write-Host "   You can either:" -ForegroundColor Gray
+    Write-Host "     1. Download latest release now (recommended)" -ForegroundColor Gray
+    Write-Host "     2. Point at an existing dune-admin.exe you already have" -ForegroundColor Gray
+    Write-Host "     3. Skip — option 21 will be hidden" -ForegroundColor Gray
+    Write-Host ""
+    $existingAdmin = $existing.DuneAdminExe
+    $defaultAdminChoice = if ($existingAdmin -and (Test-Path $existingAdmin)) { '2' } else { '1' }
+    $adminChoice = Ask -Label "Choose 1, 2, or 3" -Default $defaultAdminChoice
+    $adminExe = ""
+    if ($adminChoice -eq '1') {
+        $defaultInstallDir = if ($existingAdmin) { Split-Path $existingAdmin -Parent } else { "$env:USERPROFILE\dune-admin" }
+        $installDir = Ask -Label "Install directory" -Default $defaultInstallDir
+        try {
+            $adminExe = Install-DuneAdminLatest -InstallDir $installDir
+            if ($adminExe) {
+                Write-Host "   dune-admin installed at $adminExe" -ForegroundColor Green
+            }
+        } catch {
+            Write-Warning "Download failed: $($_.Exception.Message)"
+            Write-Host "   You can re-run setup later or manually grab a release from:" -ForegroundColor Gray
+            Write-Host "   https://github.com/Icehunter/dune-admin/releases" -ForegroundColor Gray
+            $adminExe = ""
+        }
+    } elseif ($adminChoice -eq '2') {
+        $defaultAdmin = $null
+        $adminCandidates = @(
+            "$env:USERPROFILE\dune-admin\dune-admin.exe",
+            "$env:USERPROFILE\Desktop\dune-admin-main\dune-admin.exe",
+            "$env:USERPROFILE\Desktop\dune-admin\dune-admin.exe",
+            "$scriptDir\dune-admin\dune-admin.exe"
+        )
+        foreach ($a in $adminCandidates) {
+            if (Test-Path $a) { $defaultAdmin = $a; break }
+        }
+        if ($existingAdmin) { $defaultAdmin = $existingAdmin }
+        $adminExe = Ask -Label "dune-admin.exe path" -Default $defaultAdmin
+        if ($adminExe -and -not (Test-Path $adminExe)) {
+            Write-Warning "File not found — dune-admin option will be hidden until the file exists."
+        }
     }
     Write-Host ""
 
@@ -197,6 +232,46 @@ function Run-Setup {
         PortCheckMode        = $portCheckMode
         PortCheckUrlTemplate = $portCheckUrlTemplate
     }
+}
+
+function Install-DuneAdminLatest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$InstallDir
+    )
+
+    Write-Host ""
+    Write-Host "   Fetching latest release info from Icehunter/dune-admin..." -ForegroundColor Cyan
+
+    $headers = @{ 'User-Agent' = 'Simple-Dune-Server-Management-Tool' }
+    $release = Invoke-RestMethod -Uri 'https://api.github.com/repos/Icehunter/dune-admin/releases/latest' -Headers $headers -TimeoutSec 15
+    $tag = $release.tag_name
+    Write-Host "   Latest release: $tag" -ForegroundColor DarkGray
+
+    $asset = $release.assets | Where-Object { $_.name -like '*windows_amd64.zip' } | Select-Object -First 1
+    if (-not $asset) {
+        throw "No Windows amd64 .zip asset found in release $tag."
+    }
+    Write-Host "   Asset: $($asset.name) ($([Math]::Round($asset.size/1MB,1)) MB)" -ForegroundColor DarkGray
+
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    }
+
+    $tempZip = Join-Path $env:TEMP $asset.name
+    Write-Host "   Downloading..." -ForegroundColor Cyan
+    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tempZip -Headers $headers -UseBasicParsing -TimeoutSec 120
+
+    Write-Host "   Extracting to $InstallDir..." -ForegroundColor Cyan
+    Expand-Archive -Path $tempZip -DestinationPath $InstallDir -Force
+    Remove-Item $tempZip -ErrorAction SilentlyContinue
+
+    $exe = Get-ChildItem -Path $InstallDir -Filter 'dune-admin.exe' -Recurse -ErrorAction SilentlyContinue |
+           Select-Object -First 1 -ExpandProperty FullName
+    if (-not $exe) {
+        throw "dune-admin.exe was not found in the extracted contents at $InstallDir."
+    }
+    return $exe
 }
 
 function Load-Config {
@@ -417,14 +492,13 @@ function Wait-MapPodReady {
 # ============================================================
 
 $vmCommands = @(
-    [pscustomobject]@{ Key = "a"; Name = "initial-setup";    Desc = "Run the initial VM setup" }
-    [pscustomobject]@{ Key = "b"; Name = "start-vm";         Desc = "Start the VM" }
-    [pscustomobject]@{ Key = "c"; Name = "stop-vm";          Desc = "Stop the VM" }
-    [pscustomobject]@{ Key = "h"; Name = "startup";            Desc = "Power on VM -> start battlegroup -> wait for overmap + survival maps" }
-    [pscustomobject]@{ Key = "f"; Name = "graceful-reboot";    Desc = "Stop battlegroup -> restart VM -> start battlegroup (clean cycle)" }
-    [pscustomobject]@{ Key = "g"; Name = "graceful-shutdown";  Desc = "Stop battlegroup -> power off VM (e.g. shut down for the night)" }
-    [pscustomobject]@{ Key = "d"; Name = "rotate-ssh-key";   Desc = "Generate a new SSH key and replace the one authorized on the VM" }
-    [pscustomobject]@{ Key = "e"; Name = "change-password";  Desc = "Change the password of the 'dune' user on the VM" }
+    [pscustomobject]@{ Key = "a"; Name = "initial-setup";      Desc = "Run the initial VM setup" }
+    [pscustomobject]@{ Key = "b"; Name = "web";                Desc = "Open the web UI in your browser (button panel for these commands)" }
+    [pscustomobject]@{ Key = "c"; Name = "startup";            Desc = "Power on VM -> start battlegroup -> wait for overmap + survival maps" }
+    [pscustomobject]@{ Key = "d"; Name = "graceful-reboot";    Desc = "Stop battlegroup -> restart VM -> start battlegroup (clean cycle)" }
+    [pscustomobject]@{ Key = "e"; Name = "graceful-shutdown";  Desc = "Stop battlegroup -> power off VM (e.g. shut down for the night)" }
+    [pscustomobject]@{ Key = "f"; Name = "rotate-ssh-key";     Desc = "Generate a new SSH key and replace the one authorized on the VM" }
+    [pscustomobject]@{ Key = "g"; Name = "change-password";    Desc = "Change the password of the 'dune' user on the VM" }
 )
 
 $bgCommands = @(
@@ -462,6 +536,7 @@ function Get-VmCmdAvailability {
     param($cmdName, $info)
     switch ($cmdName) {
         "initial-setup" { return @{ Available = $true; Reason = $null } }
+        "web"           { return @{ Available = $true; Reason = $null } }
         "start-vm" {
             if (-not $info.Exists)  { return @{ Available = $false; Reason = "VM '$vmName' does not exist. Run 'initial-setup' first." } }
             if ($info.Running)      { return @{ Available = $false; Reason = "VM '$vmName' is already running." } }
@@ -474,7 +549,7 @@ function Get-VmCmdAvailability {
         }
         "graceful-reboot" {
             if (-not $info.Exists)  { return @{ Available = $false; Reason = "VM '$vmName' does not exist." } }
-            if (-not $info.Running) { return @{ Available = $false; Reason = "VM '$vmName' is not running. Start it first with 'start-vm'." } }
+            if (-not $info.Running) { return @{ Available = $false; Reason = "VM '$vmName' is not running. Use 'c. startup' to cold-start." } }
             return @{ Available = $true; Reason = $null }
         }
         "graceful-shutdown" {
@@ -547,88 +622,99 @@ while ($true) {
 
     foreach ($e in $entries) { $entryByKey[$e.Key.ToLower()] = $e }
 
-    # --- Render menu ---
-    Write-Host ""
-    Write-Host "===  Dune Awakening - Server Management  ===" -ForegroundColor Cyan
-    Write-Host "  Brought to you by Coastal (Discord @allcoast)" -ForegroundColor DarkGray
-    $vmStatusColor = if ($info.Running) { 'Green' } elseif ($info.Exists) { 'Yellow' } else { 'Red' }
-    $vmStatusText  = if ($info.Running) { "Running ($($info.Ip))" } elseif ($info.Exists) { "$($info.State)" } else { "Not found" }
-    Write-Host "  VM: " -NoNewline; Write-Host $vmStatusText -ForegroundColor $vmStatusColor
-    Write-Host "  Required Port Forwarding:" -ForegroundColor DarkGray
-    if ($portCheckMode -ne 'disabled' -and $info.Running) {
-        $check = Get-PortCheckStatus -Force:$false
-        if ($check -and $check.PublicIp) {
-            foreach ($r in $check.Results) {
-                $tag = switch ($r.Status) {
-                    'open'     { '[OPEN]'              }
-                    'closed'   { '[CLOSED]'            }
-                    'udp-skip' { '[UDP - skipped]'     }
-                    default    { '[UNKNOWN]'           }
-                }
-                $color = switch ($r.Status) {
-                    'open'     { 'Green'    }
-                    'closed'   { 'Red'      }
-                    'udp-skip' { 'DarkGray' }
-                    default    { 'Yellow'   }
-                }
-                Write-Host ("    {0,-45} " -f $r.Label) -ForegroundColor DarkGray -NoNewline
-                Write-Host $tag -ForegroundColor $color
-            }
-        } else {
-            Write-Host "    UDP  7777-7810   Game servers     [check failed - no public IP]" -ForegroundColor Yellow
-            Write-Host "    TCP  31982       RabbitMQ         [check failed - no public IP]" -ForegroundColor Yellow
+    if ($Cmd) {
+        # Non-interactive dispatch (called by web UI). Skip menu render +
+        # interactive selection; look up the entry by command name and fall
+        # through to the handler block.
+        $entry = $entries | Where-Object { $_.Name -eq $Cmd } | Select-Object -First 1
+        if (-not $entry) {
+            Write-Error "Unknown command: $Cmd"
+            exit 1
         }
     } else {
-        Write-Host "    UDP  7777-7810   Game servers" -ForegroundColor DarkGray
-        Write-Host "    TCP  31982       RabbitMQ" -ForegroundColor DarkGray
-        if ($portCheckMode -eq 'disabled') {
-            Write-Host "    (port verification disabled)" -ForegroundColor DarkGray
-        }
-    }
-    Write-Host ""
-
-    $prevSection = $null
-    foreach ($e in $entries) {
-        if ($e.Section -ne $prevSection) {
-            if ($null -ne $prevSection) { Write-Host "" }
-            switch ($e.Section) {
-                'vm'          { Write-Host "VM commands:" -ForegroundColor Yellow }
-                'battlegroup' { Write-Host "Battlegroup commands:" -ForegroundColor Yellow }
-                'tools'       { Write-Host "Tools:" -ForegroundColor Yellow }
+        # --- Render menu ---
+        Write-Host ""
+        Write-Host "===  Dune Awakening - Server Management  ===" -ForegroundColor Cyan
+        Write-Host "  Brought to you by Coastal (Discord @allcoast)" -ForegroundColor DarkGray
+        $vmStatusColor = if ($info.Running) { 'Green' } elseif ($info.Exists) { 'Yellow' } else { 'Red' }
+        $vmStatusText  = if ($info.Running) { "Running ($($info.Ip))" } elseif ($info.Exists) { "$($info.State)" } else { "Not found" }
+        Write-Host "  VM: " -NoNewline; Write-Host $vmStatusText -ForegroundColor $vmStatusColor
+        Write-Host "  Required Port Forwarding:" -ForegroundColor DarkGray
+        if ($portCheckMode -ne 'disabled' -and $info.Running) {
+            $check = Get-PortCheckStatus -Force:$false
+            if ($check -and $check.PublicIp) {
+                foreach ($r in $check.Results) {
+                    $tag = switch ($r.Status) {
+                        'open'     { '[OPEN]'              }
+                        'closed'   { '[CLOSED]'            }
+                        'udp-skip' { '[UDP - skipped]'     }
+                        default    { '[UNKNOWN]'           }
+                    }
+                    $color = switch ($r.Status) {
+                        'open'     { 'Green'    }
+                        'closed'   { 'Red'      }
+                        'udp-skip' { 'DarkGray' }
+                        default    { 'Yellow'   }
+                    }
+                    Write-Host ("    {0,-45} " -f $r.Label) -ForegroundColor DarkGray -NoNewline
+                    Write-Host $tag -ForegroundColor $color
+                }
+            } else {
+                Write-Host "    UDP  7777-7810   Game servers     [check failed - no public IP]" -ForegroundColor Yellow
+                Write-Host "    TCP  31982       RabbitMQ         [check failed - no public IP]" -ForegroundColor Yellow
+            }
+        } else {
+            Write-Host "    UDP  7777-7810   Game servers" -ForegroundColor DarkGray
+            Write-Host "    TCP  31982       RabbitMQ" -ForegroundColor DarkGray
+            if ($portCheckMode -eq 'disabled') {
+                Write-Host "    (port verification disabled)" -ForegroundColor DarkGray
             }
         }
-        $color = if ($e.Available) { 'White' } else { 'DarkGray' }
-        Write-Host ("  {0,2}. {1,-30} {2}" -f $e.Key, $e.Name, $e.Desc) -ForegroundColor $color
-        $prevSection = $e.Section
-    }
-
-    Write-Host ("  {0,2}. {1,-30} {2}" -f "q", "quit", "Exit this script")
-    Write-Host ""
-
-    if (-not $info.Exists) {
-        Write-Host "Some options are unavailable because VM '$vmName' does not exist. Press 'a' to run 'initial-setup'" -ForegroundColor Yellow
         Write-Host ""
-    } elseif (-not $info.Running) {
-        Write-Host "Some options are unavailable because VM '$vmName' is currently $($info.State). Press 'b' to start it" -ForegroundColor Yellow
-        Write-Host ""
-    }
 
-    # --- Selection ---
-    $entry = $null
-    while ($null -eq $entry) {
-        $selection = (Read-Host "Select an option").Trim().ToLower()
-        if ($selection -eq 'q' -or $selection -eq 'quit') { $entry = 'quit'; break }
-        if ($entryByKey.ContainsKey($selection)) {
-            $entry = $entryByKey[$selection]
-        } else {
-            Write-Warning "Invalid selection."
+        $prevSection = $null
+        foreach ($e in $entries) {
+            if ($e.Section -ne $prevSection) {
+                if ($null -ne $prevSection) { Write-Host "" }
+                switch ($e.Section) {
+                    'vm'          { Write-Host "VM commands:" -ForegroundColor Yellow }
+                    'battlegroup' { Write-Host "Battlegroup commands:" -ForegroundColor Yellow }
+                    'tools'       { Write-Host "Tools:" -ForegroundColor Yellow }
+                }
+            }
+            $color = if ($e.Available) { 'White' } else { 'DarkGray' }
+            Write-Host ("  {0,2}. {1,-30} {2}" -f $e.Key, $e.Name, $e.Desc) -ForegroundColor $color
+            $prevSection = $e.Section
         }
+
+        Write-Host ("  {0,2}. {1,-30} {2}" -f "q", "quit", "Exit this script")
+        Write-Host ""
+
+        if (-not $info.Exists) {
+            Write-Host "Some options are unavailable because VM '$vmName' does not exist. Press 'a' to run 'initial-setup'" -ForegroundColor Yellow
+            Write-Host ""
+        } elseif (-not $info.Running) {
+            Write-Host "Some options are unavailable because VM '$vmName' is currently $($info.State). Press 'c' to run 'startup'" -ForegroundColor Yellow
+            Write-Host ""
+        }
+
+        # --- Selection ---
+        $entry = $null
+        while ($null -eq $entry) {
+            $selection = (Read-Host "Select an option").Trim().ToLower()
+            if ($selection -eq 'q' -or $selection -eq 'quit') { $entry = 'quit'; break }
+            if ($entryByKey.ContainsKey($selection)) {
+                $entry = $entryByKey[$selection]
+            } else {
+                Write-Warning "Invalid selection."
+            }
+        }
+        if ($entry -eq 'quit') { break }
     }
-    if ($entry -eq 'quit') { break }
 
     if (-not $entry.Available) {
         Write-Warning $entry.Reason
-        continue
+        if ($Cmd) { exit 1 } else { continue }
     }
 
     $cmd = $entry.Name
@@ -640,6 +726,55 @@ while ($true) {
 
     if ($cmd -eq "initial-setup") {
         . "$bgSetupPath\initial-setup.ps1"
+        if ($Cmd) { break }
+        continue
+    }
+
+    if ($cmd -eq "web") {
+        $webScript = Join-Path $scriptDir 'web\Start-DuneWeb.ps1'
+        if (-not (Test-Path $webScript)) {
+            Write-Warning "Web UI script not found at $webScript"
+            if ($Cmd) { break } else { continue }
+        }
+        if (-not (Get-Module -ListAvailable Pode)) {
+            Write-Warning "Pode PowerShell module is not installed. Install with:"
+            Write-Host "    Install-Module Pode -Scope CurrentUser" -ForegroundColor Cyan
+            if ($Cmd) { break } else { continue }
+        }
+
+        $port = 8765
+        $url  = "http://127.0.0.1:$port"
+
+        $alreadyRunning = $false
+        try {
+            $tcp = New-Object System.Net.Sockets.TcpClient
+            $iar = $tcp.BeginConnect('127.0.0.1', $port, $null, $null)
+            $alreadyRunning = $iar.AsyncWaitHandle.WaitOne(300) -and $tcp.Connected
+            $tcp.Close()
+        } catch {}
+
+        if (-not $alreadyRunning) {
+            Write-Host "Starting Pode web server on $url (minimized)..." -ForegroundColor Cyan
+            Start-Process pwsh `
+                -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File',"`"$webScript`"" `
+                -WindowStyle Minimized
+            $waited = 0
+            while ($waited -lt 8) {
+                Start-Sleep -Milliseconds 500; $waited++
+                try {
+                    $tcp = New-Object System.Net.Sockets.TcpClient
+                    $iar = $tcp.BeginConnect('127.0.0.1', $port, $null, $null)
+                    if ($iar.AsyncWaitHandle.WaitOne(200) -and $tcp.Connected) { $tcp.Close(); break }
+                    $tcp.Close()
+                } catch {}
+            }
+        } else {
+            Write-Host "Web server already running at $url" -ForegroundColor DarkGray
+        }
+
+        Write-Host "Opening $url in your default browser..." -ForegroundColor Cyan
+        Start-Process $url
+        if ($Cmd) { break }
         continue
     }
 
@@ -1190,6 +1325,8 @@ while ($true) {
         }
         if (-not $directorPort) { Write-Warning "Could not determine Director port after $timeout seconds." }
     }
+
+    if ($Cmd) { break }
 }
 
 Stop-Transcript | Out-Null

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,48 @@
+# Web UI
+
+A browser-based button panel that mirrors the console menu of
+`dune-server.ps1`. Built on [Pode](https://github.com/Badgerati/Pode),
+serves on `http://127.0.0.1:8765` (localhost only, no auth).
+
+## Quick start
+
+From the console menu, pick option **`b. web`**. That will:
+
+1. Verify Pode is installed (and tell you how to install it if not).
+2. Start `web/Start-DuneWeb.ps1` minimized if it isn't already running.
+3. Open your default browser at `http://127.0.0.1:8765`.
+
+You can also start the server manually:
+
+```powershell
+pwsh -ExecutionPolicy Bypass -File .\web\Start-DuneWeb.ps1
+```
+
+## Prereqs
+
+Install Pode once per user:
+
+```powershell
+Install-Module Pode -Scope CurrentUser
+```
+
+## How it works
+
+- **Status** (`GET /api/status`) — returns JSON: VM existence/state/IP and the
+  cached port-check results. The page polls this every 5 seconds.
+- **Commands** (`GET /api/commands`) — returns the list of VM/Battlegroup/Tools
+  buttons and per-command availability.
+- **Execute** (`POST /api/exec/{name}`) — spawns a new console window running
+  `dune-server.ps1 -Cmd <name>`. Interactive prompts (battlegroup picker,
+  password entry, confirmations) appear in that console naturally, so no
+  output streaming is required from the web side.
+
+`graceful-reboot` and `graceful-shutdown` show a JS `confirm()` dialog before
+the POST is issued.
+
+## Files
+
+- `Start-DuneWeb.ps1` — Pode server entry point.
+- `public/index.html` — single-page UI.
+- `public/app.js` — fetch + button state + click handlers.
+- `public/styles.css` — dark theme.

--- a/web/Start-DuneWeb.ps1
+++ b/web/Start-DuneWeb.ps1
@@ -1,0 +1,176 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Localhost web UI for the Dune Awakening Server Management Tool.
+
+.DESCRIPTION
+    Mirrors the dune-server.ps1 console menu as a button panel served at
+    http://127.0.0.1:8765. Each button POSTs to /api/exec/{name}, which
+    spawns dune-server.ps1 -Cmd <name> in a new console window so any
+    interactive prompts (battlegroup picker, password entry, confirms)
+    still work.
+
+    No authentication. Binds 127.0.0.1 only.
+#>
+
+[CmdletBinding()]
+param(
+    [int]$Port = 8765
+)
+
+Import-Module Pode -ErrorAction Stop
+
+$script:Root       = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$script:MainScript = Join-Path $script:Root 'dune-server.ps1'
+$script:ConfigFile = Join-Path $script:Root 'dune-server.config'
+$script:VmName     = 'dune-awakening'
+
+function Read-Config {
+    $cfg = @{}
+    if (Test-Path $script:ConfigFile) {
+        Get-Content $script:ConfigFile | ForEach-Object {
+            if ($_ -match '^([^#=]+)=(.*)$') { $cfg[$Matches[1].Trim()] = $Matches[2].Trim() }
+        }
+    }
+    return $cfg
+}
+
+function Get-VmStatus {
+    try {
+        $vm = Get-VM -Name $script:VmName -ErrorAction Stop
+        $ip = ($vm | Get-VMNetworkAdapter).IPAddresses |
+              Where-Object { $_ -match '^\d+\.\d+\.\d+\.\d+$' } |
+              Select-Object -First 1
+        return @{
+            exists  = $true
+            state   = $vm.State.ToString()
+            running = ($vm.State -eq 'Running')
+            ip      = $ip
+        }
+    } catch {
+        return @{ exists = $false; state = 'NotFound'; running = $false; ip = $null }
+    }
+}
+
+# Commands exposed in the web UI. Mirrors $vmCommands / $bgCommands /
+# $toolCommands in dune-server.ps1. Keep in sync when adding new menu items.
+$script:VmCommands = @(
+    @{ key='a'; name='initial-setup';     desc='Run the initial VM setup';                                                requires='none' }
+    # 'b' (web) intentionally omitted from the web UI itself.
+    @{ key='c'; name='startup';           desc='Power on VM, start battlegroup, wait for overmap + survival maps';        requires='exists' }
+    @{ key='d'; name='graceful-reboot';   desc='Stop battlegroup, restart VM, start battlegroup (clean cycle)';           requires='running'; confirm=$true }
+    @{ key='e'; name='graceful-shutdown'; desc='Stop battlegroup, power off VM';                                          requires='running'; confirm=$true }
+    @{ key='f'; name='rotate-ssh-key';    desc='Generate a new SSH key and replace the authorized one on the VM';        requires='running' }
+    @{ key='g'; name='change-password';   desc="Change the password of the 'dune' user on the VM";                        requires='running' }
+)
+
+$script:BgCommands = @(
+    @{ key='1';  name='status';                    desc='Status of the selected battlegroup';                  sub=$null }
+    @{ key='2';  name='start';                     desc='Start the selected battlegroup';                      sub=$null }
+    @{ key='3';  name='restart';                   desc='Restart the selected battlegroup';                    sub=$null }
+    @{ key='4';  name='stop';                      desc='Stop the selected battlegroup';                       sub=$null }
+    @{ key='5';  name='update';                    desc='Check for new versions and apply them';               sub=$null }
+    @{ key='6';  name='edit';                      desc='Edit battlegroup via utilities interface';            sub=$null }
+    @{ key='7';  name='edit-advanced';             desc='(Advanced) Edit battlegroup YAML directly';           sub=$null }
+    @{ key='8';  name='enable-experimental-swap'; desc='(Experimental) Enable experimental swap memory';      sub=$null }
+    @{ key='9';  name='backup';                    desc="Back up the battlegroup's database";                  sub='Database' }
+    @{ key='10'; name='import';                    desc='Import a database backup';                            sub='Database' }
+    @{ key='11'; name='logs-export';               desc='Retrieve logs from all pods in the battlegroup';      sub='Logs' }
+    @{ key='12'; name='operator-logs-export';      desc='Retrieve logs from all operator pods';                sub='Logs' }
+    @{ key='13'; name='open-file-browser';         desc='Open battlegroup file browser (configs/logs)';        sub='Monitoring' }
+    @{ key='14'; name='open-director';             desc='Open battlegroup director page';                      sub='Monitoring' }
+    @{ key='15'; name='shell-vm';                  desc='Open a shell to the VM';                              sub='Monitoring' }
+    @{ key='16'; name='shell-pod';                 desc='Open a shell to a pod in the battlegroup';            sub='Monitoring' }
+)
+
+function Get-ToolCommandList {
+    $cfg = Read-Config
+    $list = @(
+        @{ key='20'; name='ssh';         desc='Open an SSH terminal to the VM';                       requires='running' }
+    )
+    if ($cfg.DuneAdminExe -and (Test-Path $cfg.DuneAdminExe)) {
+        $list += @{ key='21'; name='dune-admin';  desc='Launch dune-admin.exe + open dune-admin web UI'; requires='running' }
+    }
+    $list += @{ key='22'; name='setup-guide'; desc='Open Funcom Self-Hosted Server Setup Instructions'; requires='none' }
+    return $list
+}
+
+function Resolve-Available {
+    param([hashtable]$cmd, [hashtable]$vm)
+    switch ($cmd.requires) {
+        'none'    { return $true }
+        'exists'  { return [bool]$vm.exists }
+        'running' { return [bool]$vm.running }
+        default   { return [bool]$vm.running }
+    }
+}
+
+Start-PodeServer {
+    Add-PodeEndpoint -Address 127.0.0.1 -Port $Port -Protocol Http
+
+    Add-PodeStaticRoute -Path '/' -Source (Join-Path $script:Root 'web\public') -Defaults @('index.html')
+
+    Add-PodeRoute -Method Get -Path '/api/status' -ScriptBlock {
+        $vm = Get-VmStatus
+        Write-PodeJsonResponse -Value @{
+            vm        = $vm
+            timestamp = (Get-Date).ToString('s')
+        }
+    }
+
+    Add-PodeRoute -Method Get -Path '/api/commands' -ScriptBlock {
+        $vm = Get-VmStatus
+        $sections = @()
+
+        $vmList = foreach ($c in $script:VmCommands) {
+            @{ key=$c.key; name=$c.name; desc=$c.desc; available=(Resolve-Available -cmd $c -vm $vm); confirm=([bool]$c.confirm) }
+        }
+        $sections += @{ name='VM';          items=$vmList }
+
+        $bgList = foreach ($c in $script:BgCommands) {
+            @{ key=$c.key; name=$c.name; desc=$c.desc; sub=$c.sub; available=[bool]$vm.running; confirm=$false }
+        }
+        $sections += @{ name='Battlegroup'; items=$bgList }
+
+        $toolList = foreach ($c in (Get-ToolCommandList)) {
+            @{ key=$c.key; name=$c.name; desc=$c.desc; available=(Resolve-Available -cmd $c -vm $vm); confirm=$false }
+        }
+        $sections += @{ name='Tools';       items=$toolList }
+
+        Write-PodeJsonResponse -Value @{ sections = $sections }
+    }
+
+    Add-PodeRoute -Method Post -Path '/api/exec/:name' -ScriptBlock {
+        $name = $WebEvent.Parameters['name']
+
+        $allNames = @()
+        $allNames += $script:VmCommands.name
+        $allNames += $script:BgCommands.name
+        $allNames += (Get-ToolCommandList).name
+        if ($allNames -notcontains $name) {
+            Set-PodeResponseStatus -Code 400
+            Write-PodeJsonResponse -Value @{ ok=$false; error="Unknown command: $name" }
+            return
+        }
+
+        try {
+            Start-Process pwsh -Verb RunAs -ArgumentList @(
+                '-NoExit',
+                '-NoProfile',
+                '-ExecutionPolicy','Bypass',
+                '-File',"`"$script:MainScript`"",
+                '-Cmd',$name
+            ) | Out-Null
+            Set-PodeResponseStatus -Code 202
+            Write-PodeJsonResponse -Value @{ ok=$true; spawned=$name }
+        } catch {
+            Set-PodeResponseStatus -Code 500
+            Write-PodeJsonResponse -Value @{ ok=$false; error=$_.Exception.Message }
+        }
+    }
+
+    Write-Host ""
+    Write-Host "Dune Server Web UI listening on http://127.0.0.1:$Port" -ForegroundColor Green
+    Write-Host "Press Ctrl+C to stop." -ForegroundColor DarkGray
+}

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1,0 +1,103 @@
+const POLL_MS = 5000;
+
+const $sections = document.getElementById('sections');
+const $vmDot = document.getElementById('vm-dot');
+const $vmText = document.getElementById('vm-text');
+const $ts = document.getElementById('ts');
+
+async function refresh() {
+  try {
+    const [status, commands] = await Promise.all([
+      fetch('/api/status').then(r => r.json()),
+      fetch('/api/commands').then(r => r.json())
+    ]);
+    renderStatus(status);
+    renderCommands(commands);
+  } catch (err) {
+    $vmText.textContent = 'Error fetching status';
+    $vmDot.className = 'dot dot-red';
+    console.error(err);
+  }
+}
+
+function renderStatus(s) {
+  const vm = s.vm || {};
+  if (vm.running) {
+    $vmDot.className = 'dot dot-green';
+    $vmText.textContent = `VM running (${vm.ip || 'no IP yet'})`;
+  } else if (vm.exists) {
+    $vmDot.className = 'dot dot-yellow';
+    $vmText.textContent = `VM ${vm.state || 'unknown'}`;
+  } else {
+    $vmDot.className = 'dot dot-red';
+    $vmText.textContent = 'VM not found';
+  }
+  $ts.textContent = `(refreshed ${new Date().toLocaleTimeString()})`;
+}
+
+function renderCommands(c) {
+  const sections = c.sections || [];
+  const html = sections.map(sec => {
+    let lastSub = null;
+    const items = sec.items.map(item => {
+      let subHeader = '';
+      if (item.sub && item.sub !== lastSub) {
+        subHeader = `<h3 class="sub">${escapeHtml(item.sub)}</h3>`;
+        lastSub = item.sub;
+      } else if (!item.sub && lastSub) {
+        lastSub = null;
+      }
+      const disabled = item.available ? '' : 'disabled';
+      const title = item.available
+        ? item.desc
+        : `${item.desc}  —  Currently unavailable (VM not in required state).`;
+      const confirmAttr = item.confirm ? ' data-confirm="true"' : '';
+      return `${subHeader}
+        <button class="cmd"${confirmAttr} data-name="${escapeHtml(item.name)}" ${disabled} title="${escapeHtml(title)}">
+          <span class="key">${escapeHtml(item.key)}.</span>
+          <span class="name">${escapeHtml(item.name)}</span>
+          <span class="desc">${escapeHtml(item.desc)}</span>
+        </button>`;
+    }).join('');
+    return `<section><h2>${escapeHtml(sec.name)}</h2><div class="grid">${items}</div></section>`;
+  }).join('');
+  $sections.innerHTML = html;
+
+  $sections.querySelectorAll('button.cmd').forEach(btn => {
+    btn.addEventListener('click', () => onExec(btn));
+  });
+}
+
+async function onExec(btn) {
+  const name = btn.dataset.name;
+  const needsConfirm = btn.dataset.confirm === 'true';
+  if (needsConfirm) {
+    const ok = confirm(`Run "${name}"?\n\nThis will affect the live server.`);
+    if (!ok) return;
+  }
+  btn.disabled = true;
+  const prev = btn.innerHTML;
+  btn.innerHTML = `<span class="name">Launching ${escapeHtml(name)}…</span>`;
+  try {
+    const res = await fetch(`/api/exec/${encodeURIComponent(name)}`, { method: 'POST' });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  } catch (err) {
+    alert(`Failed to launch ${name}: ${err.message}`);
+  } finally {
+    setTimeout(() => {
+      btn.innerHTML = prev;
+      btn.disabled = false;
+      refresh();
+    }, 1500);
+  }
+}
+
+function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[c]));
+}
+
+refresh();
+setInterval(refresh, POLL_MS);

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Dune Awakening — Server Management</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Dune Awakening &mdash; Server Management</h1>
+    <div id="vm-status" class="vm-status">
+      <span class="dot" id="vm-dot"></span>
+      <span id="vm-text">Loading&hellip;</span>
+      <span class="ts" id="ts"></span>
+    </div>
+  </header>
+
+  <main id="sections" aria-live="polite">
+    <p class="hint">Loading commands&hellip;</p>
+  </main>
+
+  <footer>
+    <p>
+      Localhost only &middot;
+      <a href="https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool" target="_blank" rel="noopener">Simple Dune Server Management Tool</a>
+    </p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -1,0 +1,93 @@
+:root {
+  --bg: #0f1418;
+  --panel: #161c22;
+  --border: #2a323a;
+  --text: #d6dde3;
+  --muted: #8a96a3;
+  --accent: #5fa9ff;
+  --green: #5ddc8a;
+  --yellow: #f0c674;
+  --red: #ff6f6f;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+header {
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(180deg, #1a2026, #0f1418);
+  display: flex; align-items: baseline; justify-content: space-between;
+  flex-wrap: wrap; gap: 12px;
+}
+header h1 { margin: 0; font-size: 18px; font-weight: 600; letter-spacing: 0.02em; }
+
+.vm-status { display: inline-flex; align-items: center; gap: 8px; color: var(--muted); }
+.dot { width: 10px; height: 10px; border-radius: 50%; background: #555; display: inline-block; }
+.dot-green  { background: var(--green);  box-shadow: 0 0 8px rgba(93,220,138,0.5); }
+.dot-yellow { background: var(--yellow); box-shadow: 0 0 8px rgba(240,198,116,0.4); }
+.dot-red    { background: var(--red);    box-shadow: 0 0 8px rgba(255,111,111,0.4); }
+.ts { font-size: 12px; color: var(--muted); margin-left: 6px; }
+
+main { padding: 18px 24px 40px; max-width: 1200px; margin: 0 auto; }
+
+section { margin-bottom: 28px; }
+section h2 {
+  font-size: 12px; font-weight: 700; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--accent); margin: 0 0 10px;
+  padding-bottom: 6px; border-bottom: 1px solid var(--border);
+}
+h3.sub {
+  grid-column: 1 / -1;
+  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--muted); margin: 8px 0 0; font-weight: 600;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 10px;
+}
+
+button.cmd {
+  text-align: left;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  color: var(--text);
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 8px;
+  transition: border-color 0.12s, background 0.12s, transform 0.04s;
+}
+button.cmd:hover:not([disabled]) {
+  border-color: var(--accent);
+  background: #1c242c;
+}
+button.cmd:active:not([disabled]) { transform: translateY(1px); }
+button.cmd[disabled] { opacity: 0.45; cursor: not-allowed; }
+
+.key  { grid-row: 1 / span 2; align-self: center; font-weight: 700; color: var(--accent); }
+.name { font-weight: 600; }
+.desc { grid-column: 2; color: var(--muted); font-size: 12px; }
+
+.hint { color: var(--muted); }
+
+footer {
+  text-align: center;
+  padding: 14px;
+  color: var(--muted);
+  font-size: 12px;
+  border-top: 1px solid var(--border);
+}
+footer a { color: var(--accent); text-decoration: none; }
+footer a:hover { text-decoration: underline; }


### PR DESCRIPTION
Ships v1.2.0. See CHANGELOG entry for details.

## Highlights

- **Web UI** (`b. web`): Pode server on http://127.0.0.1:8765 with a button panel that mirrors the console menu. Each click POSTs to `/api/exec/{name}` which spawns a new console window running `dune-server.ps1 -Cmd <name>` so interactive prompts (battlegroup picker, password, confirms) keep working.
- **`-Cmd <name>` non-interactive dispatch** on `dune-server.ps1`.
- **dune-admin install offer in setup**: download latest from Icehunter/dune-admin to a folder you pick, or use an existing path, or skip. Repo does NOT bundle the binary.

## Menu restructure

VM section is re-lettered sequentially so it ends at `g. change-password` before the numbered Battlegroup commands begin:

| Old key | New key | Name |
|--|--|--|
| a | a | initial-setup |
|   | b | **web** (new) |
| ~~b~~ | --- | start-vm (removed from menu) |
| ~~c~~ | --- | stop-vm (removed from menu) |
| h | c | startup |
| f | d | graceful-reboot |
| g | e | graceful-shutdown |
| d | f | rotate-ssh-key |
| e | g | change-password |

`start-vm` / `stop-vm` handlers remain in the script so backward-compat `-Cmd` invocations still work.

## Testing notes

- `Install-DuneAdminLatest` is untested end-to-end against the live GitHub API; first real-world run is the next setup.
- Web UI was not run against a live VM; routes parse-validated and Pode cmdlets resolved.
