### PR TITLE
v10.2.0: top menubar + Database group + collapsible sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.2.0] - 2026-06-03
+
+### Added
+- **Top menu bar** above the StatusBar (classic desktop-app layout). One
+  dropdown per nav group — **Server Health**, **PowerShell**, **Game Data**,
+  **Database**, **System** — plus a rightmost **Help** dropdown for
+  cross-cutting commands. Works identically in the DuneShell.exe app window
+  and in a normal web-browser tab.
+- **Help menu** items:
+  - `Create GitHub Issue` — opens the prefilled bug-report template (same
+    URL the old `?` icon used; the icon itself is removed from the sidebar
+    brand strip).
+  - `Collapse Sidebar` / `Expand Sidebar` — toggles the new icon-rail mode.
+- **Collapsible sidebar.** New icon-only rail (width 56px) with thin
+  separator lines between groups instead of textual headers. State persists
+  per surface in `localStorage` (`dst.sidebar.collapsed`).
+- **`Database` nav group** (both in the menubar dropdown and the left
+  sidebar). Houses Database, Sietches, and Map SpinUp.
+
+### Changed
+- **Sidebar regrouping.** **Database**, **Sietches**, and **Map SpinUp**
+  moved out of `Game Data` and into the new `Database` group. `Game Data`
+  now contains Characters, Game Config, and DD Map.
+- Extracted `useLaunchDuneAdmin` so the sidebar's Characters item and the
+  new menubar's Characters item share one launch implementation (no
+  behavior change — same skip-if-running + port-resolve fallback).
+
 ## [10.1.15] - 2026-06-03
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.1.15'
+$script:DuneToolVersion = '10.2.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.1.15',
+    [string]$Version = '10.2.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.1.15</Version>
+    <Version>10.2.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.1.15"
+#define MyAppVersion "10.2.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "10.1.15"
+$script:ToolVersion = "10.2.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Version bump + CHANGELOG for v10.2.0. The UI restructure itself shipped in #51 (already merged to main).