### PR TITLE
v2.0.6: rename graceful-shutdown/reboot to shutdown/reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.6] - 2026-05-24
+
+### Changed
+
+- **Menu rename + reorder.** `graceful-shutdown` is now just `shutdown`
+  (menu key `d`, moved directly under `c. startup`), and `graceful-reboot`
+  is now just `reboot` (menu key `e`). Behavior is unchanged - same
+  safety checks, same phases, same boot-time tracking. Headings and
+  status messages updated accordingly (e.g. `=== Reboot complete in Xs ===`).
+- **Web UI** mirrors the rename and reorder.
+
 ## [2.0.5] - 2026-05-24
 
 ### Added
@@ -146,7 +157,8 @@ patch releases follow as `2.0.1`, `2.0.2`, etc.
   `Copy-SshKeyToDir`, `New-DuneDesktopShortcut`.
 - `web/` folder structure added.
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.5...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.6...HEAD
+[2.0.6]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.5...v2.0.6
 [2.0.5]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.2...v2.0.3

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ VM commands:
    c. stop-vm                      Stop the VM
    d. rotate-ssh-key               Generate a new SSH key
    e. change-password              Change the 'dune' user password
-   f. graceful-reboot              Stop battlegroup -> restart VM -> start battlegroup (clean cycle)
-   g. graceful-shutdown            Stop battlegroup -> power off VM (e.g. shut down for the night)
+   f. shutdown                     Stop battlegroup -> power off VM (e.g. shut down for the night)
+   g. reboot                       Stop battlegroup -> restart VM -> start battlegroup (clean cycle)
 
 Battlegroup commands:
 
@@ -132,9 +132,9 @@ Type a letter or number and press **Enter** to run that option.
 
 ### What each section does
 
-**VM commands (a–g)** — Control the Hyper-V virtual machine itself. Start it, stop it, rotate SSH keys, change the VM password, run a graceful reboot, or shut down for the night.
+**VM commands (a–g)** — Control the Hyper-V virtual machine itself. Start it, stop it, rotate SSH keys, change the VM password, run a clean reboot, or shut down for the night.
 
-> **Graceful reboot (`f`)** — Use this when the server is misbehaving (lag, memory pressure, stuck pods) and you want a clean cycle without losing player data. It will:
+> **Reboot (`e`)** — Use this when the server is misbehaving (lag, memory pressure, stuck pods) and you want a clean cycle without losing player data. It will:
 > 1. Stop the battlegroup so all maps enter PreShutdown and persist player state to the database.
 > 2. Wait for the game, RabbitMQ, gateway, traffic-router, and director pods to fully terminate (up to 6 minutes).
 > 3. Hard-stop and restart the Hyper-V VM.
@@ -143,7 +143,7 @@ Type a letter or number and press **Enter** to run that option.
 >
 > The whole cycle typically takes 5–10 minutes. Warn your players in Discord first — there is no in-game broadcast mechanism.
 
-> **Graceful shutdown (`g`)** — Use this when you want to shut the server down for the night (or any extended period). It does the same first two phases as graceful reboot — stop the battlegroup and wait for player data to fully persist to the DB — then powers off the VM and stops there. Bring it back up with `b. start-vm` followed by `2. start`.
+> **Shutdown (`d`)** — Use this when you want to shut the server down for the night (or any extended period). It does the same first two phases as reboot — stop the battlegroup and wait for player data to fully persist to the DB — then powers off the VM and stops there. Bring it back up with `c. startup`.
 
 **Battlegroup commands (1–16)** — Manage the game server running inside the VM. These are the same options from the official Funcom `battlegroup.bat`, including starting/stopping the server, updating, editing config, backups, logs, and connecting to pods.
 
@@ -209,11 +209,11 @@ This happens if dune-admin is running as administrator. The tool already handles
 - Delete or blank the `PortCheckUrlTemplate=` line in `dune-server.config`, or delete the config file and re-run setup leaving question #5 blank.
 
 ### Graceful reboot fails at "Starting battlegroup" with `502 Bad Gateway`
-The mutating webhook from the battlegroup operator was not reachable when `battlegroup start` was called. The graceful-reboot option now waits for the webhook service endpoints to be populated before starting, but if you triggered `start` manually too soon you'll see:
+The mutating webhook from the battlegroup operator was not reachable when `battlegroup start` was called. The `reboot` option now waits for the webhook service endpoints to be populated before starting, but if you triggered `start` manually too soon you'll see:
 ```
 failed calling webhook "mbattlegroup.kb.io": ... 502 Bad Gateway
 ```
