### PR TITLE
v5.0.2 - Docs cleanup: scrub example PII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.2] - 2026-05-25
+
+Docs cleanup release. No functional changes.
+
+### Changed
+
+- Scrubbed example PII from the public documentation surface:
+    - `LICENSE` copyright holder now reads `Coastal` only.
+    - `README.md` example-output block uses RFC1918 placeholder
+      (`192.168.1.50`) instead of a real LAN IP, and the setup-wizard
+      "Windows username" example is now `Coastal`.
+    - `CHANGELOG.md` v4.4.0 entry uses an RFC5737 documentation IP
+      (`203.0.113.45`) instead of a real public IP.
+    - `app/installer/DuneServer.iss` `MyAppURL` points to the actual
+      `coastal-ms` GitHub org (was a stale pre-rename URL).
+
 ## [5.0.1] - 2026-05-25
 
 Patch release: prevent accidental re-runs of `initial-setup` once the game
@@ -225,7 +241,7 @@ Minor release: brings the **external port-check** feature from the CLI menu into
 - **Port-check status line** in the header (above the battlegroup status
   pane). Shows external reachability for the forwarded ports as a single
   colored line with the public IP and a timestamp, e.g.
-  `Ports (15.218.94.154): TCP 31982 RabbitMQ [OPEN]   updated 21:15:29`.
+  `Ports (203.0.113.45): TCP 31982 RabbitMQ [OPEN]   updated 21:15:29`.
 - **TCP 31982 (RabbitMQ)** is always checked via the built-in
   `yougetsignal.com` service (no UDP support there).
 - **UDP 7777 and 7810 (game-server range first/last)** are only shown
@@ -969,7 +985,8 @@ entry. From here on, patch releases follow as `3.0.1`, `3.0.2`, etc.
 - Boot-time history stored at `<scriptDir>\.boot-times.json` (rolling
   window of last 20 entries per phase).
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v5.0.1...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v5.0.2...HEAD
+[5.0.2]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.5.2...v5.0.0
 [4.5.2]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.5.1...v4.5.2

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Neil Broome (Coastal)
+Copyright (c) 2026 Coastal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Before using either install path above:
    | 1 | **Server install folder** | The folder where Steam installed the Dune server. It contains a `battlegroup-management` subfolder. The script tries to auto-detect this. |
    | 2 | **SSH private key** | Path to your SSH private key for the VM. Usually in `%LOCALAPPDATA%\DuneAwakeningServer\sshKey` or `~\.ssh\dune`. |
    | 3 | **dune-admin.exe path** | Path to `dune-admin.exe` if you use the community admin panel. Leave blank to skip — you can always add it later. |
-   | 4 | **Windows username** | Your Windows login name (e.g., `Neil`). Used to launch dune-admin without admin elevation. |
+   | 4 | **Windows username** | Your Windows login name (e.g., `Coastal`). Used to launch dune-admin without admin elevation. |
    | 5 | **Port verification** | Choose `1` (Built-in, default — uses [yougetsignal.com](https://www.yougetsignal.com/tools/open-ports/) for TCP), `2` (Custom URL — provide your own service that supports `{ip}`, `{port}`, `{protocol}` placeholders), or `3` (Disabled). The check runs once per launch and shows a color-coded status next to each required port in the menu header. |
 
 5. Your answers are saved to `dune-server.config`. To change them later, delete that file and re-run the tool.
@@ -128,10 +128,10 @@ After setup, you'll see the main menu every time you launch:
   Brought to you by Coastal (Discord @allcoast)
 ==========================================
 
-  VM: Running (192.168.23.219)
+  VM: Running (192.168.1.50)
 
   Required Port Forwarding:
-    (checking against public IP 203.0.113.45 -> VM 192.168.23.219)
+    (checking against public IP 203.0.113.45 -> VM 192.168.1.50)
     UDP  7777-7810   Game servers (first port)     [OPEN]
     UDP  7777-7810   Game servers (last port)      [OPEN]
     TCP  31982       RabbitMQ                      [OPEN]

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -32,7 +32,7 @@ param()
 # check (Check-ForUpdates) and the "Installed: x.y.z" header label. Must be
 # bumped in lock-step with the other 3 version constants (dune-server.ps1,
 # Build-Exe.ps1, installer .iss).
-$script:ToolVersion = "5.0.1"
+$script:ToolVersion = "5.0.2"
 
 # ANSI escape character (0x1B). The ps2exe-compiled binary runs in
 # PowerShell 5.1 (Desktop), which does NOT support the `e backtick-e
@@ -2320,7 +2320,7 @@ $ui.InstalledLbl.Text  = "Installed: $script:ToolVersion"
 # with E_ABORT (0x80004004) — the broker/zygote silently aborts during sandbox
 # bootstrap. UserDataFolder ALSO lives under %PROGRAMDATA% so the elevated
 # host and any future non-elevated subprocesses can both reach it, and so
-# OneDrive (which redirects parts of Neil's user profile) never touches it.
+# OneDrive (which redirects parts of the user's profile) never touches it.
 $script:WebView2UserData = Join-Path $env:PROGRAMDATA 'DuneServer\webview2'
 if (-not (Test-Path $script:WebView2UserData)) {
     New-Item -ItemType Directory -Force -Path $script:WebView2UserData | Out-Null
@@ -2418,7 +2418,7 @@ $ui.Terminal.add_CoreWebView2InitializationCompleted({
                         $script:PendingTermWrites.Clear()
                     }
                     $ver = $script:ToolVersion
-                    if (-not $ver) { $ver = '5.0.1' }
+                    if (-not $ver) { $ver = '5.0.2' }
                     $ESC = $script:ESC
                     if (-not $ESC) { $ESC = [char]27 }
                     $banner = "$ESC[36mDune Server v$ver$ESC[0m`r`n" +

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -14,7 +14,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '5.0.1',
+    [string]$Version = '5.0.2',
     [switch]$Quiet
 )
 

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,9 +16,9 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server"
-#define MyAppVersion "5.0.1"
+#define MyAppVersion "5.0.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
-#define MyAppURL         "https://github.com/Neil-PSP/Simple-Dune-Server-Management-Tool"
+#define MyAppURL         "https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool"
 #define MyAppExeName     "DuneServer.exe"
 #define MyAppId          "{{B3F8A2C1-7E5D-4F9A-8B2C-1D6E3A4F5C7D}"
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "5.0.1"
+$script:ToolVersion = "5.0.2"
 
 # ============================================================
 #  CRASH / EXIT CLEANUP


### PR DESCRIPTION
Scrubs example PII from public docs (LICENSE, README, CHANGELOG, installer URL). Replaces with generic / RFC1918+RFC5737 documentation values. No functional changes.