### PR TITLE
Skip startup confirmation prompt (v2.0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.4] - 2026-05-24
+
+### Changed
+
+- **`c. startup` no longer prompts for confirmation.** The "Type YES to
+  continue" gate after selecting startup was redundant; the user already
+  chose to start the server by picking the menu option. Cold-start now
+  runs immediately. Other destructive commands (`graceful-reboot`,
+  `graceful-shutdown`, etc.) keep their confirmations.
+
 ## [2.0.3] - 2026-05-24
 
 ### Fixed
@@ -122,7 +132,8 @@ patch releases follow as `2.0.1`, `2.0.2`, etc.
   `Copy-SshKeyToDir`, `New-DuneDesktopShortcut`.
 - `web/` folder structure added.
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.3...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.4...HEAD
+[2.0.4]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.0...v2.0.1

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "2.0.3"
+$script:ToolVersion = "2.0.4"
 
 # Resize console window so the full menu is visible
 try {
@@ -954,8 +954,6 @@ while ($true) {
         Write-Host "  3. Start battlegroup" -ForegroundColor DarkGray
         Write-Host "  4. Wait for overmap and survival map pods to be Ready" -ForegroundColor DarkGray
         Write-Host ""
-        $confirm = Read-Host "Type YES to continue"
-        if ($confirm -ne "YES") { Write-Host "Aborted." -ForegroundColor Cyan; continue }
 
         $t0 = Get-Date
 


### PR DESCRIPTION
Selecting `c. startup` from the menu already signals intent; the extra `Type YES to continue` gate was redundant. Cold-start now runs immediately. Destructive commands (`graceful-reboot`, `graceful-shutdown`) keep their confirmations.