### PR TITLE
v10.1.14: Enforce Invoke-V6Ssh timeout (fixes backend UI hang)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,43 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.1.14] - 2026-06-03
+
+### Fixed
+- **`Invoke-V6Ssh -TimeoutSec` is now actually enforced.** The function
+  accepted a `-TimeoutSec` parameter but completely ignored it — the only
+  OpenSSH-level timeout being set was `ConnectTimeout=8`, which caps the
+  TCP handshake but lets a connected remote command hang indefinitely.
+  When a Map SpinUp toggle triggered an ssh-over-kubectl call that hung
+  (~2026-06-03 morning), the child `ssh.exe` lived 12+ minutes with 0.02 s
+  of CPU. Because every HTTP API handler runs inline on the listener
+  thread (see _Known limitations_ below), that one stuck handler froze
+  the entire backend UI — Map SpinUp, Web Interfaces, Active Spice, the
+  dune-admin Check button, and any other VM-touching panel all showed
+  `Loading…` forever until the orphaned ssh process was killed manually.
+  The function now spawns ssh as a managed `System.Diagnostics.Process`,
+  drains stdout/stderr asynchronously to avoid pipe-buffer deadlock, and
+  calls `WaitForExit($TimeoutSec * 1000)` followed by `Kill()` past the
+  deadline. On timeout it returns the line
+  `ERROR: ssh timed out after Ns` so callers (which all already join the
+  output and pattern-match it) see a clear failure mode instead of a
+  silent `$null`.
+- Added `ServerAliveInterval=10` + `ServerAliveCountMax=3` as
+  belt-and-suspenders defense — even if the host-side `Kill()` ever
+  fails, OpenSSH itself will now tear down a silent session within
+  ~30 s instead of clinging to it forever.
+
+### Known limitations (deferred to v10.1.15)
+- The HTTP listener still dispatches API route handlers inline on a
+  single thread (`app/server/HttpServer.ps1:298-327`); only WebSocket
+  upgrades are pushed onto a runspace pool. A slow handler still blocks
+  the queue for up to its `Invoke-V6Ssh` timeout window, just no longer
+  forever. Proper concurrent dispatch — with shared-state injection,
+  per-resource locks (so two simultaneous Map SpinUp toggles can't
+  clobber each other's `director.ini` patches), backpressure (return
+  503 when the pool is saturated), and async response cleanup — is
+  designed for v10.1.15 in a follow-up issue.
+
 ## [10.1.13] - 2026-06-03
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.1.13'
+$script:DuneToolVersion = '10.1.14'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.1.13',
+    [string]$Version = '10.1.14',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.1.13</Version>
+    <Version>10.1.14</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.1.13"
+#define MyAppVersion "10.1.14"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/lib/Db-Postgres.ps1
+++ b/app/lib/Db-Postgres.ps1
@@ -35,10 +35,85 @@ function Invoke-V6Ssh {
     # preserve \r, which breaks bash (commands appear as "head -1\r" etc).
     if ($Cmd) { $Cmd = $Cmd -replace "`r","" }
     $key = Get-V6SshKeyPath
-    if ($key) {
-        & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -o ConnectTimeout=8 -i $key "dune@$Ip" $Cmd 2>$null
-    } else {
-        & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -o ConnectTimeout=8 "dune@$Ip" $Cmd 2>$null
+    if ($TimeoutSec -lt 1) { $TimeoutSec = 30 }
+
+    # NOTE 2026-06-03 (v10.1.14): previously this function called
+    # `& ssh ...` directly and SILENTLY IGNORED its $TimeoutSec parameter
+    # — only OpenSSH-level ConnectTimeout=8 was set, which caps the TCP
+    # handshake but lets a *connected* remote command hang forever. That
+    # bug caused a Map SpinUp toggle to wedge the entire backend UI when
+    # the underlying ssh child process never returned (the HTTP listener
+    # runs handlers inline on a single thread; one hung handler froze
+    # every panel — see app/server/HttpServer.ps1:298). We now spawn ssh
+    # as a managed Process and hard-kill it past the deadline.
+    # ServerAliveInterval+ServerAliveCountMax are belt-and-suspenders so
+    # OpenSSH itself tears down a silent session in ~30 s even if the
+    # host-side kill ever misfires. The single-thread-listener problem
+    # itself is the v10.1.15 work tracked separately.
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName               = 'ssh'
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute        = $false
+    $psi.CreateNoWindow         = $true
+
+    # PS 5.1 lacks ProcessStartInfo.ArgumentList — build the command line
+    # by hand. All values here are fixed literals, an IP, a file path we
+    # control ($key), or the caller's remote command ($Cmd). Quote any
+    # arg containing whitespace or quotes; escape embedded " as \".
+    $sshArgs = @(
+        '-o','BatchMode=yes'
+        '-o','StrictHostKeyChecking=no'
+        '-o','LogLevel=QUIET'
+        '-o','ConnectTimeout=8'
+        '-o','ServerAliveInterval=10'
+        '-o','ServerAliveCountMax=3'
+    )
+    if ($key) { $sshArgs += @('-i', $key) }
+    $sshArgs += @("dune@$Ip")
+    if ($null -ne $Cmd) { $sshArgs += @($Cmd) }
+    $psi.Arguments = (@($sshArgs) | ForEach-Object {
+        if ($_ -match '[\s"]') { '"' + ($_ -replace '"','\"') + '"' } else { $_ }
+    }) -join ' '
+
+    $proc = [System.Diagnostics.Process]::new()
+    $proc.StartInfo = $psi
+    try {
+        [void]$proc.Start()
+        # Drain both streams asynchronously — a chatty remote command can
+        # fill the ~4 KB pipe buffer before we reach WaitForExit, causing
+        # ssh to block on stdout.write and us to deadlock waiting for it
+        # to exit.
+        $outTask = $proc.StandardOutput.ReadToEndAsync()
+        $errTask = $proc.StandardError.ReadToEndAsync()
+        $timeoutMs = [int]$TimeoutSec * 1000
+        $exited = $proc.WaitForExit($timeoutMs)
+        if (-not $exited) {
+            try { $proc.Kill() } catch {}
+            try { [void]$proc.WaitForExit(2000) } catch {}
+            if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                Write-DuneLog "Invoke-V6Ssh: ssh to $Ip exceeded ${TimeoutSec}s, killed" 'WARN'
+            }
+            # Surface the timeout to callers via the stdout slot they
+            # already inspect — most do `($out -join "`n").Trim()` then
+            # string-match the result; an `ERROR:` line is clearly
+            # visible (vs. the silent `$null`/empty failure mode that
+            # produced the misleading "kubectl patch may have failed:"
+            # toast in the v10.1.13 incident).
+            return "ERROR: ssh timed out after ${TimeoutSec}s"
+        }
+        # Per Microsoft docs, an unbounded WaitForExit() after a bounded
+        # one ensures the async stream readers fully drain before we
+        # consume the tasks.
+        [void]$proc.WaitForExit()
+        [void]$errTask.GetAwaiter().GetResult()  # discarded — mirrors prior `2>$null`
+        $text = $outTask.GetAwaiter().GetResult()
+        if ([string]::IsNullOrEmpty($text)) { return }
+        # Emit one pipeline item per stdout line — matches the original
+        # `& ssh ...` capture semantics so existing callers keep working.
+        return ($text -split "`r?`n")
+    } finally {
+        try { $proc.Dispose() } catch {}
     }
 }
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "10.1.13"
+$script:ToolVersion = "10.1.14"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## What

