### PR TITLE
v10.1.13: Fix silent 'up to date' when release has no installer asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,71 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.1.13] - 2026-06-03
+
+### Fixed
+- **In-app updater no longer silently reports "up to date" when a newer
+  release has no installer attached.** Previously the `available` flag on
+  `/api/update/check` was gated on **both** "newer tag exists" **and** "a
+  `DuneServerSetup.exe` asset is uploaded to the release." If a release was
+  ever published without the installer asset (as v10.1.12 was), the UI
+  flipped to a green **up to date** pill and the update banner stayed
+  hidden, even though a newer tag was live on GitHub. That bug now has two
+  fixes layered on top of each other:
+  1. `available` now means "newer release exists" - asset-independent.
+  2. A new `installable` flag is the strict version (newer tag **and**
+     installer asset present). The Update banner and Settings card use
+     `installable` to decide between an in-app **Update now / Update to X**
+     button and a **View release** link that opens the release page in a
+     new tab. The header pill still flips to amber **X (N.N) available**
+     either way - so the user always knows there's an update.
+- **MapSpinUp fix from v10.1.12 carried forward** (see [10.1.12] entry for
+  the full root-cause writeup). v10.1.12 was tagged but shipped without an
+  installer asset and without the version-stamp bumps in the four release
+  files, so the auto-updater couldn't deliver it. v10.1.13 ships both the
+  MapSpinUp fix and the updater-honesty fix together, with a proper
+  installer attached.
+
+### Changed
+- Release-readiness rule (now enforced by checklist): **every** DST GitHub
+  release must upload `DuneServerSetup.exe` as its sole asset. Code-only
+  releases are forbidden - the asset-less v10.1.12 broke this rule and
+  triggered the silent "up to date" regression above.
+- `Build-Installer.ps1` now runs a **version-stamp sync check** before any
+  of the long build steps. It reads the five files that must agree
+  (`dune-server.ps1`, `app\DuneServer.ps1`, `app\build\Build-Exe.ps1`,
+  `app\installer\DuneServer.iss`, `app\desktop\DuneShell\DuneShell.csproj`)
+  and aborts the build with a per-file listing if they disagree. This is
+  what should have caught the v10.1.12 mistake (forgotten stamp bumps).
+  Pass `-SkipVersionCheck` for deliberate intermediate test builds.
+- `app\server\routes\Update.ps1` asset detection is now strict: requires
+  an asset named exactly `DuneServerSetup.exe`. The old `*.exe` fallback
+  was removed - it masked malformed releases and conflicts with the
+  one-asset rule.
+
+## [10.1.12] - 2026-06-03
+
+> **Note:** v10.1.12 was tagged and a GitHub release was published, but
+> the release was missing its `DuneServerSetup.exe` asset and the four
+> version-stamp files were never bumped from `10.1.11`. As a result the
+> in-app auto-updater couldn't deliver this version and the UI showed
+> "up to date" while v10.1.12 was the latest release. The fix it contained
+> has been carried forward into v10.1.13, which ships with a working
+> installer. **Use v10.1.13 instead.**
+
+### Fixed
+- **MapSpinUp no longer no-ops on DeepDesert_1, SH_Arrakeen, and
+  SH_HarkoVillage after the Funcom director image update
+  (`1973075-0-shipping` → `1979201-0-shipping`).** The new director only
+  honors `MinServers = N` when the same section also contains
+  `EnableAutomaticInstanceScaling = true`. Funcom ships that flag on the
+  Story/DLC sections but not on Deep Desert or the Sietches. DST now
+  writes both keys together on spin-up (and only drops `MinServers` on
+  spin-down, leaving the auto-scaling flag in place so travel-to spawn
+  still works). `MinServers` is now strictly validated to `0` or `1` and
+  written with no spaces (Funcom-strict format).
+  (coastal-ms/DST-DuneServerTool#44)
+
 ## [10.1.11] - 2026-06-03
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.1.11'
+$script:DuneToolVersion = '10.1.13'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.1.11',
+    [string]$Version = '10.1.13',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.1.11</Version>
+    <Version>10.1.13</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/Build-Installer.ps1
+++ b/app/installer/Build-Installer.ps1
@@ -12,6 +12,7 @@ param(
     [switch]$SkipExeBuild,
     [switch]$SkipWebBuild,
     [switch]$SkipShellBuild,
+    [switch]$SkipVersionCheck,
     [switch]$Open
 )
 
@@ -25,6 +26,54 @@ $iss        = Join-Path $appRoot 'installer\DuneServer.iss'
 $exePath    = Join-Path $appRoot 'build\output\DuneServer.exe'
 $outDir     = Join-Path $appRoot 'installer\output'
 $installer  = Join-Path $outDir 'DuneServerSetup.exe'
+
+# ---------------------------------------------------------------------------
+# Pre-flight: version-stamp sync check.
+#
+# DST keeps the release version in FIVE files that must all match. Historically
+# this was a manual procedure and at least once (v10.1.12) someone forgot to
+# bump them, so the installer reported the prior version's number and the
+# auto-updater couldn't deliver the release. Catch that before doing any of
+# the long build steps below.
+#
+# If the stamps disagree, abort with a clear listing. To override (e.g. for
+# a deliberate intermediate test build), pass `-SkipVersionCheck`.
+# ---------------------------------------------------------------------------
+$versionFiles = @(
+    @{ Path = Join-Path $repoRoot 'dune-server.ps1';                 Pattern = '\$script:ToolVersion\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"';     Label = '$script:ToolVersion' },
+    @{ Path = Join-Path $appRoot  'DuneServer.ps1';                  Pattern = "\`$script:DuneToolVersion\s*=\s*'([0-9]+\.[0-9]+\.[0-9]+)'"; Label = '$script:DuneToolVersion' },
+    @{ Path = Join-Path $appRoot  'build\Build-Exe.ps1';             Pattern = "\[string\]\`$Version\s*=\s*'([0-9]+\.[0-9]+\.[0-9]+)'";     Label = 'Build-Exe.ps1 default $Version' },
+    @{ Path = Join-Path $appRoot  'installer\DuneServer.iss';        Pattern = '#define\s+MyAppVersion\s+"([0-9]+\.[0-9]+\.[0-9]+)"';       Label = 'MyAppVersion' },
+    @{ Path = Join-Path $appRoot  'desktop\DuneShell\DuneShell.csproj'; Pattern = '<Version>([0-9]+\.[0-9]+\.[0-9]+)</Version>';            Label = 'DuneShell <Version>' }
+)
+if (-not $SkipVersionCheck) {
+    $stampReport = foreach ($vf in $versionFiles) {
+        if (-not (Test-Path -LiteralPath $vf.Path)) {
+            throw "Version-stamp file not found: $($vf.Path)"
+        }
+        $m = Select-String -Path $vf.Path -Pattern $vf.Pattern -List
+        if (-not $m) {
+            throw "Could not find version stamp in $($vf.Path) using pattern: $($vf.Pattern)"
+        }
+        [pscustomobject]@{
+            File    = $vf.Path.Substring($repoRoot.Length + 1)
+            Label   = $vf.Label
+            Version = $m.Matches[0].Groups[1].Value
+        }
+    }
+    $distinct = @($stampReport.Version | Sort-Object -Unique)
+    Write-Host "Version-stamp check:" -ForegroundColor Cyan
+    foreach ($r in $stampReport) {
+        $marker = if ($distinct.Count -eq 1) { '[x]' } else { '[!]' }
+        Write-Host ("  {0} {1,-32} {2}" -f $marker, $r.Label, $r.Version)
+    }
+    if ($distinct.Count -ne 1) {
+        Write-Host ""
+        throw "Version stamps disagree (found: $($distinct -join ', ')). Bump all 5 files to the same release version before building, or pass -SkipVersionCheck for a deliberate intermediate build."
+    }
+    Write-Host "  All 5 stamps match: $($distinct[0])" -ForegroundColor Green
+    Write-Host ""
+}
 
 # Locate ISCC.exe
 $isccCandidates = @(

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.1.11"
+#define MyAppVersion "10.1.13"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/routes/Update.ps1
+++ b/app/server/routes/Update.ps1
@@ -40,10 +40,14 @@ function Get-DuneLatestRelease {
         $headers = @{ 'User-Agent' = $script:DuneUpdateUA; 'Accept' = 'application/vnd.github+json' }
         $uri = "https://api.github.com/repos/$($script:DuneUpdateRepo)/releases/latest"
         $rel = Invoke-RestMethod -Uri $uri -Headers $headers -TimeoutSec 15 -ErrorAction Stop
-        $asset = $rel.assets | Where-Object { $_.name -like 'DuneServerSetup*.exe' } | Select-Object -First 1
-        if (-not $asset) {
-            $asset = $rel.assets | Where-Object { $_.name -like '*.exe' } | Select-Object -First 1
-        }
+        # Strict: the release rule requires `DuneServerSetup.exe` as the sole
+        # asset. Match it exactly. Do NOT fall back to "any *.exe" - that
+        # masked malformed releases historically and conflicts with the
+        # one-asset rule. If a release ships a differently-named installer
+        # by mistake, the UI will correctly show "available, no installer
+        # attached" with a release-page link, instead of silently treating
+        # the wrong file as the installer.
+        $asset = $rel.assets | Where-Object { $_.name -eq 'DuneServerSetup.exe' } | Select-Object -First 1
         $script:DuneUpdateCache = [pscustomobject]@{
             fetchedAt    = $now
             tag          = [string]$rel.tag_name
@@ -88,9 +92,26 @@ Register-DuneRoute -Method GET -Path '/api/update/check' -Handler {
             return
         }
         $diff      = Compare-DuneSemver -A $rel.tag -B $current
-        $available = ($diff -gt 0) -and ([string]::IsNullOrEmpty($rel.assetUrl) -eq $false)
+        # `available` means a newer release exists (independent of whether an
+        # installer asset is attached). `installable` is the stricter flag:
+        # newer release AND the installer .exe is uploaded so the in-app
+        # auto-updater can actually run it.
+        #
+        # Background: every DST release MUST upload `DuneServerSetup.exe` as
+        # its only asset (hard project rule). If a release is ever published
+        # without one, we still want the UI to alert the user that an update
+        # exists - just with a "no installer attached" notice and a link to
+        # the release page instead of an "Update now" button. We do NOT want
+        # the UI to silently report "up to date" while a newer tag is live;
+        # that's what happened with v10.1.12 (shipped asset-less) and is the
+        # bug this split fixes.
+        $available    = ($diff -gt 0)
+        $hasAsset     = -not [string]::IsNullOrEmpty($rel.assetUrl)
+        $installable  = $available -and $hasAsset
         Write-DuneJson -Response $res -Body @{
             available       = $available
+            installable     = $installable
+            assetMissing    = ($available -and -not $hasAsset)
             currentVersion  = $current
             latestVersion   = ($rel.tag -replace '^v','')
             tagName         = $rel.tag

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "10.1.3"
+$script:ToolVersion = "10.1.13"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/update.ts
+++ b/webui/src/api/update.ts
@@ -3,6 +3,18 @@ import { api } from './client'
 
 export interface UpdateCheck {
   available: boolean
+  /**
+   * True when `available` AND the release has an installer .exe asset that
+   * the in-app auto-updater can download and run. False when a newer release
+   * exists but no asset is attached — UI should still show "update available"
+   * but link to the release page instead of offering an Install button.
+   *
+   * Optional for backward compatibility with older backends that didn't
+   * split this from `available`.
+   */
+  installable?: boolean
+  /** True when `available` but no installer asset is present. Diagnostic. */
+  assetMissing?: boolean
   currentVersion: string
   latestVersion?: string
   tagName?: string

--- a/webui/src/components/UpdateBanner.tsx
+++ b/webui/src/components/UpdateBanner.tsx
@@ -120,6 +120,17 @@ export function UpdateBanner() {
   if (!data || !data.available || !data.latestVersion) return null
   if (dismissed || isDismissed(data.latestVersion)) return null
 
+  // If a newer release exists but its installer .exe is missing (project
+  // rule violation: every release must upload DuneServerSetup.exe), we
+  // still tell the user about it - just send them to the release page
+  // instead of pretending the in-app updater can install it.
+  //
+  // `installable` is set by newer (>=10.1.13) backends. Older backends
+  // only return `available`, which they already gated on assetUrl - so for
+  // those, treating undefined as "true" is the safe default (matches the
+  // old behavior of only showing the banner when an asset was present).
+  const canInstall = data.installable ?? true
+
   const onInstall = async () => {
     setInstalling(true)
     setInstallErr(null)
@@ -173,14 +184,26 @@ export function UpdateBanner() {
         )}
       </div>
       <div className="flex items-center gap-2 shrink-0">
-        <button
-          type="button"
-          className="px-3 py-1 rounded-md bg-amber-400 text-amber-950 font-semibold text-xs hover:bg-amber-300 disabled:opacity-60 disabled:cursor-wait"
-          onClick={() => { void onInstall() }}
-          disabled={installing}
-        >
-          {installing ? 'Installing…' : 'Update now'}
-        </button>
+        {canInstall ? (
+          <button
+            type="button"
+            className="px-3 py-1 rounded-md bg-amber-400 text-amber-950 font-semibold text-xs hover:bg-amber-300 disabled:opacity-60 disabled:cursor-wait"
+            onClick={() => { void onInstall() }}
+            disabled={installing}
+          >
+            {installing ? 'Installing…' : 'Update now'}
+          </button>
+        ) : (
+          <a
+            href={data.releaseUrl ?? `https://github.com/coastal-ms/DST-DuneServerTool/releases/tag/${data.tagName ?? ''}`}
+            target="_blank"
+            rel="noreferrer"
+            className="px-3 py-1 rounded-md bg-amber-400 text-amber-950 font-semibold text-xs hover:bg-amber-300"
+            title="No installer attached to this release — opens the release page"
+          >
+            View release
+          </a>
+        )}
         <button
           type="button"
           className="px-2 py-1 rounded-md text-amber-200 hover:text-white hover:bg-amber-400/10 text-xs"

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -725,7 +725,7 @@ export function Settings() {
                     release notes
                   </a>
                 )}
-                {updCheck.available && (
+                {updCheck.available && (updCheck.installable ?? true) && (
                   <button
                     type="button"
                     onClick={onInstallUpdate}
@@ -735,6 +735,21 @@ export function Settings() {
                     <Icon name={updInstalling ? 'Loader2' : 'Download'} size={15} className={updInstalling ? 'animate-spin' : ''} />
                     {updInstalling ? 'Installing…' : `Update to ${fmtToolVersion(updCheck.latestVersion)}`}
                   </button>
+                )}
+                {updCheck.available && updCheck.installable === false && (
+                  <span className="text-xs text-warning ml-auto flex items-center gap-1.5">
+                    <Icon name="AlertCircle" size={14} />
+                    Newer version available, but this release has no installer attached. Use the{' '}
+                    <a
+                      href={updCheck.releaseUrl ?? `https://github.com/coastal-ms/DST-DuneServerTool/releases/tag/${updCheck.tagName ?? ''}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline hover:text-text"
+                    >
+                      release page
+                    </a>
+                    .
+                  </span>
                 )}
                 {!updCheck.available && !updCheck.error && (
                   <span className="text-xs text-text-dim ml-auto">You're on the latest version.</span>


### PR DESCRIPTION
## What

Fixes the silent "up to date" regression triggered by **v10.1.12**, which shipped as a code-only GitHub release (no `DuneServerSetup.exe` attached) and was missing version-stamp bumps. Ships v10.1.13 with the bug fix, the carried-forward MapSpinUp fix from v10.1.12, and a new build-time guardrail so this class of mistake can't recur.

## The bug

User opened DST after the v10.1.12 release and saw this:

- Card header: amber pill `X (1.11)` + green pill `up to date`
- Card body: `Current · X (1.11)` and `Latest · X (1.12)` clearly visible
- No `Update now` button, no banner notification
- The "Check now" button reported the same conclusion

Root cause was in `app/server/routes/Update.ps1`:

```pwsh
$available = ($diff -gt 0) -and ([string]::IsNullOrEmpty($rel.assetUrl) -eq $false)
```

`available` was gated on **both** "newer tag exists" **and** "an installer .exe is uploaded". With v10.1.12 missing its installer asset, the second condition collapsed `available` to `false`, the UI flipped to "up to date", and the user had no path to install the new version.

Also discovered: the v10.1.12 commit/tag was made but the **five** version-stamp files were never bumped from `10.1.11`. So even if v10.1.12 had shipped with an installer, the installer would have claimed to be version 10.1.11 and the auto-updater wouldn''t have seen it as an upgrade. v10.1.12 is effectively burned; v10.1.13 supersedes it.

## The fix (3 layers)

### 1. Honest update state in the backend

`Update.ps1` now returns two flags:

- `available` — newer release tag exists. Asset-independent. Controls whether we tell the user an update exists at all.
- `installable` — `available` AND `DuneServerSetup.exe` is uploaded. Controls whether the in-app auto-updater can deliver it.

Asset matching is now strict: requires **exactly** `DuneServerSetup.exe`. The old `like ''*.exe''` fallback was removed.

### 2. UI that handles both states

- `UpdateBanner.tsx` shows the banner whenever `available`. When `installable === false`, the "Update now" button is replaced with a "View release" link.
- `Settings.tsx` update card does the same: install button when installable, inline warning + release-page link when available but not installable.
- The header pill flips to amber `X (N.N) available` either way.
- `canInstall = data.installable ?? true` — new UI hitting older backends defaults to "installable" (matches old behavior).

### 3. A build-time guardrail so this can''t recur

`Build-Installer.ps1` now runs a **version-stamp sync check** before any long build steps. Reads the five files that must agree (`dune-server.ps1`, `app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/installer/DuneServer.iss`, `app/desktop/DuneShell/DuneShell.csproj`) and aborts with a per-file listing if they disagree. Override with `-SkipVersionCheck`.

This is exactly what would have caught the v10.1.12 mistake — and caught a near-repeat in this PR (original commit missed `DuneShell.csproj`; rubber-duck review surfaced it).

## Hard project rule

**Every** DST GitHub release MUST upload `DuneServerSetup.exe` as its sole asset. No code-only releases. Verify with `gh release view v<X.Y.Z> --json assets` before `--latest`.

## Verification

- TypeScript: `npx tsc --noEmit` clean
- PowerShell parse: clean on `Update.ps1` and `Build-Installer.ps1`
- All 5 stamps read `10.1.13`
- Backward compat: old UI (v10.1.11) hitting new backend reads `available=true` for asset-attached releases → install works. Asset-less release (rule violation) → install POST returns 503 — same failure path as today.