### PR TITLE
feat: Port-check mode dropdown - add yougetsignal-only + canyouseeme options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+Added
+- **Settings → Port-check mode** now offers two extra providers:
+  - `yougetsignal` — yougetsignal.com only (no canyouseeme fallback hop)
+  - `canyouseeme` — canyouseeme.org as the primary checker
+  Useful if either provider is rate-limiting your public IP and you
+  want to force the other one without waiting for the builtin fallback.
+
 ## [6.1.6] - 2026-05-26
 
 Patch: **Max primed mirrors Max active on the Game Config / Spicefields card.**

--- a/app/server/lib/Ports.ps1
+++ b/app/server/lib/Ports.ps1
@@ -118,10 +118,24 @@ function Get-DunePortStatus {
 
     $results = @()
     foreach ($p in $script:DuneRequiredPorts) {
-        $status = if ($mode -eq 'builtin') {
-            Test-DunePortBuiltin -PublicIp $pubIp -Port $p.Port -Protocol $p.Protocol
-        } else {
-            Test-DunePortCustom -Template $cfg.PortCheckUrlTemplate -PublicIp $pubIp -Port $p.Port -Protocol $p.Protocol
+        $status = switch ($mode) {
+            'canyouseeme' {
+                if ($p.Protocol -ne 'TCP') { 'udp-skip' }
+                else { Test-DunePortCanYouSeeMe -PublicIp $pubIp -Port $p.Port }
+            }
+            'yougetsignal' {
+                # Force primary-only (no canyouseeme fallback) for users who
+                # want to bypass the per-IP rate-limit fallback hop.
+                if ($p.Protocol -ne 'TCP') { 'udp-skip' }
+                else { Test-DunePortYougetsignal -PublicIp $pubIp -Port $p.Port }
+            }
+            'custom' {
+                Test-DunePortCustom -Template $cfg.PortCheckUrlTemplate -PublicIp $pubIp -Port $p.Port -Protocol $p.Protocol
+            }
+            default {
+                # 'builtin' (yougetsignal w/ canyouseeme fallback) — the default.
+                Test-DunePortBuiltin -PublicIp $pubIp -Port $p.Port -Protocol $p.Protocol
+            }
         }
         $results += @{ port = $p.Port; protocol = $p.Protocol; label = $p.Label; status = $status }
     }

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -20,7 +20,7 @@ const FIELDS: { key: string; label: string; placeholder: string; help?: string; 
     help: 'Used for desktop shortcut creation.' },
   { key: 'PortCheckMode',label: 'Port-check mode', placeholder: 'builtin',
     type: 'select',
-    help: 'builtin = yougetsignal.com (TCP only) · custom = your own URL · disabled = off' },
+    help: 'builtin = yougetsignal.com w/ canyouseeme.org fallback · yougetsignal = primary only (no fallback) · canyouseeme = canyouseeme.org only · custom = your own URL · disabled = off' },
   { key: 'PortCheckUrlTemplate', label: 'Port-check URL template',
     placeholder: 'https://example.com/check?ip={ip}&port={port}&protocol={protocol}',
     help: 'Used when mode is "custom". Tokens: {ip} {port} {protocol}' },
@@ -157,7 +157,9 @@ export function Settings() {
                 className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
               >
                 <option value="">(default: builtin)</option>
-                <option value="builtin">builtin — yougetsignal.com (TCP only)</option>
+                <option value="builtin">builtin — yougetsignal + canyouseeme fallback (TCP only)</option>
+                <option value="yougetsignal">yougetsignal.com — primary only, no fallback (TCP only)</option>
+                <option value="canyouseeme">canyouseeme.org — alternate provider (TCP only)</option>
                 <option value="custom">custom — your own URL template</option>
                 <option value="disabled">disabled — no port checks</option>
               </select>


### PR DESCRIPTION
Adds two extra options to the **Settings → Port-check mode** dropdown so users can pick the public port-check provider explicitly:

- `yougetsignal` — yougetsignal.com only (no canyouseeme fallback hop)
- `canyouseeme` — canyouseeme.org as the primary checker

Useful when either provider is rate-limiting a user's public IP and they want to force the alternate without going through the builtin's fallback wait.

Backend `Get-DunePortStatus` (`app/server/lib/Ports.ps1`) is refactored from an if/else to a switch on `` and gains the two new branches. `builtin` still means yougetsignal + canyouseeme fallback.

**Non-blocking** — merging to main; will ship with the next versioned release. No version bump in this PR.
