### PR TITLE
docs: add remote-access guide (SSH port-forward, no third-party software)

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,130 @@ business logic — they're not separate codebases.
 
 ---
 
+## Remote access *(advanced — no third-party software)*
+
+DST binds its web portal to `127.0.0.1` only — there is **no** built-in
+remote login, and exposing the port to the public internet would be unsafe
+(the per-launch token is the only credential). If you want a trusted
+co-admin to reach your portal from elsewhere, the supported pattern uses
+only software that ships with Windows 10 / 11 — no Cloudflare, Tailscale,
+ngrok, VPN service, or other third-party install required.
+
+> ⚠️ **Read this first.** Anyone with your DST URL + token has full admin:
+> they can restart your battlegroup, edit `ServerSetup.ini`, drop the
+> database, or kick players. Only share access with people you trust at
+> that level. The token resets on every DST launch and lives in
+> `%LOCALAPPDATA%\DuneServer\last-url.txt`.
+
+### How it works
+
+The remote user opens an **SSH local port-forward** (a feature built into
+`ssh.exe` on every Windows 10 / 11 install) that tunnels their machine's
+`127.0.0.1:47823` to your machine's `127.0.0.1:47823`. They then browse to
+the DST URL on their own loopback. The portal itself never accepts a
+non-loopback connection, so it stays as locked down as if they were
+sitting at your desk.
+
+### One-time host setup (your machine)
+
+1. **Install OpenSSH Server** (Microsoft component, no third-party install):
+
+   ```powershell
+   # Run as Administrator
+   Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+   Set-Service -Name sshd -StartupType Automatic
+   Start-Service sshd
+   New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (TCP)' `
+     -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+   ```
+
+2. **Force key-only authentication** — edit `C:\ProgramData\ssh\sshd_config`:
+
+   ```
+   PasswordAuthentication no
+   PubkeyAuthentication yes
+   PermitRootLogin no
+   AllowUsers <your-windows-username>
+   ```
+
+   Then `Restart-Service sshd`.
+
+3. **Add your co-admin's public SSH key** to your authorized list:
+
+   ```powershell
+   # If your Windows account is in the Administrators group:
+   $key = 'ssh-ed25519 AAAA... them@laptop'   # paste their public key
+   Add-Content -Path 'C:\ProgramData\ssh\administrators_authorized_keys' -Value $key
+   icacls 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r `
+     /grant 'Administrators:F' /grant 'SYSTEM:F'
+   ```
+
+   For a non-admin Windows account, use `C:\Users\<you>\.ssh\authorized_keys`
+   instead (create the `.ssh` folder if missing; lock to user-only ACLs).
+
+4. **Open a port on your router** — forward an arbitrary public TCP port
+   (e.g. `52222`) → your PC's `22`. Use a non-standard external port to
+   cut log noise from internet scanners. If your ISP gives you a rotating
+   public IP, use a free dynamic-DNS hostname (e.g. DuckDNS, No-IP) — but
+   that's still your DNS provider, not a tunnel service.
+
+5. **(Recommended)** Rename the `sshd` Windows service log to flag brute
+   force, or disable IPv6 on the router rule.
+
+### One-time co-admin setup (their machine)
+
+1. They generate a keypair on their Windows / macOS / Linux box:
+
+   ```bash
+   ssh-keygen -t ed25519 -C "them@laptop"
+   ```
+
+2. They send you `~/.ssh/id_ed25519.pub` (public key only — never the
+   private one). You paste it into step 3 above.
+
+### Every time the co-admin wants to connect
+
+1. **You** launch DST normally, then send them the current token from
+   `%LOCALAPPDATA%\DuneServer\last-url.txt` (it rotates on every launch).
+   Use a secure channel — Signal, encrypted email, Discord DM — not a
+   public channel.
+
+2. **They** open an SSH tunnel from their machine:
+
+   ```bash
+   ssh -N -L 47823:127.0.0.1:47823 <your-windows-user>@<your-public-ip> -p 52222
+   ```
+
+   - `-N` = "don't run a remote command, just hold the tunnel"
+   - `-L 47823:127.0.0.1:47823` = "forward my local 47823 to your loopback 47823"
+   - Replace `52222` with whatever external port you forwarded on the router
+
+3. **They** open the DST URL in their own browser, but pointed at *their*
+   loopback:
+
+   ```
+   http://127.0.0.1:47823/?t=<token-you-sent-them>
+   ```
+
+4. When done, they `Ctrl+C` the SSH session to tear down the tunnel.
+
+### Notes / gotchas
+
+- **DST's port is dynamic.** It prefers `47823` but probes up to `+50`
+  if busy. Check `%LOCALAPPDATA%\DuneServer\last-url.txt` for the real
+  port and adjust the `-L 47823:127.0.0.1:<actual-port>` accordingly.
+- **The DuneShell window holds the listener.** If you close it without
+  using **Web Portal** (sidebar footer), the server stops and the
+  tunnel returns 502s. Click **Web Portal** first if you want the
+  server to keep running in the background after you close the window.
+- **Token rotates on every DST launch.** If you restart DST while the
+  co-admin is connected, re-send the new token from `last-url.txt`.
+- **PowerShell page is loopback-only by design.** Even over the tunnel,
+  the PowerShell terminal is intentionally restricted so a remote admin
+  can't get a shell on your host. Server-side commands still work.
+
+---
+
 ## Reporting issues
 
 Hit a bug, error, or unexpected behavior? **Please open a GitHub issue**

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -134,5 +134,96 @@ import DownloadButton from "../components/DownloadButton.astro";
         </div>
       </dl>
     </div>
