### PR TITLE
feat(ui): top menubar + Database group + collapsible sidebar

### DIFF
--- a/webui/src/hooks/useLaunchDuneAdmin.ts
+++ b/webui/src/hooks/useLaunchDuneAdmin.ts
@@ -1,0 +1,30 @@
+import { useCallback, useState } from 'react'
+import { api } from '../api/client'
+import { getDuneAdminWebUrl } from '../api/duneAdmin'
+
+// Launches dune-admin (Icehunter's character/player editor). Server skips the
+// spawn if it's already running, then returns its players-page URL. If the
+// launch endpoint fails we fall back to resolving the listen port and opening
+// the page directly so a user that already has dune-admin up isn't stuck.
+export function useLaunchDuneAdmin() {
+  const [launching, setLaunching] = useState(false)
+
+  const launch = useCallback(async () => {
+    if (launching) return
+    setLaunching(true)
+    try {
+      await api('/api/commands/run/dune-admin', { method: 'POST' })
+    } catch {
+      try {
+        const web = await getDuneAdminWebUrl()
+        if (web.listening) window.open(web.url, '_blank', 'noopener')
+      } catch {
+        // give up silently — better than opening the wrong port
+      }
+    } finally {
+      setLaunching(false)
+    }
+  }, [launching])
+
+  return { launching, launch }
+}

--- a/webui/src/hooks/useSidebarCollapsed.ts
+++ b/webui/src/hooks/useSidebarCollapsed.ts
@@ -1,0 +1,16 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const KEY = 'dst.sidebar.collapsed'
+
+// Persists the sidebar collapsed/expanded state across reloads. When collapsed
+// the sidebar shrinks to an icon rail; when expanded it shows the full nav.
+export function useSidebarCollapsed() {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try { return localStorage.getItem(KEY) === '1' } catch { return false }
+  })
+  useEffect(() => {
+    try { localStorage.setItem(KEY, collapsed ? '1' : '0') } catch { /* ignore */ }
+  }, [collapsed])
+  const toggle = useCallback(() => setCollapsed(v => !v), [])
+  return { collapsed, setCollapsed, toggle }
+}

--- a/webui/src/layout/AppShell.tsx
+++ b/webui/src/layout/AppShell.tsx
@@ -1,20 +1,26 @@
 import type { ReactNode } from 'react'
+import { MenuBar } from './MenuBar'
 import { Sidebar } from './Sidebar'
 import { StatusBar } from './StatusBar'
 import { UpdateBanner } from '../components/UpdateBanner'
