### PR TITLE
v3.0.0: consolidation release (supersedes v2.x)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: 🐛 Tool bug report
+description: Report a bug or unexpected behavior in the Simple Dune Server Management Tool itself (the PowerShell script, the .bat launcher, or the web UI).
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## What this tracker is for
+
+        This issue tracker is for **bugs in this tool's code** — the
+        PowerShell script, the `.bat` launcher, the localhost web UI,
+        and the setup wizard.
+
+        **Please do _not_ open issues here for:**
+        - VM connectivity / SSH / network / port-forwarding problems
+        - Hyper-V configuration or performance tuning
+        - Funcom dedicated-server bugs (game crashes, missing pods,
+          `battlegroup` CLI errors that aren't caused by this tool)
+        - General "how do I play / host" questions
+
+        For those, ping `@allcoast` on Discord or check the
+        [Funcom Self-Hosted Server docs](https://duneawakening.com/self-hosted-servers/).
+
+        ---
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      description: Please confirm this is actually a bug in the tool's code.
+      options:
+        - label: This is a bug in the tool itself (script crashes, menu option misbehaves, web UI broken, setup wizard fails, etc.) — **not** a VM/network/Funcom-server issue.
+          required: true
+
+  - type: input
+    id: tool_version
+    attributes:
+      label: Tool version
+      description: Shown in the menu header (e.g. `v3.0.0`). Find it on line 16 of `dune-server.ps1` (`$script:ToolVersion`).
+      placeholder: "v3.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: menu_option
+    attributes:
+      label: Menu option / command
+      description: Which menu letter/number or `-Cmd <name>` triggered the bug?
+      placeholder: "e.g. e. reboot, or -Cmd startup, or b. web"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened
+      description: Paste the actual error message or unexpected output from the console. Screenshots also welcome.
+      placeholder: |
+        e.g. "After selecting 'e. reboot' the script printed
+        'Waiting for k3s API...' and never advanced."
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: transcript
+    attributes:
+      label: Transcript / log excerpt
+      description: |
+        Every run is auto-logged to `.logs\dune-server-<timestamp>.log`
+        next to `dune-server.bat`. Paste the relevant section (last 30-50
+        lines around the failure is usually enough — please **redact**
+        public IPs, SSH key paths, and any secrets first).
+      render: shell
+
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: Windows version + PowerShell version (`$PSVersionTable.PSVersion`).
+      placeholder: "Windows 11 23H2, PowerShell 7.4.1"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discord (general questions, hosting help)
+    url: https://discord.com/users/allcoast
+    about: |
+      For "how do I host", VM/network connectivity, port-forwarding,
+      Hyper-V tuning, or general Dune dedicated-server questions,
+      ping @allcoast on Discord. The GitHub issue tracker is for
+      bugs in this tool's code only.
+  - name: 📘 Funcom Self-Hosted Server docs
+    url: https://duneawakening.com/self-hosted-servers/
+    about: Official setup instructions for the dedicated server itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ entry. From here on, patch releases follow as `3.0.1`, `3.0.2`, etc.
   hint based on prior runs so you know roughly how long to wait.
 - **Total elapsed time** displayed at the end of both `c. startup`
   and `e. reboot`, with an estimate line based on prior runs.
+- **`23. report-issue` menu option.** Opens a prefilled GitHub bug-report
+  form in your browser (tool version + OS/PowerShell auto-filled). The
+  issue template + `.github/ISSUE_TEMPLATE/config.yml` scope the tracker
+  to bugs in this tool's code; VM/network/Hyper-V/Funcom-server
+  questions are redirected to Discord via the "blank issue" config.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,87 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.6] - 2026-05-24
+## [3.0.0] - 2026-05-24
 
-### Changed
-
-- **Menu rename + reorder.** `graceful-shutdown` is now just `shutdown`
-  (menu key `d`, moved directly under `c. startup`), and `graceful-reboot`
-  is now just `reboot` (menu key `e`). Behavior is unchanged - same
-  safety checks, same phases, same boot-time tracking. Headings and
-  status messages updated accordingly (e.g. `=== Reboot complete in Xs ===`).
-- **Web UI** mirrors the rename and reorder.
-
-## [2.0.5] - 2026-05-24
-
-### Added
-
-- **Per-phase boot-time tracking** for `c. startup` and `d. graceful-reboot`.
-  Each wait (VM start, IP acquisition, SSH, k3s API, DB pods, operator
-  pods, webhook endpoints, battlegroup start, map pods, pod termination)
-  is now timed and persisted to `.boot-times.json` (last 20 runs per
-  phase). Before each wait, the tool prints a `(last: ~Xs, avg ~Ys of N)`
-  hint based on prior runs so you know roughly how long to wait.
-- **Total elapsed time** is now displayed at the end of `graceful-reboot`
-  too (already shown for `startup` since v2.0.0). Both totals are also
-  tracked in the history so you see your typical end-to-end boot time.
-
-## [2.0.4] - 2026-05-24
-
-### Changed
-
-- **`c. startup` no longer prompts for confirmation.** The "Type YES to
-  continue" gate after selecting startup was redundant; the user already
-  chose to start the server by picking the menu option. Cold-start now
-  runs immediately. Other destructive commands (`graceful-reboot`,
-  `graceful-shutdown`, etc.) keep their confirmations.
-
-## [2.0.3] - 2026-05-24
-
-### Fixed
-
-- **Web UI showed "Error fetching status" and rendered no command buttons.**
-  Pode route scriptblocks run in isolated runspaces and can't see
-  `$script:`-scoped variables defined at file scope. `Get-VmStatus` was
-  calling `Get-VM -Name $null` (always returned NotFound), and the
-  command-list routes iterated `$null`, returning `items: null`, which
-  blew up the front-end. Refactored to publish shared state via
-  `Set-PodeState` at server start and `Get-PodeState` inside the routes
-  and helper functions. JSON arrays are also wrapped in `@(...)` so
-  single-item lists don't get unrolled to scalars.
-
-## [2.0.2] - 2026-05-24
-
-### Fixed
-
-- **Script still exited after every interactive menu command (v2.0.1 hotfix
-  was incomplete).** The v2.0.1 rename used a case-insensitive
-  `-replace`, which also clobbered the five `if ($Cmd) { break }`
-  param-guards down to `if ($cmdName) { break }`. Since `$cmdName` is
-  set to the selected command name (e.g. `"status"`), those guards
-  fired on every iteration and exited the loop. Restored the guards
-  to `$Cmd` with a case-sensitive replace. Confirmed via parse +
-  `Select-String -CaseSensitive` audit that every remaining
-  `$cmdName` is either a parameter, an assignment, or an `-eq`
-  comparison against a string literal.
-
-## [2.0.1] - 2026-05-24
-
-### Fixed
-
-- **Script exited after a single menu command**, closing the console window
-  on every selection. The dispatch loop's local `$cmd = $entry.Name`
-  collided with the script's `$Cmd` parameter (PowerShell variables are
-  case-insensitive), so the `if ($Cmd) { break }` at the bottom of the
-  loop fired after every interactive command. Renamed the loop-local to
-  `$cmdName`. Web UI (`-Cmd` mode) is unaffected and still exits once
-  per invocation via the `$cmdHasRun` flag.
-
-## [2.0.0] - 2026-05-24
-
-Consolidation release. Supersedes all prior 1.x releases &mdash; the 1.x
-GitHub Releases were rolled into this single 2.0.0 entry. From here on,
-patch releases follow as `2.0.1`, `2.0.2`, etc.
+Consolidation release. Supersedes all prior 2.x releases &mdash; the
+2.0.0 through 2.0.6 GitHub Releases were rolled into this single 3.0.0
+entry. From here on, patch releases follow as `3.0.1`, `3.0.2`, etc.
 
 ### Added
 