+
+    <h2 class="text-2xl font-semibold mt-12 mb-4">Remote access <span class="text-dune-muted text-base font-normal">— advanced, no third-party software</span></h2>
+    <p class="text-dune-muted leading-relaxed mb-4">
+      DST binds the portal to <span class="font-mono">127.0.0.1</span> only and
+      has no built-in remote login — exposing the port to the internet would
+      be unsafe (the per-launch token is the only credential). If you want a
+      trusted co-admin to reach your portal from elsewhere, the supported
+      pattern uses only software that ships with Windows 10 / 11: the
+      built-in <strong class="text-dune-text">OpenSSH Server</strong> plus an
+      SSH local port-forward. No Cloudflare, Tailscale, ngrok, or VPN
+      service required.
+    </p>
+
+    <div class="rounded-lg border border-dune-accent/40 bg-dune-accent/10 px-5 py-4 mb-6 text-sm text-dune-text">
+      <strong class="block mb-1">⚠️ Read this first.</strong>
+      Anyone with your DST URL + token has full admin (restart battlegroup,
+      edit ServerSetup.ini, drop the database, kick players). Only share
+      access with people you trust at that level. The token resets on every
+      DST launch and lives in
+      <span class="font-mono">%LOCALAPPDATA%\DuneServer\last-url.txt</span>.
+    </div>
+
+    <h3 class="text-xl font-semibold mt-6 mb-3">Host setup (your machine, one-time)</h3>
+    <ol class="space-y-3 text-dune-muted leading-relaxed mb-6 list-decimal pl-6">
+      <li>
+        Install OpenSSH Server (Microsoft component, no third-party install)
+        in an elevated PowerShell:
+        <pre class="mt-2 p-3 rounded bg-dune-bg border border-dune-border text-xs text-dune-text overflow-x-auto"><code>Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Set-Service -Name sshd -StartupType Automatic
+Start-Service sshd
+New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (TCP)' `
+  -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22</code></pre>
+      </li>
+      <li>
+        Force key-only auth — edit
+        <span class="font-mono">C:\ProgramData\ssh\sshd_config</span> and
+        set <span class="font-mono">PasswordAuthentication no</span>,
+        <span class="font-mono">PubkeyAuthentication yes</span>,
+        <span class="font-mono">PermitRootLogin no</span>, then
+        <span class="font-mono">Restart-Service sshd</span>.
+      </li>
+      <li>
+        Add the co-admin's public key to
+        <span class="font-mono">C:\ProgramData\ssh\administrators_authorized_keys</span>
+        (if your Windows user is an Administrator) or
+        <span class="font-mono">C:\Users\&lt;you&gt;\.ssh\authorized_keys</span>
+        for a standard user.
+      </li>
+      <li>
+        On your router, forward an arbitrary public TCP port
+        (e.g. <span class="font-mono">52222</span>) → your PC's port 22. Use
+        a non-standard external port to cut log noise from internet
+        scanners. If your ISP rotates your public IP, use a free dynamic-DNS
+        hostname.
+      </li>
+    </ol>
+
+    <h3 class="text-xl font-semibold mt-6 mb-3">Connecting (every session)</h3>
+    <ol class="space-y-3 text-dune-muted leading-relaxed mb-6 list-decimal pl-6">
+      <li>
+        You launch DST normally, then send the co-admin the current token
+        from <span class="font-mono">%LOCALAPPDATA%\DuneServer\last-url.txt</span>
+        over a secure channel (Signal, encrypted email, Discord DM).
+      </li>
+      <li>
+        They open an SSH tunnel from their machine:
+        <pre class="mt-2 p-3 rounded bg-dune-bg border border-dune-border text-xs text-dune-text overflow-x-auto"><code>ssh -N -L 47823:127.0.0.1:47823 &lt;your-user&gt;@&lt;your-public-ip&gt; -p 52222</code></pre>
+      </li>
+      <li>
+        They browse to
+        <span class="font-mono">http://127.0.0.1:47823/?t=&lt;token&gt;</span>
+        on <em>their own</em> loopback. The portal itself never accepts a
+        non-loopback connection.
+      </li>
+      <li>
+        Tear down with <span class="font-mono">Ctrl+C</span> on the SSH
+        session when done.
+      </li>
+    </ol>
+
+    <p class="text-dune-muted text-sm leading-relaxed mb-12">
+      <strong class="text-dune-text">Notes:</strong> DST prefers port
+      <span class="font-mono">47823</span> but probes <span class="font-mono">+50</span>
+      if busy — check <span class="font-mono">last-url.txt</span> for the real
+      port and adjust the <span class="font-mono">-L</span> mapping. The
+      DuneShell window holds the listener; click <strong class="text-dune-text">Web
+      Portal</strong> in the sidebar before closing it to keep the server
+      running in the background. The token rotates on every DST launch — re-send
+      it after a restart. The PowerShell page is loopback-only by design even
+      over the tunnel, so a remote admin cannot get a shell on your host.
+    </p>
   </section>
 </Base>


