### PR TITLE
feat(mapspinup): add Fix partitions button for on-demand maps (v10.2.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,40 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [10.2.8] - 2026-06-04
+
+### Added
+- **Map SpinUp page: "Fix partitions" button.** New action in the page header
+  invokes the existing `POST /api/maps/fix-partitions` endpoint (which runs
+  the remote `/etc/local.d/dune-clear-partitions.start` script) to clear the
+  stuck `igwsss.spec.partitions=[N]` pin that occasionally re-appears on the
+  on-demand maps (Deep Desert, Arrakeen, Harko Village) after a VM/BG reboot
+  or operator reconcile. Without clearing, the director can't trigger
+  scale-up on player entry and the map silently refuses to launch even with
+  its SpinUp checkbox enabled. The button shows a confirmation dialog
+  explaining what will happen, then renders the script's log tail in the
+  result card so the operator can see exactly which maps were cleared or
+  skipped. Safety guards (already enforced server-side by the remote script):
+  only the 3 on-demand maps are ever touched — Overmap and Survival_1 are
+  excluded by suffix matching — and any map with a running pod is skipped
+  so live sessions are never disturbed.
+
+### Changed
+- **Boot script `/etc/local.d/dune-clear-partitions.start` hardened on the
+  VM** (manual install — not part of this app release, documented here for
+  history). The pre-existing script waited for the K3s API and the `igwsss`
+  CRD to be reachable before proceeding, but in some boot scenarios the CRD
+  is registered seconds before the Funcom server-operator finishes
+  reconciling the battlegroup and creating the per-map `ServerSetScale`
+  instances. The script would log "no igwsss objects found; nothing to do"
+  and exit, leaving DD/Arrakeen/Harko with `partitions:[N]` pre-pinned by
+  the operator a few moments later. Added a second wait loop (up to 5 min)
+  that polls for at least one expected map igwsss object to actually exist
+  before deciding the BG has nothing to clean. Old version preserved at
+  `/etc/local.d/dune-clear-partitions.start.bak.20260604`. Cron watchdog
+  (`/etc/periodic/15min/dune-clear-partitions`) is unchanged and continues
+  to act as belt-and-suspenders.
+
 ## [10.2.7] - 2026-06-04
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '10.2.7'
+$script:DuneToolVersion = '10.2.8'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '10.2.7',
+    [string]$Version = '10.2.8',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>10.2.7</Version>
+    <Version>10.2.8</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "10.2.7"
+#define MyAppVersion "10.2.8"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "10.2.7"
+$script:ToolVersion = "10.2.8"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/maps.ts
+++ b/webui/src/api/maps.ts
@@ -64,3 +64,16 @@ export function stopMap(key: string, force = false) {
     method: 'POST',
   })
 }
+
+export interface FixPartitionsResult {
+  ok: boolean
+  output?: string
+  logTail?: string
+  message?: string
+}
+
+export function fixOnDemandPartitions() {
+  return api<FixPartitionsResult>('/api/maps/fix-partitions', {
+    method: 'POST',
+  })
+}

--- a/webui/src/pages/MapSpinUp.tsx
+++ b/webui/src/pages/MapSpinUp.tsx
@@ -3,6 +3,7 @@ import { PageHeader } from '../components/PageHeader'
 import { Icon } from '../components/Icon'
 import { ApiError } from '../api/client'
 import { getMapSpinUp, setMapSpinUp, type SpinUpMap } from '../api/mapSpinUp'