Enforce the long-broken `-TimeoutSec` parameter on `Invoke-V6Ssh`.

## Why

This morning a Map SpinUp toggle wedged the entire backend UI. Root
cause: `Invoke-V6Ssh` accepted a `-TimeoutSec` parameter but
completely ignored it — only OpenSSH-level `ConnectTimeout=8` was set,
which caps the TCP handshake but lets a connected remote command hang
forever. When the kubectl-over-ssh call hung, the child `ssh.exe` lived
12+ minutes with **0.02s of CPU**. Because HTTP API handlers run inline
on the single-threaded listener (`app/server/HttpServer.ps1:298`),
that one stuck handler froze every VM-touching panel — Web Interfaces,
Active Spice, dune-admin check, Map SpinUp itself — all stuck on
`Loading...` forever until I killed the orphan ssh.exe manually.

## How

- Spawn ssh as a managed `System.Diagnostics.Process` instead of the
  `& ssh ...` shortcut.
- Drain stdout/stderr asynchronously via `ReadToEndAsync()` so a
  chatty remote command can't fill the 4 KB pipe buffer and deadlock.
- `WaitForExit(TimeoutSec * 1000)` — if it returns false, `Kill()`
  the process and return `ERROR: ssh timed out after Ns` (most
  callers already join the output and pattern-match it, so the error
  line surfaces cleanly).
- Added `ServerAliveInterval=10` + `ServerAliveCountMax=3` as
  defense in depth — even if `Kill()` ever misfires, OpenSSH itself
  tears down a silent session in ~30 s.
- PS 5.1 compatible (built with manual command-line construction, no
  `ProcessStartInfo.ArgumentList`).

## Smoke test

Against an unroutable IP (`203.0.113.99`, TEST-NET-3) with
`-TimeoutSec 5`:

- elapsed: exactly **5 s**
- returned: `ERROR: ssh timed out after 5s`
- no orphan ssh.exe left behind

## Deferred to v10.1.15

The single-thread-listener problem itself — one stuck handler freezing
the whole UI — is the v10.1.15 work tracked in a follow-up issue.
After this PR, the worst case for a stuck SSH is bounded at the
caller's `-TimeoutSec` (typically 30-60 s) instead of forever, which
alone eliminates today's specific hang.