+import { useSidebarCollapsed } from '../hooks/useSidebarCollapsed'
 
 export function AppShell({ children }: { children: ReactNode }) {
+  const { collapsed, toggle } = useSidebarCollapsed()
   return (
-    <div className="h-full flex overflow-hidden">
-      <Sidebar />
-      <div className="flex-1 flex flex-col min-w-0">
-        <UpdateBanner />
-        <StatusBar />
-        <main className="flex-1 overflow-y-auto">
-          <div className="max-w-7xl mx-auto px-6 py-6">
-            {children}
-          </div>
-        </main>
+    <div className="h-full flex flex-col overflow-hidden">
+      <MenuBar sidebarCollapsed={collapsed} onToggleSidebar={toggle} />
+      <div className="flex-1 flex overflow-hidden min-h-0">
+        <Sidebar collapsed={collapsed} />
+        <div className="flex-1 flex flex-col min-w-0">
+          <UpdateBanner />
+          <StatusBar />
+          <main className="flex-1 overflow-y-auto">
+            <div className="max-w-7xl mx-auto px-6 py-6">
+              {children}
+            </div>
+          </main>
+        </div>
       </div>
     </div>
   )

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { Icon } from '../components/Icon'
+import { NAV_ITEMS, GROUP_LABELS, GROUP_ORDER, type NavGroup } from '../nav'
+import { useUpdateCheck } from '../hooks/useUpdateCheck'
+import { useLaunchDuneAdmin } from '../hooks/useLaunchDuneAdmin'
+
+type MenuKey = NavGroup | 'help'
+
+type Props = {
+  sidebarCollapsed: boolean
+  onToggleSidebar: () => void
+}
+
+// Classic Windows-style top menu bar. Each group from the sidebar (Server
+// Health, PowerShell, Game Data, Database, System) appears here as a dropdown
+// listing its pages, plus a rightmost "Help" dropdown for cross-cutting
+// commands like "Create GitHub Issue" and the sidebar collapse toggle.
+export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { data: upd } = useUpdateCheck()
+  const version = upd?.currentVersion ?? ''
+  const { launching: daLaunching, launch: launchDuneAdmin } = useLaunchDuneAdmin()
+  const [open, setOpen] = useState<MenuKey | null>(null)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  // Click-outside and Escape to close any open dropdown.
+  useEffect(() => {
+    if (!open) return
+    const onClick = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(null)
+    }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(null) }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const issueHref = `https://github.com/coastal-ms/DST-DuneServerTool/issues/new?template=bug_report.yml${
+    version ? `&tool_version=v${encodeURIComponent(version)}` : ''
+  }`
+
+  const onItemClick = (item: typeof NAV_ITEMS[number]) => {
+    setOpen(null)
+    if (item.action === 'launch-dune-admin') {
+      void launchDuneAdmin()
+      return
+    }
+    navigate(item.to)
+  }
+
+  const isActive = (to: string) => {
+    if (to === '/') return location.pathname === '/'
+    return location.pathname === to || location.pathname.startsWith(`${to}/`)
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      className="h-8 shrink-0 border-b border-border bg-surface/80 backdrop-blur-md flex items-center px-1 text-[13px] select-none relative z-40"
+    >
+      {GROUP_ORDER.map(g => {
+        const items = NAV_ITEMS.filter(i => i.group === g)
+        if (items.length === 0) return null
+        const isOpen = open === g
+        return (
+          <div key={g} className="relative">
+            <button
+              type="button"
+              onClick={() => setOpen(isOpen ? null : g)}
+              onMouseEnter={() => { if (open !== null) setOpen(g) }}
+              className={`px-3 h-7 rounded-md transition-colors ${
+                isOpen
+                  ? 'bg-surface-3 text-text'
+                  : 'text-text-muted hover:text-text hover:bg-surface-2/80'
+              }`}
+            >
+              {GROUP_LABELS[g]}
+            </button>
+            {isOpen && (
+              <div className="absolute left-0 top-full mt-1 min-w-[200px] card p-1 shadow-xl shadow-black/40 z-50">
+                {items.map(item => (
+                  <button
+                    key={item.to}
+                    type="button"
+                    onClick={() => onItemClick(item)}
+                    className={`w-full flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-left transition-colors ${
+                      isActive(item.to)
+                        ? 'bg-accent/15 text-accent-bright'
+                        : 'text-text-muted hover:text-text hover:bg-surface-2'
+                    }`}
+                  >
+                    <Icon
+                      name={item.action === 'launch-dune-admin' && daLaunching ? 'Loader2' : item.icon}
+                      size={14}
+                      className={item.action === 'launch-dune-admin' && daLaunching ? 'animate-spin' : ''}
+                    />
+                    <span className="flex-1">{item.label}</span>
+                    {item.action === 'launch-dune-admin' && (
+                      <Icon name="ExternalLink" size={11} className="text-text-dim" />
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      })}
+
+      {/* Spacer pushes Help to the right edge. */}
+      <div className="flex-1" />
+
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setOpen(open === 'help' ? null : 'help')}
+          onMouseEnter={() => { if (open !== null) setOpen('help') }}
+          className={`px-3 h-7 rounded-md transition-colors ${
+            open === 'help'
+              ? 'bg-surface-3 text-text'
+              : 'text-text-muted hover:text-text hover:bg-surface-2/80'
+          }`}
+        >
+          Help
+        </button>
+        {open === 'help' && (
+          <div className="absolute right-0 top-full mt-1 min-w-[220px] card p-1 shadow-xl shadow-black/40 z-50">
+            <a
+              href={issueHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(null)}
+              className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors"
+            >
+              <Icon name="Github" size={14} />
+              <span className="flex-1">Create GitHub Issue</span>
+              <Icon name="ExternalLink" size={11} className="text-text-dim" />
+            </a>
+            <button
+              type="button"
+              onClick={() => { onToggleSidebar(); setOpen(null) }}
+              className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors"
+            >
+              <Icon name={sidebarCollapsed ? 'PanelLeftOpen' : 'PanelLeftClose'} size={14} />
+              <span className="flex-1">
+                {sidebarCollapsed ? 'Expand Sidebar' : 'Collapse Sidebar'}
+              </span>
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -2,10 +2,10 @@ import { NavLink } from 'react-router-dom'
 import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Icon } from '../components/Icon'
-import { NAV_ITEMS, GROUP_LABELS } from '../nav'
+import { NAV_ITEMS, GROUP_LABELS, GROUP_ORDER } from '../nav'
 import { useUpdateCheck } from '../hooks/useUpdateCheck'
+import { useLaunchDuneAdmin } from '../hooks/useLaunchDuneAdmin'
 import { api } from '../api/client'
-import { getDuneAdminWebUrl } from '../api/duneAdmin'
 import { fmtToolVersion } from '../format'
 
 // WebView2 host bridge — present only when the portal is rendered inside the
@@ -18,42 +18,21 @@ function getWebView2(): WebView2Host | null {
   return w.chrome?.webview ?? null
 }
 
-export function Sidebar() {
+type Props = {
+  collapsed: boolean
+}
+
+export function Sidebar({ collapsed }: Props) {
   const { data: upd } = useUpdateCheck()
   const version = upd?.currentVersion ?? ''
   const [showPortalConfirm, setShowPortalConfirm] = useState(false)
   const [portalDetaching, setPortalDetaching] = useState(false)
   const [portalError, setPortalError] = useState<string | null>(null)
-  const [daLaunching, setDaLaunching] = useState(false)
+  const { launching: daLaunching, launch: launchDuneAdmin } = useLaunchDuneAdmin()
 
   // "Web Portal" is meaningful only inside the native shell. In a regular
   // browser tab the user is already in their browser, so we hide the button.
   const inShellWindow = getWebView2() !== null
-
-  // Characters live in dune-admin (Icehunter's tool), not in this portal.
-  // Launch dune-admin (skipped server-side if already running) then open its
-  // players web UI. The launch command opens the page itself, so we don't
-  // window.open here — that would double-open the tab.
-  const launchDuneAdmin = async () => {
-    if (daLaunching) return
-    setDaLaunching(true)
-    try {
-      await api('/api/commands/run/dune-admin', { method: 'POST' })
-    } catch {
-      // Best-effort fallback: if the launch endpoint fails, open the page so the
-      // user can connect to an already-running instance. Resolve the REAL port
-      // from the backend (per-user listen_addr — never assume 8080, which may be
-      // AMP's panel). Only open if dune-admin is actually listening.
-      try {
-        const web = await getDuneAdminWebUrl()
-        if (web.listening) window.open(web.url, '_blank', 'noopener')
-      } catch {
-        // give up silently — better than opening the wrong port
-      }
-    } finally {
-      setDaLaunching(false)
-    }
-  }
 
   const onOpenWebPortal = async () => {
     if (portalDetaching) return
@@ -83,92 +62,134 @@ export function Sidebar() {
     }
   }
 
-  const groups = (['overview', 'terminal', 'data', 'system'] as const).map(g => ({
+  const groups = GROUP_ORDER.map(g => ({
     key: g,
     label: GROUP_LABELS[g],
     items: NAV_ITEMS.filter(i => i.group === g),
-  }))
+  })).filter(g => g.items.length > 0)
+
+  // Shared row renderer for a single nav item, in either layout mode.
+  const renderItem = (item: typeof NAV_ITEMS[number]) => {
+    const iconName = item.action === 'launch-dune-admin' && daLaunching ? 'Loader2' : item.icon
+    const iconCls = item.action === 'launch-dune-admin' && daLaunching ? 'animate-spin' : ''
+
+    if (item.action === 'launch-dune-admin') {
+      return (
+        <button
+          type="button"
+          onClick={() => { void launchDuneAdmin() }}
+          title={collapsed
+            ? `${item.label} — opens player/character editing in dune-admin`
+            : 'Opens player/character editing in dune-admin (launches it if not already running)'}
+          className={
+            collapsed
+              ? 'w-full flex items-center justify-center h-9 rounded-lg transition-all text-text-muted hover:text-text hover:bg-surface-2/60 border border-transparent'
+              : 'w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-all text-text-muted hover:text-text hover:bg-surface-2/60 border border-transparent'
+          }
+        >
+          <Icon name={iconName} size={collapsed ? 18 : 16} className={iconCls} />
+          {!collapsed && <span>{item.label}</span>}
+          {!collapsed && <Icon name="ExternalLink" size={12} className="ml-auto text-text-dim" />}
+        </button>
+      )
+    }
+
+    return (
+      <NavLink
+        to={item.to}
+        end={item.to === '/'}
+        title={collapsed ? item.label : undefined}
+        className={({ isActive }) =>
+          collapsed
+            ? `w-full flex items-center justify-center h-9 rounded-lg transition-all border ${
+                isActive
+                  ? 'bg-accent/15 text-accent-bright border-accent/30 shadow-inner'
+                  : 'text-text-muted hover:text-text hover:bg-surface-2/60 border-transparent'
+              }`
+            : `flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-all border ${
+                isActive
+                  ? 'bg-accent/15 text-accent-bright border-accent/30 shadow-inner'
+                  : 'text-text-muted hover:text-text hover:bg-surface-2/60 border-transparent'
+              }`
+        }
+      >
+        <Icon name={item.icon} size={collapsed ? 18 : 16} />
+        {!collapsed && <span>{item.label}</span>}
+      </NavLink>
+    )
+  }
 
   return (
-    <aside className="w-60 shrink-0 border-r border-border bg-surface/60 backdrop-blur-md flex flex-col">
-      <div className="px-5 py-4 border-b border-border flex items-center gap-2.5">
-        <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-accent-bright to-accent flex items-center justify-center shadow-lg shadow-accent/20">
+    <aside
+      className={`${collapsed ? 'w-14' : 'w-60'} shrink-0 border-r border-border bg-surface/60 backdrop-blur-md flex flex-col transition-[width] duration-150`}
+    >
+      <div
+        className={`${
+          collapsed ? 'px-2 justify-center' : 'px-5'
+        } py-4 border-b border-border flex items-center gap-2.5`}
+      >
+        <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-accent-bright to-accent flex items-center justify-center shadow-lg shadow-accent/20 shrink-0">
           <Icon name="Hexagon" size={18} className="text-base" strokeWidth={2.5} />
         </div>
-        <div className="flex-1 min-w-0">
-          <div className="text-sm font-semibold tracking-wide">Dune Server Tool</div>
-          <div className="text-[10px] text-text-dim uppercase tracking-widest">Management Portal</div>
-        </div>
-        <a
-          href={`https://github.com/coastal-ms/DST-DuneServerTool/issues/new?template=bug_report.yml${version ? `&tool_version=v${encodeURIComponent(version)}` : ''}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          title="Report a bug / open a GitHub issue (prefilled template)"
-          className="w-8 h-8 rounded-full border border-accent/40 bg-accent/10 text-accent-bright hover:text-accent hover:bg-accent/20 hover:border-accent/60 flex items-center justify-center transition-colors shrink-0"
-        >
-          <Icon name="HelpCircle" size={16} strokeWidth={2.25} />
-        </a>
+        {!collapsed && (
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-semibold tracking-wide">Dune Server Tool</div>
+            <div className="text-[10px] text-text-dim uppercase tracking-widest">Management Portal</div>
+          </div>
+        )}
       </div>
 
-      <nav className="flex-1 overflow-y-auto px-2 py-3 space-y-5">
-        {groups.map(g => (
+      <nav
+        className={`flex-1 overflow-y-auto ${
+          collapsed ? 'px-1.5 py-2' : 'px-2 py-3'
+        } ${collapsed ? '' : 'space-y-5'}`}
+      >
+        {groups.map((g, idx) => (
           <div key={g.key}>
-            <div className="px-3 mb-1 text-[10px] font-semibold uppercase tracking-widest text-text-dim">
-              {g.label}
-            </div>
-            <ul className="space-y-0.5">
+            {/* In collapsed mode we draw a thin divider between groups instead
+                of repeating the textual label, to keep the rail compact. */}
+            {collapsed
+              ? idx > 0 && <div className="my-2 border-t border-border/70" />
+              : (
+                <div className="px-3 mb-1 text-[10px] font-semibold uppercase tracking-widest text-text-dim">
+                  {g.label}
+                </div>
+              )}
+            <ul className={collapsed ? 'space-y-1' : 'space-y-0.5'}>
               {g.items.map(item => (
-                <li key={item.to}>
-                  {item.action === 'launch-dune-admin' ? (
-                    <button
-                      type="button"
-                      onClick={() => { void launchDuneAdmin() }}
-                      title="Opens player/character editing in dune-admin (launches it if not already running)"
-                      className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-all
-                                 text-text-muted hover:text-text hover:bg-surface-2/60 border border-transparent"
-                    >
-                      <Icon name={daLaunching ? 'Loader2' : item.icon} size={16} className={daLaunching ? 'animate-spin' : ''} />
-                      <span>{item.label}</span>
-                      <Icon name="ExternalLink" size={12} className="ml-auto text-text-dim" />
-                    </button>
-                  ) : (
-                    <NavLink
-                      to={item.to}
-                      end={item.to === '/'}
-                      className={({ isActive }) =>
-                        `flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-all
-                         ${isActive
-                           ? 'bg-accent/15 text-accent-bright border border-accent/30 shadow-inner'
-                           : 'text-text-muted hover:text-text hover:bg-surface-2/60 border border-transparent'}`
-                      }
-                    >
-                      <Icon name={item.icon} size={16} />
-                      <span>{item.label}</span>
-                    </NavLink>
-                  )}
-                </li>
+                <li key={item.to}>{renderItem(item)}</li>
               ))}
             </ul>
           </div>
         ))}
       </nav>
 
-      <div className="px-4 py-3 border-t border-border text-[10px] text-text-dim space-y-2">
+      <div
+        className={`${
+          collapsed ? 'px-1.5 py-2' : 'px-4 py-3'
+        } border-t border-border text-[10px] text-text-dim space-y-2`}
+      >
         {inShellWindow && (
           <button
             type="button"
             onClick={() => { setPortalError(null); setShowPortalConfirm(true) }}
             title="Open the portal in your default web browser and close this app window"
-            className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-accent/30 text-accent-bright/90 hover:text-accent-bright hover:bg-accent/10 hover:border-accent/50 transition-colors uppercase tracking-widest"
+            className={
+              collapsed
+                ? 'w-full flex items-center justify-center h-8 rounded-md border border-accent/30 text-accent-bright/90 hover:text-accent-bright hover:bg-accent/10 hover:border-accent/50 transition-colors'
+                : 'w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-accent/30 text-accent-bright/90 hover:text-accent-bright hover:bg-accent/10 hover:border-accent/50 transition-colors uppercase tracking-widest'
+            }
           >
-            <Icon name="ExternalLink" size={11} />
-            <span>Web Portal</span>
+            <Icon name="ExternalLink" size={collapsed ? 14 : 11} />
+            {!collapsed && <span>Web Portal</span>}
           </button>
         )}
-        <div className="flex items-center justify-between">
-          <span>{version ? fmtToolVersion(version) : '—'}</span>
-          <span className="font-mono">coastal-ms</span>
-        </div>
+        {!collapsed && (
+          <div className="flex items-center justify-between">
+            <span>{version ? fmtToolVersion(version) : '—'}</span>
+            <span className="font-mono">coastal-ms</span>
+          </div>
+        )}
       </div>
 
       {showPortalConfirm && createPortal(

--- a/webui/src/nav.ts
+++ b/webui/src/nav.ts
@@ -1,8 +1,10 @@
+export type NavGroup = 'overview' | 'terminal' | 'data' | 'database' | 'system'
+
 export type NavItem = {
   to: string
   label: string
   icon: string  // lucide-react icon name
-  group?: 'overview' | 'terminal' | 'data' | 'system'
+  group?: NavGroup
   // When set, clicking runs an action instead of navigating. 'launch-dune-admin'
   // starts dune-admin (if not already running) and opens its players web UI.
   action?: 'launch-dune-admin'
@@ -14,17 +16,29 @@ export const NAV_ITEMS: NavItem[] = [
   { to: '/terminal',    label: 'PowerShell',   icon: 'SquareTerminal',  group: 'terminal' },
   { to: 'launch:dune-admin', label: 'Characters', icon: 'Users', group: 'data', action: 'launch-dune-admin' },
   { to: '/gameconfig',  label: 'Game Config',  icon: 'Sliders',         group: 'data' },
-  { to: '/database',    label: 'Database',     icon: 'Database',        group: 'data' },
-  { to: '/sietches',    label: 'Sietches',     icon: 'Network',         group: 'data' },
   { to: '/dd-map',      label: 'DD Map',       icon: 'Map',             group: 'data' },
-  { to: '/map-spinup',  label: 'Map SpinUp',   icon: 'Power',           group: 'data' },
+  { to: '/database',    label: 'Database',     icon: 'Database',        group: 'database' },
+  { to: '/sietches',    label: 'Sietches',     icon: 'Network',         group: 'database' },
+  { to: '/map-spinup',  label: 'Map SpinUp',   icon: 'Power',           group: 'database' },
   { to: '/settings',    label: 'Settings',     icon: 'Settings',        group: 'system' },
   { to: '/setup',       label: 'Setup Wizard', icon: 'Wand2',           group: 'system' },
 ]
 
-export const GROUP_LABELS: Record<NonNullable<NavItem['group']>, string> = {
+export const GROUP_ORDER: readonly NavGroup[] = ['overview', 'terminal', 'data', 'database', 'system'] as const
+
+export const GROUP_LABELS: Record<NavGroup, string> = {
   overview: 'Server Health',
   terminal: 'PowerShell',
   data:     'Game Data',
+  database: 'Database',
   system:   'System',
+}
+
+// Icon shown for the whole group (used in collapsed sidebar + menubar headers).
+export const GROUP_ICONS: Record<NavGroup, string> = {
+  overview: 'LayoutDashboard',
+  terminal: 'SquareTerminal',
+  data:     'Gamepad2',
+  database: 'Database',
+  system:   'Settings',
 }


### PR DESCRIPTION
Restructures the portal navigation into a classic desktop layout.

### What changed
- **New top menu bar** (above the StatusBar) with one dropdown per nav group: Server Health, PowerShell, Game Data, Database, System, and **Help** (rightmost). Each dropdown lists that group's pages.
- **New `Database` group** in both the menubar and the left sidebar. Contains **Database**, **Sietches**, and **Map SpinUp** (moved out of Game Data).
- **Help menu** replaces the bug-report `?` icon previously docked next to the sidebar brand. Items:
  - `Create GitHub Issue` (same prefilled GitHub URL the icon used)
  - `Collapse Sidebar` / `Expand Sidebar` toggle
- **Sidebar** now supports a collapsed icon-rail mode (width 14 ↔ 60), with thin separator lines between groups instead of textual labels. State persists in `localStorage` (`dst.sidebar.collapsed`).
- Extracted `useLaunchDuneAdmin` so both the sidebar item and the new menubar item share one implementation (no behavior change).

### Files
| File | Change |
| --- | --- |
| `webui/src/nav.ts` | Added `database` group; moved Database/Sietches/Map SpinUp into it |
| `webui/src/layout/MenuBar.tsx` | **new** — top menubar |
| `webui/src/layout/Sidebar.tsx` | Collapsible mode, separators, removed `?` icon |
| `webui/src/layout/AppShell.tsx` | Renders MenuBar; owns sidebar collapse state |
| `webui/src/hooks/useSidebarCollapsed.ts` | **new** — persisted toggle |
| `webui/src/hooks/useLaunchDuneAdmin.ts` | **new** — shared dune-admin launch |

### Verification
- `pnpm run build` — ✓ green
- `pnpm run lint` — ✓ no new issues from these files (pre-existing errors in `SpicefieldsCard.tsx` are unrelated)

### Manual test checklist
- [ ] Each menubar dropdown opens, navigates, closes on outside click/Escape
- [ ] Help → Create GitHub Issue opens prefilled template in new tab
- [ ] Help → Collapse Sidebar collapses to icon rail; Expand restores
- [ ] Collapsed state survives a portal reload
- [ ] Database group shows Database / Sietches / Map SpinUp in both menubar and sidebar
- [ ] Characters (dune-admin launch) still works from both menubar and sidebar