### PR TITLE
site: clickable screenshots open a full-viewport lightbox

### DIFF
--- a/site/src/components/Lightbox.astro
+++ b/site/src/components/Lightbox.astro
@@ -1,0 +1,86 @@
+---
+// Shared full-screen image viewer used by <Screenshot /> components.
+// Any element with [data-lightbox-trigger] + [data-lightbox-src] opens this
+// dialog with the larger image. Close on backdrop click, ESC, or close button.
+---
+
+<dialog
+  id="dst-lightbox"
+  class="w-screen h-screen max-w-none max-h-none m-0 p-0 bg-transparent backdrop:bg-black/85 backdrop:backdrop-blur-sm"
+  aria-label="Image viewer"
+>
+  <div class="relative w-full h-full flex items-center justify-center p-4 sm:p-8">
+    <button
+      type="button"
+      data-lightbox-close
+      aria-label="Close image viewer"
+      class="absolute top-4 right-4 z-10 rounded-full bg-dune-surface/90 hover:bg-dune-surface text-dune-text w-10 h-10 flex items-center justify-center border border-dune-border focus:outline-none focus-visible:ring-2 focus-visible:ring-dune-accent"
+    >
+      <svg viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <path d="M6 6l12 12M18 6L6 18" stroke-linecap="round" />
+      </svg>
+    </button>
+    <img
+      id="dst-lightbox-img"
+      alt=""
+      class="max-w-full max-h-full object-contain rounded-lg shadow-2xl shadow-black/60"
+    />
+  </div>
+</dialog>
+
+<script>
+  const dialog = document.getElementById("dst-lightbox") as HTMLDialogElement | null;
+  const img = document.getElementById("dst-lightbox-img") as HTMLImageElement | null;
+
+  if (dialog && img) {
+    const open = (src: string, alt: string) => {
+      img.src = src;
+      img.alt = alt;
+      if (typeof dialog.showModal === "function") {
+        dialog.showModal();
+      } else {
+        dialog.setAttribute("open", "");
+      }
+      document.documentElement.style.overflow = "hidden";
+    };
+
+    const close = () => {
+      if (dialog.open) dialog.close();
+      document.documentElement.style.overflow = "";
+      // Drop the src so the image isn't held in memory while closed.
+      img.removeAttribute("src");
+      img.alt = "";
+    };
+
+    document.addEventListener("click", (e) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      const trigger = target.closest<HTMLElement>("[data-lightbox-trigger]");
+      if (trigger) {
+        const src = trigger.getAttribute("data-lightbox-src");
+        const alt = trigger.getAttribute("data-lightbox-alt") ?? "";
+        if (src) {
+          e.preventDefault();
+          open(src, alt);
+        }
+        return;
+      }
+      if (target.closest("[data-lightbox-close]")) {
+        close();
+      }
+    });
+
+    // Click on the backdrop (outside the inner flex container) closes too.
+    dialog.addEventListener("click", (e) => {
+      if (e.target === dialog) close();
+    });
+
+    // Native dialog ESC fires a `cancel` event then `close`; make sure we
+    // restore body scroll and clear the src.
+    dialog.addEventListener("close", () => {
+      document.documentElement.style.overflow = "";
+      img.removeAttribute("src");
+      img.alt = "";
+    });
+  }
+</script>

--- a/site/src/components/Screenshot.astro
+++ b/site/src/components/Screenshot.astro
@@ -7,11 +7,21 @@ const { src, alt, caption } = Astro.props as {
 ---
 
 <figure class="my-8">
-  <div
-    class="overflow-hidden rounded-lg border border-dune-border bg-dune-surface"
+  <button
+    type="button"
+    data-lightbox-trigger
+    data-lightbox-src={src}
+    data-lightbox-alt={alt}
+    aria-label={`Open larger view: ${alt}`}
+    class="group block w-full overflow-hidden rounded-lg border border-dune-border bg-dune-surface cursor-zoom-in focus:outline-none focus-visible:ring-2 focus-visible:ring-dune-accent"
   >
-    <img src={src} alt={alt} loading="lazy" class="w-full h-auto" />
-  </div>
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      class="w-full h-auto transition-transform duration-200 group-hover:scale-[1.01]"
+    />
+  </button>
   {caption && (
     <figcaption class="mt-2 text-sm text-dune-muted">{caption}</figcaption>
   )}

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import Lightbox from "../components/Lightbox.astro";
 const { title, description, ogImage } = Astro.props as {
   title: string;
   description?: string;
@@ -109,5 +110,6 @@ const ogImg = new URL(ogImage ?? `${base}og.png`, Astro.site).toString();
         </div>
       </div>
     </footer>
+    <Lightbox />
   </body>
 </html>


### PR DESCRIPTION
Screenshots on the marketing site are too small to read in the page layout. Click any one of them now and a full-viewport lightbox opens so you can actually see what's on the page.

## What changed

- New `site/src/components/Lightbox.astro` — a single shared `<dialog>` rendered in `Base.astro`, so the viewer is available on every page (home + features + install) without duplicating markup.
- `Screenshot.astro` now wraps the image in a `<button data-lightbox-trigger>` with `cursor-zoom-in`, a subtle hover scale, and a visible focus ring for keyboard users.
- A tiny inline script delegates clicks to open the dialog with the right image. Closes on backdrop click, **ESC**, or the close button. Locks page scroll while open and clears the image `src` on close so the bitmap isn't held in memory.

## Behaviour

- Image renders at `max-w-full max-h-full object-contain` — it scales up to fit the viewport while preserving aspect ratio.
- Native `<dialog>.showModal()` gives correct focus trapping + inert background for free.
- Falls back to setting `open` attribute if `showModal` isn't available (very old browsers).

## Verified

Built locally; both pages have `data-lightbox-trigger` on every screenshot button and exactly one `#dst-lightbox` `<dialog>` per page (from the shared layout).