### PR TITLE
v10.2.1: opaque menubar + dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.2.1] - 2026-06-03
+
+### Changed
+- **Top menu bar and its dropdowns are now fully opaque.** Removed the
+  semi-transparent surface tint + `backdrop-blur-md` (menubar strip) and
+  the `card` translucency + `backdrop-blur-sm` (dropdown panels) so page
+  content underneath no longer bleeds through. Solid `bg-surface` on both.
+
 ## [10.2.0] - 2026-06-03
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.2.0'
+$script:DuneToolVersion = '10.2.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.2.0',
+    [string]$Version = '10.2.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.2.0</Version>
+    <Version>10.2.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.2.0"
+#define MyAppVersion "10.2.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "10.2.0"
+$script:ToolVersion = "10.2.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -61,7 +61,7 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
   return (
     <div
       ref={rootRef}
-      className="h-8 shrink-0 border-b border-border bg-surface/80 backdrop-blur-md flex items-center px-1 text-[13px] select-none relative z-40"
+      className="h-8 shrink-0 border-b border-border bg-surface flex items-center px-1 text-[13px] select-none relative z-40"
     >
       {GROUP_ORDER.map(g => {
         const items = NAV_ITEMS.filter(i => i.group === g)
@@ -82,7 +82,7 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               {GROUP_LABELS[g]}
             </button>
             {isOpen && (
-              <div className="absolute left-0 top-full mt-1 min-w-[200px] card p-1 shadow-xl shadow-black/40 z-50">
+              <div className="absolute left-0 top-full mt-1 min-w-[200px] bg-surface border border-border rounded-xl p-1 shadow-xl shadow-black/40 z-50">
                 {items.map(item => (
                   <button
                     key={item.to}
@@ -128,7 +128,7 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
           Help
         </button>
         {open === 'help' && (
-          <div className="absolute right-0 top-full mt-1 min-w-[220px] card p-1 shadow-xl shadow-black/40 z-50">
+          <div className="absolute right-0 top-full mt-1 min-w-[220px] bg-surface border border-border rounded-xl p-1 shadow-xl shadow-black/40 z-50">
             <a
               href={issueHref}
               target="_blank"


### PR DESCRIPTION
Removes `bg-surface/80` + `backdrop-blur` from the new top menu bar and its dropdown panels — content underneath no longer bleeds through.