### PR TITLE
Remove Roman-numeral version display (revert pre-v11.0.0 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,11 @@ here cover everything those tags shipped.
   Replaced with `color-mix(in oklab, var(--color-accent) 12%,
   transparent)` and the same for `--color-ibad`, so the body glow now
   follows whatever palette is active.
-- **Version display extended to Roman major XI.** `fmtToolVersion`
-  (portal) and `formatDisplayVersion` (marketing site) now recognise
-  majors 10–20 (X through XX). The on-disk semver stays purely numeric
-  (`11.0.0`) so update-check comparisons keep working.
+- **Version display reverted to plain semver.** Previous releases
+  stylized the major version as a Roman numeral (e.g. `XI` for `11.0.0`,
+  `XI (0.1)` for `11.0.1`). That mapping has been removed from both the
+  portal (`fmtToolVersion`) and the marketing site (`formatDisplayVersion`);
+  both now render `v<major>.<minor>.<patch>` to match the git tags.
 
 ## [10.2.8] - 2026-06-04
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **version XI** (shown stylized as **XI** in-app; patch
-updates display as **XI (0.1)**, **XI (0.2)**, … under the hood these are
-`11.0.0`, `11.0.1`, … so update-checks and version comparisons keep working).
+The current release is **v11.0.0**. The in-app version label and the
+website now show plain semver tags (e.g. `v11.0.0`, `v11.0.1`) — the
+previous Roman-numeral stylization has been removed.
 It runs as a single-window Windows app (native WebView2 shell) that hosts a
 local web portal (React + Vite + Tailwind) on `127.0.0.1` with a per-launch
 tokenized URL. Same battle-tested SSH + Hyper-V + battlegroup automation

--- a/site/src/lib/release.ts
+++ b/site/src/lib/release.ts
@@ -63,28 +63,15 @@ export async function getLatestRelease(): Promise<LatestRelease> {
 
 // Renders a version string for display in the site UI (everywhere except the
 // changelog / release-notes page, which prints raw tags from CHANGELOG.md).
-// Convention: current and recent major series render as Roman numerals
-// ("X", "XI", "XII", …) with the minor.patch suffix in parentheses.
+// Plain semver with a "v" prefix to match git tags.
 // Examples:
-//   "11.0.0" -> "XI"
-//   "11.0.1" -> "XI (0.1)"
-//   "10.2.4" -> "X (2.4)"
-//   "9.1.2"  -> "v9.1.2"   (older majors untouched)
+//   "11.0.0" -> "v11.0.0"
+//   "11.0.1" -> "v11.0.1"
+//   "10.2.4" -> "v10.2.4"
 //   "latest" -> "the latest release"
-const ROMAN_MAJORS: Record<string, string> = {
-  "10": "X", "11": "XI", "12": "XII", "13": "XIII", "14": "XIV", "15": "XV",
-  "16": "XVI", "17": "XVII", "18": "XVIII", "19": "XIX", "20": "XX",
-};
 
 export function formatDisplayVersion(version: string): string {
   if (!version || version === "latest") return "the latest release";
   const cleaned = version.replace(/^v/, "");
-  const parts = cleaned.split(".");
-  const major = parts[0];
-  const label = ROMAN_MAJORS[major];
-  if (label) {
-    const rest = parts.slice(1).join(".").replace(/(\.0)+$/, "");
-    return rest ? `${label} (${rest})` : label;
-  }
   return `v${cleaned}`;
 }

--- a/webui/src/format.ts
+++ b/webui/src/format.ts
@@ -1,25 +1,15 @@
 // Display formatting for the Dune Server Tool's own version.
-// The on-disk / git-tag version stays numeric (e.g. 11.0.0) so the updater's
-// [System.Version] / semver comparisons keep working; we only stylize it for
-// display. Major versions render as Roman numerals (X, XI, XII, …); the
-// minor.patch suffix is shown in parentheses for any non-.0.0 release.
-//   11.0.0 -> "XI"
-//   11.0.1 -> "XI (0.1)"
-//   10.1.2 -> "X (1.2)"
-const ROMAN_MAJORS: Record<number, string> = {
-  10: 'X', 11: 'XI', 12: 'XII', 13: 'XIII', 14: 'XIV', 15: 'XV',
-  16: 'XVI', 17: 'XVII', 18: 'XVIII', 19: 'XIX', 20: 'XX',
-}
+// Plain semver with a "v" prefix — matches git tags and what users see in
+// the GitHub releases list. The on-disk version stays purely numeric
+// (e.g. 11.0.0) so the updater's [System.Version] / semver comparisons
+// keep working; this helper just prefixes the "v" for UI display.
+//   11.0.0 -> "v11.0.0"
+//   11.0.1 -> "v11.0.1"
+//   10.1.2 -> "v10.1.2"
 
 export function fmtToolVersion(v?: string | null): string {
   if (!v) return ''
   const s = String(v).replace(/^v/i, '').trim()
-  const m = s.match(/^(\d+)\.(\d+)\.(\d+)/)
-  if (!m) return s
-  const major = parseInt(m[1], 10)
-  const minor = parseInt(m[2], 10)
-  const patch = parseInt(m[3], 10)
-  const label = ROMAN_MAJORS[major] ?? String(major)
-  if (minor === 0 && patch === 0) return label
-  return `${label} (${minor}.${patch})`
+  if (!s) return ''
+  return `v${s}`
 }


### PR DESCRIPTION
## Summary

Remove the Roman-numeral version stylization that was extended in #70. Every UI surface (portal sidebar, update banner, Settings update card, marketing site download button) now renders the plain semver tag — matching GitHub releases, the installer filename, and the `[System.Version]` comparisons used under the hood.

Before → after for a few example versions:

| Tag | Old | New |
| --- | --- | --- |
| `11.0.0` | `XI` | `v11.0.0` |
| `11.0.1` | `XI (0.1)` | `v11.0.1` |
| `10.2.8` | `X (2.8)` | `v10.2.8` |

## Changes

* `webui/src/format.ts` — `fmtToolVersion` simplified; Roman map removed.
* `site/src/lib/release.ts` — `formatDisplayVersion` simplified; Roman map removed.
* `README.md` — drop the "version XI" wording, explain the revert.
* `CHANGELOG.md` — replace the "Version display extended to Roman major XI" bullet in the v11.0.0 entry with one documenting the revert.

## Test plan

* `npm run build` in `webui/` compiles clean (verified locally).
* No production code reads the Roman-numeral output, so removing the map can't break any update-check comparison — those have always operated on the raw numeric `[System.Version]` upstream of the formatter.

## Release plan

Once this merges, tag `v11.0.0` from the resulting main commit and publish the GitHub release with `DuneServerSetup.exe` as the sole asset (HARD installer-asset rule).