### PR TITLE
fix: TCP port-check rate-limit fallback (v6.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [6.1.5] - 2026-05-26
+
+Patch: **Public port-check now falls back to canyouseeme.org when
+yougetsignal.com rate-limits the request.**
+
+Fixed
+- **TCP Ports Open card showed "0/1" with status "unknown" for RabbitMQ
+  (31982) even when the port was actually open.** Root cause: the primary
+  port checker (yougetsignal.com) has a daily per-public-IP rate limit;
+  once hit, it returns the message `"Daily open port check limit reached
+  for <ip>..."` with a 200 status. The body didn't match the open/closed
+  regex, so the checker returned `unknown` and the dashboard counted it
+  as "not open". `app/server/lib/Ports.ps1` now:
+  - explicitly recognises the rate-limit response,
+  - falls back to `canyouseeme.org` (POST `port` + `IP` form fields)
+    when yougetsignal returns `ratelimit` or `unknown`,
+  - parses the canyouseeme verdict (`<b>Success:</b> I can see your
+    service` → open; `<b>Error:</b> I could not see...` → closed).
+
+
 ## [6.1.4] - 2026-05-26
 
 Patch: **drag-and-drop reorder on the Commands page**, plus a fix for a

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -6,7 +6,7 @@
 $ErrorActionPreference = 'Stop'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '6.1.4'
+$script:DuneToolVersion = '6.1.5'
 
 # ---------- Single-instance gate ----------------------------------------------
 # Every click of the desktop shortcut runs DuneServer.exe again. Without a

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -24,7 +24,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '6.1.4',
+    [string]$Version = '6.1.5',
     [switch]$Quiet
 )
 

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server"
-#define MyAppVersion "6.1.4"
+#define MyAppVersion "6.1.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Ports.ps1
+++ b/app/server/lib/Ports.ps1
@@ -21,21 +21,57 @@ function Get-DunePublicIp {
     return $null
 }
 
-function Test-DunePortBuiltin {
-    param([string]$PublicIp, [int]$Port, [string]$Protocol)
-    if ($Protocol -ne 'TCP') { return 'udp-skip' }
+function Test-DunePortYougetsignal {
+    param([string]$PublicIp, [int]$Port)
+    # Returns 'open' | 'closed' | 'ratelimit' | 'unknown'
     try {
         $resp = Invoke-WebRequest -Uri 'https://ports.yougetsignal.com/check-port.php' `
             -Method POST -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop `
             -Body @{ remoteAddress = $PublicIp; portNumber = "$Port" } `
             -Headers @{ 'User-Agent' = 'Mozilla/5.0 (dune-server-tool)' }
         $body = "$($resp.Content)"
-        if ($body -match '(?i)is\s+open|"open"\s*:\s*true')   { return 'open' }
+        if ($body -match '(?i)Daily\s+open\s+port\s+check\s+limit\s+reached') { return 'ratelimit' }
+        if ($body -match '(?i)is\s+open|"open"\s*:\s*true')                    { return 'open' }
         if ($body -match '(?i)is\s+(closed|not\s+visible|not\s+open)|"open"\s*:\s*false') { return 'closed' }
         return 'unknown'
     } catch {
         return 'unknown'
     }
+}
+
+function Test-DunePortCanYouSeeMe {
+    param([string]$PublicIp, [int]$Port)
+    # Fallback when yougetsignal rate-limits us. POSTs to canyouseeme.org and
+    # parses the success/error verdict line out of the response HTML.
+    try {
+        $resp = Invoke-WebRequest -Uri 'https://canyouseeme.org/' `
+            -Method POST -UseBasicParsing -TimeoutSec 12 -ErrorAction Stop `
+            -Body @{ port = "$Port"; IP = $PublicIp } `
+            -Headers @{
+                'User-Agent' = 'Mozilla/5.0 (dune-server-tool)'
+                'Referer'    = 'https://canyouseeme.org/'
+            }
+        $body = "$($resp.Content)"
+        if ($body -match '(?i)<b>Success:</b>.{0,80}I can see your service') { return 'open' }
+        if ($body -match '(?i)<b>Error:</b>.{0,80}(I could not see|connection refused|timed out)') { return 'closed' }
+        return 'unknown'
+    } catch {
+        return 'unknown'
+    }
+}
+
+function Test-DunePortBuiltin {
+    param([string]$PublicIp, [int]$Port, [string]$Protocol)
+    # No public UDP checker available across free services - mark as skipped
+    # and let the UI render "UDP - skipped" so the user knows to check manually.
+    if ($Protocol -ne 'TCP') { return 'udp-skip' }
+    # Primary: yougetsignal (fast, no referer dance). Falls through to
+    # canyouseeme.org when yougetsignal is rate-limited (per-public-IP daily
+    # cap; the response body says "Daily open port check limit reached for ...")
+    # or returns an unparseable body.
+    $s = Test-DunePortYougetsignal -PublicIp $PublicIp -Port $Port
+    if ($s -eq 'open' -or $s -eq 'closed') { return $s }
+    return Test-DunePortCanYouSeeMe -PublicIp $PublicIp -Port $Port
 }
 
 function Test-DunePortCustom {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "6.1.4"
+$script:ToolVersion = "6.1.5"
 
 # ============================================================
 #  CRASH / EXIT CLEANUP


### PR DESCRIPTION
yougetsignal.com daily rate-limit was reached on the host's public IP, returning `Daily open port check limit reached for <ip>` which our regex didn't match. Status fell through to `unknown`, dashboard rendered `0/1` open even though port 31982 was actually open.

## Changes
- `app/server/lib/Ports.ps1`: split builtin checker into `Test-DunePortYougetsignal` (primary) and new `Test-DunePortCanYouSeeMe` (fallback). `Test-DunePortBuiltin` now tries yougetsignal first; on `ratelimit` or `unknown` falls through to canyouseeme.org (POST + Referer header, parses Success / Error verdict).
- Version bumped to `6.1.5` across all 5 constants.
- CHANGELOG entry added.

## Smoke test
Hot-patched copy at `C:\Program Files\Dune Server` returned: `31982/TCP (RabbitMQ): open` on `/api/status/refresh` (Version 6.1.5).