+import { fixOnDemandPartitions } from '../api/maps'
 
 export function MapSpinUp() {
   const [maps, setMaps] = useState<SpinUpMap[] | null>(null)
@@ -10,6 +11,8 @@ export function MapSpinUp() {
   const [error, setError] = useState<string | null>(null)
   const [message, setMessage] = useState<string | null>(null)
   const [busy, setBusy] = useState<string | null>(null)
+  const [fixBusy, setFixBusy] = useState(false)
+  const [fixLog, setFixLog] = useState<string | null>(null)
 
   const refresh = useCallback(async () => {
     setLoading(true); setError(null)
@@ -43,6 +46,31 @@ export function MapSpinUp() {
     }
   }, [refresh])
 
+  const onFixPartitions = useCallback(async () => {
+    const ok = window.confirm(
+      'Clear stuck partition pins on the on-demand maps (Deep Desert, Arrakeen, '
+      + 'Harko Village) so the director can re-assign partitions and spin them up '
+      + 'on demand?\n\n'
+      + 'Safety:\n'
+      + '• Only those 3 maps are touched. Overmap and Survival_1 are never affected.\n'
+      + '• Any map with a running pod is skipped — no live session will be disturbed.\n'
+      + '• Partitions are re-assigned by the director on next spawn.\n\n'
+      + 'Use this when a map refuses to launch after a reboot or BG restart.',
+    )
+    if (!ok) return
+    setFixBusy(true); setMessage(null); setError(null); setFixLog(null)
+    try {
+      const r = await fixOnDemandPartitions()
+      setMessage(r.message ?? 'Partition cleanup ran.')
+      const tail = (r.logTail && r.logTail.trim().length > 0) ? r.logTail : (r.output ?? '')
+      setFixLog(tail || null)
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : String(e))
+    } finally {
+      setFixBusy(false)
+    }
+  }, [])
+
   const supported = (maps ?? []).filter(m => m.group === 'supported')
   const experimental = (maps ?? []).filter(m => m.group === 'experimental')
 
@@ -53,9 +81,20 @@ export function MapSpinUp() {
         icon="Power"
         description="Keep at least one server warm for a map (MinServers = 1). Hot-swappable — no restart needed."
         actions={
-          <button className="btn-secondary" onClick={() => { void refresh() }} disabled={loading || busy !== null}>
-            <Icon name="RefreshCw" size={15} className={loading ? 'animate-spin' : ''} /> Refresh
-          </button>
+          <>
+            <button
+              className="btn-secondary"
+              onClick={() => { void onFixPartitions() }}
+              disabled={loading || busy !== null || fixBusy}
+              title="Clear stuck igwsss.spec.partitions pins on Deep Desert / Arrakeen / Harko Village. Safe — only touches those 3 maps, skips any with a running pod, and never touches Overmap or Survival_1."
+            >
+              <Icon name={fixBusy ? 'Loader2' : 'Wrench'} size={15} className={fixBusy ? 'animate-spin' : ''} />
+              {fixBusy ? 'Fixing…' : 'Fix partitions'}
+            </button>
+            <button className="btn-secondary" onClick={() => { void refresh() }} disabled={loading || busy !== null || fixBusy}>
+              <Icon name="RefreshCw" size={15} className={loading ? 'animate-spin' : ''} /> Refresh
+            </button>
+          </>
         }
       />
 
@@ -67,6 +106,11 @@ export function MapSpinUp() {
       {message && (
         <div className="card p-4 mb-4 border-accent/40">
           <p className="text-sm text-text">{message}</p>
+          {fixLog && (
+            <pre className="mt-3 text-[11px] leading-snug text-text-dim font-mono whitespace-pre-wrap break-words max-h-60 overflow-auto border-t border-border/40 pt-2">
+              {fixLog}
+            </pre>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Adds a **Fix partitions** action to the **Map SpinUp** page header that invokes the existing `POST /api/maps/fix-partitions` endpoint. The endpoint runs the remote `/etc/local.d/dune-clear-partitions.start` script to clear the stuck `igwsss.spec.partitions=[N]` pin that occasionally re-appears on the on-demand maps (Deep Desert, Arrakeen, Harko Village) after a VM/BG reboot or operator reconcile.

Without clearing, the director can't trigger scale-up on player entry and the map silently refuses to launch even when its SpinUp checkbox is enabled. Symptom observed 2026-06-04 after a full battlegroup + VM reboot: DD igwsss came back at `{partitions:[8], replicas:0}` instead of the required `{partitions:[], replicas:0}` clean state.

## Why a button (not just background automation)

A cron watchdog already runs every 15 min as a safety net, and a hardened boot script self-heals on reboot. But there's still a worst-case 15-min window where a player tries to enter a map and gets a failed-launch. Putting a button on the page the operator is already looking at (Map SpinUp) makes it a single click to self-recover instead of needing to SSH into the VM.

## Safety guards (already enforced server-side)

The button just dispatches to existing infrastructure -- all guards live in the remote script:

- Only matches map-name suffixes `-deepdesert-1`, `-sh-arrakeen`, `-sh-harkovillage`. Overmap and Survival_1 (and any other map) are **never** touched.
- Skips any map with a running pod so live sessions are not disturbed.
- Director re-assigns partitions on the next spawn -- clearing is idempotent and safe.

The frontend shows a confirmation dialog explaining all three guards before running, and renders the script's log tail in the result card so the operator can see exactly which maps were cleared or skipped.

## Files changed

- `webui/src/api/maps.ts` -- add `fixOnDemandPartitions()` + `FixPartitionsResult` type
- `webui/src/pages/MapSpinUp.tsx` -- new header action button, confirm dialog, log-tail rendering
- Version bumps to **10.2.8** in `app/DuneServer.ps1`, `dune-server.ps1`, `app/installer/DuneServer.iss`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`
- `CHANGELOG.md` -- `[10.2.8]` entry covering both the button and a related hardening of the VM-side boot script (waits for actual igwsss objects to exist before exiting, not just for the CRD to be reachable -- fixes a boot race observed today where the operator hadn't yet created the per-map ServerSetScale instances by the time the script ran)

## Testing

- `npm run build` clean (1808 modules, no errors)
- `npm run lint` -- no new errors introduced (the 21 pre-existing errors in `SpicefieldsCard.tsx` are unrelated)
- Backend route + script verified working on live VM during today's incident investigation (cleared DD drift, player entered, director scaled up cleanly)
