### PR TITLE
fix(v6.1.19): Settings page edits were silently dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ here cover everything those tags shipped.
 ## [Unreleased]
 
 
+## [6.1.19] - 2026-05-28
+
+Patch: **Fix Settings page silently dropping all configuration changes.**
+
+### Fixed
+- **Settings page edits were silently discarded.** Saving any field
+  (e.g. `DuneAdminExe`, `SteamPath`, `SshKey`, port-check mode) appeared
+  to succeed but the value reverted on the next load. Root cause: the
+  `PUT /api/config` handler treated the request body as a flat
+  hashtable when it was actually `{ values: { ... } }`, so the inner
+  values dict was passed straight to `Save-DuneConfig` whose key
+  whitelist then filtered out the lone `values` key — no fields ever
+  reached the persisted file. Handler now unwraps the `values` wrapper
+  first, then merges into the on-disk `dune-server.config`.
+
 ## [6.1.18] - 2026-05-27
 
 Patch: **dune-admin updater in Settings** + **Broadcasts shutdown fix**.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -61,7 +61,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '6.1.18'
+$script:DuneToolVersion = '6.1.19'
 
 # ---------- Single-instance gate ----------------------------------------------
 # Every click of the desktop shortcut runs DuneServer.exe again. Without a

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '6.1.18',
+    [string]$Version = '6.1.19',
     [switch]$Quiet
 )
 

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server"
-#define MyAppVersion "6.1.18"
+#define MyAppVersion "6.1.19"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/Simple-Dune-Server-Management-Tool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/routes/Config.ps1
+++ b/app/server/routes/Config.ps1
@@ -22,7 +22,12 @@ Register-DuneRoute -Method PUT -Path '/api/config' -Handler {
     }
     $patch = @{}
     if ($body -is [hashtable]) {
-        $patch = $body
+        # Frontend sends { values: { ... } }; older/alt callers send a flat hashtable.
+        if ($body.Contains('values') -and ($body['values'] -is [hashtable])) {
+            foreach ($k in $body['values'].Keys) { $patch[$k] = $body['values'][$k] }
+        } else {
+            foreach ($k in $body.Keys) { $patch[$k] = $body[$k] }
+        }
     } elseif ($body.values) {
         foreach ($k in $body.values.Keys) { $patch[$k] = $body.values[$k] }
     } else {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "6.1.18"
+$script:ToolVersion = "6.1.19"
 
 # ============================================================
 #  CRASH / EXIT CLEANUP


### PR DESCRIPTION
## v6.1.19 - Fix Settings page silently dropping all changes

### Fixed
- **Settings page edits were silently discarded.** Saving any field (`DuneAdminExe`, `SteamPath`, `SshKey`, `PortCheckMode`, etc.) appeared to succeed but the value reverted on the next page load. Root cause: `PUT /api/config` treated the request body as a flat hashtable when it was actually `{ values: { ... } }`, so the inner values dict was passed straight to `Save-DuneConfig` whose key whitelist then filtered out the lone `values` key - no fields ever reached the persisted file. Handler now unwraps the `values` wrapper first, then merges into `dune-server.config`.

Verified end-to-end via PUT /api/config + GET /api/config round-trip on the running build.