### PR TITLE
ci(deploy-site): drop release:published trigger

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -16,8 +16,11 @@ on:
       - "CHANGELOG.md"
       - "docs/img/**"
       - ".github/workflows/deploy-site.yml"
-  release:
-    types: [published]
+  # NOTE: we intentionally do NOT trigger on `release: published`. The
+  # `release: v10.2.X ...` merge commit to main always touches CHANGELOG.md
+  # and re-deploys the site, and the github-pages environment only allows
+  # one concurrent deploy — so a release-event run that fires while the
+  # CHANGELOG-push run is in flight just gets rejected and spams CI email.
   workflow_dispatch:
 
 # Allow only one deploy at a time; cancel in-progress runs on new pushes.


### PR DESCRIPTION
The github-pages environment only allows one concurrent deploy. Every release ships via a `release: vX.Y.Z …` merge commit that also touches `CHANGELOG.md` and kicks the push-event deploy. The duplicate release-event run that fires moments later just gets rejected by the environment protection rule and emails a "jobs were not successful" notification for no useful reason (which is exactly what just happened for v10.2.5).

Drop the `release: published` trigger; keep `workflow_dispatch` as the manual fallback (used when the homepage's GitHub-API-driven "latest release" card needs a rebuild after a release ships without a CHANGELOG bump — like we did manually after v10.2.5 published).