### PR TITLE
fix(dune-admin-patches): purge stale flat-file shadows before pnpm build (v10.2.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.2.6] - 2026-06-04
+
+### Fixed
+- **Dune-admin pricing patch: rebuild now survives upstream file-to-directory
+  refactors.** After Icehunter/dune-admin v0.24.0 refactored
+  `web/src/tabs/WelcomePackageTab.tsx` into `web/src/tabs/WelcomePackageTab/`
+  (`index.tsx` + `views/` + `types.ts`), every "Reinstall + keep sane-pricing
+  patch" failed with `pnpm build` errors:
+  `src/App.tsx(20,10): error TS2614: ... has no exported member 'WelcomePackageTab'`
+  and `src/tabs/WelcomePackageTab.tsx(138,13): error TS2741: Property 'active_versions' is missing`.
+  Root cause was in **our** overlay step, not upstream: `Sync-DuneAdminSourceTarball`
+  uses `robocopy /E`, which is additive — it never deletes files that were
+  removed in the new release. The deleted flat `WelcomePackageTab.tsx`
+  stayed on disk as an orphan from the prior v0.23.x install, and
+  TypeScript/Vite module resolution prefers a bare `.tsx` over a sibling
+  `dir/index.tsx`, so the stale file shadowed the new directory and `tsc`
+  saw the wrong export shape. Go build succeeded (the patched
+  `dune-admin.exe` was replaced cleanly with v0.24.0), but the embedded
+  web UI never compiled, so the build wrapper failed with exit 1 and the
+  marketplace bot panel was effectively unbuildable.
+- `app/resources/dune-admin-patches/build-patched.ps1` now scans
+  `web/src/` for any `Foo.tsx` / `Foo.ts` that has a sibling `Foo/`
+  directory containing `index.tsx` / `index.ts`, and deletes the flat
+  file before running `pnpm install` / `pnpm build`. The check is safe
+  by construction (you never legitimately ship a flat component file
+  next to a sibling barrel directory of the same name; the collision is
+  always a refactor leftover) and only fires on the exact shadow
+  pattern. Any removal also invalidates `.dst-web-build-stamp` so the
+  cached `web/dist/` (which may have been compiled from the stale file)
+  gets rebuilt instead of reused. Fixes future upstream refactors of
+  this shape without needing per-release patches.
+
 ## [10.2.5] - 2026-06-03
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.2.5'
+$script:DuneToolVersion = '10.2.6'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.2.5',
+    [string]$Version = '10.2.6',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.2.5</Version>
+    <Version>10.2.6</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.2.5"
+#define MyAppVersion "10.2.6"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/resources/dune-admin-patches/build-patched.ps1
+++ b/app/resources/dune-admin-patches/build-patched.ps1
@@ -244,6 +244,66 @@ if (-not $pnpm) {
 $pnpmExe = $pnpm.Exe
 $pnpmPre = $pnpm.Pre
 
+# --- Stale flat-file shadow cleanup (web/src/) -------------------------------
+# Sync-DuneAdminSourceTarball in DuneAdmin.ps1 overlays the upstream tarball
+# with `robocopy /E`, which is additive — it never deletes files that were
+# removed upstream. When the upstream `web/src/` tree refactors a flat
+# component file (Foo.tsx) into a directory (Foo/index.tsx), the deleted
+# flat file lingers on disk as an orphan from the prior install. TypeScript
+# / Vite module resolution prefers a bare `.tsx` over a sibling `dir/index.tsx`,
+# so the stale flat file SHADOWS the new directory and the build picks it up
+# instead — with predictable disasters: named imports of a default-exported
+# symbol fail (TS2614), type literals miss new required fields (TS2741), etc.
+#
+# Concrete instance that motivated this code: upstream Icehunter/dune-admin
+# v0.24.0 refactored web/src/tabs/WelcomePackageTab.tsx into
+# web/src/tabs/WelcomePackageTab/index.tsx (plus views/, types.ts). Users
+# upgrading from v0.23.x kept the old flat file, App.tsx's
+# `import { WelcomePackageTab } from './tabs/WelcomePackageTab'` resolved to
+# the stale flat file (which exported the symbol as default and lacked the
+# new active_versions field), and `pnpm build` failed every reinstall with:
+#   src/App.tsx(20,10): error TS2614 ...
+#   src/tabs/WelcomePackageTab.tsx(138,13): error TS2741 ...
+#
+# The fix is purely local: scan web/src/ for any `Foo.tsx` / `Foo.ts` that
+# has a sibling `Foo/` directory containing `index.tsx` / `index.ts`, and
+# delete the flat file (the directory wins on disk if the flat sibling is
+# gone). This is safe by construction — you never legitimately ship a flat
+# `Foo.tsx` next to a sibling `Foo/index.tsx`; the pattern only arises as a
+# refactor leftover. We also nuke the .dst-web-build-stamp on any removal so
+# the prior dist (which may have been built FROM the stale file) gets
+# rebuilt, not reused.
+function Remove-StaleFlatFileShadows {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Root)
+    $removed = New-Object System.Collections.Generic.List[string]
+    if (-not (Test-Path -LiteralPath $Root -PathType Container)) { return $removed }
+    $candidates = Get-ChildItem -LiteralPath $Root -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object {
+            ($_.Extension -eq '.tsx' -or $_.Extension -eq '.ts') -and
+            $_.Name -ne 'index.tsx' -and $_.Name -ne 'index.ts' -and
+            $_.Name -notlike '*.d.ts'
+        }
+    foreach ($f in $candidates) {
+        $base = [System.IO.Path]::GetFileNameWithoutExtension($f.Name)
+        $siblingDir = Join-Path $f.Directory.FullName $base
+        if (-not (Test-Path -LiteralPath $siblingDir -PathType Container)) { continue }
+        $hasIndex = (Test-Path -LiteralPath (Join-Path $siblingDir 'index.tsx')) -or
+                    (Test-Path -LiteralPath (Join-Path $siblingDir 'index.ts'))
+        if (-not $hasIndex) { continue }
+        try {
+            Remove-Item -LiteralPath $f.FullName -Force -ErrorAction Stop
+            $removed.Add($f.FullName) | Out-Null
+        } catch {
+            # Best-effort: if we can't delete (locked, AV, perms), the build
+            # will fail with the original TS error below — which is no worse
+            # than the pre-fix behavior. Log and continue.
+            Write-Host "    WARN: could not remove stale shadow $($f.FullName): $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+    }
+    return $removed
+}
+
 Push-Location $repoRoot
 try {
     function Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
@@ -575,6 +635,28 @@ try {
         $nodeModules = Join-Path $webDir 'node_modules'
         $lockFile    = Join-Path $webDir 'pnpm-lock.yaml'
         $webStamp    = Join-Path $webDir '.dst-web-build-stamp'
+
+        # Purge stale flat-file shadows left over by the additive tarball
+        # overlay (see Remove-StaleFlatFileShadows docs above). Must run
+        # BEFORE the prereqs check — any removal forces a rebuild because the
+        # prior dist may have embedded code from the stale file.
+        $webSrc = Join-Path $webDir 'src'
+        $shadowsRemoved = Remove-StaleFlatFileShadows -Root $webSrc
+        if ($shadowsRemoved.Count -gt 0) {
+            Step "Removed $($shadowsRemoved.Count) stale flat-file shadow(s) under web\src\ (upstream refactor leftovers)"
+            foreach ($r in $shadowsRemoved) {
+                $rel = $r
+                if ($r.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $rel = $r.Substring($repoRoot.Length).TrimStart('\','/')
+                }
+                Info "removed $rel (shadowed by sibling directory with index.ts[x])"
+            }
+            # Invalidate the build stamp so the cached dist (potentially built
+            # FROM the stale file) gets rebuilt.
+            if (Test-Path -LiteralPath $webStamp) {
+                try { Remove-Item -LiteralPath $webStamp -Force -ErrorAction Stop } catch { }
+            }
+        }
         $lockHash = ''
         if (Test-Path -LiteralPath $lockFile) {
             try { $lockHash = (Get-FileHash -LiteralPath $lockFile -Algorithm SHA256).Hash } catch { }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "10.2.5"
+$script:ToolVersion = "10.2.6"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Symptom

After updating Icehunter/dune-admin to **v0.24.0**, every "Reinstall + keep sane-pricing patch" failed with:

```
src/App.tsx(20,10): error TS2614:
  Module './tabs/WelcomePackageTab' has no exported member 'WelcomePackageTab'.
  Did you mean to use 'import WelcomePackageTab from "./tabs/WelcomePackageTab"' instead?
src/tabs/WelcomePackageTab.tsx(138,13): error TS2741:
  Property 'active_versions' is missing in type '{ enabled: boolean; ... }'
  but required in type 'WelcomePackageConfig'.
```

Go build succeeded (patched `dune-admin.exe` replaced cleanly with v0.24.0), but `pnpm build` failed → exit 1 → "Patched build failed" in the DST UI. Market bot panel effectively unbuildable.

## Root cause (in *our* code, not upstream)

Upstream v0.24.0 refactored the flat `web/src/tabs/WelcomePackageTab.tsx` into a directory:

```
web/src/tabs/WelcomePackageTab/
├── index.tsx        (named export `WelcomePackageTab`, handles new `active_versions` field)
├── types.ts
└── views/
    ├── ConfigView.tsx
    ├── GrantsView.tsx
    └── PackagesView.tsx
```

The flat `WelcomePackageTab.tsx` was deleted upstream.

But `Sync-DuneAdminSourceTarball` in `app/server/routes/DuneAdmin.ps1` overlays the tarball with `robocopy /E` — **additive only, never deletes files removed in the new release**. So on every v0.23.x → v0.24.0 upgrade the deleted flat file stayed on disk as an orphan.

TypeScript / Vite module resolution prefers a bare `Foo.tsx` over a sibling `Foo/index.tsx`, so the stale flat file shadowed the new directory and `tsc` compiled the old code — which exported `WelcomePackageTab` as default (`App.tsx` now uses a named import) and lacked the new `active_versions` field. Hence both TS errors above.

Verified by listing the v0.24.0 source tarball:

```
$ tar -tzf dune-admin_0.24.0_source.tar.gz | rg WelcomePackageTab
web/src/tabs/WelcomePackageTab/
web/src/tabs/WelcomePackageTab/index.tsx
web/src/tabs/WelcomePackageTab/types.ts
web/src/tabs/WelcomePackageTab/views/
web/src/tabs/WelcomePackageTab/views/ConfigView.tsx
web/src/tabs/WelcomePackageTab/views/GrantsView.tsx
web/src/tabs/WelcomePackageTab/views/PackagesView.tsx
```

No flat `.tsx` in the tarball — confirms it's an orphan from the prior install, not an upstream bug.

## Fix

`app/resources/dune-admin-patches/build-patched.ps1` now scans `web/src/` for any `Foo.tsx` / `Foo.ts` that has a sibling `Foo/` directory containing `index.tsx` / `index.ts`, and deletes the flat file before `pnpm install` / `pnpm build`.

**Safe by construction:** you never legitimately ship a flat component file next to a sibling barrel directory of the same name. The collision is always a refactor leftover. Removal only fires on the exact shadow pattern (file *and* sibling dir *and* sibling dir contains an index module).

Any removal also invalidates `.dst-web-build-stamp` so the cached `web/dist/` (potentially compiled FROM the stale file) gets rebuilt instead of reused.

Fixes future upstream refactors of this shape without per-release patches.

## What this does NOT change

- Zero changes to Icehunter/dune-admin source — no new `.patch` files, no edits to existing patches.
- `0001-sane-pricing-100k-cap.patch` is untouched.
- Go build path, market bot config injection, version stamping, fuzz-fallback logic, all untouched.

## Validation

- ✅ `[System.Management.Automation.Language.Parser]::ParseFile` clean on the modified `.ps1` (773 lines, 0 errors).
- ✅ Manually deleted the orphan from `E:\DuneAdminMain\web\src\tabs\WelcomePackageTab.tsx` — DST "Reinstall" now succeeds against v0.24.0.
- ✅ Full build pipeline ran clean: `webui` → `Build-Exe.ps1` (10.2.6) → `Build-Installer.ps1` → `DuneServerSetup.exe` (45.29 MB).
- ✅ All 5 version stamps match 10.2.6 (Build-Installer's `Version-stamp check` passed).

## Release

Will tag `v10.2.6` from the merge commit and upload `DuneServerSetup.exe` as the sole asset (per the standing DST releases hard-rule — code-only releases would silently fail the in-app updater check).