### PR TITLE
v6.1.4: drag-reorder commands + post-Shutdown relaunch token race fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [6.1.4] - 2026-05-26
+
+Patch: **drag-and-drop reorder on the Commands page**, plus a fix for a
+relaunch-after-Shutdown race that briefly showed every panel as "Unknown"
+with "Invalid or missing token" until the user closed and reopened the
+portal a second time.
+
+Added
+- **Drag-to-reorder commands.** Each card on the Commands page now has a
+  grip handle on the left. Drag to rearrange commands within their section
+  (VM, Battlegroup, Tools). The order auto-saves to
+  `%APPDATA%\DuneServer\button-order.json` (`PUT /api/commands/order`,
+  400ms debounce) and persists across launches.
+- **Reset layout** button on the Commands page header — clears the saved
+  order and reverts to the default arrangement.
+- `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` added to
+  `webui/` for the drag-and-drop machinery. The grip is the only drag
+  source (6px activation distance), so clicks on the rest of the card
+  still launch commands as before.
+
+Fixed
+- **"Invalid or missing token" after using Shutdown then relaunching.**
+  When the in-portal Shutdown button stopped the EXE and the user
+  immediately clicked the desktop shortcut to relaunch, the new EXE's
+  browser-launcher background job would win a race against the new HTTP
+  server's `last-url.txt` write, read the *previous* run's URL (with the
+  *previous* run's token), and open the browser at that stale URL. The
+  new listener (now bound on the same port) rejected every `/api/*` call
+  as "Invalid or missing token" until the user closed the tab and
+  reopened the shortcut a second time. Fixes:
+  - `app/DuneServer.ps1` now deletes any stale `last-url.txt` before
+    spawning the polling jobs, so the browser can only ever read the
+    fresh URL written by the new listener.
+  - The shutdown `finally` block now wipes `last-url.txt` and explicitly
+    releases the single-instance mutex, rather than relying on OS
+    process-exit cleanup (which is racy under fast reopen).
+
+
 ## [6.1.3] - 2026-05-26
 
 Patch: **silence Write-DuneLog popup modals on startup**, plus a new

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -6,7 +6,7 @@
 $ErrorActionPreference = 'Stop'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '6.1.3'
+$script:DuneToolVersion = '6.1.4'
 
 # ---------- Single-instance gate ----------------------------------------------
 # Every click of the desktop shortcut runs DuneServer.exe again. Without a
@@ -232,10 +232,23 @@ if ($iconPath) {
     Write-DuneLog "Tray icon disabled - icon.ico not found" 'WARN'
 }
 
+# Delete any stale last-url.txt from a previous run BEFORE starting the
+# polling jobs. Otherwise the browserJob's first poll wins the race against
+# Start-DuneHttpServer's write, opens the browser at the OLD url with the
+# OLD token, and every /api call returns 401 "Invalid or missing token".
+$urlFilePath = Join-Path $env:LOCALAPPDATA 'DuneServer\last-url.txt'
+try {
+    if (Test-Path -LiteralPath $urlFilePath) {
+        Remove-Item -LiteralPath $urlFilePath -Force -ErrorAction Stop
+    }
+} catch {
+    Write-DuneLog "Could not remove stale last-url.txt: $($_.Exception.Message)" 'WARN'
+}
+
 # Kick the browser open after the listener binds. Reads last-url.txt that
 # Start-DuneHttpServer writes once it knows the actual bound port.
-$browserJob = Start-Job -ScriptBlock {
-    $urlFile = Join-Path $env:LOCALAPPDATA 'DuneServer\last-url.txt'
+$browserJob = Start-Job -ArgumentList $urlFilePath -ScriptBlock {
+    param($urlFile)
     for ($i = 0; $i -lt 50; $i++) {
         if (Test-Path -LiteralPath $urlFile) {
             $u = (Get-Content -LiteralPath $urlFile -Raw).Trim()
@@ -246,9 +259,8 @@ $browserJob = Start-Job -ScriptBlock {
 }
 
 # Side-thread to publish the URL and listener to the tray state once bound.
-$urlPublishJob = Start-Job -ArgumentList $script:DuneTrayState -ScriptBlock {
-    param($state)
-    $urlFile = Join-Path $env:LOCALAPPDATA 'DuneServer\last-url.txt'
+$urlPublishJob = Start-Job -ArgumentList $script:DuneTrayState, $urlFilePath -ScriptBlock {
+    param($state, $urlFile)
     for ($i = 0; $i -lt 100; $i++) {
         if (Test-Path -LiteralPath $urlFile) {
             $u = (Get-Content -LiteralPath $urlFile -Raw).Trim()
@@ -270,5 +282,25 @@ try {
     if (Get-Command Stop-DuneTrayIcon -ErrorAction SilentlyContinue) {
         Stop-DuneTrayIcon -State $script:DuneTrayState
     }
+    # Wipe last-url.txt so the next launch can't race-read a stale URL with
+    # a token that no longer matches a running listener.
+    try {
+        $urlFile = Join-Path $env:LOCALAPPDATA 'DuneServer\last-url.txt'
+        if (Test-Path -LiteralPath $urlFile) {
+            Remove-Item -LiteralPath $urlFile -Force -ErrorAction SilentlyContinue
+        }
+    } catch { }
+    # Release the single-instance mutex explicitly so the next click of the
+    # desktop shortcut can acquire it immediately (rather than relying on
+    # OS process-exit cleanup, which is racy under fast reopen).
+    try {
+        if ($script:SingleInstanceMutex) {
+            if ($script:SingleInstanceOwned) {
+                try { $script:SingleInstanceMutex.ReleaseMutex() } catch { }
+            }
+            $script:SingleInstanceMutex.Dispose()
+            $script:SingleInstanceMutex = $null
+        }
+    } catch { }
     Write-DuneLog "Dune Server stopped"
 }

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -24,7 +24,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '6.1.3',
+    [string]$Version = '6.1.4',
     [switch]$Quiet
 )
 

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server"
-#define MyAppVersion "6.1.3"
+#define MyAppVersion "6.1.4"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "6.1.3"
+$script:ToolVersion = "6.1.4"
 
 # ============================================================
 #  CRASH / EXIT CLEANUP

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -8,6 +8,9 @@
       "name": "webui",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tailwindcss/vite": "^4.3.0",
         "@xterm/addon-fit": "^0.11.0",
@@ -271,6 +274,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2907,8 +2963,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tailwindcss/vite": "^4.3.0",
     "@xterm/addon-fit": "^0.11.0",

--- a/webui/src/pages/Commands.tsx
+++ b/webui/src/pages/Commands.tsx
@@ -1,4 +1,21 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { PageHeader } from '../components/PageHeader'
 import { Icon } from '../components/Icon'
 import { useStatus } from '../hooks/useStatus'
@@ -21,42 +38,75 @@ const SECTION_ICONS: Record<Command['section'], string> = {
   Tools: 'Wrench',
 }
 
-function CommandButton({
+function SortableCommandButton({
   cmd, onRun, busy,
 }: { cmd: Command; onRun: (c: Command) => void; busy: boolean }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: cmd.name })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.55 : undefined,
+    zIndex: isDragging ? 10 : undefined,
+  }
+
   const disabled = !cmd.available || busy
+
   return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={() => onRun(cmd)}
-      title={cmd.available ? cmd.desc : (cmd.reason || cmd.desc)}
-      className="group w-full text-left card card-hover p-3 disabled:opacity-50 disabled:cursor-not-allowed
-                 disabled:hover:border-border disabled:hover:bg-surface/80"
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`group card card-hover p-3 flex items-stretch gap-2 ${
+        isDragging ? 'border-accent/60 shadow-lg shadow-accent/20' : ''
+      } ${disabled ? 'opacity-60' : ''}`}
     >
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <kbd className="shrink-0 inline-flex items-center justify-center w-5 h-5 rounded
-                          bg-surface-3 border border-border text-[10px] font-mono text-text-dim
-                          group-hover:text-text-muted group-hover:border-border-bright">
-            {cmd.key}
-          </kbd>
-          <span className="font-mono text-sm truncate text-text">{cmd.name}</span>
+      {/* Drag handle — only this triggers a drag, so the rest of the card is still clickable */}
+      <button
+        type="button"
+        aria-label={`Reorder ${cmd.name}`}
+        title="Drag to reorder"
+        {...attributes}
+        {...listeners}
+        className="shrink-0 -ml-1 flex items-center justify-center w-6 text-text-dim
+                   hover:text-accent cursor-grab active:cursor-grabbing
+                   focus:outline-none focus:text-accent touch-none"
+      >
+        <Icon name="GripVertical" size={14} />
+      </button>
+
+      {/* Clickable launch surface */}
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => onRun(cmd)}
+        title={cmd.available ? cmd.desc : (cmd.reason || cmd.desc)}
+        className="flex-1 text-left disabled:cursor-not-allowed"
+      >
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <kbd className="shrink-0 inline-flex items-center justify-center w-5 h-5 rounded
+                            bg-surface-3 border border-border text-[10px] font-mono text-text-dim
+                            group-hover:text-text-muted group-hover:border-border-bright">
+              {cmd.key}
+            </kbd>
+            <span className="font-mono text-sm truncate text-text">{cmd.name}</span>
+          </div>
+          <span className={
+            cmd.mode === 'Console' ? 'pill-info shrink-0' : 'pill-muted shrink-0'
+          }>
+            <Icon name={cmd.mode === 'Console' ? 'SquareTerminal' : 'Zap'} size={10} />
+            {cmd.mode}
+          </span>
         </div>
-        <span className={
-          cmd.mode === 'Console' ? 'pill-info shrink-0' : 'pill-muted shrink-0'
-        }>
-          <Icon name={cmd.mode === 'Console' ? 'SquareTerminal' : 'Zap'} size={10} />
-          {cmd.mode}
-        </span>
-      </div>
-      <p className="mt-1.5 text-xs text-text-muted line-clamp-2">{cmd.desc}</p>
-      {!cmd.available && cmd.reason && (
-        <p className="mt-1 text-[11px] text-warning/80 flex items-center gap-1">
-          <Icon name="AlertTriangle" size={10} /> {cmd.reason}
-        </p>
-      )}
-    </button>
+        <p className="mt-1.5 text-xs text-text-muted line-clamp-2">{cmd.desc}</p>
+        {!cmd.available && cmd.reason && (
+          <p className="mt-1 text-[11px] text-warning/80 flex items-center gap-1">
+            <Icon name="AlertTriangle" size={10} /> {cmd.reason}
+          </p>
+        )}
+      </button>
+    </div>
   )
 }
 
@@ -66,6 +116,16 @@ export function Commands() {
 
   const [running, setRunning] = useState<Set<string>>(new Set())
   const [toast, setToast] = useState<{ kind: 'ok' | 'err'; msg: string } | null>(null)
+  // Local order overlay applied on top of server data; lets us reflect drags
+  // instantly without round-tripping through useApi's refresh cycle.
+  const [localOrder, setLocalOrder] = useState<string[] | null>(null)
+  const [savingOrder, setSavingOrder] = useState(false)
+  const saveTimer = useRef<number | null>(null)
+
+  // Reset the local overlay whenever the server returns a new authoritative order.
+  useEffect(() => {
+    setLocalOrder(null)
+  }, [cmdsState.data?.order])
 
   function showToast(kind: 'ok' | 'err', msg: string) {
     setToast({ kind, msg })
@@ -88,13 +148,13 @@ export function Commands() {
 
   const ordered = useMemo(() => {
     const commands = cmdsState.data?.commands ?? []
-    const order = cmdsState.data?.order
-    if (!Array.isArray(order) || order.length === 0) return commands
+    const effectiveOrder = localOrder ?? cmdsState.data?.order
+    if (!Array.isArray(effectiveOrder) || effectiveOrder.length === 0) return commands
     const byName = new Map(commands.map(c => [c.name, c]))
     const result: Command[] = []
-    for (const n of order) { const c = byName.get(n); if (c) { result.push(c); byName.delete(n) } }
+    for (const n of effectiveOrder) { const c = byName.get(n); if (c) { result.push(c); byName.delete(n) } }
     return [...result, ...byName.values()]
-  }, [cmdsState.data])
+  }, [cmdsState.data, localOrder])
 
   const grouped = useMemo(() => {
     const g: Record<Command['section'], Command[]> = { VM: [], Battlegroup: [], Tools: [] }
@@ -104,20 +164,95 @@ export function Commands() {
     return g
   }, [ordered])
 
+  // Debounced PUT to /api/commands/order. Caller passes the new full flat order.
+  function persistOrder(newOrder: string[]) {
+    if (saveTimer.current) window.clearTimeout(saveTimer.current)
+    saveTimer.current = window.setTimeout(async () => {
+      setSavingOrder(true)
+      try {
+        await api('/api/commands/order', { method: 'PUT', body: JSON.stringify({ order: newOrder }) })
+        // Soft refresh so subsequent updates start from server truth.
+        void cmdsState.refresh()
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        showToast('err', `Failed to save layout: ${msg}`)
+      } finally {
+        setSavingOrder(false)
+      }
+    }, 400)
+  }
+
+  function handleDragEnd(section: Command['section'], e: DragEndEvent) {
+    const { active, over } = e
+    if (!over || active.id === over.id) return
+    const items = grouped[section]
+    const oldIndex = items.findIndex(c => c.name === active.id)
+    const newIndex = items.findIndex(c => c.name === over.id)
+    if (oldIndex < 0 || newIndex < 0) return
+    const reordered = arrayMove(items, oldIndex, newIndex)
+    // Build new full-flat order by replacing this section's slice.
+    const next: Command[] = []
+    for (const s of SECTION_ORDER) {
+      if (s === section) next.push(...reordered)
+      else next.push(...grouped[s])
+    }
+    const names = next.map(c => c.name)
+    setLocalOrder(names)
+    persistOrder(names)
+  }
+
+  async function resetLayout() {
+    if (!window.confirm('Reset the Commands page to its default layout?')) return
+    setSavingOrder(true)
+    try {
+      await api('/api/commands/order/reset', { method: 'POST' })
+      setLocalOrder(null)
+      await cmdsState.refresh()
+      showToast('ok', 'Layout reset to default.')
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      showToast('err', `Reset failed: ${msg}`)
+    } finally {
+      setSavingOrder(false)
+    }
+  }
+
+  const sensors = useSensors(
+    // 6px activation distance — distinguishes a click from a drag so the launch
+    // button under the card body doesn't fire when the user grabs the handle.
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
   return (
     <>
       <PageHeader
         title="Commands"
         icon="Zap"
-        description="Quick actions for the VM, battlegroup, and supporting tools. Each command launches in a new console window."
+        description="Quick actions for the VM, battlegroup, and supporting tools. Drag the grip on any card to reorder within a section."
         actions={
-          <button
-            className="btn-secondary"
-            onClick={() => { void cmdsState.refresh(); void forceRefresh() }}
-            disabled={cmdsState.loading}
-          >
-            <Icon name="RefreshCw" size={15} className={cmdsState.loading ? 'animate-spin' : ''} /> Refresh
-          </button>
+          <div className="flex items-center gap-2">
+            {savingOrder && (
+              <span className="text-xs text-text-dim flex items-center gap-1">
+                <Icon name="Loader2" size={12} className="animate-spin" /> Saving layout…
+              </span>
+            )}
+            <button
+              className="btn-secondary"
+              onClick={resetLayout}
+              disabled={savingOrder}
+              title="Reset to default layout"
+            >
+              <Icon name="RotateCcw" size={14} /> Reset layout
+            </button>
+            <button
+              className="btn-secondary"
+              onClick={() => { void cmdsState.refresh(); void forceRefresh() }}
+              disabled={cmdsState.loading}
+            >
+              <Icon name="RefreshCw" size={15} className={cmdsState.loading ? 'animate-spin' : ''} /> Refresh
+            </button>
+          </div>
         }
       />
 
@@ -151,11 +286,22 @@ export function Commands() {
                 </h2>
                 <span className="text-xs text-text-dim">{items.length} {items.length === 1 ? 'command' : 'commands'}</span>
               </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
-                {items.map(c => (
-                  <CommandButton key={c.name} cmd={c} onRun={runCommand} busy={running.has(c.name)} />
-                ))}
-              </div>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={(e) => handleDragEnd(section, e)}
+              >
+                <SortableContext
+                  items={items.map(c => c.name)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+                    {items.map(c => (
+                      <SortableCommandButton key={c.name} cmd={c} onRun={runCommand} busy={running.has(c.name)} />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
             </div>
           )
         })}


### PR DESCRIPTION
## Drag-to-reorder on the Commands page

Each command card now has a grip handle on the left. Drag it to rearrange commands within the section (VM / Battlegroup / Tools). Order auto-saves to `%APPDATA%\DuneServer\button-order.json` via `PUT /api/commands/order` (400 ms debounce). A **Reset layout** button on the page header clears the saved order.

The grip is the only drag source (6 px activation distance), so clicks on the rest of the card still launch the command as before — no mode toggle needed.

Adds `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` to `webui/`.

## Fix: `Invalid or missing token` after Shutdown + relaunch

When you clicked the new Shutdown button (v6.1.3) and then immediately reopened the desktop shortcut, every panel showed **Unknown** / **No VM data** / **Invalid or missing token** until you closed the browser and reopened the shortcut a second time.

Root cause: the EXE spawns a background polling job that watches `%LOCALAPPDATA%\DuneServer\last-url.txt` and opens the browser at whatever URL it finds. On a fresh launch the file from the previous run was still on disk with the *previous* run's token, so the job's first poll won the race against the new HTTP server's write — the browser opened at the old URL with the old token, and the new listener (now bound on the same port) rejected every `/api/*` call as 401.

Fixes:
- `app/DuneServer.ps1` deletes any stale `last-url.txt` **before** spawning the polling jobs.
- The shutdown `finally` block now wipes `last-url.txt` **and** explicitly releases the single-instance mutex, rather than relying on OS process-exit cleanup.

## Test plan

- `PUT /api/commands/order` — verified end-to-end: GET → PUT → re-GET → POST reset.
- Stale-token race — verified by manually pre-seeding `last-url.txt` with a fake token, launching the EXE, confirming the file gets overwritten with the new fresh URL before the browser job reads it.
- Drag-reorder UX — verified in the browser via the hot-patched installed copy.