### PR TITLE
site: document v11.0.0 theming engine in features tour

### DIFF
--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -61,6 +61,12 @@ const sections = [
     body: "Add or remove additional Survival_1 shards. Each costs ~12 GB RAM and a UDP port range, so it's gated behind an explicit confirmation and patches the battlegroup CRD directly.",
   },
   {
+    id: "appearance",
+    title: "Appearance (themes)",
+    img: "appearance-card.png",
+    body: "Settings → Appearance ships with six built-in presets — Eyes of Ibad, Sietch Tabr, Caladan, Giedi Prime, House Harkonnen, and Atreides — plus per-token color customization and JSON import/export. The portal recolors live (including any open embedded terminal) and your choice is persisted locally, with a tiny pre-React script that applies the saved palette before the page paints so there's no flash of the default theme on launch.",
+  },
+  {
     id: "settings",
     title: "Settings",
     img: "v6-settings.png",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -96,6 +96,7 @@ const features = [
         <div>✓ dune-admin integration (optional)</div>
         <div>✓ Setup wizard (Hyper-V, SSH, firewall)</div>
         <div>✓ Built-in auto-updater</div>
+        <div>✓ Six built-in themes + custom color picker</div>
       </div>
       <div class="mt-8 flex flex-wrap gap-4">
         <a


### PR DESCRIPTION
## Summary

Document the v11.0.0 theming engine on the marketing site so the new feature actually shows up at coastal-ms.github.io/DST-DuneServerTool (not just in the README).

## Changes

* **`site/src/pages/features.astro`** — adds an **"Appearance (themes)"** entry to the features tour, slotted in just above Settings. Points at `appearance-card.png`, which is already synced into `site/public/screenshots/` by the `predev` / `prebuild` hook that runs `scripts/sync-images.mjs`.
* **`site/src/pages/index.astro`** — adds a `✓ Six built-in themes + custom color picker` bullet to the home page's "What's in the box" grid.

## Test plan

* `npm run build` in `site/` completes cleanly — 6 pages built, sitemap regenerated.
* `sync-images.mjs` picked up `docs/img/appearance-card.png` on the predev hook, so the screenshot is available at `/screenshots/appearance-card.png` once deployed.