### PR TITLE
Fix Web Portal button silently dropping click (v10.1.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.1.10] - 2026-06-02
+
+### Fixed
+- **"Web Portal" sidebar button now actually opens the browser.** Clicking the
+  button in 10.1.9 set the server-side detach flag but the WebView2 host
+  silently dropped the "open URL and close" message — the React UI posts a JS
+  object via `chrome.webview.postMessage(obj)`, but the C# bridge was reading
+  it with `TryGetWebMessageAsString()`, which only succeeds for raw-string
+  payloads and throws (then swallowed) for objects. The bridge now reads
+  `WebMessageAsJson` first and falls back to the string accessor, so both
+  object and stringified payloads work and the app window closes + the
+  default browser opens to the live portal URL as intended.
+
 ## [10.1.9] - 2026-06-02
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.1.9'
+$script:DuneToolVersion = '10.1.10'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.1.9',
+    [string]$Version = '10.1.10',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.1.9</Version>
+    <Version>10.1.10</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -205,15 +205,45 @@ internal sealed class MainForm : Form
         string? url = null;
         try
         {
-            // The portal sends a JSON object via postMessage(obj); WebView2
-            // serializes that into TryGetWebMessageAsString().
-            string json = e.TryGetWebMessageAsString();
-            if (string.IsNullOrWhiteSpace(json)) return;
+            // The portal sends a JS object via postMessage(obj). For non-string
+            // payloads WebView2 exposes the serialized JSON on WebMessageAsJson;
+            // TryGetWebMessageAsString() throws InvalidOperationException for
+            // object payloads (it only succeeds when JS posts a raw string).
+            string? json = e.WebMessageAsJson;
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                // Fallback: a caller that posts a JSON *string* (e.g.
+                // postMessage(JSON.stringify(obj))) — read the inner string and
+                // re-parse it. Wrapped in try/catch so a plain-text payload
+                // doesn't blow up the handler.
+                try { json = e.TryGetWebMessageAsString(); } catch { return; }
+                if (string.IsNullOrWhiteSpace(json)) return;
+            }
             using var doc = System.Text.Json.JsonDocument.Parse(json);
             var root = doc.RootElement;
-            if (root.ValueKind != System.Text.Json.JsonValueKind.Object) return;
-            if (root.TryGetProperty("action", out var a)) action = a.GetString();
-            if (root.TryGetProperty("url",    out var u)) url    = u.GetString();
+
+            // Unwrap one layer of string-encoded JSON if the caller stringified
+            // before posting. WebMessageAsJson returns "\"{\\\"action\\\"...}\""
+            // in that case, which parses to a JSON string, not an object.
+            if (root.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                string inner = root.GetString() ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(inner)) return;
+                using var inner_doc = System.Text.Json.JsonDocument.Parse(inner);
+                var inner_root = inner_doc.RootElement;
+                if (inner_root.ValueKind != System.Text.Json.JsonValueKind.Object) return;
+                if (inner_root.TryGetProperty("action", out var ia)) action = ia.GetString();
+                if (inner_root.TryGetProperty("url",    out var iu)) url    = iu.GetString();
+            }
+            else if (root.ValueKind == System.Text.Json.JsonValueKind.Object)
+            {
+                if (root.TryGetProperty("action", out var a)) action = a.GetString();
+                if (root.TryGetProperty("url",    out var u)) url    = u.GetString();
+            }
+            else
+            {
+                return;
+            }
         }
         catch
         {

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.1.9"
+#define MyAppVersion "10.1.10"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"


### PR DESCRIPTION
## Hotfix for 10.1.9 Web Portal button

10.1.9's sidebar **Web Portal** button looked like it did nothing: the confirm dialog appeared, the user clicked **Open in browser**, the request to `/api/portal/open-in-browser` succeeded (server-side detach flag was set), but the app window never closed and no browser opened.

### Root cause

The React UI posts a JS object:

```ts
wv.postMessage({ action: 'open-and-close', url: r.url })
```

The C# bridge in `MainForm.cs` was reading it as a string:

```csharp
string json = e.TryGetWebMessageAsString();
```

`TryGetWebMessageAsString()` only succeeds when JS posts a **raw string**. For object payloads it throws `InvalidOperationException`, which the `catch` block swallowed — so the handler returned without opening the browser or closing the window.

### Fix

Read `WebMessageAsJson` first (which is populated for object payloads), and fall back to `TryGetWebMessageAsString()` for the string-payload case. Also unwrap one layer of string-encoded JSON in case any caller stringifies before posting.

### Verified

- `dotnet build -c Release` clean (no warnings/errors).
- `app/installer/Build-Installer.ps1` produces a fresh `DuneServerSetup.exe` (45.27 MB) at v10.1.10.

Version bumped across `DuneServer.ps1`, `Build-Exe.ps1`, `DuneServer.iss`, `DuneShell.csproj`, and CHANGELOG.