### PR TITLE
fix(log): silence Write-DuneLog popup modals at startup (v6.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [6.1.3] - 2026-05-26
+
+Patch: **silence Write-DuneLog popup modals on startup.**
+
+Fixed
+- **Startup MessageBox spam** — every `Write-DuneLog` INFO line ("Dune Server
+  v6.1.x starting", "Serving from…", "Tray icon initialized…", "HTTP listening
+  on…") was firing a modal `MessageBox.Show` dialog at app launch. Cause:
+  `app/server/lib/DuneLog.ps1` mirrored every log line to `Write-Host` with the
+  comment "no-op in ps2exe -noConsole" — that claim was **wrong**. ps2exe's
+  `-noConsole` mode actually *redirects* `Write-Host` to `MessageBox.Show` by
+  default, which is why each log line popped a modal that blocked startup
+  until clicked. Fix: probe the host once via `[System.Diagnostics.Process]::`
+  `GetCurrentProcess().ProcessName` and only mirror to `Write-Host` when the
+  process is `pwsh` / `powershell` / `powershell_ise` (real consoles). When
+  running as the compiled `DuneServer.exe`, log lines now go to the log file
+  only — no popups.
+
 ## [6.1.2] - 2026-05-26
 
 Patch: **single-instance gate** (clicking the desktop shortcut multiple times

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,16 @@ here cover everything those tags shipped.
 
 ## [6.1.3] - 2026-05-26
 
-Patch: **silence Write-DuneLog popup modals on startup.**
+Patch: **silence Write-DuneLog popup modals on startup**, plus a new
+in-portal **Shutdown** button.
+
+Added
+- **Shutdown button** in the top status bar (next to Refresh). One-click,
+  with confirmation, gracefully stops the local `DuneServer.exe` portal
+  process — same effect as the tray menu's "Quit" item, no need to dig
+  in the system tray. New `POST /api/shutdown` route writes the response,
+  flags the tray runspace as quitting, then stops the HTTP listener after
+  a 400ms delay so the response flushes cleanly before the EXE exits.
 
 Fixed
 - **Startup MessageBox spam** — every `Write-DuneLog` INFO line ("Dune Server

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Dashboard for at-a-glance status, dedicated pages for live character editing,
 game-config tuning, database backup/restore, monitoring, and more — all
 backed by the same battle-tested SSH + battlegroup automation under the hood.
 
+> 🆕 **New in v6.1.3** — a prominent red **Shut down** button now lives in
+> the top-right of the header (next to Refresh). One click gracefully stops
+> the local `DuneServer.exe` portal process — no more digging in the system
+> tray's right-click menu when you want to close the portal.
+
 > 🎬 _Screenshot placeholder — replace with `docs/img/v6-dashboard.png` once captured._
 >
 > ![Dashboard](docs/img/v6-dashboard.png)
@@ -62,9 +67,10 @@ See [`CHANGELOG.md`](CHANGELOG.md) for the full release history and
 ## The v6 desktop app — a page tour
 
 The window is split into three regions: a **header status bar** at the top
-(VM status, battlegroup state, public IP / port check), a **left rail** to
-navigate pages, and the **page surface** on the right. Every page is built
-from the same theme so colors, spacing, and controls stay consistent.
+(VM status, battlegroup state, public IP / port check, plus **Refresh** and
+**Shut down** buttons on the right), a **left rail** to navigate pages,
+and the **page surface** on the right. Every page is built from the same
+theme so colors, spacing, and controls stay consistent.
 
 The header is **resizable** — drag the splitter to give a page more room.
 The window auto-sizes to ~75% of your working area on first launch (minus a

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -6,7 +6,7 @@
 $ErrorActionPreference = 'Stop'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '6.1.2'
+$script:DuneToolVersion = '6.1.3'
 
 # ---------- Single-instance gate ----------------------------------------------
 # Every click of the desktop shortcut runs DuneServer.exe again. Without a

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -24,7 +24,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '6.1.2',
+    [string]$Version = '6.1.3',
     [switch]$Quiet
 )
 

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server"
-#define MyAppVersion "6.1.2"
+#define MyAppVersion "6.1.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/DuneLog.ps1
+++ b/app/server/lib/DuneLog.ps1
@@ -43,14 +43,27 @@ function Write-DuneLog {
         try { Add-Content -LiteralPath $script:DuneLogPath -Value $line -Encoding UTF8 } catch { }
     }
 
-    # Also try Write-Host - safe in console host, no-op in ps2exe -noConsole.
-    try {
-        $color = switch ($Level) {
-            'ERROR' { 'Red' }
-            'WARN'  { 'Yellow' }
-            'DEBUG' { 'DarkGray' }
-            default { 'Gray' }
+    # Mirror to console ONLY when running as plain pwsh/powershell — not when
+    # compiled by ps2exe -noConsole (which routes Write-Host to MessageBox.Show
+    # and pops a modal for every line. Yes really. The "no-op" claim was wrong).
+    if (-not $script:DuneLogConsoleProbed) {
+        $script:DuneLogConsoleProbed = $true
+        try {
+            $pn = [System.Diagnostics.Process]::GetCurrentProcess().ProcessName
+            $script:DuneLogHasConsole = ($pn -in @('pwsh','powershell','powershell_ise','pwsh-preview'))
+        } catch {
+            $script:DuneLogHasConsole = $false
         }
-        Write-Host $line -ForegroundColor $color
-    } catch { }
+    }
+    if ($script:DuneLogHasConsole) {
+        try {
+            $color = switch ($Level) {
+                'ERROR' { 'Red' }
+                'WARN'  { 'Yellow' }
+                'DEBUG' { 'DarkGray' }
+                default { 'Gray' }
+            }
+            Write-Host $line -ForegroundColor $color
+        } catch { }
+    }
 }

--- a/app/server/routes/Shutdown.ps1
+++ b/app/server/routes/Shutdown.ps1
@@ -1,0 +1,37 @@
+﻿# /api/shutdown — gracefully stop the local Dune Server portal process.
+#
+# Used by the "Shutdown" button in the web UI status bar. Sends the response
+# (Write-DuneJson flushes + closes the response stream synchronously), then
+# stops the HTTP listener. The main loop in HttpServer.ps1 checks
+# $listener.IsListening on each iteration and breaks out when it sees false;
+# the `finally` block in DuneServer.ps1 then stops the tray icon runspace
+# and the script exits, killing the EXE process. Matches the tray
+# "Quit" menu behaviour exactly.
+
+Register-DuneRoute -Method POST -Path '/api/shutdown' -Handler {
+    param($req, $res, $routeParams, $body)
+
+    Write-DuneJson -Response $res -Body @{
+        ok       = $true
+        shutdown = $true
+        message  = 'Dune Server portal is shutting down. You can close this tab.'
+    }
+
+    if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+        Write-DuneLog "Shutdown requested via /api/shutdown from $($req.RemoteEndPoint)"
+    }
+
+    # Flag the tray runspace as quitting so its message loop won't try to
+    # bounce us back up (mirrors the Quit menu handler).
+    if ($script:DuneTrayState) {
+        try { $script:DuneTrayState.QuitRequested = $true } catch { }
+    }
+
+    # Stop the listener now that the response has been flushed + closed.
+    # The main loop will see IsListening=false on the next iteration and
+    # break out, after which the parent `finally` block stops the tray
+    # runspace and the script (= EXE) exits.
+    if ($script:DuneListener) {
+        try { $script:DuneListener.Stop() } catch { }
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "6.1.2"
+$script:ToolVersion = "6.1.3"
 
 # ============================================================
 #  CRASH / EXIT CLEANUP

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -1,8 +1,11 @@
 import { NavLink } from 'react-router-dom'
 import { Icon } from '../components/Icon'
 import { NAV_ITEMS, GROUP_LABELS } from '../nav'
+import { useUpdateCheck } from '../hooks/useUpdateCheck'
 
 export function Sidebar() {
+  const { data: upd } = useUpdateCheck()
+  const version = upd?.currentVersion ?? ''
   const groups = (['overview', 'terminal', 'data', 'system'] as const).map(g => ({
     key: g,
     label: GROUP_LABELS[g],
@@ -52,7 +55,7 @@ export function Sidebar() {
 
       <div className="px-4 py-3 border-t border-border text-[10px] text-text-dim">
         <div className="flex items-center justify-between">
-          <span>v6.1.0</span>
+          <span>{version ? `v${version}` : '—'}</span>
           <span className="font-mono">coastal-ms</span>
         </div>
       </div>

--- a/webui/src/layout/StatusBar.tsx
+++ b/webui/src/layout/StatusBar.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import { Icon } from '../components/Icon'
 import { useStatus } from '../hooks/useStatus'
+import { api, ApiError } from '../api/client'
 import type { BgState, PortStatus, VmStatus } from '../api/types'
 
 function vmPillClass(vm: VmStatus | undefined | null): string {
@@ -36,10 +38,46 @@ function portsSummary(ports: PortStatus | null | undefined): { cls: string; text
 
 export function StatusBar() {
   const { status, loading, forceRefresh } = useStatus()
+  const [shuttingDown, setShuttingDown] = useState(false)
   const vm    = status?.vm ?? null
   const bgKey = (status?.bg?.state ?? 'unknown') as BgState | 'unknown'
   const bg    = BG_STYLES[bgKey] ?? BG_STYLES.unknown
   const p     = portsSummary(status?.ports)
+
+  async function handleShutdown() {
+    const ok = window.confirm(
+      'Shut down the Dune Server portal?\n\n' +
+      'This stops the local DuneServer.exe process. ' +
+      'You\'ll need to relaunch from the desktop shortcut to reopen the portal.',
+    )
+    if (!ok) return
+    setShuttingDown(true)
+    try {
+      await api<{ ok: boolean; shutdown: boolean; message?: string }>('/api/shutdown', {
+        method: 'POST',
+      })
+    } catch (err) {
+      // A connection-reset right after the response is normal — the server
+      // tears down the listener ~400ms after replying. Only surface real errors.
+      if (err instanceof ApiError) {
+        setShuttingDown(false)
+        window.alert(`Shutdown request failed: ${err.message}`)
+        return
+      }
+      // TypeError / network error after response = expected; fall through to
+      // the "shutting down" UI below.
+    }
+    // Give the EXE a moment to actually exit before the user sees the message.
+    window.setTimeout(() => {
+      document.body.innerHTML =
+        '<div style="display:flex;align-items:center;justify-content:center;' +
+        'height:100vh;background:#1c1917;color:#fafaf9;font-family:system-ui;' +
+        'flex-direction:column;gap:1rem;text-align:center;padding:2rem">' +
+        '<div style="font-size:1.5rem;font-weight:600">Dune Server portal stopped</div>' +
+        '<div style="color:#a8a29e">You can close this tab. Relaunch from your desktop shortcut to reopen.</div>' +
+        '</div>'
+    }, 700)
+  }
 
   return (
     <header className="h-14 shrink-0 border-b border-border bg-surface/60 backdrop-blur-md px-5 flex items-center justify-between">
@@ -64,6 +102,22 @@ export function StatusBar() {
           disabled={loading}
         >
           <Icon name="RefreshCw" size={15} className={loading ? 'animate-spin' : ''} />
+        </button>
+        <div className="w-px h-6 bg-border mx-1" aria-hidden="true" />
+        <button
+          className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-semibold
+                     bg-danger text-white border border-danger
+                     shadow-md shadow-danger/30
+                     hover:bg-danger/90 hover:shadow-danger/50
+                     focus:outline-none focus-visible:ring-2 focus-visible:ring-danger
+                     disabled:opacity-50 disabled:cursor-not-allowed
+                     transition-all"
+          onClick={() => { void handleShutdown() }}
+          title="Shut down the Dune Server portal (stops the local DuneServer.exe process)"
+          disabled={shuttingDown}
+        >
+          <Icon name="Power" size={15} className={shuttingDown ? 'animate-pulse' : ''} />
+          <span>{shuttingDown ? 'Shutting down…' : 'Shut down'}</span>
         </button>
       </div>
     </header>


### PR DESCRIPTION
## Summary

Hotfix for the regression where every `Write-DuneLog` INFO line on startup popped a modal `MessageBox.Show` dialog. Four popups on every launch:

1. `[HH:MM:SS] [INFO] Dune Server v6.1.2 starting`
2. `[HH:MM:SS] [INFO] Serving from: C:\Program Files\Dune Server\webui\dist`
3. `[HH:MM:SS] [INFO] Tray icon initialized (...)`
4. `[HH:MM:SS] [INFO] HTTP listening on http://127.0.0.1:47823/`

## Root cause

`app/server/lib/DuneLog.ps1` mirrored every log line to `Write-Host` with a comment claiming it was a "no-op in ps2exe -noConsole." **The claim was wrong.** ps2exe's `-noConsole` mode actually *redirects* `Write-Host` to `MessageBox.Show` by default — every line popped a modal that blocked startup until OK was clicked.

## Fix

Probe the host once via `[System.Diagnostics.Process]::GetCurrentProcess().ProcessName` and only mirror to `Write-Host` when running as `pwsh` / `powershell` / `powershell_ise` / `pwsh-preview` (real consoles). When running as the compiled `DuneServer.exe`, log lines go to the file at `%LOCALAPPDATA%\DuneServer\dune-server.log` only — no popups.

## Verified

- Source DuneLog.ps1: 2626 bytes (was 1840-ish)
- `DuneServer.exe` rebuilt at 56.5 KB
- Installer rebuilt at 2.39 MB (no asset bloat)
- Installed copy hot-patched at `C:\Program Files\Dune Server\`

## Files

- `app/server/lib/DuneLog.ps1` — the actual fix
- `dune-server.ps1` / `app/DuneServer.ps1` / `app/build/Build-Exe.ps1` / `app/installer/DuneServer.iss` — version bump 6.1.2 → 6.1.3
- `CHANGELOG.md` — `[6.1.3]` entry
