### PR TITLE
v4.5.1: draggable separators in command list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.5.2] - 2026-05-25
+
+Patch on top of v4.5.1.
+
+### Fixed
+
+- **"Report an Issue" (and other URL-opening menu items) now open the
+  user's default browser on Windows 11 24H2.** The previous pattern
+  `Start-Process "$env:SystemRoot\explorer.exe" $url` stopped working
+  correctly on 24H2 — `explorer.exe` now ignores the system default
+  browser and either silently fails (from an elevated PowerShell host)
+  or forces Microsoft Edge regardless of the user's preference. Switched
+  every URL launch in `dune-server.ps1` to `Start-Process $url`, which
+  dispatches through the registered `https://` protocol handler and
+  honors the user's default browser. Affects: `report-issue`,
+  `setup-guide`, `dune-admin` (web UI), `open-file-browser`,
+  `open-director`.
+
 ## [4.5.1] - 2026-05-25
 
 Patch on top of v4.5.0.
@@ -808,7 +826,8 @@ entry. From here on, patch releases follow as `3.0.1`, `3.0.2`, etc.
 - Boot-time history stored at `<scriptDir>\.boot-times.json` (rolling
   window of last 20 entries per phase).
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.5.1...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.5.2...HEAD
+[4.5.2]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.5.1...v4.5.2
 [4.5.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.5.0...v4.5.1
 [4.5.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.4.0...v4.5.0
 [4.4.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.3.3...v4.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.5.1] - 2026-05-25
+
+Patch on top of v4.5.0.
+
+### Fixed
+
+- **Separators (and any card) can now be reordered regardless of VM state.**
+  Previously, when the VM was off, the greyed-out command buttons stopped
+  receiving mouse events, which meant the user could not drag separators
+  across them — the only valid drop targets were other separators and the
+  few always-available commands. Now every card stays enabled for
+  drag/drop at all times; unavailable commands are visually muted
+  (foreground colors + reduced opacity) and the click handler short-circuits
+  with a friendly message if the command can't run yet (e.g.
+  `[Cannot run 'startup' - the VM is not running.]`).
+- Tooltips on unavailable commands now mention that drag-reorder still
+  works ("You can still drag this card to reorder the list.").
+
+## [4.5.0] - 2026-05-25
+
+Minor release: **draggable separators** in the command list, so the user can
+visually group commands without changing what each command does.
+
+### Added
+
+- **Four draggable separators** (`Separator 1` … `Separator 4`) at the end of
+  the command list. Each one renders as a slim horizontal divider chip with
+  grip dots on either side.
+- Separators **participate in the existing drag-reorder system**: drag any
+  separator up into the list to insert a visual break between commands, and
+  drag it back down (or onto another row) to move it. They share the same
+  drop-indicator behavior as regular command cards.
+- **Persistence**: separator positions are saved to
+  `%APPDATA%\DuneServer\button-order.json` alongside the command order, so
+  groupings survive restarts and updates.
+- **Right-click → "Reset separator positions"** on any separator sends all
+  four back to the bottom of the list without touching the user's command
+  order. The existing "Reset button order to default" entry is also still
+  available on every separator's context menu.
+
+### Notes
+
+- Separators are not clickable — they exist purely to organize the list.
+- The 3-column layout still distributes items left-to-right, so a separator
+  occupies one cell in whichever column it lands in. If you want a separator
+  to fully span all three columns, drop one near the same position in each
+  column (e.g., positions 6, 13, 20 in a 20-command catalog).
+
 ## [4.4.0] - 2026-05-24
 
 Minor release: brings the **external port-check** feature from the CLI menu into the WPF app's top bar.
@@ -760,7 +808,9 @@ entry. From here on, patch releases follow as `3.0.1`, `3.0.2`, etc.
 - Boot-time history stored at `<scriptDir>\.boot-times.json` (rolling
   window of last 20 entries per phase).
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.4.0...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.5.1...HEAD
+[4.5.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.5.0...v4.5.1
+[4.5.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.4.0...v4.5.0
 [4.4.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.3.3...v4.4.0
 [4.3.3]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.3.2...v4.3.3
 [4.3.2]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.3.1...v4.3.2

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -36,7 +36,7 @@ param()
 # check (Check-ForUpdates) and the "Installed: x.y.z" header label. Must be
 # bumped in lock-step with the other 3 version constants (dune-server.ps1,
 # Build-Exe.ps1, installer .iss).
-$script:ToolVersion = "4.5.1"
+$script:ToolVersion = "4.5.2"
 
 # ────────────────────────────────────────────────────────────────────────────
 #  Prerequisite check: PowerShell 7 (pwsh.exe)
@@ -1954,7 +1954,7 @@ $autoRefresh.Add_Tick({
 
 # Initial paint
 Build-ButtonPanel -Vm $script:LastVmKnown
-$ui.FooterVersion.Text = "Dune Server v4.5.1"
+$ui.FooterVersion.Text = "Dune Server v4.5.2"
 $ui.InstalledLbl.Text  = "Installed: $script:ToolVersion"
 
 # Kick off first status fetch on window load

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -36,7 +36,7 @@ param()
 # check (Check-ForUpdates) and the "Installed: x.y.z" header label. Must be
 # bumped in lock-step with the other 3 version constants (dune-server.ps1,
 # Build-Exe.ps1, installer .iss).
-$script:ToolVersion = "4.4.0"
+$script:ToolVersion = "4.5.1"
 
 # ────────────────────────────────────────────────────────────────────────────
 #  Prerequisite check: PowerShell 7 (pwsh.exe)
@@ -729,7 +729,21 @@ $script:Commands = @(
     @{ Section='Tools';       Key='18'; Name='dune-admin';   Mode='InApp';   Requires='running'; Desc='Launch dune-admin + open its web UI' }
     @{ Section='Tools';       Key='19'; Name='setup-guide';  Mode='InApp';   Requires='none';    Desc='Open Funcom self-hosted setup guide in your browser' }
     @{ Section='Tools';       Key='20'; Name='report-issue'; Mode='InApp';   Requires='none';    Desc='Report a bug (opens a prefilled GitHub issue)' }
+
+    # ─── Draggable separators ───
+    # Four optional visual dividers. They start parked at the end of the list
+    # so existing layouts are unchanged; the user drags them up into position
+    # to group commands. They participate in the same drag-reorder + persisted
+    # order system as regular commands, but they are not clickable.
+    @{ Section='Separator';   Key='s1'; Name='__separator_1'; Mode='InApp'; Requires='none'; Desc='Separator 1'; IsSeparator=$true }
+    @{ Section='Separator';   Key='s2'; Name='__separator_2'; Mode='InApp'; Requires='none'; Desc='Separator 2'; IsSeparator=$true }
+    @{ Section='Separator';   Key='s3'; Name='__separator_3'; Mode='InApp'; Requires='none'; Desc='Separator 3'; IsSeparator=$true }
+    @{ Section='Separator';   Key='s4'; Name='__separator_4'; Mode='InApp'; Requires='none'; Desc='Separator 4'; IsSeparator=$true }
 )
+
+# Names of the separator pseudo-commands, used by Reset-SeparatorPositions and
+# the renderer to short-circuit click/availability logic.
+$script:SeparatorNames = @('__separator_1','__separator_2','__separator_3','__separator_4')
 
 function Test-CmdAvailable {
     param($Cmd, $Vm)
@@ -1304,6 +1318,20 @@ function Reset-ButtonOrder {
     Build-ButtonPanel
 }
 
+function Reset-SeparatorPositions {
+    # Send the 4 separators back to the end of the list without disturbing the
+    # user's command order. Implemented by writing a new saved order with the
+    # current order minus the separators; Get-OrderedCommands will then re-append
+    # the separators at the end in catalog order.
+    $ordered = @(Get-OrderedCommands)
+    $names = New-Object System.Collections.Generic.List[string]
+    foreach ($c in $ordered) {
+        if (-not $c.IsSeparator) { $names.Add($c.Name) }
+    }
+    Save-ButtonOrderList -Order $names.ToArray()
+    Build-ButtonPanel
+}
+
 # Acronyms that should stay uppercase when expanding kebab-case command names
 # into human-readable Title Case labels.
 $script:LabelAcronyms = @{
@@ -1371,6 +1399,154 @@ function Build-ButtonPanel {
 
     $addButton = {
         param($panel, $cmd)
+
+        # ────────────────────────────────────────────────────────────────────
+        # Separator branch: render as a slim horizontal divider chip with grip
+        # dots. Not clickable. Shares the same drag-and-drop wiring as regular
+        # cards so it can be repositioned and used as a drop target.
+        # ────────────────────────────────────────────────────────────────────
+        if ($cmd.IsSeparator) {
+            $sepBorder = New-Object Windows.Controls.Border
+            $sepBorder.Margin = New-Object Windows.Thickness 3,8,3,8
+            $sepBorder.Padding = New-Object Windows.Thickness 8,4,8,4
+            $sepBorder.CornerRadius = New-Object Windows.CornerRadius 2
+            $sepBorder.Background = [Windows.Media.BrushConverter]::new().ConvertFromString('#1A140E')
+            $sepBorder.BorderBrush = [Windows.Media.BrushConverter]::new().ConvertFromString('#3A2818')
+            $sepBorder.BorderThickness = New-Object Windows.Thickness 0,1,0,1
+            $sepBorder.HorizontalAlignment = 'Stretch'
+            $sepBorder.AllowDrop = $true
+            $sepBorder.DataContext = $cmd
+            $sepBorder.Cursor = [System.Windows.Input.Cursors]::SizeAll
+            $sepBorder.ToolTip = "Separator — drag to reposition. Right-click for options.`n`nUse separators to visually group commands in the list."
+
+            # Three-column grid: grip ┊ dashed line ┊ grip
+            $sepGrid = New-Object Windows.Controls.Grid
+            $cd1 = New-Object Windows.Controls.ColumnDefinition; $cd1.Width = 'Auto'
+            $cd2 = New-Object Windows.Controls.ColumnDefinition; $cd2.Width = New-Object Windows.GridLength 1, 'Star'
+            $cd3 = New-Object Windows.Controls.ColumnDefinition; $cd3.Width = 'Auto'
+            [void]$sepGrid.ColumnDefinitions.Add($cd1)
+            [void]$sepGrid.ColumnDefinitions.Add($cd2)
+            [void]$sepGrid.ColumnDefinitions.Add($cd3)
+
+            $gripBrush = [Windows.Media.BrushConverter]::new().ConvertFromString('#C28840')
+            $lineBrush = [Windows.Media.BrushConverter]::new().ConvertFromString('#5A4023')
+
+            $gripL = New-Object Windows.Controls.TextBlock
+            $gripL.Text = '⋮⋮'
+            $gripL.FontSize = 11
+            $gripL.Foreground = $gripBrush
+            $gripL.VerticalAlignment = 'Center'
+            $gripL.Margin = New-Object Windows.Thickness 0,0,8,0
+            [Windows.Controls.Grid]::SetColumn($gripL, 0)
+            [void]$sepGrid.Children.Add($gripL)
+
+            $line = New-Object Windows.Shapes.Rectangle
+            $line.Height = 1
+            $line.Fill = $lineBrush
+            $line.VerticalAlignment = 'Center'
+            [Windows.Controls.Grid]::SetColumn($line, 1)
+            [void]$sepGrid.Children.Add($line)
+
+            $gripR = New-Object Windows.Controls.TextBlock
+            $gripR.Text = '⋮⋮'
+            $gripR.FontSize = 11
+            $gripR.Foreground = $gripBrush
+            $gripR.VerticalAlignment = 'Center'
+            $gripR.Margin = New-Object Windows.Thickness 8,0,0,0
+            [Windows.Controls.Grid]::SetColumn($gripR, 2)
+            [void]$sepGrid.Children.Add($gripR)
+
+            $sepBorder.Child = $sepGrid
+
+            # Right-click menu: reset separator positions + reset button order.
+            $sepMenu = New-Object Windows.Controls.ContextMenu
+            $miSepReset = New-Object Windows.Controls.MenuItem
+            $miSepReset.Header = 'Reset separator positions'
+            $miSepReset.Add_Click({ Reset-SeparatorPositions })
+            [void]$sepMenu.Items.Add($miSepReset)
+            $miBtnReset = New-Object Windows.Controls.MenuItem
+            $miBtnReset.Header = 'Reset button order to default'
+            $miBtnReset.Add_Click({ Reset-ButtonOrder })
+            [void]$sepMenu.Items.Add($miBtnReset)
+            $sepBorder.ContextMenu = $sepMenu
+
+            # Drag handlers — initiate drag and accept drops. We use a small
+            # in-element insertion line by toggling BorderThickness on top/bottom.
+            $sepBorder.Add_PreviewMouseLeftButtonDown({
+                param($s, $e)
+                $script:DragStartPoint = $e.GetPosition($null)
+            })
+            $sepBorder.Add_PreviewMouseMove({
+                param($s, $e)
+                if ($e.LeftButton -ne [System.Windows.Input.MouseButtonState]::Pressed) { return }
+                if (-not $script:DragStartPoint) { return }
+                $pos = $e.GetPosition($null)
+                $dx = [Math]::Abs($pos.X - $script:DragStartPoint.X)
+                $dy = [Math]::Abs($pos.Y - $script:DragStartPoint.Y)
+                if ($dx -lt [System.Windows.SystemParameters]::MinimumHorizontalDragDistance -and
+                    $dy -lt [System.Windows.SystemParameters]::MinimumVerticalDragDistance) { return }
+                $c = $s.DataContext
+                if (-not $c) { return }
+                $script:DragStartPoint = $null
+                $origOp = $s.Opacity
+                $s.Opacity = 0.35
+                try {
+                    [void][System.Windows.DragDrop]::DoDragDrop($s, $c.Name, [System.Windows.DragDropEffects]::Move)
+                } catch {} finally {
+                    $s.Opacity = $origOp
+                }
+            })
+            $sepBorder.Add_DragEnter({ param($s, $e) $e.Handled = $true })
+            $sepBorder.Add_DragOver({
+                param($s, $e)
+                $srcName = $null
+                try { $srcName = $e.Data.GetData([System.Windows.DataFormats]::Text) } catch {}
+                $tgt = $s.DataContext
+                if ($srcName -and $tgt -and $srcName -ne $tgt.Name) {
+                    $e.Effects = [System.Windows.DragDropEffects]::Move
+                    $pos = $e.GetPosition($s)
+                    $h = $s.ActualHeight
+                    if ($h -le 0) { $h = 1 }
+                    if ($pos.Y -ge ($h / 2.0)) {
+                        $s.BorderBrush = [Windows.Media.BrushConverter]::new().ConvertFromString('#4FC3F7')
+                        $s.BorderThickness = New-Object Windows.Thickness 0,1,0,3
+                        $script:DropPosition = 'after'
+                    } else {
+                        $s.BorderBrush = [Windows.Media.BrushConverter]::new().ConvertFromString('#4FC3F7')
+                        $s.BorderThickness = New-Object Windows.Thickness 0,3,0,1
+                        $script:DropPosition = 'before'
+                    }
+                } else {
+                    $e.Effects = [System.Windows.DragDropEffects]::None
+                }
+                $e.Handled = $true
+            })
+            $sepBorder.Add_DragLeave({
+                param($s, $e)
+                $s.BorderBrush = [Windows.Media.BrushConverter]::new().ConvertFromString('#3A2818')
+                $s.BorderThickness = New-Object Windows.Thickness 0,1,0,1
+                $e.Handled = $true
+            })
+            $sepBorder.Add_Drop({
+                param($s, $e)
+                $s.BorderBrush = [Windows.Media.BrushConverter]::new().ConvertFromString('#3A2818')
+                $s.BorderThickness = New-Object Windows.Thickness 0,1,0,1
+                $srcName = $null
+                try { $srcName = $e.Data.GetData([System.Windows.DataFormats]::Text) } catch {}
+                $tgt = $s.DataContext
+                if ($srcName -and $tgt) {
+                    Move-Command -SourceName $srcName -TargetName $tgt.Name -Position $script:DropPosition
+                }
+                $e.Handled = $true
+            })
+
+            [void]$panel.Children.Add($sepBorder)
+            return
+        }
+
+        # ────────────────────────────────────────────────────────────────────
+        # Regular command button branch (unchanged from prior behavior).
+        # ────────────────────────────────────────────────────────────────────
         $btn = New-Object Windows.Controls.Button
         $btn.Style = $ui.Window.FindResource('CmdButton')
         $btn.DataContext = $cmd
@@ -1413,16 +1589,23 @@ function Build-ButtonPanel {
         $btn.ToolTip = "$($cmd.Desc)`n`nMode: $($cmd.Mode)  -  Requires: $($cmd.Requires)`n`n(Drag any button to reorder. Right-click for options.)"
 
         $available = Test-CmdAvailable -Cmd $cmd -Vm $vm
-        $btn.IsEnabled = $available
+        # NOTE: We deliberately do NOT set $btn.IsEnabled = $false here.
+        # WPF blocks ALL mouse events on disabled controls, which would mean
+        # the user could not drag separators (or any card) across greyed-out
+        # buttons when the VM is off. Keeping the button enabled lets the
+        # drag-reorder system work in all VM states. The click handler below
+        # checks availability and short-circuits with a helpful message when
+        # the underlying command can't actually run.
         if (-not $available) {
             $nameLine.Foreground = $textDisable
             $descLine.Foreground = $textDisable
+            $btn.Opacity = 0.55
             $reason = switch ($cmd.Requires) {
                 'exists'  { "VM '$($script:VmName)' does not exist" }
                 'running' { "VM not running" }
                 default   { '' }
             }
-            if ($reason) { $btn.ToolTip = "$($cmd.Desc)`n`nUnavailable: $reason" }
+            if ($reason) { $btn.ToolTip = "$($cmd.Desc)`n`nUnavailable: $reason`n`n(You can still drag this card to reorder the list.)" }
         }
 
         # Right-click "Reset order" menu (always available, even when button disabled)
@@ -1524,7 +1707,20 @@ function Build-ButtonPanel {
         })
 
         $cmdCopy = $cmd
-        $btn.Add_Click({ Invoke-DuneCmd -Cmd $cmdCopy }.GetNewClosure())
+        $btn.Add_Click({
+            $avail = Test-CmdAvailable -Cmd $cmdCopy -Vm $script:LastVmKnown
+            if (-not $avail) {
+                $reason = switch ($cmdCopy.Requires) {
+                    'exists'  { "the VM '$($script:VmName)' does not exist yet" }
+                    'running' { "the VM is not running" }
+                    default   { 'the command is unavailable' }
+                }
+                Write-Output-Line ""
+                Write-Output-Line "[Cannot run '$($cmdCopy.Name)' - $reason.]"
+                return
+            }
+            Invoke-DuneCmd -Cmd $cmdCopy
+        }.GetNewClosure())
         [void]$panel.Children.Add($btn)
     }
 
@@ -1758,7 +1954,7 @@ $autoRefresh.Add_Tick({
 
 # Initial paint
 Build-ButtonPanel -Vm $script:LastVmKnown
-$ui.FooterVersion.Text = "Dune Server v4.4.0"
+$ui.FooterVersion.Text = "Dune Server v4.5.1"
 $ui.InstalledLbl.Text  = "Installed: $script:ToolVersion"
 
 # Kick off first status fetch on window load

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -14,7 +14,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '4.5.1',
+    [string]$Version = '4.5.2',
     [switch]$Quiet
 )
 

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -14,7 +14,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '4.4.0',
+    [string]$Version = '4.5.1',
     [switch]$Quiet
 )
 

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server"
-#define MyAppVersion "4.4.0"
+#define MyAppVersion "4.5.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/Neil-PSP/Simple-Dune-Server-Management-Tool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server"
-#define MyAppVersion "4.5.1"
+#define MyAppVersion "4.5.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/Neil-PSP/Simple-Dune-Server-Management-Tool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "4.4.0"
+$script:ToolVersion = "4.5.1"
 
 # ============================================================
 #  CRASH / EXIT CLEANUP

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "4.5.1"
+$script:ToolVersion = "4.5.2"
 
 # ============================================================
 #  CRASH / EXIT CLEANUP
@@ -1673,7 +1673,7 @@ while ($true) {
     # ========================================================
 
     if ($cmdName -eq "open-file-browser") {
-        Start-Process "$env:SystemRoot\explorer.exe" "http://${ip}:18888/"
+        Start-Process "http://${ip}:18888/"
         continue
     }
 
@@ -1684,7 +1684,7 @@ while ($true) {
             if ($directorNodePort -match '^\d+$') { $directorPort = $directorNodePort.Trim() }
         }
         if (-not $directorPort) { Write-Warning "Could not determine Director port."; continue }
-        Start-Process "$env:SystemRoot\explorer.exe" "http://${ip}:${directorPort}/"
+        Start-Process "http://${ip}:${directorPort}/"
         continue
     }
 
@@ -1794,14 +1794,16 @@ while ($true) {
         Start-ScheduledTask -TaskName "DuneAdminLaunch"
         Start-Sleep -Seconds 1
         Unregister-ScheduledTask -TaskName "DuneAdminLaunch" -Confirm:$false
-        # Open web UI via explorer (always runs as logged-in user)
-        Start-Process "$env:SystemRoot\explorer.exe" $duneAdminWeb
+        # Open web UI in default browser (Start-Process <url> uses the
+        # registered https:// protocol handler, honoring the user's default
+        # browser. Avoids Windows 11 24H2's explorer.exe-forces-Edge bug.)
+        Start-Process $duneAdminWeb
         Write-Host "Done. dune-admin.exe is running and web UI opened in browser." -ForegroundColor Green
         continue
     }
 
     if ($cmdName -eq "setup-guide") {
-        Start-Process "$env:SystemRoot\explorer.exe" "https://duneawakening.com/self-hosted-servers/"
+        Start-Process "https://duneawakening.com/self-hosted-servers/"
         continue
     }
 
@@ -1831,7 +1833,7 @@ while ($true) {
         $url = "https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/issues/new?$params"
 
         Write-Host "  $url" -ForegroundColor DarkGray
-        Start-Process "$env:SystemRoot\explorer.exe" $url
+        Start-Process $url
         continue
     }
 


### PR DESCRIPTION
## Summary

Adds four draggable visual **separators** to the WPF command list. The user can drop them anywhere between commands to create groupings; positions persist alongside the existing command order.

## What changed

### Feature (v4.5.0 portion)
- 4 separator pseudo-commands (`__separator_1`..`__separator_4`) appended to `$script:Commands`. Default to end-of-list so existing layouts are untouched.
- Separator branch in `Build-ButtonPanel` renders a slim divider chip (grip dots ⋮⋮ on each side, dashed line, dune palette) instead of a CmdButton. Shares the same drag-source / drop-target wiring as regular cards.
- New `Reset-SeparatorPositions` function + right-click menu item — strips separators from saved order and re-saves, so they reappear at the bottom via `Get-OrderedCommands` natural-append behavior.

### Fix (v4.5.1 portion)
- Greyed-out command buttons (`VM not running`) were blocking drags from crossing them, because `IsEnabled=$false` suppresses all mouse events in WPF. Result: separators couldn't be moved unless the VM was up.
- Buttons now stay `IsEnabled=$true` always. Unavailable commands are visually muted via foreground colors + `Opacity = 0.55`, and the click handler short-circuits with `[Cannot run 'startup' - the VM is not running.]` in the output pane instead of running.
- Drag/drop now works in every VM state.

## Files
- `app/DuneServer.ps1` — separator branch, click-time gating, new `Reset-SeparatorPositions`.
- `CHANGELOG.md` — v4.5.0 + v4.5.1 entries, compare links.
- `dune-server.ps1`, `app/installer/DuneServer.iss`, `app/build/Build-Exe.ps1` — version bumped to 4.5.1.

## Testing
- Parser: `Parser.ParseFile()` returns 0 errors.
- PSScriptAnalyzer: 0 errors (warnings unchanged from baseline).
- Manual: run app with VM off → drag separator between two greyed commands → reorders correctly; click a greyed command → output pane reads `[Cannot run 'X' - the VM is not running.]`.