### PR TITLE
app: add diagnostic bundle builder + Help menu integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,6 +14,15 @@ body:
         PowerShell script (`dune-server.ps1`), the `.bat` launcher, and the
         installer (`DuneServerSetup.exe`).
 
+        > 💡 **One-click report from the app.** In the desktop app, click
+        > **Help → Create GitHub Issue + Save Logs**. It opens this form
+        > pre-filled AND saves `dst-diagnostics-<timestamp>.zip` to your
+        > Desktop (Explorer pops with the ZIP selected). **Drag the ZIP
+        > into the comment area below** to attach all logs at once — VM IPs,
+        > SSH paths, Windows usernames, and config secrets are redacted before
+        > the ZIP is written. The bundle's `manifest.txt` lists what's inside
+        > and any sanitization warnings.
+
         **✅ Do open an issue here** when the tool shows you a problem, e.g.:
         - The **Server Health** page shows the battlegroup as **Unknown** with
           a yellow message under it (SSH key / connection diagnostics).
@@ -165,12 +174,17 @@ body:
     attributes:
       label: Transcript / log excerpt
       description: |
-        Every CLI run is auto-logged to `.logs\dune-server-<timestamp>.log`
-        next to `dune-server.bat`. The desktop app also writes
-        `%APPDATA%\DuneServer\webview2-debug.log`. Paste the relevant
-        section (last 30-50 lines around the failure is usually enough
-        — please **redact** public IPs, SSH key paths, hostnames, and
-        any secrets first).
+        💡 **Easiest path: attach the diagnostic ZIP.** Use **Help → Create
+        GitHub Issue + Save Logs** in the desktop app — it saves a redacted
+        `dst-diagnostics-<timestamp>.zip` to your Desktop and reveals it in
+        Explorer. Drag it onto this comment area to attach.
+
+        If you'd rather paste manually, every CLI run is auto-logged to
+        `.logs\dune-server-<timestamp>.log` next to `dune-server.bat`. The
+        desktop app also writes `%APPDATA%\DuneServer\webview2-debug.log`.
+        Paste the relevant section (last 30-50 lines around the failure is
+        usually enough — please **redact** public IPs, SSH key paths,
+        hostnames, and any secrets first).
       render: shell
 
   - type: textarea

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -1,0 +1,308 @@
+﻿# /api/diagnostics — build a redacted ZIP of logs the user can attach to a
+# GitHub bug report. Triggered from the React "Help → Create GitHub Issue +
+# Save Logs" menu item and from the CLI `report-issue` command.
+#
+# Hard rules:
+#   - Everything that lands in the ZIP runs through Invoke-DstRedaction first.
+#     We never write the user's real VM IP, SSH key path, or Windows username
+#     into a file they're about to attach to a public issue.
+#   - Failures on individual sources (missing log, locked file, OneDrive
+#     Desktop read-only) are recorded in manifest.txt as warnings; the ZIP
+#     still builds with whatever did succeed.
+#   - The ZIP is staged under %TEMP% and only renamed into place after a
+#     successful Compress-Archive — no partial files on the user's Desktop.
+
+# --- Sanitization ------------------------------------------------------------
+
+# Returns a copy of $Text with anything personally identifying replaced.
+# Cheap to call on every line / every file we include in the bundle.
+function Invoke-DstRedaction {
+    param(
+        [string]$Text,
+        [string]$WindowsUser,
+        [string]$SshKeyPath,
+        [string]$SteamPath,
+        [string]$DuneAdminExe
+    )
+    if ([string]::IsNullOrEmpty($Text)) { return $Text }
+    $out = $Text
+
+    # 1) ?t=<token>  -> ?t=<redacted>   (the local-portal auth token)
+    $out = [regex]::Replace($out, '([?&;])t=[^&\s"''<>]+', '$1t=<redacted>')
+
+    # 2) IPv4 addresses (but leave 127.0.0.1 / 0.0.0.0 / 255.255.255.255 alone —
+    #    those carry no identifying info and matter for log readability).
+    $out = [regex]::Replace($out, '\b(?!(?:127\.0\.0\.1|0\.0\.0\.0|255\.255\.255\.255)\b)(?:\d{1,3}\.){3}\d{1,3}\b', '<ip>')
+
+    # 3) IPv6 addresses (anything with two or more colon-separated hex groups,
+    #    minus the loopback ::1).
+    $out = [regex]::Replace($out, '(?<![:\w])(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}(?![:\w])', {
+        param($m) if ($m.Value -eq '::1') { return '::1' } else { return '<ipv6>' }
+    })
+
+    # 4) Specific config paths we know carry the username.
+    if ($WindowsUser) {
+        $out = [regex]::Replace($out, [regex]::Escape($WindowsUser), '<user>', 'IgnoreCase')
+    }
+    if ($SshKeyPath) {
+        $out = [regex]::Replace($out, [regex]::Escape($SshKeyPath), '<ssh-key-path>', 'IgnoreCase')
+    }
+    if ($SteamPath) {
+        $out = [regex]::Replace($out, [regex]::Escape($SteamPath), '<steam-path>', 'IgnoreCase')
+    }
+    if ($DuneAdminExe) {
+        $out = [regex]::Replace($out, [regex]::Escape($DuneAdminExe), '<dune-admin-path>', 'IgnoreCase')
+    }
+
+    # 5) Generic Windows user-profile path:  C:\Users\<anyone>\  ->  C:\Users\<user>\
+    $out = [regex]::Replace($out, '([A-Za-z]):\\Users\\[^\\/:*?"<>|\r\n]+', '$1:\Users\<user>', 'IgnoreCase')
+
+    # 6) SshKey=<value> / SteamPath=<value> / WindowsUser=<value> lines in
+    #    INI-style config files. Belt-and-braces in case the value didn't
+    #    match the explicit redactions above.
+    foreach ($k in @('SshKey', 'WindowsUser', 'SteamPath', 'DuneAdminExe', 'PortCheckUrlTemplate')) {
+        $out = [regex]::Replace($out, "(?m)^(\s*$k\s*=\s*).+$", "`${1}<redacted>")
+    }
+
+    return $out
+}
+
+# --- Bundle builder ----------------------------------------------------------
+
+function Get-DstDesktopPath {
+    # Resolve Desktop via .NET (respects OneDrive / Group Policy redirection).
+    # Falls back to %APPDATA%\DuneServer\Diagnostics if Desktop is unwritable.
+    try {
+        $desktop = [Environment]::GetFolderPath('Desktop')
+        if ($desktop -and (Test-Path -LiteralPath $desktop)) {
+            $probe = Join-Path $desktop ".dst-diag-write-test-$([guid]::NewGuid().ToString('N'))"
+            try {
+                Set-Content -LiteralPath $probe -Value 'x' -Encoding ASCII -ErrorAction Stop
+                Remove-Item -LiteralPath $probe -ErrorAction SilentlyContinue
+                return @{ path = $desktop; fallback = $false }
+            } catch {}
+        }
+    } catch {}
+    $fallback = Join-Path $env:APPDATA 'DuneServer\Diagnostics'
+    [void](New-Item -ItemType Directory -Force -Path $fallback -ErrorAction SilentlyContinue)
+    return @{ path = $fallback; fallback = $true }
+}
+
+function Get-DstWebView2Version {
+    foreach ($p in @(
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
+        'HKLM:\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
+        'HKCU:\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}'
+    )) {
+        try {
+            $v = (Get-ItemProperty -Path $p -Name 'pv' -ErrorAction Stop).pv
+            if ($v -and $v -ne '0.0.0.0') { return $v }
+        } catch {}
+    }
+    return '(not installed / not detected)'
+}
+
+# Read a file that may be open for append (logs). Returns the LAST $MaxBytes
+# of content, or $null on failure. Uses FileShare.ReadWrite so a writer that
+# holds the file open doesn't block us.
+function Read-DstLogTail {
+    param([string]$Path, [int]$MaxBytes = 204800)
+    if (-not (Test-Path -LiteralPath $Path)) { return $null }
+    try {
+        $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open,
+                                            [System.IO.FileAccess]::Read,
+                                            [System.IO.FileShare]::ReadWrite)
+        try {
+            $len = $fs.Length
+            if ($len -gt $MaxBytes) {
+                [void]$fs.Seek($len - $MaxBytes, [System.IO.SeekOrigin]::Begin)
+            }
+            $reader = New-Object System.IO.StreamReader($fs, [System.Text.Encoding]::UTF8, $true)
+            try { return $reader.ReadToEnd() } finally { $reader.Dispose() }
+        } finally { $fs.Dispose() }
+    } catch {
+        return $null
+    }
+}
+
+# Builds the diagnostic bundle. Returns a hashtable with the same shape the
+# /api/diagnostics/bundle handler echoes back to the React client (so the CLI
+# `report-issue` command can use the exact same code path).
+function New-DstDiagnosticBundle {
+    [CmdletBinding()]
+    param()
+
+    $warnings = New-Object System.Collections.Generic.List[string]
+    $included = New-Object System.Collections.Generic.List[hashtable]
+
+    # 1) Pick the on-disk destination ----------------------------------------
+    $destInfo = Get-DstDesktopPath
+    if ($destInfo.fallback) {
+        $warnings.Add("Desktop is not writable (OneDrive / Group Policy?). Saved under %APPDATA%\DuneServer\Diagnostics instead.")
+    }
+    $ts = (Get-Date).ToString('yyyyMMdd-HHmmss-fff')
+    $finalZip = Join-Path $destInfo.path "dst-diagnostics-$ts.zip"
+    $tmpZip   = "$finalZip.tmp"
+
+    # Stage everything in %TEMP% so writes to the user's Desktop are atomic
+    # (we Compress-Archive into the .tmp name, then rename on success).
+    $stageDir = Join-Path $env:TEMP "dst-diagnostics-$ts"
+    [void](New-Item -ItemType Directory -Force -Path $stageDir -ErrorAction SilentlyContinue)
+
+    # 2) Resolve config so we know what to redact ----------------------------
+    $cfg = $null
+    try { $cfg = Read-DuneConfigRaw } catch { $warnings.Add("Could not read dune-server.config: $($_.Exception.Message)") }
+    $redactArgs = @{
+        WindowsUser  = if ($cfg) { [string]$cfg.WindowsUser  } else { '' }
+        SshKeyPath   = if ($cfg) { [string]$cfg.SshKey       } else { '' }
+        SteamPath    = if ($cfg) { [string]$cfg.SteamPath    } else { '' }
+        DuneAdminExe = if ($cfg) { [string]$cfg.DuneAdminExe } else { '' }
+    }
+
+    # 3) env.txt -------------------------------------------------------------
+    $envInfo = [System.Collections.Generic.List[string]]::new()
+    $envInfo.Add("Tool version       : v$script:DuneToolVersion")
+    $envInfo.Add("PowerShell         : $($PSVersionTable.PSVersion) ($($PSVersionTable.PSEdition))")
+    $envInfo.Add("OS                 : Windows $([System.Environment]::OSVersion.Version)")
+    $envInfo.Add("WebView2 runtime   : $(Get-DstWebView2Version)")
+    $envInfo.Add("AppDir             : $script:AppDir")
+    $envInfo.Add("UserDataFolder     : $(Join-Path $env:LOCALAPPDATA 'DuneServer\webview2')")
+    $envInfo.Add("Config dir         : $(Join-Path $env:APPDATA 'DuneServer')")
+    $envInfo.Add("Generated          : $(Get-Date -Format 'o')")
+    $envText = Invoke-DstRedaction -Text ($envInfo -join "`r`n") @redactArgs
+    $envPath = Join-Path $stageDir 'env.txt'
+    Set-Content -LiteralPath $envPath -Value $envText -Encoding UTF8
+    $included.Add(@{ name = 'env.txt'; bytes = (Get-Item -LiteralPath $envPath).Length })
+
+    # 4) Sanitized config copy -----------------------------------------------
+    $cfgPath = Get-DuneConfigPath
+    if (Test-Path -LiteralPath $cfgPath) {
+        try {
+            $raw  = Get-Content -LiteralPath $cfgPath -Raw -ErrorAction Stop
+            $san  = Invoke-DstRedaction -Text $raw @redactArgs
+            $out  = Join-Path $stageDir 'dune-server.config.sanitized.txt'
+            Set-Content -LiteralPath $out -Value $san -Encoding UTF8
+            $included.Add(@{ name = 'dune-server.config.sanitized.txt'; bytes = (Get-Item -LiteralPath $out).Length })
+        } catch {
+            $warnings.Add("Failed to sanitize dune-server.config: $($_.Exception.Message)")
+        }
+    } else {
+        $warnings.Add("dune-server.config not found at $cfgPath.")
+    }
+
+    # 5) WebView2 debug log (tail, sanitized) --------------------------------
+    $wv2 = Join-Path $env:APPDATA 'DuneServer\webview2-debug.log'
+    $wv2Tail = Read-DstLogTail -Path $wv2 -MaxBytes 204800
+    if ($null -ne $wv2Tail) {
+        try {
+            $wv2Bytes  = (Get-Item -LiteralPath $wv2 -ErrorAction Stop).Length
+            $header    = "# webview2-debug.log (tail, sanitized; source size: $wv2Bytes bytes)`r`n# Path: $wv2`r`n`r`n"
+            $san       = $header + (Invoke-DstRedaction -Text $wv2Tail @redactArgs)
+            $out       = Join-Path $stageDir 'webview2-debug.log'
+            Set-Content -LiteralPath $out -Value $san -Encoding UTF8
+            $included.Add(@{ name = 'webview2-debug.log'; bytes = (Get-Item -LiteralPath $out).Length })
+            if ($wv2Bytes -gt 204800) { $warnings.Add('webview2-debug.log was truncated to the last 200 KB.') }
+        } catch {
+            $warnings.Add("Failed to copy webview2-debug.log: $($_.Exception.Message)")
+        }
+    } else {
+        $warnings.Add('webview2-debug.log not present — the desktop app may not have been launched on this machine yet.')
+    }
+
+    # 6) Recent CLI logs (last 3 dune-server-*.log) --------------------------
+    $logRoots = @(
+        (Join-Path (Split-Path -Parent $script:AppDir) '.logs'),
+        (Join-Path $env:APPDATA 'DuneServer\.logs')
+    ) | Where-Object { $_ -and (Test-Path -LiteralPath $_) } | Select-Object -Unique
+    $foundCliLogs = $false
+    foreach ($root in $logRoots) {
+        $logs = Get-ChildItem -LiteralPath $root -Filter 'dune-server-*.log' -File -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending | Select-Object -First 3
+        foreach ($lg in $logs) {
+            $foundCliLogs = $true
+            $tail = Read-DstLogTail -Path $lg.FullName -MaxBytes 51200   # 50 KB each
+            if ($null -ne $tail) {
+                $header = "# $($lg.Name) (tail, sanitized; source size: $($lg.Length) bytes)`r`n# Path: $($lg.FullName)`r`n`r`n"
+                $san    = $header + (Invoke-DstRedaction -Text $tail @redactArgs)
+                $out    = Join-Path $stageDir $lg.Name
+                Set-Content -LiteralPath $out -Value $san -Encoding UTF8
+                $included.Add(@{ name = $lg.Name; bytes = (Get-Item -LiteralPath $out).Length })
+            } else {
+                $warnings.Add("Could not read $($lg.FullName).")
+            }
+        }
+    }
+    if (-not $foundCliLogs) {
+        $warnings.Add('No dune-server-*.log CLI transcripts found.')
+    }
+
+    # 7) Manifest ------------------------------------------------------------
+    $manLines = [System.Collections.Generic.List[string]]::new()
+    $manLines.Add("Dune Server Tool diagnostic bundle")
+    $manLines.Add("Generated $(Get-Date -Format 'o') by v$script:DuneToolVersion")
+    $manLines.Add('')
+    $manLines.Add('Sanitization applied to every text file in this bundle:')
+    $manLines.Add('  - IPv4 / IPv6 addresses (except loopback) -> <ip> / <ipv6>')
+    $manLines.Add('  - C:\Users\<anyone>\... paths              -> C:\Users\<user>\...')
+    $manLines.Add('  - WindowsUser / SshKey / SteamPath /       -> <user> / <ssh-key-path> /')
+    $manLines.Add('    DuneAdminExe values                         <steam-path> / <dune-admin-path>')
+    $manLines.Add('  - ?t=<token> query params                  -> ?t=<redacted>')
+    $manLines.Add('  - INI key=value redaction for the keys above as a safety net')
+    $manLines.Add('')
+    $manLines.Add('Files included:')
+    foreach ($f in $included) {
+        $manLines.Add(("  {0,-40} {1,10} bytes" -f $f.name, $f.bytes))
+    }
+    if ($warnings.Count -gt 0) {
+        $manLines.Add('')
+        $manLines.Add('Warnings:')
+        foreach ($w in $warnings) { $manLines.Add("  - $w") }
+    }
+    $manPath = Join-Path $stageDir 'manifest.txt'
+    Set-Content -LiteralPath $manPath -Value ($manLines -join "`r`n") -Encoding UTF8
+    $included.Add(@{ name = 'manifest.txt'; bytes = (Get-Item -LiteralPath $manPath).Length })
+
+    # 8) Compress into .tmp then atomically rename ---------------------------
+    if (Test-Path -LiteralPath $tmpZip)   { Remove-Item -LiteralPath $tmpZip -Force -ErrorAction SilentlyContinue }
+    if (Test-Path -LiteralPath $finalZip) { Remove-Item -LiteralPath $finalZip -Force -ErrorAction SilentlyContinue }
+    try {
+        Compress-Archive -Path (Join-Path $stageDir '*') -DestinationPath $tmpZip -Force -ErrorAction Stop
+        Rename-Item -LiteralPath $tmpZip -NewName (Split-Path -Leaf $finalZip) -ErrorAction Stop
+    } catch {
+        if (Test-Path -LiteralPath $tmpZip) { Remove-Item -LiteralPath $tmpZip -Force -ErrorAction SilentlyContinue }
+        Remove-Item -LiteralPath $stageDir -Recurse -Force -ErrorAction SilentlyContinue
+        throw "Failed to build diagnostic ZIP: $($_.Exception.Message)"
+    }
+    Remove-Item -LiteralPath $stageDir -Recurse -Force -ErrorAction SilentlyContinue
+
+    $zipSize = (Get-Item -LiteralPath $finalZip).Length
+
+    # 9) Best-effort: pop Explorer with the ZIP selected ---------------------
+    try {
+        Start-Process -FilePath 'explorer.exe' -ArgumentList "/select,`"$finalZip`"" -ErrorAction Stop | Out-Null
+    } catch {
+        $warnings.Add("Could not open Explorer to reveal the ZIP: $($_.Exception.Message)")
+    }
+
+    return @{
+        ok        = $true
+        path      = $finalZip
+        sizeBytes = $zipSize
+        fileCount = $included.Count
+        sanitized = $true
+        warnings  = @($warnings)
+    }
+}
+
+# --- Route -------------------------------------------------------------------
+
+# POST /api/diagnostics/bundle — build the ZIP and reveal it in Explorer.
+Register-DuneRoute -Method POST -Path '/api/diagnostics/bundle' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $result = New-DstDiagnosticBundle
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -2216,6 +2216,11 @@ while ($true) {
         Write-Host "  Not for raw router/port-forwarding or Funcom game-server issues -" -ForegroundColor Yellow
         Write-Host "  for those, ping @allcoast on Discord." -ForegroundColor DarkGray
         Write-Host ""
+        Write-Host "  TIP: For the easiest bug report, launch the desktop app and" -ForegroundColor Cyan
+        Write-Host "       click Help -> Create GitHub Issue + Save Logs. That" -ForegroundColor Cyan
+        Write-Host "       saves a redacted dst-diagnostics-<ts>.zip on your Desktop" -ForegroundColor Cyan
+        Write-Host "       you can drag straight into the issue comment." -ForegroundColor Cyan
+        Write-Host ""
 
         # GitHub issue forms accept URL params keyed by the input id in the
         # YAML form. Prefill what we already know so the user only fills in

--- a/webui/src/api/diagnostics.ts
+++ b/webui/src/api/diagnostics.ts
@@ -1,0 +1,19 @@
+// Diagnostics API — build a redacted bundle of logs the user can drag into
+// their GitHub bug report. Triggered from the Help dropdown.
+import { api } from './client'
+
+export interface DiagnosticBundle {
+  ok: boolean
+  path: string
+  sizeBytes: number
+  fileCount: number
+  sanitized: boolean
+  warnings: string[]
+}
+
+export function buildDiagnosticBundle() {
+  return api<DiagnosticBundle>('/api/diagnostics/bundle', {
+    method: 'POST',
+    body: '{}',
+  })
+}

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -4,6 +4,7 @@ import { Icon } from '../components/Icon'
 import { NAV_ITEMS, GROUP_LABELS, GROUP_ORDER, type NavGroup } from '../nav'
 import { useUpdateCheck } from '../hooks/useUpdateCheck'
 import { useLaunchDuneAdmin } from '../hooks/useLaunchDuneAdmin'
+import { buildDiagnosticBundle } from '../api/diagnostics'
 
 type MenuKey = NavGroup | 'help'
 
@@ -44,6 +45,23 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
   const issueHref = `https://github.com/coastal-ms/DST-DuneServerTool/issues/new?template=bug_report.yml${
     version ? `&tool_version=v${encodeURIComponent(version)}` : ''
   }`
+
+  // Help → Create GitHub Issue + Save Logs. Opens the prefilled issue form
+  // synchronously inside the click handler (so the popup-blocker treats it as
+  // a user gesture), then fires the diagnostics-bundle build in the
+  // background. The backend pops an Explorer window with the ZIP selected so
+  // the user can drag it straight into the new issue comment. We intentionally
+  // do NOT await the bundle before opening the issue — a slow zip should
+  // never make the issue tab fail to open.
+  const onReportIssue = () => {
+    setOpen(null)
+    window.open(issueHref, '_blank', 'noopener,noreferrer')
+    void buildDiagnosticBundle().catch(() => {
+      /* the toastless world: backend already revealed the ZIP if it succeeded.
+         A failure here just means no auto-bundle — the user can still file the
+         issue manually and attach logs themselves. */
+    })
+  }
 
   const onItemClick = (item: typeof NAV_ITEMS[number]) => {
     setOpen(null)
@@ -127,18 +145,22 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
           Help
         </button>
         {open === 'help' && (
-          <div className="absolute left-0 top-full mt-1 min-w-[220px] bg-surface border border-border rounded-xl p-1 shadow-xl shadow-black/40 z-50">
-            <a
-              href={issueHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setOpen(null)}
-              className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors"
+          <div className="absolute left-0 top-full mt-1 min-w-[260px] bg-surface border border-border rounded-xl p-1 shadow-xl shadow-black/40 z-50">
+            <button
+              type="button"
+              onClick={onReportIssue}
+              className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors text-left"
+              title="Opens the prefilled GitHub bug-report form and saves a redacted log ZIP to your Desktop (Explorer will pop with the ZIP selected — drag it into the issue comment)."
             >
-              <Icon name="Github" size={14} />
-              <span className="flex-1">Create GitHub Issue</span>
-              <Icon name="ExternalLink" size={11} className="text-text-dim" />
-            </a>
+              <Icon name="Github" size={14} className="mt-0.5" />
+              <span className="flex-1">
+                <span className="block">Create GitHub Issue + Save Logs</span>
+                <span className="block text-[11px] text-text-dim">
+                  Opens the issue form &amp; drops a redacted ZIP on your Desktop
+                </span>
+              </span>
+              <Icon name="ExternalLink" size={11} className="text-text-dim mt-1" />
+            </button>
             <button
               type="button"
               onClick={() => { onToggleSidebar(); setOpen(null) }}


### PR DESCRIPTION
Closes the loop on "have the user click a button to send you a log" — adds **Help → Create GitHub Issue + Save Logs** in the desktop app.

## What it does

One click:
1. Opens the prefilled `bug_report.yml` form in a new tab (synchronously, so the popup blocker leaves it alone).
2. In the background, builds `dst-diagnostics-<timestamp>.zip` on the user's Desktop and pops Explorer with the ZIP selected — ready to drag into the issue comment.

## Bundle contents (all sanitized)

| File | Source | Cap |
|---|---|---|
| `env.txt` | Tool/PS/OS/WebView2 versions, paths | — |
| `dune-server.config.sanitized.txt` | `%APPDATA%\DuneServer\dune-server.config` | full |
| `webview2-debug.log` | `%APPDATA%\DuneServer\webview2-debug.log` | last 200 KB |
| `dune-server-*.log` ×3 | `.logs\dune-server-*.log` (CLI transcripts) | last 50 KB each |
| `manifest.txt` | file list + warnings | — |

## Sanitization

Every text file in the ZIP runs through `Invoke-DstRedaction`:
- IPv4 / IPv6 (except `127.0.0.1`, `::1`, `0.0.0.0`) → `<ip>` / `<ipv6>`
- `C:\Users\<anyone>\...` → `C:\Users\<user>\...`
- Config values for `WindowsUser` / `SshKey` / `SteamPath` / `DuneAdminExe` replaced everywhere
- `?t=<token>` query params → `?t=<redacted>`
- Belt-and-braces INI `key=value` redaction for `SshKey`, `WindowsUser`, `SteamPath`, `DuneAdminExe`, `PortCheckUrlTemplate`

Users are still told to review before attaching (sanitization is best-effort, never advertised as perfect).

## Design details

- **Popup-blocker safe.** `window.open(issueHref)` fires synchronously inside the click handler; the bundle `fetch` is fire-and-forget after.
- **Atomic ZIP.** Staged under `%TEMP%\dst-diagnostics-<ts>`, compressed to `<Desktop>\dst-diagnostics-<ts>.zip.tmp`, then renamed. No half-written files on the Desktop.
- **Desktop fallback.** If Desktop is read-only (OneDrive / Group Policy), drops the ZIP under `%APPDATA%\DuneServer\Diagnostics\` and notes it in `manifest.txt`.
- **Concurrent-write safe.** `FileShare.ReadWrite` opens for the live `webview2-debug.log` and current CLI log so the writer never blocks us.
- **Always produces something.** Missing/locked sources become warnings in `manifest.txt`; the ZIP still builds with whatever did succeed.
- **Best-effort Explorer.** `explorer.exe /select` is wrapped in `try`/`catch` — never fails the route.
- **Millisecond timestamps.** Two clicks in the same second won't collide.

## Files touched

- `app/server/routes/Diagnostics.ps1` — new route + bundle builder + sanitizer (POST `/api/diagnostics/bundle`)
- `webui/src/api/diagnostics.ts` — typed client wrapper
- `webui/src/layout/MenuBar.tsx` — Help dropdown wired to button with synchronous `window.open` + async bundle build
- `dune-server.ps1` — CLI `report-issue` now points users at the app for the easier flow
- `.github/ISSUE_TEMPLATE/bug_report.yml` — intro callout + transcript-field guidance updated

## Validation

- ✅ `npm run build` (webui) — TypeScript clean
- ✅ `Parser::ParseFile` — both `Diagnostics.ps1` and `dune-server.ps1` parse clean
- ✅ `yaml.safe_load` — `bug_report.yml` parses
- ⚠️ No end-to-end test possible from CI (DST runs on Windows + WebView2). Reviewed against rubber-duck design critique before implementation.

Rubber-duck-approved blind spots that were caught early and baked in: sanitize all text files (not just config), tail not full log, sync popup open before await, OneDrive Desktop fallback, FileShare.ReadWrite for live logs, atomic .tmp/rename, warnings instead of failure, label the button so the side-effect is visible.