### PR TITLE
fix: -Cmd mode infinite loop (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-05-24
+
+### Fixed
+- `-Cmd <name>` mode (used by every web UI button) would infinite-loop
+  re-running the same command. Handlers use `continue` to skip the
+  remaining loop body, which also skipped the bottom-of-loop `break`
+  intended to exit after one dispatch. Visible symptom: clicking
+  `dune-admin` (or any other) button spawned launch attempts repeatedly
+  until the process was killed. Now gated at the top of the loop so
+  exactly one handler runs per `-Cmd` invocation.
+
 ## [1.2.0] - 2026-05-24
 
 ### Added
@@ -127,7 +138,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened the post-reboot readiness check to verify webhook Service endpoints
   are populated (not just pods Running) before calling battlegroup start.
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.0.1...v1.1.0

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "1.2.0"
+$script:ToolVersion = "1.2.1"
 
 # Resize console window so the full menu is visible
 try {
@@ -599,8 +599,15 @@ function Get-ToolCmdAvailability {
 
 $directorPort = $null
 $bgBinPath    = '/home/dune/.dune/bin/battlegroup'
+$cmdHasRun    = $false
 
 while ($true) {
+    # In -Cmd (non-interactive) mode, exit after exactly one handler runs.
+    # Handlers use `continue` which would otherwise skip the bottom-of-loop
+    # `if ($Cmd) { break }` and cause an infinite re-dispatch.
+    if ($Cmd -and $cmdHasRun) { break }
+    if ($Cmd) { $cmdHasRun = $true }
+
     $info = Get-VmInfo
 
     # Build entries list


### PR DESCRIPTION
Critical patch for v1.2.0. Every web UI button click invokes `dune-server.ps1 -Cmd <name>`, which infinite-looped re-running the same handler. See CHANGELOG entry for details and root cause.