### PR TITLE
chore: default dune-admin install dir to Desktop (v1.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3] - 2026-05-24
+
+### Changed
+- Setup wizard now defaults the `dune-admin` install directory to
+  `%USERPROFILE%\Desktop\dune-admin` (was `%USERPROFILE%\dune-admin`)
+  so the tool is more visible after install. The desktop location is
+  also checked first when offering to point at an existing install.
+
 ## [1.2.2] - 2026-05-24
 
 ### Added
@@ -164,7 +172,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened the post-reboot readiness check to verify webhook Service endpoints
   are populated (not just pods Running) before calling battlegroup start.
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.2...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.3...HEAD
+[1.2.3]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.1...v1.2.0

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "1.2.2"
+$script:ToolVersion = "1.2.3"
 
 # Resize console window so the full menu is visible
 try {
@@ -123,7 +123,7 @@ function Run-Setup {
     $adminChoice = Ask -Label "Choose 1, 2, or 3" -Default $defaultAdminChoice
     $adminExe = ""
     if ($adminChoice -eq '1') {
-        $defaultInstallDir = if ($existingAdmin) { Split-Path $existingAdmin -Parent } else { "$env:USERPROFILE\dune-admin" }
+        $defaultInstallDir = if ($existingAdmin) { Split-Path $existingAdmin -Parent } else { Join-Path ([Environment]::GetFolderPath('Desktop')) 'dune-admin' }
         $installDir = Ask -Label "Install directory" -Default $defaultInstallDir
         try {
             $adminExe = Install-DuneAdminLatest -InstallDir $installDir
@@ -139,9 +139,9 @@ function Run-Setup {
     } elseif ($adminChoice -eq '2') {
         $defaultAdmin = $null
         $adminCandidates = @(
+            (Join-Path ([Environment]::GetFolderPath('Desktop')) 'dune-admin\dune-admin.exe'),
             "$env:USERPROFILE\dune-admin\dune-admin.exe",
             "$env:USERPROFILE\Desktop\dune-admin-main\dune-admin.exe",
-            "$env:USERPROFILE\Desktop\dune-admin\dune-admin.exe",
             "$scriptDir\dune-admin\dune-admin.exe"
         )
         foreach ($a in $adminCandidates) {


### PR DESCRIPTION
User requested the default install dir for `dune-admin` (download flow + existing-path candidate) be on the desktop instead of the user profile root.