### PR TITLE
fix(launcher): single-instance gate + no UAC on repeated shortcut clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,24 @@ here cover everything those tags shipped.
 
 ## [6.1.2] - 2026-05-26
 
-Patch: **`dune-admin` command now self-heals** when the bundled
-`dune-admin.exe` is missing.
+Patch: **single-instance gate** (clicking the desktop shortcut multiple times
+no longer spawns multiple servers or UAC prompts) and **`dune-admin` self-heal**
+when the bundled `dune-admin.exe` is missing.
 
 Fixed
+- **Multi-instance bug** — every click of the desktop shortcut spawned a
+  brand-new `DuneServer.exe` (new port, new tray icon, **new UAC prompt**).
+  Added a named-mutex gate (`Global\DuneServer-Portal-v6`): if the portal
+  is already running, subsequent launches just open the existing portal
+  URL (`%LOCALAPPDATA%\DuneServer\last-url.txt`) in the default browser
+  and exit silently — no second listener, no second tray icon, no UAC.
+- **UAC-on-every-click** — `DuneServer.exe` no longer ships a `requireAdmin`
+  manifest. The single-instance check runs *first*; elevation happens
+  *in-script* only when this is the canonical instance (so first launch
+  prompts once, subsequent clicks never prompt). Hyper-V cmdlets still get
+  admin via the in-script self-elevate (`Start-Process -Verb RunAs`); CLI
+  commands still get admin via `dune-server.ps1`'s
+  `#Requires -RunAsAdministrator`.
 - Command 18 (`dune-admin`) silently registered a scheduled task
   pointed at a missing executable when `DuneAdminExe` in
   `dune-server.config` pointed nowhere — the spawned console window

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -8,9 +8,40 @@ $ErrorActionPreference = 'Stop'
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
 $script:DuneToolVersion = '6.1.2'
 
+# ---------- Single-instance gate ----------------------------------------------
+# Every click of the desktop shortcut runs DuneServer.exe again. Without a
+# gate this spawns N independent servers (each on a fresh port), N tray icons,
+# and N UAC prompts. Acquire a named mutex; if it's already held, just open
+# the existing portal URL in the user's browser and exit — no elevation, no
+# duplicate listener, no second tray icon.
+$script:SingleInstanceMutex = $null
+$script:SingleInstanceOwned = $false
+try {
+    $created = $false
+    $script:SingleInstanceMutex = New-Object System.Threading.Mutex($true, 'Global\DuneServer-Portal-v6', [ref]$created)
+    $script:SingleInstanceOwned = [bool]$created
+} catch {
+    # If the named mutex can't be created (locked-down session, etc.),
+    # fall through and let the rest of startup decide.
+    $script:SingleInstanceOwned = $true
+}
+if (-not $script:SingleInstanceOwned) {
+    # Another instance is already running. Open its portal URL and exit.
+    try {
+        $urlFile = Join-Path $env:LOCALAPPDATA 'DuneServer\last-url.txt'
+        if (Test-Path -LiteralPath $urlFile) {
+            $u = (Get-Content -LiteralPath $urlFile -Raw).Trim()
+            if ($u) { Start-Process $u | Out-Null }
+        }
+    } catch { }
+    exit 0
+}
+
 # ---------- Self-elevate -------------------------------------------------------
 # Hyper-V cmdlets (Get-VM etc.) require admin or Hyper-V Administrators group.
