### PR TITLE
v10.2.4: move Help dropdown next to System in top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.2.4] - 2026-06-03
+
+### Changed
+- **Help dropdown** in the top menu bar moved from the right edge to
+  immediately right of `System` (the last sidebar group). Removed the
+  flex spacer that pushed it to the far right; the dropdown panel now
+  anchors `left-0` so it opens directly under the Help button.
+
 ## [10.2.3] - 2026-06-03
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.2.3'
+$script:DuneToolVersion = '10.2.4'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.2.3',
+    [string]$Version = '10.2.4',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.2.3</Version>
+    <Version>10.2.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.2.3"
+#define MyAppVersion "10.2.4"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "10.2.3"
+$script:ToolVersion = "10.2.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -14,8 +14,9 @@ type Props = {
 
 // Classic Windows-style top menu bar. Each group from the sidebar (Server
 // Health, PowerShell, Game Data, Database, System) appears here as a dropdown
-// listing its pages, plus a rightmost "Help" dropdown for cross-cutting
-// commands like "Create GitHub Issue" and the sidebar collapse toggle.
+// listing its pages, plus a "Help" dropdown immediately to the right of
+// System for cross-cutting commands like "Create GitHub Issue" and the
+// sidebar collapse toggle.
 export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
   const navigate = useNavigate()
   const location = useLocation()
@@ -111,9 +112,7 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
         )
       })}
 
-      {/* Spacer pushes Help to the right edge. */}
-      <div className="flex-1" />
-
+      {/* Help sits immediately to the right of the last group (System). */}
       <div className="relative">
         <button
           type="button"
@@ -128,7 +127,7 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
           Help
         </button>
         {open === 'help' && (
-          <div className="absolute right-0 top-full mt-1 min-w-[220px] bg-surface border border-border rounded-xl p-1 shadow-xl shadow-black/40 z-50">
+          <div className="absolute left-0 top-full mt-1 min-w-[220px] bg-surface border border-border rounded-xl p-1 shadow-xl shadow-black/40 z-50">
             <a
               href={issueHref}
               target="_blank"


### PR DESCRIPTION
Removes the flex spacer that pushed `Help` to the right edge of the top menu bar. `Help` now sits immediately to the right of the last sidebar group (`System`), and its dropdown panel is anchored `left-0` so it opens directly under the button.

Changelog entry added under `[10.2.4]`. Version bumped across `dune-server.ps1`, `app/DuneServer.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/installer/DuneServer.iss`, and `app/build/Build-Exe.ps1`.