### PR TITLE
release: v10.2.5 — diagnostic bundle button + bug-report template refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.2.5] - 2026-06-03
+
+### Added
+- **Help → Create GitHub Issue + Save Logs** in the top menu bar — one
+  click opens the prefilled `bug_report.yml` issue form **and** drops a
+  redacted `dst-diagnostics-<timestamp>.zip` on the user's Desktop with
+  Explorer popped to it, so reporters can drag-and-drop attach all
+  relevant logs to the new issue comment in one motion. Bundle contains
+  `env.txt` (tool/PS/OS/WebView2 versions), a sanitized copy of
+  `dune-server.config`, the tail of `webview2-debug.log` (last 200 KB),
+  the last 3 CLI `dune-server-*.log` files (tails, 50 KB each), and a
+  `manifest.txt` listing what's inside and any sanitization warnings.
+- New `POST /api/diagnostics/bundle` route + `Invoke-DstRedaction`
+  helper that scrubs IPv4 / IPv6 (loopback preserved), Windows
+  user-profile paths, `?t=<token>` query params, and INI `key=value`
+  secrets for `SshKey`, `WindowsUser`, `SteamPath`, `DuneAdminExe`,
+  `PortCheckUrlTemplate` from every text file written into the bundle.
+
+### Changed
+- **Bug report template (`bug_report.yml`)** updated for the v10.2.x
+  app layout — surface dropdown now lists Server Health, Commands,
+  PowerShell, Characters, Game Config, DD Map, Database, Sietches, Map
+  SpinUp, Settings (split into 3 sub-areas), Setup Wizard, the top
+  menu bar/Help dropdown, sidebar/chrome, desktop shell, CLI, and the
+  installer — and the intro callout + Transcript field now point
+  reporters at the new diagnostic bundle button as the easiest way to
+  attach logs.
+- **CLI `report-issue`** prints a hint pointing CLI users at the
+  desktop app's Help → Create GitHub Issue + Save Logs flow for the
+  one-click attachable ZIP. URL-prefilled diagnostics are unchanged.
+
+### Removed
+- Legacy `bug_report.md` issue template (duplicate on the issue
+  chooser; the YAML form supersedes it).
+
 ## [10.2.4] - 2026-06-03
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.2.4'
+$script:DuneToolVersion = '10.2.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.2.4',
+    [string]$Version = '10.2.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.2.4</Version>
+    <Version>10.2.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.2.4"
+#define MyAppVersion "10.2.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "10.2.4"
+$script:ToolVersion = "10.2.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Cuts v10.2.5. Bumps the 5 version stamps and rolls #57-#64 worth of changes into the CHANGELOG.

Headline: **Help → Create GitHub Issue + Save Logs** in the desktop app — one click opens the prefilled bug-report form *and* drops a redacted `dst-diagnostics-<ts>.zip` on the user's Desktop with Explorer popped to it. See [10.2.5] in CHANGELOG for the full notes.

Once this merges → tag `v10.2.5` → build installer → upload `DuneServerSetup.exe` to the GitHub release (per the hard rule: every DST release must include the installer .exe).