### PR TITLE
fix: dune-admin command self-installs when EXE missing (v6.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [6.1.2] - 2026-05-26
+
+Patch: **`dune-admin` command now self-heals** when the bundled
+`dune-admin.exe` is missing.
+
+Fixed
+- Command 18 (`dune-admin`) silently registered a scheduled task
+  pointed at a missing executable when `DuneAdminExe` in
+  `dune-server.config` pointed nowhere — the spawned console window
+  flashed and closed, dune-admin.exe never started, and the
+  `dune-admin.layout.tools` web UI loaded but showed no data because
+  its local backend wasn't running.
+- The `dune-admin` handler now `Test-Path`s the configured EXE
+  first. If missing or unset it offers to download the latest
+  release from `github.com/Icehunter/dune-admin` (reuses the
+  existing `Install-DuneAdminLatest` helper), persists the new
+  path back to `dune-server.config`, and seeds the install
+  directory with the current SSH key — same flow as
+  `initial-setup`. Errors and the first-time install path now
+  pause with **"Press Enter to close this window"** so the user
+  actually sees what happened before the console disappears.
+
 ## [6.1.1] - 2026-05-26
 
 Patch: **headless launcher with system-tray icon**. The console window
@@ -804,7 +826,8 @@ at the time. Also folds in the v3.0.1 / v3.1.2 patches.
   (`ssh`, `dune-admin`, `setup-guide`, `report-issue`). _(originally
   3.1.2)_
 
-[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v6.0.1...HEAD
+[Unreleased]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v6.1.2...HEAD
+[6.1.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v6.0.1...v6.1.2
 [6.0.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v5.0.2...v6.0.1
 [5.0.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v4.5.2...v5.0.2
 [4.0.0]: https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool/compare/v3.1.2...v4.5.2

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -1,4 +1,4 @@
-﻿# Dune Server — entry point (v6.1 web portal)
+# Dune Server — entry point (v6.1 web portal)
 #
 # Bootstrap: pick a free port, start HttpListener, open default browser at the
 # tokened localhost URL. The full UI is the React SPA in webui/dist/.
@@ -6,7 +6,7 @@
 $ErrorActionPreference = 'Stop'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '6.1.1'
+$script:DuneToolVersion = '6.1.2'
 
 # ---------- Self-elevate -------------------------------------------------------
 # Hyper-V cmdlets (Get-VM etc.) require admin or Hyper-V Administrators group.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -1,4 +1,4 @@
-﻿# Build-Exe.ps1 - Compiles app/DuneServer.ps1 into DuneServer.exe via ps2exe.
+# Build-Exe.ps1 - Compiles app/DuneServer.ps1 into DuneServer.exe via ps2exe.
 #
 # Output: app/build/output/DuneServer.exe
 #
@@ -6,7 +6,7 @@
 #   - PowerShell 7+ (pwsh)
 #   - ps2exe module (auto-installed if missing)
 #
-# The compiled .exe (v6.1.1+):
+# The compiled .exe (v6.1.2+):
 #   - Embeds a UAC manifest (-requireAdmin) so launching always elevates
 #     (Hyper-V cmdlets need admin, matching the v6.0.x WPF host behavior)
 #   - Runs hidden (-noConsole) - server presents as a tray icon (NotifyIcon)
@@ -16,12 +16,12 @@
 #   - Self-bootstraps the local HTTP server + opens the default browser
 #
 # v6.0.x was WPF noConsole; v6.1.0 briefly enabled the console for live logs;
-# v6.1.1 went back to noConsole + tray icon. Logs are written to:
+# v6.1.2 went back to noConsole + tray icon. Logs are written to:
 #   %LOCALAPPDATA%\DuneServer\dune-server.log
 
 [CmdletBinding()]
 param(
-    [string]$Version = '6.1.1',
+    [string]$Version = '6.1.2',
     [switch]$Quiet
 )
 
@@ -48,7 +48,7 @@ $verNum = "$Version.0"  # ps2exe wants 4-part version
 
 Write-Host "Compiling DuneServer.exe (v$Version)..." -ForegroundColor Cyan
 
-# Critical flags (v6.1.1):
+# Critical flags (v6.1.2):
 #   -requireAdmin  : embeds UAC manifest -> always launches elevated
 #   -noConsole     : windowless EXE - tray icon is the only UI surface
 #   -STA           : required for System.Windows.Forms.NotifyIcon / MessageBox

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server"
-#define MyAppVersion "6.1.1"
+#define MyAppVersion "6.1.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -RunAsAdministrator
+#Requires -RunAsAdministrator
 
 [CmdletBinding()]
 param(
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "6.1.1"
+$script:ToolVersion = "6.1.2"
 
 # ============================================================
 #  CRASH / EXIT CLEANUP
@@ -1794,21 +1794,94 @@ while ($true) {
     }
 
     if ($cmdName -eq "dune-admin") {
+        # Verify the configured exe exists. If it doesn't (user uninstalled,
+        # moved the folder, or never installed it), auto-install the latest
+        # release rather than silently registering a scheduled task pointed
+        # at a missing file (which fires-and-forgets and leaves dune-admin's
+        # web UI showing no data).
+        $needsInstall = (-not $duneAdminExe) -or (-not (Test-Path -LiteralPath $duneAdminExe))
+        $didInstallWork = $false
+        if ($needsInstall) {
+            $didInstallWork = $true
+            Write-Host ""
+            Write-Host "dune-admin.exe was not found." -ForegroundColor Yellow
+            if ($duneAdminExe) {
+                Write-Host "  Configured path: $duneAdminExe" -ForegroundColor DarkGray
+            }
+            Write-Host ""
+            Write-Host "  This tool can install the latest dune-admin release for you" -ForegroundColor Gray
+            Write-Host "  from https://github.com/Icehunter/dune-admin/releases" -ForegroundColor Gray
+            Write-Host ""
+            $resp = Read-Host "Install dune-admin now? [Y/n]"
+            if ($resp -and $resp -notmatch '^(y|yes)$') {
+                Write-Host "Aborted." -ForegroundColor Yellow
+                Read-Host "Press Enter to close this window"
+                continue
+            }
+            $installDir = if ($duneAdminExe) { Split-Path $duneAdminExe -Parent } else { Join-Path ([Environment]::GetFolderPath('Desktop')) 'dune-admin' }
+            try {
+                $newExe = Install-DuneAdminLatest -InstallDir $installDir
+                if (-not $newExe -or -not (Test-Path -LiteralPath $newExe)) {
+                    throw "Install completed but dune-admin.exe was not found in $installDir."
+                }
+                $duneAdminExe = $newExe
+                # Persist the new path so future runs find it without re-installing.
+                try {
+                    if (Test-Path -LiteralPath $configFile) {
+                        $lines = Get-Content -LiteralPath $configFile
+                        if ($lines -match '^DuneAdminExe=') {
+                            $lines = $lines | ForEach-Object { if ($_ -match '^DuneAdminExe=') { "DuneAdminExe=$duneAdminExe" } else { $_ } }
+                        } else {
+                            $lines += "DuneAdminExe=$duneAdminExe"
+                        }
+                        $lines | Set-Content -LiteralPath $configFile -Encoding UTF8
+                        Write-Host "  Updated config: $configFile" -ForegroundColor DarkGray
+                    }
+                } catch {
+                    Write-Warning "Installed dune-admin OK but could not update config: $($_.Exception.Message)"
+                }
+                # Seed the install dir with our SSH key so dune-admin can SSH
+                # to the VM the same way this tool does. Mirrors initial-setup.
+                try {
+                    $adminDir = Split-Path $duneAdminExe -Parent
+                    $srcKey   = Resolve-FreshSshKey -ConfiguredPath $sshKey
+                    if ($srcKey -and $adminDir) {
+                        Copy-SshKeyToDir -SourceKey $srcKey -DestDir $adminDir | Out-Null
+                        Write-Host "  Copied SSH key into $adminDir" -ForegroundColor DarkGray
+                    }
+                } catch {
+                    Write-Warning "Could not copy SSH key into dune-admin folder: $($_.Exception.Message)"
+                }
+            } catch {
+                Write-Host ""
+                Write-Host "Install failed: $($_.Exception.Message)" -ForegroundColor Red
+                Write-Host "You can download manually from https://github.com/Icehunter/dune-admin/releases" -ForegroundColor Gray
+                Read-Host "Press Enter to close this window"
+                continue
+            }
+        }
+
         Write-Host "Launching dune-admin.exe and web UI as $windowsUser..." -ForegroundColor Cyan
         $duneAdminDir = Split-Path $duneAdminExe -Parent
-        $duneAdminName = Split-Path $duneAdminExe -Leaf
         # Launch as the logged-in user via scheduled task (avoids admin elevation)
-        $action = New-ScheduledTaskAction -Execute $duneAdminExe -WorkingDirectory $duneAdminDir
-        $principal = New-ScheduledTaskPrincipal -UserId $windowsUser -LogonType Interactive -RunLevel Limited
-        Register-ScheduledTask -TaskName "DuneAdminLaunch" -Action $action -Principal $principal -Force | Out-Null
-        Start-ScheduledTask -TaskName "DuneAdminLaunch"
-        Start-Sleep -Seconds 1
-        Unregister-ScheduledTask -TaskName "DuneAdminLaunch" -Confirm:$false
+        try {
+            $action = New-ScheduledTaskAction -Execute $duneAdminExe -WorkingDirectory $duneAdminDir
+            $principal = New-ScheduledTaskPrincipal -UserId $windowsUser -LogonType Interactive -RunLevel Limited
+            Register-ScheduledTask -TaskName "DuneAdminLaunch" -Action $action -Principal $principal -Force | Out-Null
+            Start-ScheduledTask -TaskName "DuneAdminLaunch"
+            Start-Sleep -Seconds 1
+            Unregister-ScheduledTask -TaskName "DuneAdminLaunch" -Confirm:$false
+        } catch {
+            Write-Host "Failed to launch dune-admin.exe: $($_.Exception.Message)" -ForegroundColor Red
+            Read-Host "Press Enter to close this window"
+            continue
+        }
         # Open web UI in default browser (Start-Process <url> uses the
         # registered https:// protocol handler, honoring the user's default
         # browser. Avoids Windows 11 24H2's explorer.exe-forces-Edge bug.)
         Start-Process $duneAdminWeb
         Write-Host "Done. dune-admin.exe is running and web UI opened in browser." -ForegroundColor Green
+        if ($didInstallWork) { Read-Host "Press Enter to close this window" }
         continue
     }
 


### PR DESCRIPTION
## Symptom (the maintainer reported 2026-05-26)
- Clicking command 18 (`dune-admin`) in the web portal Commands page: console window flashes open and closes immediately.
- The dune-admin web UI (`dune-admin.layout.tools`) loads but shows no data.

## Root cause
`dune-admin.exe` did not exist at the path stored in `dune-server.config` (`C:\Users\<USER>\Desktop\dune-admin\dune-admin.exe` — folder had been removed). The `dune-admin` handler blindly called `New-ScheduledTaskAction -Execute $duneAdminExe` / `Start-ScheduledTask`, which succeeds at registration time but the task fires-and-forgets — dune-admin.exe never starts. The handler then prints `Done. dune-admin.exe is running` (a lie), opens the dune-admin web UI in the browser, and exits. The web UI shows no data because there's no local backend to talk to.

## Fix (`dune-server.ps1` `dune-admin` handler)
- `Test-Path` the configured EXE before any launch.
- If missing or unset: prompt to install latest release from `github.com/Icehunter/dune-admin` (reuses existing `Install-DuneAdminLatest`).
- Persist the new path back to `dune-server.config`.
- Seed the install dir with the current SSH key (matches the `initial-setup` flow).
- Wrap the scheduled-task launch in try/catch; pause with `Read-Host` on the install / error paths so the user sees the result before the spawned console window closes.

## Version
6.1.1 → **6.1.2** in `dune-server.ps1`, `app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/installer/DuneServer.iss`. CHANGELOG entry added. Compare-link block updated (was still pointing at v6.0.1).

## Build
- `DuneServer.exe`: 54.5 KB
- `DuneServerSetup.exe`: 2.39 MB

## Verified locally
- Source `dune-server.ps1` parses clean.
- Installed copy hot-patched into `C:\Program Files\Dune Server\` so the maintainer can test command 18 right now.
