### PR TITLE
release: v2.0.0 (consolidate all v1.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,177 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.3] - 2026-05-24
+## [2.0.0] - 2026-05-24
 
-### Changed
-- Setup wizard now defaults the `dune-admin` install directory to
-  `%USERPROFILE%\Desktop\dune-admin` (was `%USERPROFILE%\dune-admin`)
-  so the tool is more visible after install. The desktop location is
-  also checked first when offering to point at an existing install.
-
-## [1.2.2] - 2026-05-24
+Consolidation release. Supersedes all prior 1.x releases &mdash; the 1.x
+GitHub Releases were rolled into this single 2.0.0 entry. From here on,
+patch releases follow as `2.0.1`, `2.0.2`, etc.
 
 ### Added
-- Setup wizard now copies your SSH private key (and `.pub` if present)
-  into the `dune-admin` install folder so `dune-admin.exe` can SSH to the
-  VM out of the box without extra configuration. Always pulls the
-  freshest key (compares `%LOCALAPPDATA%\DuneAwakeningServer\sshKey`
-  &mdash; where `rotate-ssh-key` writes &mdash; against the path stored in
-  `dune-server.config` and picks whichever is newer).
-- `f. rotate-ssh-key` now also refreshes the copy of the key in the
-  `dune-admin` folder so it stays in sync after a rotation.
-- Setup wizard ends with an optional "create a desktop shortcut?" prompt.
-  Answering yes drops a `Dune Server (Admin).lnk` on the desktop that
-  targets `dune-server.bat` with the **Run as Administrator** flag set
-  (so SSH-key file permissions and Hyper-V cmdlets work without extra
-  prompts).
 