@@ -97,7 +21,7 @@ patch releases follow as `2.0.1`, `2.0.2`, etc.
   `dune-server.ps1 -Cmd <name>` in a new console window so interactive
   prompts (battlegroup picker, password entry, confirmations) keep working.
   Status panel polls every 5 seconds. Confirmation dialog on
-  `graceful-reboot` and `graceful-shutdown`. Lives under `web/`
+  `reboot` and `shutdown`. Lives under `web/`
   &mdash; `Start-DuneWeb.ps1` + `public/{index.html,app.js,styles.css}`.
 - **`-Cmd <name>` parameter** on `dune-server.ps1` for non-interactive
   dispatch. Skips the menu, looks up the command by name, runs the handler
@@ -118,13 +42,55 @@ patch releases follow as `2.0.1`, `2.0.2`, etc.
 - **Optional "Run as Administrator" desktop shortcut.** End-of-setup prompt
   drops a `Dune Server (Admin).lnk` on your desktop targeting
   `dune-server.bat` with the elevated-launch flag set in the `.lnk` binary.
+- **Per-phase boot-time tracking** for `c. startup` and `e. reboot`.
+  Each wait (VM start, IP acquisition, SSH, k3s API, DB pods, operator
+  pods, webhook endpoints, battlegroup start, map pods, pod termination)
+  is now timed and persisted to `.boot-times.json` (last 20 runs per
+  phase). Before each wait, the tool prints a `(last: ~Xs, avg ~Ys of N)`
+  hint based on prior runs so you know roughly how long to wait.
+- **Total elapsed time** displayed at the end of both `c. startup`
+  and `e. reboot`, with an estimate line based on prior runs.
+
+### Changed
+
+- **Menu rename + reorder.** `graceful-shutdown` is now just `shutdown`
+  (menu key `d`, directly under `c. startup`), and `graceful-reboot`
+  is now just `reboot` (menu key `e`). Behavior is unchanged &mdash; same
+  safety checks, same phases, same boot-time tracking. Headings and
+  status messages updated accordingly (e.g. `=== Reboot complete in Xs ===`).
+  Web UI mirrors the rename and reorder.
+
+  **Breaking:** anyone driving the tool with `-Cmd graceful-shutdown` or
+  `-Cmd graceful-reboot` must update to `-Cmd shutdown` / `-Cmd reboot`.
+- **`c. startup` no longer prompts for confirmation.** The "Type YES to
+  continue" gate after selecting startup was redundant; the user already
+  chose to start the server by picking the menu option. Cold-start now
+  runs immediately. Other destructive commands (`reboot`, `shutdown`,
+  etc.) keep their confirmations.
 - **VM section re-lettered sequentially** so it ends cleanly at
   `g. change-password` before the numbered Battlegroup commands:
