### PR TITLE
v11.0.1 — Auto-clear pinned on-demand partitions on every BG start/restart/reboot

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,7 @@
 # Shell scripts must stay LF — they're meant to be pasted into Linux SSH
 # sessions. CRLF causes `$'\r': command not found` errors on bash.
 *.sh text eol=lf
+
+# Remote VM scripts pushed by Sync-DunePartitionAutomation must be LF —
+# Alpine /bin/sh sees $'\r' on CRLF and fails with cryptic errors.
+app/resources/remote-scripts/* text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.0.1] - 2026-06-05
+
+### Fixed
+- **Auto-clear pinned on-demand map partitions on every battlegroup start.**
+  Previously, after a Commands-menu `startup`, `reboot`, `start`, or `restart`,
+  the Funcom server-operator would re-pin `igwsss.spec.partitions:[N]` for
+  DeepDesert / SH_Arrakeen / SH_HarkoVillage, blocking the director from
+  triggering on-demand spawn — players hit "failed to launch" until the next
+  15-min cron pass or until you manually clicked **Fix partitions**.
+  DST now runs the idempotent clear script automatically after each of those
+  commands (best-effort — never aborts a successful battlegroup start, just
+  warns), with a short settling delay so the operator has time to reconcile
+  before the clean-up pass.
+
+### Added
+- **VM-side partition automation is now versioned and self-healing.** The
+  installer ships `app/resources/remote-scripts/dune-clear-partitions.start`,
+  and every start / restart / reboot calls a new `Sync-DunePartitionAutomation`
+  that pushes the script to `/etc/local.d/` and a wrapper to
+  `/etc/periodic/15min/` on the VM whenever the on-disk copy is missing or
+  the sha256 differs. The OpenRC `local` service is added to the default
+  runlevel idempotently. This means VM rebuilds, snapshot restores, or a
+  fresh-from-Funcom Alpine image all get the boot script + 15-min watchdog
+  installed automatically — no SSH-and-paste required.
+
 ## [11.0.0] - 2026-06-04
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.0.0'
+$script:DuneToolVersion = '11.0.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.0.0',
+    [string]$Version = '11.0.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.0.0</Version>
+    <Version>11.0.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.0.0"
+#define MyAppVersion "11.0.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"
@@ -99,6 +99,13 @@ Source: "..\..\webui\dist\*"; DestDir: "{app}\webui\dist"; Flags: ignoreversion 
 ; the user's dune-admin source repo (derived from DuneAdminExe) at apply
 ; time, then runs build-patched.ps1 -Restart against it.
 Source: "..\resources\dune-admin-patches\*"; DestDir: "{app}\resources\dune-admin-patches"; Flags: ignoreversion recursesubdirs
+
+; v11.0.1: Versioned copy of the remote partition-clear boot script.
+; Sync-DunePartitionAutomation pushes this to the VM's /etc/local.d/ +
+; /etc/periodic/15min/ on every start/restart/reboot so the on-demand
+; partition fix (and the 15-min watchdog) survive VM rebuilds and
+; snapshot restores. Auto-skipped on the VM via sha256 match.
+Source: "..\resources\remote-scripts\*"; DestDir: "{app}\resources\remote-scripts"; Flags: ignoreversion recursesubdirs
 
 ; v6.1.24: Drop-in preflight checker users can run when something goes wrong.
 ; DunePreflight.bat is the entry point (right-click -> Run as administrator),

--- a/app/resources/remote-scripts/dune-clear-partitions.start
+++ b/app/resources/remote-scripts/dune-clear-partitions.start
@@ -1,0 +1,117 @@
+#!/bin/sh
+# Clear on-demand map partitions at boot so director-driven auto-spawn works.
+# Without this, igwsss for DD/Arrakeen/Harko ends up with partitions:[N] pinned
+# at replicas:0 — which blocks the director from triggering scale-up when a
+# player tries to enter. Confirmed working state per session 2026-05-27:
+# clean igwsss.spec = {replicas:0, partitions:[]} for each on-demand map.
+#
+# Auto-discovers namespace + battlegroup ID at runtime by scanning all igwsss
+# cluster-wide and matching map-name suffix. Survives BG recreate, helm
+# upgrades, and Funcom server upgrades — only fails if Funcom renames the
+# igwsss CRD itself.
+#
+# Hardened 2026-06-04: after k3s API + CRD are reachable, ALSO waits up to
+# 5 min for at least one of the expected map igwsss objects to actually exist
+# before deciding "nothing to do". Fixes a boot race where the CRD is
+# registered before the Funcom server-operator has finished reconciling the
+# battlegroup and created the per-map igwsss instances (observed after VM
+# reboot 2026-06-04: script ran ~3 min after boot, CRD was queryable but
+# zero objects existed; objects appeared moments later with partitions:[N]
+# pre-pinned, blocking DD auto-spawn until the 15-min cron pass).
+#
+# Logged to /var/log/dune-clear-partitions.log
+
+set -u
+
+LOG=/var/log/dune-clear-partitions.log
+MAP_SUFFIXES="-deepdesert-1 -sh-arrakeen -sh-harkovillage"
+KUBE="/usr/local/bin/k3s kubectl"
+
+ts() { date "+%Y-%m-%d %H:%M:%S"; }
+log() { echo "[$(ts)] $*" >> "$LOG"; }
+
+log "dune-clear-partitions: start"
+
+# Wait up to 5 min for k3s API + igwsss CRD to be available.
+for i in $(seq 1 60); do
+  if $KUBE get igwsss --all-namespaces >/dev/null 2>&1; then
+    log "api + igwsss CRD ready after ${i} attempts"
+    break
+  fi
+  sleep 5
+done
+
+if ! $KUBE get igwsss --all-namespaces >/dev/null 2>&1; then
+  log "ERROR: k3s API / igwsss CRD not reachable, giving up"
+  exit 1
+fi
+
+# Helper: return non-empty if at least one igwsss exists whose name ends in
+# one of our MAP_SUFFIXES.
+has_expected_match() {
+  $KUBE get igwsss --all-namespaces --no-headers 2>/dev/null | awk '{print $2}' | while read -r n; do
+    for suffix in $MAP_SUFFIXES; do
+      case "$n" in
+        *"$suffix") echo "y"; return ;;
+      esac
+    done
+  done
+}
+
+# Wait up to 5 min for at least one expected map igwsss object to exist.
+# This is the race-window fix: CRD can be reachable before the server-operator
+# has created the per-map ServerSetScale instances during a fresh boot.
+for i in $(seq 1 60); do
+  if [ -n "$(has_expected_match)" ]; then
+    log "expected map igwsss object(s) present after ${i} attempts"
+    break
+  fi
+  sleep 5
+done
+
+# Auto-discover all on-demand igwsss by matching map-name suffix.
+# Output: NS<TAB>NAME for every matching object.
+matches=$($KUBE get igwsss --all-namespaces --no-headers 2>/dev/null | awk '{print $1"\t"$2}')
+if [ -z "$matches" ]; then
+  log "no igwsss objects found in any namespace after wait; nothing to do"
+  exit 0
+fi
+
+# Verify we actually saw at least one expected map; otherwise the BG never
+# reconciled and there's nothing for us to clean.
+if [ -z "$(has_expected_match)" ]; then
+  log "no on-demand map igwsss matched ($MAP_SUFFIXES) after wait; nothing to do"
+  exit 0
+fi
+
+echo "$matches" | while IFS="$(printf '\t')" read -r ns name; do
+  [ -z "$ns" ] || [ -z "$name" ] && continue
+  for suffix in $MAP_SUFFIXES; do
+    case "$name" in
+      *"$suffix")
+        # Skip if a pod is running for this ServerSet (don't kick a player at boot)
+        # Pod name pattern: <bg-id>-sg<suffix>-pod-<n>  e.g. ...-sg-deepdesert-1-pod-8
+        ss_name="${name%$suffix}-sg${suffix}"
+        podcount=$($KUBE -n "$ns" get pods --no-headers 2>/dev/null | grep -c "^${ss_name}-pod-" || true)
+        if [ "$podcount" -gt 0 ]; then
+          log "$ns/$name: pod running ($podcount for ${ss_name}-pod-*), skipping clear"
+          break
+        fi
+        cur=$($KUBE -n "$ns" get igwsss "$name" -o jsonpath="{.spec.partitions}" 2>/dev/null)
+        if [ "$cur" = "[]" ] || [ -z "$cur" ]; then
+          log "$ns/$name: partitions already empty ($cur), no change"
+          break
+        fi
+        if $KUBE -n "$ns" patch igwsss "$name" --type=merge -p '{"spec":{"replicas":0,"partitions":[]}}' >>"$LOG" 2>&1; then
+          log "$ns/$name: cleared (was partitions=$cur)"
+        else
+          log "$ns/$name: ERROR patching"
+        fi
+        break
+        ;;
+    esac
+  done
+done
+
+log "dune-clear-partitions: done"
+exit 0

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.0.0"
+$script:ToolVersion = "11.0.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a
@@ -1013,6 +1013,172 @@ function Wait-MapPodReady {
 }
 
 # ============================================================
+#  ON-DEMAND PARTITION CLEAR (Funcom drift workaround)
+# ============================================================
+#
+# The Funcom server-operator periodically copies the parent ServerSet's
+# spec.partitions:[N] into the child ServerSetScale (igwsss), which blocks
+# the battlegroup director from triggering on-demand spawn for
+# DeepDesert / SH_Arrakeen / SH_HarkoVillage. The remote shell script
+# /etc/local.d/dune-clear-partitions.start fixes that idempotently and is
+# safe to re-run (skips any map whose pod is currently running). It also
+# runs at VM boot (OpenRC 'local') and every 15 min via
+# /etc/periodic/15min/dune-clear-partitions. We auto-invoke it after every
+# DST command that brings the battlegroup up so users no longer have to.
+
+function Get-DuneRemotePartitionScriptPath {
+    $candidates = @(
+        (Join-Path $scriptDir 'resources\remote-scripts\dune-clear-partitions.start')
+        (Join-Path $scriptDir 'app\resources\remote-scripts\dune-clear-partitions.start')
+    )
+    foreach ($p in $candidates) {
+        if (Test-Path -LiteralPath $p) { return $p }
+    }
+    return $null
+}
+
+function Sync-DunePartitionAutomation {
+    # Idempotently push the boot script + 15-min cron wrapper to the VM.
+    # Uses sha256 to skip the upload when the on-VM copy already matches the
+    # bundled one, so this is cheap to call on every start/restart/reboot.
+    # Best-effort: returns $false on any failure but never throws.
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [switch]$Quiet
+    )
+    $local = Get-DuneRemotePartitionScriptPath
+    if (-not $local) {
+        if (-not $Quiet) {
+            Write-Host "  Skip: bundled dune-clear-partitions.start not found in install dir" -ForegroundColor DarkYellow
+        }
+        return $false
+    }
+
+    # Read + force LF line endings — Alpine /bin/sh chokes on CRLF.
+    $raw   = [System.IO.File]::ReadAllText($local)
+    $lf    = $raw -replace "`r`n", "`n" -replace "`r", "`n"
+    $bytes = [Text.Encoding]::UTF8.GetBytes($lf)
+    $b64   = [Convert]::ToBase64String($bytes)
+    $sha   = [BitConverter]::ToString(
+        [Security.Cryptography.SHA256]::Create().ComputeHash($bytes)
+    ).Replace('-','').ToLower()
+
+    $remoteScript = @"
+set -u
+SCRIPT_PATH=/etc/local.d/dune-clear-partitions.start
+CRON_PATH=/etc/periodic/15min/dune-clear-partitions
+EXPECTED_SHA='$sha'
+
+changed=0
+current_sha=''
+if [ -f "`$SCRIPT_PATH" ]; then
+  current_sha=`$(sha256sum "`$SCRIPT_PATH" 2>/dev/null | awk '{print `$1}')
+fi
+if [ "`$current_sha" != "`$EXPECTED_SHA" ]; then
+  printf '%s' '$b64' | base64 -d > "`$SCRIPT_PATH"
+  chmod 0755 "`$SCRIPT_PATH"
+  chown root:root "`$SCRIPT_PATH"
+  echo "installed-or-updated `$SCRIPT_PATH"
+  changed=1
+fi
+
+if [ ! -x "`$CRON_PATH" ]; then
+  cat > "`$CRON_PATH" <<'EOC'
+#!/bin/sh
+# 15-min watchdog wrapper for the on-demand partition clear script.
+# Managed by DST (Dune Server Tool) — see /etc/local.d/dune-clear-partitions.start.
+exec /etc/local.d/dune-clear-partitions.start
+EOC
+  chmod 0755 "`$CRON_PATH"
+  chown root:root "`$CRON_PATH"
+  echo "installed `$CRON_PATH"
+  changed=1
+fi
+
+# Make sure OpenRC's 'local' service is in the default runlevel so the boot
+# script actually fires next reboot. Idempotent — quiet add, ignore error.
+if command -v rc-update >/dev/null 2>&1; then
+  rc-update -q add local default 2>/dev/null || true
+fi
+
+if [ "`$changed" -eq 0 ]; then
+  echo "already-current"
+fi
+exit 0
+"@
+
+    $payloadB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($remoteScript))
+    $output = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$Ip" `
+        "echo $payloadB64 | base64 -d | sudo -n sh" 2>&1
+    $rc = $LASTEXITCODE
+    if ($rc -ne 0) {
+        if (-not $Quiet) {
+            Write-Host "  Warning: partition-clear automation sync exited $rc (best-effort, parent command continues)." -ForegroundColor Yellow
+            if ($output) { $output | Select-Object -Last 5 | ForEach-Object { Write-Host "    $_" -ForegroundColor DarkGray } }
+        }
+        return $false
+    }
+    if (-not $Quiet) {
+        $summary = ($output | Out-String).Trim()
+        if (-not $summary -or $summary -eq 'already-current') {
+            Write-Host "  Partition-clear boot script + 15-min cron already current on VM." -ForegroundColor DarkGray
+        } else {
+            Write-Host "  Partition-clear automation refreshed on VM:" -ForegroundColor DarkGray
+            $summary -split "`r?`n" | ForEach-Object { Write-Host "    $_" -ForegroundColor DarkGray }
+        }
+    }
+    return $true
+}
+
+function Invoke-OnDemandPartitionClear {
+    # Best-effort wrapper: sync the boot script + cron to the VM, settle for
+    # DelaySec to let the Funcom server-operator finish reconciling on-demand
+    # ServerSets (otherwise the script runs before partitions are pinned and
+    # finds nothing to clear), then run the script and tail its log.
+    #
+    # Never throws — partition-clear failure is surfaced as a yellow warning
+    # so a successful battlegroup start doesn't get reported as failed when
+    # this auxiliary step fails.
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [int]$DelaySec = 30,
+        [string]$Phase = 'post-start'
+    )
+    Write-Host ""
+    Write-Host "[$Phase] Clearing on-demand map partition pins (auto-fix so DeepDesert / Arrakeen / Harko spawn on demand)..." -ForegroundColor Cyan
+
+    # Always (re)assert the boot script + cron — survives VM rebuilds.
+    Sync-DunePartitionAutomation -Ip $Ip | Out-Null
+
+    if ($DelaySec -gt 0) {
+        Write-Host "  Settling ${DelaySec}s so the server operator finishes reconciling on-demand ServerSets..." -ForegroundColor DarkGray
+        Start-Sleep -Seconds $DelaySec
+    }
+
+    $runOut = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$Ip" `
+        "sudo -n /etc/local.d/dune-clear-partitions.start" 2>&1
+    $runRc = $LASTEXITCODE
+
+    if ($runRc -ne 0) {
+        Write-Host "  Warning: partition-clear script exited $runRc — server is up but on-demand maps may not auto-spawn." -ForegroundColor Yellow
+        Write-Host "  Use command 21 (fix-on-demand-maps) or the Map SpinUp 'Fix partitions' button if a player can't enter DD/Arrakeen/Harko." -ForegroundColor DarkGray
+        if ($runOut) { $runOut | Select-Object -Last 5 | ForEach-Object { Write-Host "    $_" -ForegroundColor DarkGray } }
+        return
+    }
+    if ($runOut) { $runOut | ForEach-Object { Write-Host "    $_" -ForegroundColor DarkGray } }
+
+    # Tail log after the run — capture exit code before any further ssh so we
+    # don't lose it. Failure to read the log is non-fatal.
+    $tail = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$Ip" `
+        "tail -n 10 /var/log/dune-clear-partitions.log" 2>&1
+    if ($LASTEXITCODE -eq 0 -and $tail) {
+        Write-Host "  Last 10 lines of /var/log/dune-clear-partitions.log:" -ForegroundColor DarkGray
+        $tail | ForEach-Object { Write-Host "    $_" -ForegroundColor Gray }
+    }
+    Write-Host "  Done — on-demand maps will spawn for the next player." -ForegroundColor Green
+}
+
+# ============================================================
 #  MENU DEFINITIONS
 # ============================================================
 
@@ -1518,6 +1684,7 @@ while ($true) {
         Write-Host "[3/4] Starting battlegroup...$bgHint" -ForegroundColor Cyan
         $t_bg = Get-Date
         ssh -t -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" "$bgBinPath start"
+        $bgStartExit = $LASTEXITCODE
         Save-PhaseTiming 'battlegroup-start' ([int]((Get-Date) - $t_bg).TotalSeconds)
 
         # ---- Step 4: wait for map pods ----
@@ -1554,6 +1721,16 @@ while ($true) {
             Write-Host "Use 'status' (1) or 'shell-pod' (16) to investigate any map that didn't reach Ready." -ForegroundColor DarkGray
         }
         if ($estTotal) { Write-Host "  $estTotal" -ForegroundColor DarkGray }
+
+        # Auto-clear pinned on-demand partitions so DD/Arrakeen/Harko spawn for
+        # the next player without manual intervention. Skipped if `bg start`
+        # itself failed (no point waiting on operator that never reconciled).
+        if ($bgStartExit -eq 0) {
+            Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 15 -Phase 'post-startup'
+        } else {
+            Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
+        }
+
         $directorPort = $null
         continue
     }
@@ -1782,6 +1959,7 @@ while ($true) {
         Write-Host "[3/3] Starting battlegroup...$bgHint" -ForegroundColor Cyan
         $t_bg = Get-Date
         ssh -t -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" "$bgBinPath start"
+        $bgStartExit = $LASTEXITCODE
         Save-PhaseTiming 'battlegroup-start' ([int]((Get-Date) - $t_bg).TotalSeconds)
 
         # Reset cached director port; it'll be resolved on next 'open-director'
@@ -1794,6 +1972,16 @@ while ($true) {
         Write-Host "=== Reboot complete in $(Format-Duration $totalSec) ===" -ForegroundColor Green
         if ($estTotal) { Write-Host "  $estTotal" -ForegroundColor DarkGray }
         Write-Host "Pods may take another 1-2 min to all reach Healthy. Check with 'status'." -ForegroundColor DarkGray
+
+        # Auto-clear on-demand partitions so DD/Arrakeen/Harko spawn on demand
+        # post-reboot. 45s settling delay because (unlike startup) we did not
+        # already wait on overmap/survival Ready — the server-operator may
+        # still be reconciling on-demand ServerSets.
+        if ($bgStartExit -eq 0) {
+            Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 45 -Phase 'post-reboot'
+        } else {
+            Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
+        }
         continue
     }
 
@@ -2309,31 +2497,29 @@ while ($true) {
     }
 
     if ($cmdName -eq "fix-on-demand-maps") {
-        Write-Host ""
-        Write-Host "Fixing on-demand map partitions on the VM..." -ForegroundColor Cyan
-        Write-Host "  This clears the drifted igwsss.spec.partitions pin so DeepDesert," -ForegroundColor DarkGray
-        Write-Host "  SH_Arrakeen and SH_HarkoVillage can launch on demand again." -ForegroundColor DarkGray
-        Write-Host ""
-        Write-Host "  Running: sudo /etc/local.d/dune-clear-partitions.start" -ForegroundColor DarkGray
-        ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" `
-            "sudo /etc/local.d/dune-clear-partitions.start" 2>&1 | ForEach-Object { Write-Host "    $_" }
-        Write-Host ""
-        Write-Host "  Last 10 lines of /var/log/dune-clear-partitions.log:" -ForegroundColor Cyan
-        ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" `
-            "tail -n 10 /var/log/dune-clear-partitions.log" 2>&1 | ForEach-Object { Write-Host "    $_" -ForegroundColor Gray }
-        Write-Host ""
-        Write-Host "Done. The remote script is idempotent and skips any map with a running pod," -ForegroundColor Green
-        Write-Host "so it's safe to run again whenever a map refuses to start." -ForegroundColor Green
+        # Manual on-demand-map repair — also (re)installs the boot script + cron
+        # if missing, then runs the partition-clear script with no settling
+        # delay (operator has already had whatever time it needed by the time
+        # the user invokes this).
+        Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'fix-on-demand-maps'
         continue
     }
 
     # --- Fallback: delegate to battlegroup CLI on VM ---
     ssh -t -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" "$bgBinPath $cmdName"
+    $bgFallbackExit = $LASTEXITCODE
 
     # Battlegroup commands (status/start/restart/stop) can change observable
     # port state, so invalidate the cached external port-check results to
     # force a fresh check on the next menu render.
     $script:portCheckCache = $null
+
+    # After a successful bg start / restart, auto-clear the on-demand-map
+    # partition pins so DD/Arrakeen/Harko spawn for the next player without
+    # the user having to invoke fix-on-demand-maps manually.
+    if ($bgFallbackExit -eq 0 -and ($cmdName -eq 'start' -or $cmdName -eq 'restart')) {
+        Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 45 -Phase "post-$cmdName"
+    }
 
     # After start/restart, resolve director port
     if ($cmdName -eq "start" -or $cmdName -eq "restart") {


### PR DESCRIPTION
## Why

Every Commands-menu `startup`, `reboot`, `start`, or `restart` left DD / SH_Arrakeen / SH_HarkoVillage with `igwsss.spec.partitions:[N]` pinned, blocking the director from triggering on-demand spawn. Until now you had to click **Map SpinUp → Fix partitions** (or run command 21) after every battlegroup restart — the 15-min cron watchdog catches drift eventually but players can't enter in the meantime.

> "why would a company require this, where ai has to fix it. this isnt user friendly"

Agreed. DST now does it for you.

## What changed

**Two new helpers in `dune-server.ps1`:**

- `Sync-DunePartitionAutomation` — pushes a versioned copy of `/etc/local.d/dune-clear-partitions.start` + the 15-min cron wrapper at `/etc/periodic/15min/dune-clear-partitions` to the VM whenever the on-disk sha256 doesn't match the bundled one. Idempotent, `sudo -n` (no prompt hangs), OpenRC `local` service added to default runlevel. **VM rebuilds / snapshot restores / fresh Funcom Alpine images now self-heal** — no SSH-and-paste required.
- `Invoke-OnDemandPartitionClear` — best-effort wrapper: syncs automation → settles for an operator-reconcile window → runs the clear script → tails the log. **Never aborts a successful battlegroup start** when this auxiliary step fails — yellow-warns and tells the user to use command 21 / Map SpinUp button.

**Wired into the 4 BG-starting handlers:**

| Handler | Settling delay | Notes |
|---|---|---|
| `startup` | 15s | post step-4 map waits (operator has already reconciled a lot) |
| `reboot` | 45s | post step-3 bg start, no map wait |
| `start` (fallback) | 45s | gated on `cmdName` to not fire on other passthrough cmds |
| `restart` (fallback) | 45s | same |
| `fix-on-demand-maps` | 0s | refactored through the same helper |

All 4 auto-call sites are gated on the bg-start exit code — a failed start won't trigger the script's 5-min internal wait-for-igwsss.

**Versioned asset:** `app/resources/remote-scripts/dune-clear-partitions.start` is the bundled source of truth, shipped by the installer (`DuneServer.iss`). `.gitattributes` locks it to `eol=lf` so Alpine `/bin/sh` doesn't choke on `$'\r'`.

## Files

- `dune-server.ps1` — 2 helpers + 4 call sites + version bump
- `app/resources/remote-scripts/dune-clear-partitions.start` — bundled asset (new)
- `app/installer/DuneServer.iss` — install the new resources dir + version bump
- `app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj` — version bumps (all 5 stamps match per Build-Installer.ps1 preflight)
- `.gitattributes` — `app/resources/remote-scripts/* text eol=lf`
- `CHANGELOG.md` — 11.0.1 entry

## Risk

Low. The remote script is the exact same one that's already running on the host's VM (boot + 15-min cron), so behavior is identical to "you ran command 21 manually every time" — just automatic. Best-effort error handling means a failed clear can never turn a working server start into a reported failure.
