### PR TITLE
fix: mirror Max primed to Max active on Spicefields card (v6.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [6.1.6] - 2026-05-26
+
+Patch: **Max primed mirrors Max active on the Game Config / Spicefields card.**
+
+Changed
+- On the **Game Config → Spicefields** editor, changing **Max active**
+  now automatically sets **Max primed** to the same value. Max primed
+  remains independently editable afterward if you need to set it lower.
+
 ## [6.1.5] - 2026-05-26
 
 Patch: **Public port-check now falls back to canyouseeme.org when

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -6,7 +6,7 @@
 $ErrorActionPreference = 'Stop'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '6.1.5'
+$script:DuneToolVersion = '6.1.6'
 
 # ---------- Single-instance gate ----------------------------------------------
 # Every click of the desktop shortcut runs DuneServer.exe again. Without a

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -24,7 +24,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '6.1.5',
+    [string]$Version = '6.1.6',
     [switch]$Quiet
 )
 

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server"
-#define MyAppVersion "6.1.5"
+#define MyAppVersion "6.1.6"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "6.1.5"
+$script:ToolVersion = "6.1.6"
 
 # ============================================================
 #  CRASH / EXIT CLEANUP

--- a/webui/src/pages/gameconfig/SpicefieldsCard.tsx
+++ b/webui/src/pages/gameconfig/SpicefieldsCard.tsx
@@ -272,7 +272,7 @@ export function SpicefieldsCard({ vmRunning }: Props) {
 
                       <div className="grid grid-cols-2 md:grid-cols-[1fr_1fr_1fr_auto_auto] gap-3 items-end">
                         <NumField label="Max active" value={d.maxActive}
-                                  onChange={v => setDraft(r.spicefieldTypeId, { maxActive: v })} />
+                                  onChange={v => setDraft(r.spicefieldTypeId, { maxActive: v, maxPrimed: v })} />
                         <NumField label="Max primed" value={d.maxPrimed}
                                   onChange={v => setDraft(r.spicefieldTypeId, { maxPrimed: v })} />
                         <NumField label="Spawn weight" value={d.spawnWeight} step="0.1"


### PR DESCRIPTION
Small UX tweak requested by the maintainer: on the Game Config Spicefields card, typing in **Max active** now also fills **Max primed** with the same value. Max primed remains editable independently afterward in case the user wants a lower primed cap.

## Smoke test
Hot-patched copy reports version 6.1.6 and the mirroring works on the live editor.