-# Matches the v6.0.x WPF .exe behavior (requireAdmin manifest).
+# We elevate in-script (rather than via a ps2exe -requireAdmin manifest) so the
+# single-instance check above runs FIRST and subsequent shortcut clicks open
+# the browser without a UAC prompt.
 function Test-DuneIsAdmin {
     try {
         $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
@@ -28,6 +59,17 @@ function Show-DuneMessage {
     }
 }
 if (-not (Test-DuneIsAdmin)) {
+    # Release the mutex BEFORE the elevated child starts, so the child can
+    # acquire it. Without this the child would see "already running" and exit.
+    try {
+        if ($script:SingleInstanceMutex) {
+            $script:SingleInstanceMutex.ReleaseMutex()
+            $script:SingleInstanceMutex.Dispose()
+            $script:SingleInstanceMutex = $null
+            $script:SingleInstanceOwned = $false
+        }
+    } catch { }
+
     $exePath = $null
     try { $exePath = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName } catch { }
     try {

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -7,8 +7,10 @@
 #   - ps2exe module (auto-installed if missing)
 #
 # The compiled .exe (v6.1.2+):
-#   - Embeds a UAC manifest (-requireAdmin) so launching always elevates
-#     (Hyper-V cmdlets need admin, matching the v6.0.x WPF host behavior)
+#   - NO -requireAdmin manifest. Elevation is handled IN-SCRIPT after the
+#     single-instance mutex check, so a second click on the desktop shortcut
+#     just opens the existing portal URL in the browser without a UAC prompt.
+#     (Hyper-V cmdlets still need admin; the first launch self-elevates.)
 #   - Runs hidden (-noConsole) - server presents as a tray icon (NotifyIcon)
 #     with menu: Open Portal / Copy URL / View Log / Quit
 #   - STA apartment so WinForms (NotifyIcon, MessageBox) is safe
@@ -16,8 +18,9 @@
 #   - Self-bootstraps the local HTTP server + opens the default browser
 #
 # v6.0.x was WPF noConsole; v6.1.0 briefly enabled the console for live logs;
-# v6.1.2 went back to noConsole + tray icon. Logs are written to:
-#   %LOCALAPPDATA%\DuneServer\dune-server.log
+# v6.1.2 went back to noConsole + tray icon AND dropped -requireAdmin in favor
+# of in-script elevation (so the single-instance gate runs before UAC).
+# Logs are written to: %LOCALAPPDATA%\DuneServer\dune-server.log
 
 [CmdletBinding()]
 param(
@@ -49,10 +52,12 @@ $verNum = "$Version.0"  # ps2exe wants 4-part version
 Write-Host "Compiling DuneServer.exe (v$Version)..." -ForegroundColor Cyan
 
 # Critical flags (v6.1.2):
-#   -requireAdmin  : embeds UAC manifest -> always launches elevated
 #   -noConsole     : windowless EXE - tray icon is the only UI surface
 #   -STA           : required for System.Windows.Forms.NotifyIcon / MessageBox
 #   -iconFile      : taskbar / file explorer / tray icon
+# NOTE: -requireAdmin INTENTIONALLY OMITTED. The script self-elevates after
+# the single-instance mutex check so subsequent shortcut clicks just open the
+# browser to the existing portal URL without prompting for UAC again.
 $ps2exeArgs = @{
     InputFile      = $src
     OutputFile     = $outExe
@@ -63,7 +68,6 @@ $ps2exeArgs = @{
     Product        = 'Dune Server'
     Version        = $verNum
     Copyright      = '(c) 2026 Dune Awakening Self-Hosted Tool'
-    RequireAdmin   = $true
     NoConsole      = $true
     STA            = $true
 }
@@ -81,7 +85,7 @@ Write-Host ""
 
 if (-not $Quiet) {
     Write-Host "Admin requirements:" -ForegroundColor Cyan
-    Write-Host "  [x] UAC manifest embedded (-requireAdmin)" -ForegroundColor Green
+    Write-Host "  [x] No UAC manifest - self-elevates in-script after single-instance check" -ForegroundColor Green
     Write-Host "  [x] No console window (-noConsole), tray icon UI" -ForegroundColor Green
     Write-Host "  [x] STA apartment (WinForms NotifyIcon)" -ForegroundColor Green
     Write-Host ""

--- a/app/installer/Build-Installer.ps1
+++ b/app/installer/Build-Installer.ps1
@@ -85,7 +85,7 @@ Write-Host "  Built: $installer ($size MB)" -ForegroundColor Green
 Write-Host ""
 Write-Host "Admin requirements (all 3 layers):" -ForegroundColor Cyan
 Write-Host "  [x] Setup itself: PrivilegesRequired=admin (writes to Program Files)" -ForegroundColor Green
-Write-Host "  [x] DuneServer.exe: embedded UAC manifest via ps2exe -requireAdmin"   -ForegroundColor Green
+Write-Host "  [x] DuneServer.exe: self-elevates in-script (after single-instance check)"   -ForegroundColor Green
 Write-Host "  [x] dune-server.ps1: #Requires -RunAsAdministrator"                   -ForegroundColor Green
 
 if ($Open) {


### PR DESCRIPTION
**Symptom (the maintainer reported \when i open from my desktop, i get alerts\):** clicking the public-desktop \Dune Server.lnk\ shortcut repeatedly spawned a brand-new \DuneServer.exe\ each time — separate server on the next free port, separate tray icon, separate UAC prompt. Today's log shows 5 servers on 47823-47827.

**Root cause:**
1. No single-instance check anywhere in startup. Each EXE launch ran the full bootstrap.
2. \ps2exe -requireAdmin\ embeds a UAC manifest, so UAC fires *before* the script even loads — there's no chance to detect 'already running' first.

**Fix (folded into the unreleased v6.1.2):**
- Acquire a named mutex \Global\DuneServer-Portal-v6\ at the top of \^Gpp/DuneServer.ps1\ (before self-elevate). If already held, read \%LOCALAPPDATA%\DuneServer\last-url.txt\, \Start-Process\ the URL, exit 0.
- Drop \-requireAdmin\ from ps2exe so the un-elevated stub runs the mutex check first. Hyper-V cmdlets still need admin — handled by the existing in-script \Start-Process -Verb RunAs\ self-elevate.
- Release the mutex before relaunching elevated (otherwise the elevated child sees the mutex held by its parent and exits too).

**Safety unchanged (the 3-layer rule per persistent-notes.md):**
- ✅ Installer still \PrivilegesRequired=admin\ (writes to Program Files)
- ❌ \~\DuneServer.exe -requireAdmin\ manifest\~ — *removed*, replaced by mutex-gated in-script elevation
- ✅ \dune-server.ps1\ still \#Requires -RunAsAdministrator\ (CLI commands)
- ✅ DuneServer.exe still runs elevated when serving (because it self-elevates on first launch)

**New behavior:**
| Scenario | Before | After |
|---|---|---|
| First click ever | UAC → server starts | UAC → server starts |
| Second click while running | UAC → 2nd server on 47824 + 2nd tray | Browser opens existing URL, no UAC |
| Click after quit | UAC → fresh server | UAC → fresh server |

Local test: hot-patched \C:\Program Files\Dune Server\DuneServer.exe\ (56.5 KB build), verified clean state (no leftover processes, no listening ports). Ready for click-test.
