### PR TITLE
site: display major v10 as "X (minor.patch)" outside release notes

### DIFF
--- a/site/src/components/DownloadButton.astro
+++ b/site/src/components/DownloadButton.astro
@@ -1,10 +1,11 @@
 ---
-import { getLatestRelease } from "../lib/release";
+import { formatDisplayVersion, getLatestRelease } from "../lib/release";
 const { variant = "primary" } = Astro.props as {
   variant?: "primary" | "ghost";
 };
 const release = await getLatestRelease();
-const versionLabel = release.version === "latest" ? "" : `v${release.version.replace(/^v/, "")}`;
+const versionLabel =
+  release.version === "latest" ? "" : formatDisplayVersion(release.version);
 const classes =
   variant === "primary"
     ? "inline-flex items-center gap-3 rounded-lg bg-dune-accent hover:bg-dune-accent-soft text-dune-bg font-medium px-6 py-3 transition-colors shadow-lg shadow-amber-900/30"

--- a/site/src/lib/release.ts
+++ b/site/src/lib/release.ts
@@ -60,3 +60,23 @@ export async function getLatestRelease(): Promise<LatestRelease> {
     return FALLBACK;
   }
 }
+
+// Renders a version string for display in the site UI (everywhere except the
+// changelog / release-notes page, which prints raw tags from CHANGELOG.md).
+// Convention: the current major series (10) is shown as the Roman numeral "X",
+// with the minor.patch suffix in parentheses. Examples:
+//   "10.2.4" -> "X (2.4)"
+//   "10.0"   -> "X"
+//   "10"     -> "X"
+//   "9.1.2"  -> "v9.1.2"   (other majors untouched)
+//   "latest" -> "the latest release"
+export function formatDisplayVersion(version: string): string {
+  if (!version || version === "latest") return "the latest release";
+  const cleaned = version.replace(/^v/, "");
+  const parts = cleaned.split(".");
+  if (parts[0] === "10") {
+    const rest = parts.slice(1).join(".").replace(/(\.0)+$/, "");
+    return rest ? `X (${rest})` : "X";
+  }
+  return `v${cleaned}`;
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -2,12 +2,11 @@
 import Base from "../layouts/Base.astro";
 import DownloadButton from "../components/DownloadButton.astro";
 import Screenshot from "../components/Screenshot.astro";
-import { getLatestRelease } from "../lib/release";
+import { formatDisplayVersion, getLatestRelease } from "../lib/release";
 
 const base = import.meta.env.BASE_URL;
 const release = await getLatestRelease();
-const versionLabel =
-  release.version === "latest" ? "the latest release" : `v${release.version}`;
+const versionLabel = formatDisplayVersion(release.version);
 
 const features = [
   {


### PR DESCRIPTION
Renders the current major series (10) as the Roman numeral **X** with the minor/patch suffix in parens everywhere on the marketing site, except the changelog page which keeps the literal release tags.

## What changed

- New `formatDisplayVersion()` helper in `site/src/lib/release.ts`:
  - `10.2.4` → `X (2.4)`
  - `10.0`   → `X`
  - `9.1.2`  → `v9.1.2` (other majors untouched)
  - `latest` → `the latest release`
- `pages/index.astro` hero strapline uses the helper.
- `components/DownloadButton.astro` (home + install pages) uses the helper.

## What didn't change

- **`pages/changelog.astro`** still renders `CHANGELOG.md` raw, so release notes keep printing `[10.2.4]`, `[10.2.3]`, etc.
- **Download URL** still resolves to the live GitHub Releases asset (`DuneServerSetup.exe` from the latest tag), so the link target always matches official release info.

## Verified

Built locally — rendered output:
- Home: `Open source · Apache 2.0 · X (2.4)`
- Download buttons: `Download for Windows  X (2.4)` → `…/releases/download/v10.2.4/DuneServerSetup.exe`
- Changelog: unchanged (`[10.2.4] - 2026-06-03`, etc.)