### PR TITLE
fix: do not pause dune-server.bat on clean exit (v1.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4] - 2026-05-24
+
+### Fixed
+- `dune-server.bat` no longer pauses with "Press any key to continue"
+  after a clean exit (e.g. after picking `q. quit` or finishing a `1.
+  status` run). The `pause` now only fires when the PowerShell script
+  exits with a non-zero error code, which is its original purpose:
+  keep the window open so a startup crash is readable. Also forwards
+  `%*` to the script so command-line arguments (`-Cmd <name>`) work
+  when invoked via the .bat.
+
 ## [1.2.3] - 2026-05-24
 
 ### Changed
@@ -172,7 +183,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened the post-reboot readiness check to verify webhook Service endpoints
   are populated (not just pods Running) before calling battlegroup start.
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.3...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.4...HEAD
+[1.2.4]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.0...v1.2.1

--- a/dune-server.bat
+++ b/dune-server.bat
@@ -1,3 +1,3 @@
 @echo off
-pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0dune-server.ps1"
-pause
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0dune-server.ps1" %*
+if errorlevel 1 pause

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "1.2.3"
+$script:ToolVersion = "1.2.4"
 
 # Resize console window so the full menu is visible
 try {


### PR DESCRIPTION
User: 'i got the press any key to continue option again'. Same as before: pause only on non-zero exit.