### PR TITLE
Fix #38: surface SSH failure reason instead of a bare "Unknown" battlegroup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,13 +18,24 @@ labels: bug
 
 ## Where in the tool
 
-<!-- Pick the closest: Dashboard / Monitoring / Terminal / Characters /
-     Game Config / Database / Settings / Setup Wizard / Additional Sietches /
+<!-- Pick the closest: Dashboard / Server Health / Monitoring / Terminal /
+     Characters / Game Config / Database / Settings / Setup Wizard /
+     Additional Sietches / "Battlegroup shows Unknown / can't connect to VM" /
      CLI (dune-server.ps1) / Installer / Update checker -->
+
+## Connection / VM status message (only if your bug involves the VM / SSH / battlegroup)
+
+<!-- The tool tells you WHY it can't reach the battlegroup. Copy the exact text:
+     - Dashboard → "Battlegroup + VM" card: the yellow line under the status
+       (e.g. "SSH key is passphrase-protected…", "VM rejected the SSH key…").
+     - Setup Wizard / Settings → "Re-run checks": the "SSH key authorized on VM" row.
+     - Settings → SSH Key field: the key path the tool is using.
+     Also note: does the in-app "Open an SSH terminal to the VM" (Commands / CLI
+     option 17) still connect even though the Dashboard shows Unknown? -->
 
 ## Environment
 
-- Tool version (header bar `Installed: x.y.z`, or `$script:ToolVersion` in `dune-server.ps1`):
+- Tool version (header bar `Installed: x.y.z`, bottom-left of the web portal sidebar, or CLI menu header):
 - Windows version:
 - PowerShell version (`$PSVersionTable.PSVersion`):
 - WebView2 runtime (if desktop app):

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,12 +14,25 @@ body:
         the PowerShell script (`dune-server.ps1`), the `.bat`
         launcher, and the installer.
 
+        **✅ Do open an issue here** when the tool shows you a problem, e.g.:
+        - The **Dashboard** shows the battlegroup as **Unknown** with a yellow
+          message under it (SSH key / connection diagnostics).
+        - The **Setup Wizard / preflight** "SSH key authorized on VM" check
+          fails, or any other preflight check is wrong.
+        - **Server Health**, **Game Config**, **Database**, **Characters**, a
+          button, page, or the terminal pane misbehaves.
+
+        > 💡 The tool now explains *why* it can't reach the VM. If you see one of
+        > those yellow messages, copy it into the **Connection / VM status
+        > message** box below — that's usually all we need to pinpoint it.
+
         **Please do _not_ open issues here for:**