-  `a` initial-setup, `b` web (new), `c` startup, `d` graceful-reboot,
-  `e` graceful-shutdown, `f` rotate-ssh-key, `g` change-password.
+  `a` initial-setup, `b` web, `c` startup, `d` shutdown,
+  `e` reboot, `f` rotate-ssh-key, `g` change-password.
 
 ### Fixed
 
+- **Web UI showed "Error fetching status" and rendered no command buttons.**
+  Pode route scriptblocks run in isolated runspaces and can't see
+  `$script:`-scoped variables defined at file scope. `Get-VmStatus` was
+  calling `Get-VM -Name $null` (always returned NotFound), and the
+  command-list routes iterated `$null`, returning `items: null`, which
+  blew up the front-end. Refactored to publish shared state via
+  `Set-PodeState` at server start and `Get-PodeState` inside the routes
+  and helper functions. JSON arrays are also wrapped in `@(...)` so
+  single-item lists don't get unrolled to scalars.
+- **Interactive menu exited after a single command**, closing the console
+  window on every selection. The dispatch loop's local `$cmd = $entry.Name`
+  collided with the script's `$Cmd` parameter (PowerShell variables are
+  case-insensitive), so the `if ($Cmd) { break }` at the bottom of the
+  loop fired after every interactive command. Renamed the loop-local to
+  `$cmdName` (using a case-sensitive replace, so the `if ($Cmd) { break }`
+  guards survive intact). Web UI (`-Cmd` mode) is unaffected and still
+  exits once per invocation via the `$cmdHasRun` flag.
 - `-Cmd <name>` mode (used by every web UI button) would infinite-loop
   re-running the same command. Handlers use `continue` to skip the
   remaining loop body, which also skipped the bottom-of-loop `break`.
@@ -146,7 +112,7 @@ patch releases follow as `2.0.1`, `2.0.2`, etc.
 ### Removed
 
 - `b. start-vm` and `c. stop-vm` menu entries. The graceful