### PR DESCRIPTION
Documents the supported pattern for letting a trusted co-admin reach the local DST portal from another machine using **only software that ships with Windows 10 / 11** — the built-in **OpenSSH Server** plus an SSH local port-forward. No Cloudflare Tunnel, Tailscale, ngrok, or VPN service required.

## What's added

- **`README.md`** — new top-level `## Remote access (advanced — no third-party software)` section between `## CLI launcher` and `## Reporting issues`. Covers:
  - Why DST stays loopback-only (token is the only credential — exposing the port directly would be unsafe)
  - One-time host setup: enable OpenSSH Server, force key-only auth, add co-admin's pubkey, router port-forward
  - One-time co-admin setup: keypair
  - Every-session flow: share token from `last-url.txt`, `ssh -N -L 47823:127.0.0.1:47823 user@ip -p 52222`, browse own loopback
  - Gotchas: dynamic port (47823 + offset), DuneShell window holds listener, token rotates on launch, PowerShell page intentionally stays loopback-only
- **`site/src/pages/install.astro`** — same content rendered as a styled section at the bottom of the Install page (uses existing `dune-*` tokens; no new colors). `npm run build` passes.

## Why now

Asked by the maintainer. The full remote-portal feature (Cloudflare Tunnel + Cloudflare Access + role-based ACL) is still spec'd in #74 and far from shipping. This documents what's available **today** for a single trusted co-admin without waiting for v11.1.0 and without forcing them to install third-party software.

## Out of scope

- No code changes to DST itself — the portal binding is unchanged.
- The future #74 remote portal will add server-side auth (`Cf-Access-Authenticated-User-Email`) and a role-restricted route set (`/remote/*`); that work is orthogonal to this doc.