### PR TITLE
Render Web Portal confirm dialog in body portal, stack buttons (v10.1.10 re-roll)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ here cover everything those tags shipped.
   `WebMessageAsJson` first and falls back to the string accessor, so both
   object and stringified payloads work and the app window closes + the
   default browser opens to the live portal URL as intended.
+- **"Open in web browser" confirm dialog was clipped off-screen.** The dialog
+  is rendered inside the sidebar `<aside>`, which uses `backdrop-blur` —
+  applying a `backdrop-filter` to an element makes it a containing block for
+  `position: fixed` descendants, so the modal centered itself inside the
+  240px sidebar instead of the viewport and the **Cancel** button was cut
+  off at the screen edge. The dialog is now mounted at `document.body` via a
+  React portal so it centers in the viewport regardless of sidebar styling.
+- **Dialog buttons are now stacked full-width** (primary on top, Cancel
+  below) so they read cleanly on narrow layouts.
 
 ## [10.1.9] - 2026-06-02
 

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { NavLink } from 'react-router-dom'
 import { useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Icon } from '../components/Icon'
 import { NAV_ITEMS, GROUP_LABELS } from '../nav'
 import { useUpdateCheck } from '../hooks/useUpdateCheck'
@@ -170,7 +171,7 @@ export function Sidebar() {
         </div>
       </div>
 
-      {showPortalConfirm && (
+      {showPortalConfirm && createPortal(
         <div
           className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4"
           onClick={() => { if (!portalDetaching) setShowPortalConfirm(false) }}
@@ -197,25 +198,26 @@ export function Sidebar() {
                 {portalError}
               </div>
             )}
-            <div className="mt-4 flex justify-end gap-2">
+            <div className="mt-4 flex flex-col gap-2">
               <button
-                className="btn-secondary"
-                onClick={() => setShowPortalConfirm(false)}
-                disabled={portalDetaching}
-              >
-                <Icon name="X" size={12} /> Cancel
-              </button>
-              <button
-                className="btn-primary"
+                className="btn-primary w-full justify-center"
                 onClick={() => { void onOpenWebPortal() }}
                 disabled={portalDetaching}
               >
                 <Icon name={portalDetaching ? 'Loader2' : 'ExternalLink'} size={12} className={portalDetaching ? 'animate-spin' : ''} />
                 {portalDetaching ? 'Opening…' : 'Open in browser'}
               </button>
+              <button
+                className="btn-secondary w-full justify-center"
+                onClick={() => setShowPortalConfirm(false)}
+                disabled={portalDetaching}
+              >
+                <Icon name="X" size={12} /> Cancel
+              </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </aside>
   )


### PR DESCRIPTION
## Re-roll of v10.1.10

10.1.10 still had a visible bug in the Web Portal confirm dialog: the **Cancel** button was clipped off-screen because the modal was rendering inside the sidebar's bounds, not the viewport.

### Root cause

The sidebar `<aside>` uses `backdrop-blur-md` (i.e. `backdrop-filter`). Per the CSS spec, applying `backdrop-filter` to an element makes it a **containing block for `position: fixed` descendants**. So the modal — declared with `fixed inset-0` — was centered inside the 240px sidebar instead of the viewport. At `max-w-md` (448px) the dialog couldn't fit in 240px and the Cancel button hung off the left edge of the screen.

### Fix

- Mount the dialog at `document.body` via `react-dom`'s `createPortal`. That escapes the sidebar's containing block and the `fixed inset-0` overlay now correctly fills the viewport.
- Stack the two action buttons full-width (primary on top, Cancel below) so they read cleanly even on narrower windows.

### Release plan

The user wants this **re-rolled into v10.1.10** rather than bumped to 10.1.11. After merge:
1. Delete the existing `v10.1.10` tag + GitHub release
2. Re-tag `v10.1.10` at the new main HEAD
3. Re-publish the release with the freshly-built installer

### Verified

- `tsc -b` clean
- `app/installer/Build-Installer.ps1` produces a fresh 45.28 MB `DuneServerSetup.exe` at v10.1.10