### PR TITLE
v10.2.2: remove native WinForms menu strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.2.2] - 2026-06-03
+
+### Removed
+- **Native WinForms `MenuStrip`** (the thin strip directly under the
+  Windows title bar with `Server Health · Settings · View`). Redundant
+  with the React top menu bar shipped in v10.2.0 — it duplicated nav
+  targets and produced two menu rows stacked on top of each other.
+  `BuildMenu()` and the unused `NavigateRoute` helper in `MainForm.cs`
+  are gone.
+
 ## [10.2.1] - 2026-06-03
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.2.1'
+$script:DuneToolVersion = '10.2.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.2.1',
+    [string]$Version = '10.2.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.2.1</Version>
+    <Version>10.2.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -9,7 +9,6 @@ namespace DuneShell;
 internal sealed class MainForm : Form
 {
     private readonly WebView2 _web = new();
-    private readonly MenuStrip _menu = new();
     private readonly Label _status = new();
 
     private readonly string? _initialUrl;
@@ -37,44 +36,12 @@ internal sealed class MainForm : Form
 
         FormClosing += (_, _) => SaveWindowState();
 
-        // Add order matters for docking: the Fill controls (WebView, status)
-        // must sit BEHIND the Top-docked menu so the menu reserves the top
-        // strip instead of the WebView painting underneath it.
+        // The React portal owns its own top menu bar, so the native window has
+        // just the WebView and a transient status label — no MenuStrip.
         BuildWebView();
         BuildStatus();
-        BuildMenu();
 
         Load += async (_, _) => await InitializeAsync();
-    }
-
-    private void BuildMenu()
-    {
-        _menu.RenderMode = ToolStripRenderMode.System;
-
-        var serverHealth = new ToolStripMenuItem("Server Health");
-        serverHealth.Click += (_, _) => NavigateRoute("/");
-
-        var settings = new ToolStripMenuItem("Settings");
-        settings.Click += (_, _) => NavigateRoute("/settings");
-
-        var view = new ToolStripMenuItem("View");
-        var reload = new ToolStripMenuItem("Reload") { ShortcutKeys = Keys.F5 };
-        reload.Click += (_, _) => _web.CoreWebView2?.Reload();
-        var openExternal = new ToolStripMenuItem("Open in browser");
-        openExternal.Click += (_, _) =>
-        {
-            var src = _web.Source?.ToString();
-            if (!string.IsNullOrEmpty(src)) OpenExternal(src);
-        };
-        view.DropDownItems.Add(reload);
-        view.DropDownItems.Add(openExternal);
-
-        _menu.Items.Add(serverHealth);
-        _menu.Items.Add(settings);
-        _menu.Items.Add(view);
-
-        MainMenuStrip = _menu;
-        Controls.Add(_menu);
     }
 
     private void BuildStatus()
@@ -259,21 +226,6 @@ internal sealed class MainForm : Form
             // WebMessageReceived handler can return cleanly first.
             BeginInvoke(new Action(() => { try { Close(); } catch { } }));
         }
-    }
-
-    /// <summary>
-    /// Navigate within the SPA without a server round-trip. The portal uses
-    /// react-router BrowserRouter, so pushState + a synthetic popstate makes it
-    /// switch routes client-side — no dependency on server SPA fallback.
-    /// </summary>
-    private async void NavigateRoute(string path)
-    {
-        var core = _web.CoreWebView2;
-        if (core == null) return;
-        string js =
-            "(function(){try{history.pushState({},'','" + path + "');" +
-            "window.dispatchEvent(new PopStateEvent('popstate'));}catch(e){location.pathname='" + path + "';}})();";
-        await core.ExecuteScriptAsync(js);
     }
 
     private static void OpenExternal(string url)

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.2.1"
+#define MyAppVersion "10.2.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "10.2.1"
+$script:ToolVersion = "10.2.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
The native WinForms MenuStrip (Server Health | Settings | View) directly under the title bar is redundant with the React top menu bar shipped in v10.2.0. Removes `BuildMenu()` and the now-unused `NavigateRoute` helper from `MainForm.cs`.