-### Fixed
-- Wrapped the setup wizard in a top-level try/catch so failures show a
-  readable error + stack trace and pause for `Enter` before exiting,
-  instead of vanishing in a closing console window.
-
-### Internal
-- New helpers: `Resolve-FreshSshKey`, `Copy-SshKeyToDir`,
-  `New-DuneDesktopShortcut`.
-
-## [1.2.1] - 2026-05-24
-
-### Fixed
-- `-Cmd <name>` mode (used by every web UI button) would infinite-loop
-  re-running the same command. Handlers use `continue` to skip the
-  remaining loop body, which also skipped the bottom-of-loop `break`
-  intended to exit after one dispatch. Visible symptom: clicking
-  `dune-admin` (or any other) button spawned launch attempts repeatedly
-  until the process was killed. Now gated at the top of the loop so
-  exactly one handler runs per `-Cmd` invocation.
-
-## [1.2.0] - 2026-05-24
-
-### Added
-- **Localhost web UI** (`b. web` menu option). Spins up a [Pode](https://github.com/Badgerati/Pode)
-  server on `http://127.0.0.1:8765` and opens your default browser to a
-  button panel that mirrors the console menu. Each click POSTs to
-  `/api/exec/{name}`, which spawns `dune-server.ps1 -Cmd <name>` in a new
-  console window so interactive prompts (battlegroup picker, password entry,
-  confirmations) keep working. Status panel polls every 5 seconds.
-  Confirmation dialog on `graceful-reboot` and `graceful-shutdown`.
-  Lives under `web/` &mdash; `Start-DuneWeb.ps1` + `public/{index.html,app.js,styles.css}`.
+- **Localhost web UI** (`b. web` menu option). [Pode](https://github.com/Badgerati/Pode)-based
+  server on `http://127.0.0.1:8765` with a button panel that mirrors the
+  console menu. Each click POSTs to `/api/exec/{name}`, which spawns
+  `dune-server.ps1 -Cmd <name>` in a new console window so interactive
+  prompts (battlegroup picker, password entry, confirmations) keep working.
+  Status panel polls every 5 seconds. Confirmation dialog on
+  `graceful-reboot` and `graceful-shutdown`. Lives under `web/`
+  &mdash; `Start-DuneWeb.ps1` + `public/{index.html,app.js,styles.css}`.
 - **`-Cmd <name>` parameter** on `dune-server.ps1` for non-interactive
   dispatch. Skips the menu, looks up the command by name, runs the handler
   once, and exits. Used by the web UI; also handy for shortcuts and scripts.
 - **`dune-admin` install offer during setup** (step 3). Prompts to either
   download the latest release from
   [`Icehunter/dune-admin`](https://github.com/Icehunter/dune-admin)
-  to a directory you choose (default `%USERPROFILE%\dune-admin`), use an
-  existing local install, or skip. The chosen `dune-admin.exe` path is stored
-  in `dune-server.config` exactly as before; this repo does not bundle the
+  to a directory you choose (default `%USERPROFILE%\Desktop\dune-admin`),
+  use an existing local install, or skip. The chosen `dune-admin.exe`
+  path is stored in `dune-server.config`; this repo does not bundle the
   binary.
+- **SSH key auto-copy to `dune-admin` folder.** Setup seeds the
+  `dune-admin` install dir with the freshest SSH key (compares
+  `%LOCALAPPDATA%\DuneAwakeningServer\sshKey` &mdash; where
+  `rotate-ssh-key` writes &mdash; against the path stored in
+  `dune-server.config` and picks whichever is newer). `f. rotate-ssh-key`
+  also refreshes that copy so it stays in sync after a rotation.
+- **Optional "Run as Administrator" desktop shortcut.** End-of-setup prompt
+  drops a `Dune Server (Admin).lnk` on your desktop targeting
+  `dune-server.bat` with the elevated-launch flag set in the `.lnk` binary.
+- **VM section re-lettered sequentially** so it ends cleanly at
+  `g. change-password` before the numbered Battlegroup commands:
+  `a` initial-setup, `b` web (new), `c` startup, `d` graceful-reboot,
+  `e` graceful-shutdown, `f` rotate-ssh-key, `g` change-password.
 
-### Changed
-- VM section re-lettered sequentially so the section ends cleanly at
-  `g. change-password` before the numbered Battlegroup commands begin:
-  - `a. initial-setup`
-  - `b. web` *(new)*
-  - `c. startup` *(was `h`)*
-  - `d. graceful-reboot` *(was `f`)*
-  - `e. graceful-shutdown` *(was `g`)*
-  - `f. rotate-ssh-key` *(was `d`)*
-  - `g. change-password` *(was `e`)*
-- Post-menu hint when the VM isn't running now reads "Press 'c' to run
-  'startup'" instead of the removed "Press 'b' to start it".
+### Fixed
+
+- `-Cmd <name>` mode (used by every web UI button) would infinite-loop
+  re-running the same command. Handlers use `continue` to skip the
+  remaining loop body, which also skipped the bottom-of-loop `break`.
+  Now gated at the top of the loop so exactly one handler runs per
+  `-Cmd` invocation.
+- `dune-server.bat` no longer pauses with "Press any key to continue"
+  on a clean exit. The `pause` now only fires when the PowerShell script
+  exits non-zero. Also forwards `%*` so `-Cmd <name>` works via the
+  `.bat` too.
+- Setup wizard is now wrapped in a top-level try/catch &mdash; failures
+  print a readable error + stack trace and pause for Enter, instead of
+  the console window vanishing.
+- Port-check status in the menu header now refreshes after running any
+  battlegroup CLI command (`1. status`, `2. start`, `3. restart`,
+  `4. stop`). Previously the cached results were keyed only by public
+  IP with no TTL, so the `[OPEN]` / `[CLOSED]` indicators would stick
+  at their first observed values for the entire session.
 
 ### Removed
-- `b. start-vm` and `c. stop-vm` menu entries. The graceful counterparts
-  (`c. startup` cold-starts the full stack; `e. graceful-shutdown` stops
-  battlegroup and powers off) cover everything they did without leaving
-  pods in inconsistent state. The underlying handlers remain in the script
-  so existing automation calling them by name still works.
 
-## [1.1.1] - 2026-05-24
+- `b. start-vm` and `c. stop-vm` menu entries. The graceful
+  counterparts (`c. startup` cold-starts the full stack; `e. graceful-shutdown`
+  stops battlegroup and powers off) cover everything they did without
+  leaving pods in inconsistent state. The underlying handlers remain so
+  existing automation calling them by name still works.
 
-### Fixed
-- Port-check status in the menu header now refreshes after running any
-  battlegroup CLI command (`1. status`, `2. start`, `3. restart`, `4. stop`).
-  Previously the cached results were keyed only by public IP with no TTL, so
-  the `[OPEN]` / `[CLOSED]` indicators would stick at their first observed
-  values for the entire session even when the server's actual port state
-  changed.
+### Internal
 
-## [1.1.0] - 2026-05-24
+- New helpers: `Install-DuneAdminLatest`, `Resolve-FreshSshKey`,
+  `Copy-SshKeyToDir`, `New-DuneDesktopShortcut`.
+- `web/` folder structure added.
 
-### Added
-- New `h. startup` menu option (and matching handler) that orchestrates a clean
-  cold-start of the server with timed gates at each step:
-  1. Powers on the Hyper-V VM (skipped if already running) and waits for an IP.
-  2. Waits for SSH, the k3s API (`/readyz`), the DB pod(s) Ready,
-     `funcom-operators` pods Ready, and the
-     `battlegroupoperator-webhook-svc` Service endpoints to be populated
-     (the same gate `f. graceful-reboot` uses to avoid the `502 Bad Gateway`
-     mutating-webhook race).
-  3. Runs `battlegroup start`.
-  4. Polls until the `overmap` and `survival` map pods are both
-     `Running` with all containers Ready (timeout 300s each).
-  Prints elapsed seconds for each phase and a total at the end.
-- New `Wait-MapPodReady` helper used by step 4 above. Generic enough to be
-  reused by any future "wait for a named pod" feature.
-
-### Changed
-- Menu UI is now visually compact (~14 fewer rows): merged the double `===`
-  header bar into a single line, removed cosmetic blank lines between sections,
-  dropped the redundant `(checking via ...)` preamble and the UDP-not-verifiable
-  disclaimer from the port block, replaced the dashed separator before `Tools:`
-  with just the section header, and removed the `Database:` / `Logs:` /
-  `Monitoring:` sub-section headers (the entries are still numbered the same).
-  All functionality, key bindings, and color coding are unchanged.
-
-## [1.0.1] - 2026-05-24
-
-### Fixed
-- Menu option `21. dune-admin` is now correctly disabled (greyed out with a reason)
-  when the Hyper-V VM does not exist or is not running, matching the behavior of
-  every other VM-dependent menu item. Previously it was always shown as available.
-
-## [1.0.0] - 2026-05-24
-
-### Added
-- Initial public release.
-- Menu-driven launcher (`dune-server.bat` + `dune-server.ps1`) that wraps Funcom's
-  `battlegroup.ps1` and adds extra utilities.
-- First-time setup wizard (`Run-Setup`) that writes `dune-server.config`.
-- VM management commands (a–g): start, stop, restart, hard-reset, status, console,
-  graceful-reboot, graceful-shutdown.
-- **Graceful reboot** (`f`): stops battlegroup, waits for game/mq/gateway/director
-  pods to drain, hard-resets the VM, then restarts battlegroup with a strong
-  readiness gate (k3s API `/readyz` + DB pods Ready + operator pods Ready +
-  webhook service endpoints populated + settle delay). Fixes the
-  `failed calling webhook "mbattlegroup.kb.io": 502 Bad Gateway` race.
-- **Graceful shutdown** (`g`): stops battlegroup cleanly, then powers off the VM.
-  Intended for nightly shutdowns; player data persists to the DB.
-- **Online-player safety check**: graceful-reboot and graceful-shutdown query
-  the Postgres `player_state` table over `kubectl exec`, list any online
-  players by character name, and require a `YES` confirmation before
-  disconnecting them.
-- **Port verification** in the menu header: color-coded `[OPEN]` / `[CLOSED]` /
-  `[UNKNOWN]` / `[UDP - skipped]` status for required game ports. Three modes
-  selectable in setup: built-in (yougetsignal.com, TCP only), custom URL
-  template with `{ip}` / `{port}` / `{protocol}` placeholders, or disabled.
-- Public IP lookup via `api.ipify.org` with 5s timeout and per-session cache.
-- DB namespace auto-discovery (matches pod names containing `-db-`, `postgres`,
-  or `-pg-`); silently skips when not present.
-- Setup wizard now records `PortCheckMode` and `PortCheckUrlTemplate` in
-  `dune-server.config`. Existing installs default to `builtin` silently.
-
-### Changed
-- Hardened the post-reboot readiness check to verify webhook Service endpoints
-  are populated (not just pods Running) before calling battlegroup start.
-
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.3...HEAD
-[1.2.3]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.2...v1.2.3
-[1.2.2]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.1...v1.2.2
-[1.2.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.2.0...v1.2.1
-[1.2.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.1...v1.2.0
-[1.1.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.0.1...v1.1.0
-[1.0.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/releases/tag/v1.0.0
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/releases/tag/v2.0.0

--- a/dune-server.bat
+++ b/dune-server.bat
@@ -1,3 +1,3 @@
 @echo off
-pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0dune-server.ps1"
-pause
+pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0dune-server.ps1" %*
+if errorlevel 1 pause

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "1.2.3"
+$script:ToolVersion = "2.0.0"
 
 # Resize console window so the full menu is visible
 try {


### PR DESCRIPTION
Consolidation release. Rolls every shipped v1.x change into a single v2.0.0 entry.

## Why
Per request: package the v1.x line into v2.0.0 and delete the old releases/tags. Going forward, patch releases are 2.0.1, 2.0.2, etc.

## Includes
- Everything previously shipped in v1.0.0 through v1.2.3
- The dune-server.bat clean-exit fix from the now-closed PR #12 (`pause` -> `if errorlevel 1 pause` + `%*` forwarding)
- `ToolVersion` bumped to `2.0.0`
- `CHANGELOG.md` rewritten as one `[2.0.0]` entry

## Post-merge
- Delete v1.0.0 through v1.2.3 GitHub Releases + tags
- Tag and create v2.0.0 release