-        - VM connectivity / SSH / network / port-forwarding problems
-        - Hyper-V configuration or performance tuning
+        - Raw network / router / port-forwarding setup where the **tool itself
+          shows no message** (ping `@allcoast` on Discord instead).
+        - Hyper-V configuration or performance tuning.
         - Funcom dedicated-server bugs (game crashes, missing pods,
-          `battlegroup` CLI errors that aren't caused by this tool)
-        - General "how do I play / host" questions
+          `battlegroup` CLI errors that aren't caused by this tool).
+        - General "how do I play / host" questions.
 
         For those, ping `@allcoast` on Discord or check the
         [Funcom Self-Hosted Server docs](https://duneawakening.com/self-hosted-servers/).
@@ -30,9 +43,9 @@ body:
     id: scope
     attributes:
       label: Scope check
-      description: Please confirm this is actually a bug in the tool's code.
+      description: Please confirm this is about the tool, not a raw Funcom/network problem.
       options:
-        - label: This is a bug in the tool itself (app crashes, a page misrenders, a button does nothing, terminal pane broken, setup wizard fails, character/database/game-config edits don't save, etc.) — **not** a VM/network/Funcom-server issue.
+        - label: This is about the tool — the app/CLI itself misbehaves, **or** the tool shows me an error/diagnostic message (e.g. the Dashboard battlegroup status, a Setup "SSH key" check, Server Health). It is **not** a pure Funcom game-server crash or router/port-forwarding question with no tool message.
           required: true
 
   - type: input
@@ -51,6 +64,7 @@ body:
       description: Which part of the tool was affected? Pick the closest match.
       options:
         - Web portal — Dashboard / Server Health
+        - Web portal — Battlegroup shows "Unknown" / tool can't connect to the VM (SSH)
         - Web portal — Monitoring
         - Web portal — Commands
         - Web portal — PowerShell pane
@@ -100,6 +114,48 @@ body:
       label: What you expected to happen
     validations:
       required: true
+
+  - type: textarea
+    id: connection_diag
+    attributes:
+      label: Connection / VM status message (only if your bug involves the VM / SSH / battlegroup)
+      description: |
+        The tool now tells you **why** it can't reach the battlegroup — copy the
+        exact message it shows. Where to find each piece (skip what doesn't apply):
+
+        - **Dashboard → "Battlegroup + VM" card:** the yellow line under the
+          status (e.g. *"SSH key is passphrase-protected…"*, *"VM rejected the
+          SSH key…"*, *"Battlegroup not started…"*, *"VM is not answering SSH
+          yet…"*). Also shown under **Battlegroup info**.
+        - **Setup Wizard / Settings → "Re-run checks":** paste the detail text
+          from the **"SSH key authorized on VM"** row.
+        - **Settings → SSH Key field:** the path to the key the tool is using.
+
+        Leave blank if your bug has nothing to do with the VM/SSH.
+      placeholder: |
+        Dashboard message: "SSH key is passphrase-protected, so background checks can't use it…"
+        Setup "SSH key authorized on VM": "The VM rejected this key…"
+        SSH Key path (Settings): C:\Users\me\.ssh\dune_key
+      render: shell
+    validations:
+      required: false
+
+  - type: dropdown
+    id: ssh_interactive
+    attributes:
+      label: Does an interactive SSH terminal still work?
+      description: |
+        Only relevant for VM/SSH bugs. Open **Commands → "Open an SSH terminal to
+        the VM"** (CLI option `17`/`ssh`) and see if it connects. This single
+        answer tells us apart a passphrase-protected key (works here, fails the
+        dashboard) from a key the VM never authorized (fails everywhere).
+      options:
+        - Not applicable — my bug isn't about VM/SSH connectivity
+        - "Yes — the interactive SSH terminal connects, but the Dashboard still shows Unknown"
+        - No — the interactive SSH terminal also fails
+        - Haven't tried
+    validations:
+      required: false
 
   - type: textarea
     id: transcript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.1.11] - 2026-06-03
+
+### Fixed
+- **Battlegroup no longer shows a bare "Unknown" when SSH fails — the Dashboard
+  now tells you _why_.** The status snapshot runs `battlegroup status` over a
+  non-interactive (`BatchMode=yes`) SSH session. Previously, if that SSH call
+  failed (auth rejected, key passphrase-protected, VM still booting) the error
+  was swallowed (`LogLevel=QUIET`, stderr merged into stdout) and the UI just
+  showed **Unknown** with no explanation. `Get-DuneBattlegroupSnapshot` now
+  captures ssh's stderr separately, checks the exit code, and surfaces an
+  actionable `reason` that the Dashboard already renders under the battlegroup
+  status. (coastal-ms/DST-DuneServerTool#38)
+- **Passphrase-protected SSH keys are now detected and called out.** This is the
+  classic "I can open an SSH terminal and restart the battlegroup, but the
+  dashboard / Server Health / game-data all show nothing" trap: an interactive
+  SSH session can prompt for the key passphrase, but the tool's background
+  checks run non-interactively and can't. The Setup preflight **"SSH key
+  authorized on VM"** check and the Dashboard status message now explicitly say
+  the key is passphrase-protected and how to fix it (Rotate SSH Key, or
+  `ssh-keygen -p`). New helpers `Test-DuneSshKeyEncrypted` and
+  `Get-DuneSshFailureReason` in `app/server/lib/Status.ps1`.
+
+### Changed
+- **Bug-report template (the in-app **?** help button) now covers VM/SSH
+  diagnostics and tells you exactly where to find them.** The template used to
+  tell users *not* to report any SSH/VM-connectivity problem — which hid the
+  very class of issue the tool now diagnoses. It now: (1) says to report when the
+  Dashboard shows the battlegroup as **Unknown** with a message or the Setup
+  "SSH key" check fails; (2) adds a **Connection / VM status message** field with
+  step-by-step "where to find it" pointers (Dashboard card, Setup "Re-run
+  checks", Settings → SSH Key); and (3) adds a one-click **"Does an interactive
+  SSH terminal still work?"** question that distinguishes a passphrase-protected
+  key from an unauthorized one. The CLI `report-issue` wording and the legacy
+  Markdown template were updated to match.
+
 ## [10.1.10] - 2026-06-02
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.1.10'
+$script:DuneToolVersion = '10.1.11'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.1.10',
+    [string]$Version = '10.1.11',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.1.10</Version>
+    <Version>10.1.11</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.1.10"
+#define MyAppVersion "10.1.11"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Setup.ps1
+++ b/app/server/lib/Setup.ps1
@@ -151,11 +151,20 @@ function Get-DuneSetupPreflight {
                 }
                 elseif ($sshErr -match 'Permission denied|no supported methods|authentication fail|publickey') {
                     $pubPath = "$keyPath.pub"
-                    $checks.Add(@{
-                        key = 'sshkey'; label = 'SSH key authorized on VM'; ok = $false; severity = 'warning'
-                        detail = "The VM rejected this key (its public half isn't in dune@${ip}:~/.ssh/authorized_keys). This usually means a new key was generated outside the tool. Fix it one of two ways: (A) generate a properly-authorized key with the tool's Rotate SSH Key action (VM menu, key 'g'), or (B) if another key already has working SSH access, authorize this one with the command below."
-                        fix    = "Run from a machine that already has working SSH access (replace <working-key>):`ntype `"$pubPath`" | ssh -i `"<working-key>`" dune@$ip `"cat >> ~/.ssh/authorized_keys`""
-                    }) | Out-Null
+                    if ((Test-DuneSshKeyEncrypted -KeyPath $keyPath) -eq $true) {
+                        $checks.Add(@{
+                            key = 'sshkey'; label = 'SSH key authorized on VM'; ok = $false; severity = 'warning'
+                            detail = "This SSH key is passphrase-protected, so the tool can't use it for background checks (battlegroup status, server health, game data) — those run non-interactively and can't answer a passphrase prompt. An interactive SSH terminal still works because it can prompt you, which is why the VM looks reachable while the dashboard shows Unknown. Fix it with the Rotate SSH Key action (VM menu, key 'g') to generate a passphrase-less key, or strip the passphrase from this one."
+                            fix    = "Remove the passphrase from the existing key (press Enter when asked for the new passphrase to leave it empty):`nssh-keygen -p -f `"$keyPath`""
+                        }) | Out-Null
+                    }
+                    else {
+                        $checks.Add(@{
+                            key = 'sshkey'; label = 'SSH key authorized on VM'; ok = $false; severity = 'warning'
+                            detail = "The VM rejected this key (its public half isn't in dune@${ip}:~/.ssh/authorized_keys). This usually means a new key was generated outside the tool. Fix it one of two ways: (A) generate a properly-authorized key with the tool's Rotate SSH Key action (VM menu, key 'g'), or (B) if another key already has working SSH access, authorize this one with the command below."
+                            fix    = "Run from a machine that already has working SSH access (replace <working-key>):`ntype `"$pubPath`" | ssh -i `"<working-key>`" dune@$ip `"cat >> ~/.ssh/authorized_keys`""
+                        }) | Out-Null
+                    }
                 }
                 else {
                     $checks.Add(@{

--- a/app/server/lib/Status.ps1
+++ b/app/server/lib/Status.ps1
@@ -2,6 +2,50 @@
 
 $script:DuneVmName = 'dune-awakening'
 
+# Detect whether an SSH private key file is passphrase-protected (encrypted).
+# Returns $true / $false, or $null when it can't be determined (file missing,
+# ssh-keygen unavailable). `ssh-keygen -y -P ''` prints the public key for an
+# unencrypted key (exit 0) and fails with an "incorrect passphrase" error for an
+# encrypted one — this works for both PEM and modern OpenSSH key formats.
+function Test-DuneSshKeyEncrypted {
+    param([string]$KeyPath)
+    if (-not $KeyPath -or -not (Test-Path -LiteralPath $KeyPath)) { return $null }
+    try {
+        $out  = & ssh-keygen -y -P '' -f $KeyPath 2>&1
+        $code = $LASTEXITCODE
+        if ($code -eq 0) { return $false }
+        $text = ($out | Out-String)
+        if ($text -match '(?im)incorrect passphrase|passphrase') { return $true }
+        return $null
+    } catch { return $null }
+}
+
+# Translate a raw `ssh` stderr blob + exit code into an actionable reason string
+# the UI can show. Returns $null when there's nothing useful to say.
+function Get-DuneSshFailureReason {
+    param([string]$Stderr, [int]$ExitCode, [string]$KeyPath)
+    $err = ($Stderr | Out-String).Trim()
+
+    # Authentication rejected: either the key isn't authorized on the VM, or it's
+    # a passphrase-protected key that can't be unlocked in BatchMode. The latter
+    # is the classic "interactive SSH works but the dashboard shows Unknown" trap.
+    if ($err -match '(?im)Permission denied|no supported authentication|authentication fail|publickey') {
+        if ((Test-DuneSshKeyEncrypted -KeyPath $KeyPath) -eq $true) {
+            return "SSH key is passphrase-protected, so background checks (battlegroup status, server health, game data) can't use it — they run non-interactively and can't answer a passphrase prompt. An interactive SSH terminal still works because it can prompt you. Fix it with the Rotate SSH Key action (VM menu, key 'g'), or strip the passphrase: ssh-keygen -p -f `"$KeyPath`""
+        }
+        return "VM rejected the SSH key (its public half isn't in dune@VM:~/.ssh/authorized_keys). Run the Rotate SSH Key action (VM menu, key 'g') to generate and authorize a fresh key."
+    }
+    if ($err -match '(?im)Connection timed out|Connection refused|No route to host|Operation timed out|timed out|Could not resolve') {
+        return 'VM is not answering SSH yet — it may still be booting. This clears once the battlegroup is up.'
+    }
+    if ($err -match '(?im)Host key verification failed') {
+        return 'SSH host key verification failed for the VM. Remove the stale entry from known_hosts and retry.'
+    }
+    if ($err) { return "Couldn't get battlegroup status over SSH: $err" }
+    if ($ExitCode -ne 0) { return "Battlegroup status command failed over SSH (exit $ExitCode)." }
+    return $null
+}
+
 function Get-DuneVmStatus {
     try {
         $vm = Get-VM -Name $script:DuneVmName -ErrorAction Stop
@@ -44,17 +88,48 @@ function Get-DuneBattlegroupSnapshot {
     }
 
     try {
-        $raw = & ssh -o StrictHostKeyChecking=no -o LogLevel=QUIET `
-                     -o ConnectTimeout=10 -o BatchMode=yes `
-                     -i $sshKey "dune@$($vm.ip)" '/home/dune/.dune/bin/battlegroup status' 2>&1 |
-               ForEach-Object {
-                   if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ }
-               }
-        $text = ($raw | Out-String).TrimEnd()
-        $text = $text -replace "`e\[[0-9;]*[A-Za-z]", ''
+        # Run the status command over a non-interactive (BatchMode) SSH session.
+        # Capture stderr separately so a real SSH failure (auth / connection)
+        # can be surfaced as a clear reason instead of collapsing into a blank
+        # "Unknown" state. LogLevel=ERROR (not QUIET) lets ssh's own diagnostics
+        # through to the error file.
+        $errFile = [System.IO.Path]::GetTempFileName()
+        try {
+            $raw = & ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR `
+                         -o ConnectTimeout=10 -o BatchMode=yes `
+                         -i $sshKey "dune@$($vm.ip)" '/home/dune/.dune/bin/battlegroup status' 2>$errFile
+            $exit   = $LASTEXITCODE
+            $sshErr = if (Test-Path $errFile) { Get-Content -Raw -ErrorAction SilentlyContinue $errFile } else { '' }
+        } finally {
+            Remove-Item $errFile -ErrorAction SilentlyContinue
+        }
+
+        # `battlegroup status` (a kubectl wrapper) can write status-shaped text —
+        # notably the empty-namespace "No resources found" stopped signal — to
+        # *stderr* rather than stdout, so detect/parse against both streams to
+        # avoid regressing the stopped/running classification.
+        $stdoutText = ($raw    | Out-String).TrimEnd()
+        $stderrText = ($sshErr | Out-String).TrimEnd()
+        $combined   = (@($stdoutText, $stderrText) | Where-Object { $_ }) -join "`n"
+        $combined   = $combined -replace "`e\[[0-9;]*[A-Za-z]", ''
+        $result.exitCode = $exit
+
+        # A non-zero exit with no status-shaped output (on either stream) means
+        # SSH itself failed — surface *why* (passphrase-protected key, unauthorized
+        # key, VM still booting) rather than silently reporting "Unknown".
+        $looksLikeStatus = $combined -match '(?im)Battlegroup|No resources found|STATUS\s*:'
+        $text = if ($looksLikeStatus) { $combined } else { $stdoutText }
+        if ($exit -ne 0 -and -not $looksLikeStatus) {
+            $result.available = $false
+            $result.state     = 'unknown'
+            $result.output    = $text
+            $reason           = Get-DuneSshFailureReason -Stderr $sshErr -ExitCode $exit -KeyPath $sshKey
+            $result.reason    = if ($reason) { $reason } else { 'Could not reach the battlegroup over SSH.' }
+            return $result
+        }
+
         $result.available = $true
         $result.output    = $text
-        $result.exitCode  = $LASTEXITCODE
         $result.state     = Get-BgStateFromStatusText -Text $text
         if ($result.state -eq 'stopped' -and $text -match '(?im)No resources found in .* namespace') {
             $result.reason = 'Battlegroup not started (namespace is empty).'

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -2209,9 +2209,12 @@ while ($true) {
         Write-Host ""
         Write-Host "=== Report an Issue ===" -ForegroundColor Cyan
         Write-Host "  Opening a prefilled bug report in your browser." -ForegroundColor DarkGray
-        Write-Host "  This tracker is for bugs in the TOOL ITSELF -" -ForegroundColor Yellow
-        Write-Host "  not for VM connectivity, Hyper-V, port forwarding, or Funcom server issues." -ForegroundColor Yellow
-        Write-Host "  For those, ping @allcoast on Discord." -ForegroundColor DarkGray
+        Write-Host "  This tracker is for bugs in the TOOL ITSELF (the app/CLI)," -ForegroundColor Yellow
+        Write-Host "  including the diagnostics it shows you (Dashboard battlegroup" -ForegroundColor Yellow
+        Write-Host "  status, Setup 'SSH key' checks, Server Health). If you see one" -ForegroundColor Yellow
+        Write-Host "  of those messages, copy it into the report." -ForegroundColor Yellow
+        Write-Host "  Not for raw router/port-forwarding or Funcom game-server issues -" -ForegroundColor Yellow
+        Write-Host "  for those, ping @allcoast on Discord." -ForegroundColor DarkGray
         Write-Host ""
 
         # GitHub issue forms accept URL params keyed by the input id in the


### PR DESCRIPTION
Fixes #38.

## Problem
The Dashboard ran `battlegroup status` over a non-interactive (`BatchMode=yes`) SSH session. When that SSH call failed — auth rejected, **key passphrase-protected**, or the VM still booting — the old code swallowed the error (`LogLevel=QUIET`, stderr merged into stdout, `available` always `$true`, `reason` never set), so the UI just showed the battlegroup as **Unknown** with no explanation. Server Health / Game Config behave the same way.

This is the classic *"I can open an SSH terminal and restart the battlegroup, but the dashboard shows nothing"* trap: an **interactive** SSH session can prompt for the key passphrase, but the tool's **background** checks run non-interactively and can't — so they silently fail.

## Changes
- **`app/server/lib/Status.ps1` — `Get-DuneBattlegroupSnapshot`:** capture ssh stderr separately (`LogLevel=ERROR`), check `$LASTEXITCODE`, and on a real SSH failure set `available=$false` + a populated, actionable `reason` (already rendered by `Dashboard.tsx`). Status detection/parsing now reads **both stdout+stderr** so the empty-namespace *stopped* signal (`No resources found…`, which kubectl can emit on stderr) isn't misclassified as an error.
- **New helpers** `Test-DuneSshKeyEncrypted` (via `ssh-keygen -y -P ''`) and `Get-DuneSshFailureReason` (maps ssh stderr + exit + key path → a fix), with explicit detection of a passphrase-protected key.
- **`app/server/lib/Setup.ps1`** preflight: the *"SSH key authorized on VM"* check now calls out a passphrase-protected key specifically (with `ssh-keygen -p` / Rotate SSH Key remedies).
- **Issue template** (`bug_report.yml`, the in-app **?** help button target), the legacy `.md`, and the CLI `report-issue` wording: VM/SSH diagnostics are now *reportable* (the old template told users **not** to report them — hiding the exact class the tool now diagnoses), with step-by-step "where to find it" pointers (Dashboard card, Setup → Re-run checks, Settings → SSH Key) and a one-click "does interactive SSH still work?" question.
- **Version** bumped `10.1.10` → `10.1.11` across the 4 synced constants + CHANGELOG.

## Validation
- New helpers unit-tested against real encrypted vs. plain `ed25519` keys and every `stderr → reason` mapping.
- Gating logic simulated for: stopped-on-stderr (exit 0 **and** non-zero), auth failure, timeout, running — all classify correctly.
- All `.ps1` parse-validate; `bug_report.yml` is valid YAML; PSScriptAnalyzer shows only pre-existing warnings.

> Note: this ships the diagnostics + passphrase detection. Cutting the tagged `DuneServerSetup*.exe` release that the in-app auto-updater consumes is the separate manual publish step.