-Wait 30–60 seconds and try option `2. start` again, or just rerun option `f. graceful-reboot` from the beginning.
+Wait 30–60 seconds and try option `2. start` again, or just rerun option `e. reboot` from the beginning.
 
 ### I want to change my settings
 Delete `dune-server.config` (in the same folder as the scripts) and run `dune-server.bat` again. The setup wizard will re-appear.

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "2.0.5"
+$script:ToolVersion = "2.0.6"
 
 # Resize console window so the full menu is visible
 try {
@@ -522,7 +522,7 @@ $logFile = "$scriptDir\.logs\dune-server-$(Get-Date -Format 'yyyy-MM-dd_HH-mm-ss
 New-Item -ItemType Directory -Force -Path (Split-Path $logFile) | Out-Null
 Start-Transcript -Path $logFile -Append | Out-Null
 
-# --- Boot-time history (per-phase timing for startup and graceful-reboot) ---
+# --- Boot-time history (per-phase timing for startup and reboot) ---
 # Persists wait-times for each phase to .boot-times.json (last 20 runs per phase)
 # so subsequent runs can display an estimate before each wait.
 $script:BootTimesFile = Join-Path $scriptDir ".boot-times.json"
@@ -610,7 +610,7 @@ function Get-OnlinePlayers {
     return @{ Names = $names; Error = $null }
 }
 
-# Helper used by both graceful-reboot and graceful-shutdown handlers.
+# Helper used by both reboot and shutdown handlers.
 # Returns $true if user confirmed (or no players online), $false to abort.
 function Confirm-NoPlayersOnline {
     param([string]$ActionLabel)
@@ -673,8 +673,8 @@ $vmCommands = @(
     [pscustomobject]@{ Key = "a"; Name = "initial-setup";      Desc = "Run the initial VM setup" }
     [pscustomobject]@{ Key = "b"; Name = "web";                Desc = "Open the web UI in your browser (button panel for these commands)" }
     [pscustomobject]@{ Key = "c"; Name = "startup";            Desc = "Power on VM -> start battlegroup -> wait for overmap + survival maps" }
-    [pscustomobject]@{ Key = "d"; Name = "graceful-reboot";    Desc = "Stop battlegroup -> restart VM -> start battlegroup (clean cycle)" }
-    [pscustomobject]@{ Key = "e"; Name = "graceful-shutdown";  Desc = "Stop battlegroup -> power off VM (e.g. shut down for the night)" }
+    [pscustomobject]@{ Key = "d"; Name = "shutdown";           Desc = "Stop battlegroup -> power off VM (e.g. shut down for the night)" }
+    [pscustomobject]@{ Key = "e"; Name = "reboot";             Desc = "Stop battlegroup -> restart VM -> start battlegroup (clean cycle)" }
     [pscustomobject]@{ Key = "f"; Name = "rotate-ssh-key";     Desc = "Generate a new SSH key and replace the one authorized on the VM" }
     [pscustomobject]@{ Key = "g"; Name = "change-password";    Desc = "Change the password of the 'dune' user on the VM" }
 )
@@ -725,12 +725,12 @@ function Get-VmCmdAvailability {
             if (-not $info.Running) { return @{ Available = $false; Reason = "VM '$vmName' is not running (currently $($info.State))." } }
             return @{ Available = $true; Reason = $null }
         }
-        "graceful-reboot" {
+        "reboot" {
             if (-not $info.Exists)  { return @{ Available = $false; Reason = "VM '$vmName' does not exist." } }
             if (-not $info.Running) { return @{ Available = $false; Reason = "VM '$vmName' is not running. Use 'c. startup' to cold-start." } }
             return @{ Available = $true; Reason = $null }
         }
-        "graceful-shutdown" {
+        "shutdown" {
             if (-not $info.Exists)  { return @{ Available = $false; Reason = "VM '$vmName' does not exist." } }
             if (-not $info.Running) { return @{ Available = $false; Reason = "VM '$vmName' is not running." } }
             return @{ Available = $true; Reason = $null }
@@ -1164,14 +1164,14 @@ while ($true) {
         continue
     }
 
-    if ($cmdName -eq "graceful-reboot") {
+    if ($cmdName -eq "reboot") {
         Write-Host ""
-        Write-Host "=== Graceful Reboot ===" -ForegroundColor Cyan
+        Write-Host "=== Reboot ===" -ForegroundColor Cyan
         Write-Host "  1. Stop battlegroup (waits for game/mq/gateway/director pods to terminate)" -ForegroundColor DarkGray
         Write-Host "  2. Hard-stop and restart the VM" -ForegroundColor DarkGray
         Write-Host "  3. Start battlegroup again" -ForegroundColor DarkGray
         Write-Host ""
-        if (-not (Confirm-NoPlayersOnline -ActionLabel "graceful-reboot")) {
+        if (-not (Confirm-NoPlayersOnline -ActionLabel "reboot")) {
             Write-Host "Aborted." -ForegroundColor Cyan; continue
         }
 
@@ -1182,7 +1182,7 @@ while ($true) {
         Write-Host "[1/3] Stopping battlegroup..." -ForegroundColor Cyan
         ssh -t -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" "$bgBinPath stop"
         if ($LASTEXITCODE -ne 0) {
-            Write-Warning "battlegroup stop returned exit code $LASTEXITCODE. Aborting graceful-reboot."
+            Write-Warning "battlegroup stop returned exit code $LASTEXITCODE. Aborting reboot."
             continue
         }
 
@@ -1346,20 +1346,20 @@ while ($true) {
         Save-PhaseTiming 'total-reboot' $totalSec
         $estTotal = Format-PhaseEstimate 'total-reboot'
         Write-Host ""
-        Write-Host "=== Graceful reboot complete in ${totalSec}s ===" -ForegroundColor Green
+        Write-Host "=== Reboot complete in ${totalSec}s ===" -ForegroundColor Green
         if ($estTotal) { Write-Host "  $estTotal" -ForegroundColor DarkGray }
         Write-Host "Pods may take another 1-2 min to all reach Healthy. Check with 'status'." -ForegroundColor DarkGray
         continue
     }
 
-    if ($cmdName -eq "graceful-shutdown") {
+    if ($cmdName -eq "shutdown") {
         Write-Host ""
-        Write-Host "=== Graceful Shutdown ===" -ForegroundColor Cyan
+        Write-Host "=== Shutdown ===" -ForegroundColor Cyan
         Write-Host "  1. Stop battlegroup (waits for game/mq/gateway/director pods to terminate)" -ForegroundColor DarkGray
         Write-Host "  2. Power off the VM" -ForegroundColor DarkGray
         Write-Host "  Use this when shutting down for the night - player data is persisted to DB." -ForegroundColor DarkGray
         Write-Host ""
-        if (-not (Confirm-NoPlayersOnline -ActionLabel "graceful-shutdown")) {
+        if (-not (Confirm-NoPlayersOnline -ActionLabel "shutdown")) {
             Write-Host "Aborted." -ForegroundColor Cyan; continue
         }
 
@@ -1408,7 +1408,7 @@ while ($true) {
         $script:portCheckCache = $null
 
         Write-Host ""
-        Write-Host "=== Graceful shutdown complete ===" -ForegroundColor Green
+        Write-Host "=== Shutdown complete ===" -ForegroundColor Green
         Write-Host "Use option 'b. start-vm' (and then '2. start') when you're ready to bring it back up." -ForegroundColor DarkGray
         continue
     }

--- a/web/README.md
+++ b/web/README.md
@@ -37,7 +37,7 @@ Install-Module Pode -Scope CurrentUser
   password entry, confirmations) appear in that console naturally, so no
   output streaming is required from the web side.
 
-`graceful-reboot` and `graceful-shutdown` show a JS `confirm()` dialog before
+`reboot` and `shutdown` show a JS `confirm()` dialog before
 the POST is issued.
 
 ## Files

--- a/web/Start-DuneWeb.ps1
+++ b/web/Start-DuneWeb.ps1
@@ -61,8 +61,8 @@ $script:VmCommands = @(
     @{ key='a'; name='initial-setup';     desc='Run the initial VM setup';                                                requires='none' }
     # 'b' (web) intentionally omitted from the web UI itself.
     @{ key='c'; name='startup';           desc='Power on VM, start battlegroup, wait for overmap + survival maps';        requires='exists' }
-    @{ key='d'; name='graceful-reboot';   desc='Stop battlegroup, restart VM, start battlegroup (clean cycle)';           requires='running'; confirm=$true }
-    @{ key='e'; name='graceful-shutdown'; desc='Stop battlegroup, power off VM';                                          requires='running'; confirm=$true }
+    @{ key='d'; name='shutdown';          desc='Stop battlegroup, power off VM';                                          requires='running'; confirm=$true }
+    @{ key='e'; name='reboot';            desc='Stop battlegroup, restart VM, start battlegroup (clean cycle)';           requires='running'; confirm=$true }
     @{ key='f'; name='rotate-ssh-key';    desc='Generate a new SSH key and replace the authorized one on the VM';        requires='running' }
     @{ key='g'; name='change-password';   desc="Change the password of the 'dune' user on the VM";                        requires='running' }
 )


### PR DESCRIPTION
Menu reorder: `c=startup`, `d=shutdown`, `e=reboot`. Behavior unchanged - same safety checks, phases, and boot-time tracking. Headings and status messages updated. Web UI mirrors the change.