-  counterparts (`c. startup` cold-starts the full stack; `e. graceful-shutdown`
+  counterparts (`c. startup` cold-starts the full stack; `d. shutdown`
   stops battlegroup and powers off) cover everything they did without
   leaving pods in inconsistent state. The underlying handlers remain so
   existing automation calling them by name still works.
@@ -154,14 +120,11 @@ patch releases follow as `2.0.1`, `2.0.2`, etc.
 ### Internal
 
 - New helpers: `Install-DuneAdminLatest`, `Resolve-FreshSshKey`,
-  `Copy-SshKeyToDir`, `New-DuneDesktopShortcut`.
+  `Copy-SshKeyToDir`, `New-DuneDesktopShortcut`, `Get-BootTimes`,
+  `Format-PhaseEstimate`, `Save-PhaseTiming`.
 - `web/` folder structure added.
+- Boot-time history stored at `<scriptDir>\.boot-times.json` (rolling
+  window of last 20 entries per phase).
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.6...HEAD
-[2.0.6]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.5...v2.0.6
-[2.0.5]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.4...v2.0.5
-[2.0.4]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.3...v2.0.4
-[2.0.3]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.2...v2.0.3
-[2.0.2]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.1...v2.0.2
-[2.0.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v2.0.0...v2.0.1
-[2.0.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/releases/tag/v2.0.0
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/releases/tag/v3.0.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,25 @@ A menu-driven tool for managing your Dune Awakening self-hosted dedicated server
 See [`CHANGELOG.md`](CHANGELOG.md) for release history and
 [`CONTRIBUTING.md`](CONTRIBUTING.md) for the change-control workflow.
 
+## Reporting issues
+
+Hit a bug, error, or unexpected behavior? **Please open a GitHub issue**
+so it can be tracked and fixed:
+
+> 👉 [**Open an issue**](https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/issues/new/choose) &nbsp;·&nbsp;
+> [Browse existing issues](https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/issues)
+
+When filing, please include:
+
+- The tool version (shown in the menu header, e.g. `v3.0.0`)
+- The exact menu option you ran (e.g. `e. reboot`)
+- The error message or unexpected output (copy-paste from the console)
+- Anything in the transcript log (`.logs\dune-server-*.log` next to `dune-server.bat`)
+
+Discord pings to `@allcoast` are fine for quick questions, but use the
+issue tracker for anything that needs a fix &mdash; it keeps the history
+public so other server admins can find the same answer.
+
 
 ---
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "2.0.6"
+$script:ToolVersion = "3.0.0"
 
 # Resize console window so the full menu is visible
 try {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -705,6 +705,7 @@ if ($duneAdminExe) {
     $toolCommands += [pscustomobject]@{ Key = "21"; Name = "dune-admin";      Desc = "Launch dune-admin.exe  +  Open dune-admin web UI" }
 }
 $toolCommands += [pscustomobject]@{ Key = "22"; Name = "setup-guide";    Desc = "Open Funcom Self-Hosted Server Setup Instructions" }
+$toolCommands += [pscustomobject]@{ Key = "23"; Name = "report-issue";   Desc = "Report a bug in this tool (opens prefilled GitHub issue in browser)" }
 
 # ============================================================
 #  AVAILABILITY CHECKS
@@ -1577,6 +1578,36 @@ while ($true) {
 
     if ($cmdName -eq "setup-guide") {
         Start-Process "https://duneawakening.com/self-hosted-servers/"
+        continue
+    }
+
+    if ($cmdName -eq "report-issue") {
+        Write-Host ""
+        Write-Host "=== Report an Issue ===" -ForegroundColor Cyan
+        Write-Host "  Opening a prefilled bug report in your browser." -ForegroundColor DarkGray
+        Write-Host "  This tracker is for bugs in the TOOL ITSELF -" -ForegroundColor Yellow
+        Write-Host "  not for VM connectivity, Hyper-V, port forwarding, or Funcom server issues." -ForegroundColor Yellow
+        Write-Host "  For those, ping @allcoast on Discord." -ForegroundColor DarkGray
+        Write-Host ""
+
+        # GitHub issue forms accept URL params keyed by the input id in the
+        # YAML form. Prefill what we already know so the user only fills in
+        # what they hit. Values must be URL-encoded.
+        Add-Type -AssemblyName System.Web -ErrorAction SilentlyContinue
+        function Get-EncodedParam([string]$v) {
+            if ([string]::IsNullOrEmpty($v)) { return "" }
+            return [System.Web.HttpUtility]::UrlEncode($v)
+        }
+        $envStr = "Windows $([System.Environment]::OSVersion.Version), PowerShell $($PSVersionTable.PSVersion)"
+        $params = @(
+            "template=bug_report.yml"
+            "tool_version=" + (Get-EncodedParam "v$script:ToolVersion")
+            "env="          + (Get-EncodedParam $envStr)
+        ) -join "&"
+        $url = "https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/issues/new?$params"
+
+        Write-Host "  $url" -ForegroundColor DarkGray
+        Start-Process $url
         continue
     }
 

--- a/web/Start-DuneWeb.ps1
+++ b/web/Start-DuneWeb.ps1
@@ -94,7 +94,8 @@ function Get-ToolCommandList {
     if ($cfg.DuneAdminExe -and (Test-Path $cfg.DuneAdminExe)) {
         $list += @{ key='21'; name='dune-admin';  desc='Launch dune-admin.exe + open dune-admin web UI'; requires='running' }
     }
-    $list += @{ key='22'; name='setup-guide'; desc='Open Funcom Self-Hosted Server Setup Instructions'; requires='none' }
+    $list += @{ key='22'; name='setup-guide';  desc='Open Funcom Self-Hosted Server Setup Instructions'; requires='none' }
+    $list += @{ key='23'; name='report-issue'; desc='Report a bug in this tool (opens prefilled GitHub issue)'; requires='none' }
     return $list
 }
 


### PR DESCRIPTION
Mirrors how v2.0.0 consolidated v1.x. Collapses v2.0.0-v2.0.6 GitHub Releases into a single v3.0.0 entry. Major bump reflects the breaking `-Cmd graceful-shutdown`/`-Cmd graceful-reboot` rename.