### PR TITLE
v11.0.2 - Fix Windows Defender false positive on Sync-DunePartitionAutomation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.0.2] - 2026-06-05
+
+### Fixed
+- **Defender false positive (`Trojan:Script/Wacatac.H!ml`) tripped by v11.0.1's
+  new partition-clear deploy code.** The `Sync-DunePartitionAutomation` helper
+  used the pattern `Convert::ToBase64String` → `ssh "echo <b64> | base64 -d | sudo sh"`
+  to atomically push the boot script to the VM. That pattern is shape-identical
+  to `powershell -enc <b64>` malware and trips Microsoft Defender's ML
+  heuristic on PS2EXE-wrapped admin tools. Reworked the helper to stage the
+  script + a small installer via `scp` and run them with `sudo -n sh <file>` —
+  same end state, no obfuscation-looking code path. No behavior change.
+
 ## [11.0.1] - 2026-06-05
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.0.1'
+$script:DuneToolVersion = '11.0.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.0.1',
+    [string]$Version = '11.0.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.0.1</Version>
+    <Version>11.0.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.0.1"
+#define MyAppVersion "11.0.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.0.1"
+$script:ToolVersion = "11.0.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a
@@ -1054,17 +1054,36 @@ function Sync-DunePartitionAutomation {
         return $false
     }
 
-    # Read + force LF line endings — Alpine /bin/sh chokes on CRLF.
+    # Compute sha256 of the bundled (LF-normalized) script content so the
+    # remote installer can skip the in-place replace when nothing changed.
     $raw   = [System.IO.File]::ReadAllText($local)
     $lf    = $raw -replace "`r`n", "`n" -replace "`r", "`n"
     $bytes = [Text.Encoding]::UTF8.GetBytes($lf)
-    $b64   = [Convert]::ToBase64String($bytes)
     $sha   = [BitConverter]::ToString(
         [Security.Cryptography.SHA256]::Create().ComputeHash($bytes)
     ).Replace('-','').ToLower()
 
-    $remoteScript = @"
+    # v11.0.2: deliver via scp + on-disk installer instead of inline
+    # base64-payload-piped-to-`base64 -d | sh`. The latter pattern is a
+    # generic ML heuristic trigger (Trojan:Script/Wacatac.H!ml) on PS2EXE-
+    # compiled admin tools because it shapes-up identical to
+    # `powershell -enc <b64>` malware. Same end state, no obfuscation-looking
+    # code path.
+    $stamp      = [Guid]::NewGuid().ToString('N').Substring(0, 12)
+    $localTmp   = Join-Path $env:TEMP "dune-sync-$stamp.start"
+    $localInst  = Join-Path $env:TEMP "dune-sync-$stamp.installer.sh"
+    $remoteNew  = "/tmp/dune-sync-$stamp.start"
+    $remoteInst = "/tmp/dune-sync-$stamp.installer.sh"
+
+    # Local temp 1: the LF-encoded partition-clear script body itself.
+    [System.IO.File]::WriteAllBytes($localTmp, $bytes)
+
+    # Local temp 2: a small POSIX installer that diffs sha256 and atomically
+    # moves the staged file into place. Plain shell, no base64 payloads.
+    $installer = @"
+#!/bin/sh
 set -u
+NEW='$remoteNew'
 SCRIPT_PATH=/etc/local.d/dune-clear-partitions.start
 CRON_PATH=/etc/periodic/15min/dune-clear-partitions
 EXPECTED_SHA='$sha'
@@ -1075,9 +1094,7 @@ if [ -f "`$SCRIPT_PATH" ]; then
   current_sha=`$(sha256sum "`$SCRIPT_PATH" 2>/dev/null | awk '{print `$1}')
 fi
 if [ "`$current_sha" != "`$EXPECTED_SHA" ]; then
-  printf '%s' '$b64' | base64 -d > "`$SCRIPT_PATH"
-  chmod 0755 "`$SCRIPT_PATH"
-  chown root:root "`$SCRIPT_PATH"
+  install -o root -g root -m 0755 "`$NEW" "`$SCRIPT_PATH"
   echo "installed-or-updated `$SCRIPT_PATH"
   changed=1
 fi
@@ -1086,7 +1103,7 @@ if [ ! -x "`$CRON_PATH" ]; then
   cat > "`$CRON_PATH" <<'EOC'
 #!/bin/sh
 # 15-min watchdog wrapper for the on-demand partition clear script.
-# Managed by DST (Dune Server Tool) — see /etc/local.d/dune-clear-partitions.start.
+# Managed by DST (Dune Server Tool) -- see /etc/local.d/dune-clear-partitions.start.
 exec /etc/local.d/dune-clear-partitions.start
 EOC
   chmod 0755 "`$CRON_PATH"
@@ -1096,21 +1113,42 @@ EOC
 fi
 
 # Make sure OpenRC's 'local' service is in the default runlevel so the boot
-# script actually fires next reboot. Idempotent — quiet add, ignore error.
+# script actually fires next reboot. Idempotent.
 if command -v rc-update >/dev/null 2>&1; then
   rc-update -q add local default 2>/dev/null || true
 fi
+
+rm -f "`$NEW"
 
 if [ "`$changed" -eq 0 ]; then
   echo "already-current"
 fi
 exit 0
 "@
+    # LF-encode the installer too so Alpine /bin/sh doesn't see CRLF.
+    [System.IO.File]::WriteAllText($localInst, ($installer -replace "`r`n", "`n"))
 
-    $payloadB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($remoteScript))
-    $output = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$Ip" `
-        "echo $payloadB64 | base64 -d | sudo -n sh" 2>&1
-    $rc = $LASTEXITCODE
+    try {
+        # Push both files to /tmp via scp (no payload-in-shell-command tricks).
+        & scp -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
+              -i "$sshKey" $localTmp $localInst "${sshUser}@${Ip}:/tmp/" 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            if (-not $Quiet) {
+                Write-Host "  Warning: scp of partition-sync files failed (exit $LASTEXITCODE)." -ForegroundColor Yellow
+            }
+            return $false
+        }
+
+        # Run the staged installer via sudo. The installer mv's the staged
+        # script into /etc/local.d and removes its own staged copy when done.
+        $output = & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
+                        -i "$sshKey" "$sshUser@$Ip" `
+                        "sudo -n sh $remoteInst; rc=`$?; rm -f $remoteInst; exit `$rc" 2>&1
+        $rc = $LASTEXITCODE
+    } finally {
+        Remove-Item -LiteralPath $localTmp  -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $localInst -Force -ErrorAction SilentlyContinue
+    }
     if ($rc -ne 0) {
         if (-not $Quiet) {
             Write-Host "  Warning: partition-clear automation sync exited $rc (best-effort, parent command continues)." -ForegroundColor Yellow


### PR DESCRIPTION
## Summary

Minimal hotfix on top of v11.0.1 to clear the `Trojan:Script/Wacatac.H!ml` Defender flag on `DuneServerSetup.exe`. ML-only heuristic (`!ml` suffix) — no signature match.

## Root cause

The `Sync-DunePartitionAutomation` helper added in v11.0.1 (the only meaningful code change since the clean v11.0.0) installed its remote payload via:

```
$payloadB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($script))
ssh ... "echo $payloadB64 | base64 -d | sudo -n sh"
```

This `base64 -> pipe -> sh` shape is shape-identical to `powershell -enc <b64>` malware and tripped Defender''s ML classifier on the PS2EXE-wrapped installer.

## Fix

Rewrote ONLY the new v11.0.1 helper. Same end state, no base64-decode-and-exec on the SSH command line:

1. Write two host-side temp files: an LF-encoded payload script and a small POSIX installer
2. `scp` both to `/tmp/` on the VM
3. `ssh ... "sudo -n sh /tmp/<id>.installer.sh"` (atomic `install -o root -g root -m 0755`)
4. Cleanup local temp files in `finally`

Other `base64 | sh` instances elsewhere in the codebase (`Db-Postgres.ps1`, `K8s.ps1`, `Broadcast.ps1`, etc., going back to v6.x) are NOT touched in this hotfix — they weren''t flagged. If Defender re-flags after this ships, v12.0.0 will refactor all of them.

## Changes

- `dune-server.ps1` — `Sync-DunePartitionAutomation` rewritten (lines ~1057-1131); version -> 11.0.2
- `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/DuneServer.ps1`, `app/installer/DuneServer.iss` — version stamps -> 11.0.2
- `CHANGELOG.md` — new `[11.0.2]` Fixed section

## Verification

- Parse-checked: clean
- 5/5 version stamps: enforced by `Build-Installer.ps1` preflight
- Installer built locally: `DuneServerSetup.exe` 45.3 MB
  - New SHA256: `9CC48DE0ED893F866CFF96EDE8D4FF06F2FBE787AEBDDA362A703E74261FCBEF`
  - Old (v11.0.1, flagged): `80A97C24EB9400D62EA1DDD710A3CEC1FFBB66B5DA48564AD8A28B0F1E65E5DB`

## Post-merge

1. Tag `v11.0.2` from merge commit on `main`
2. `gh release create v11.0.2 ./app/installer/output/DuneServerSetup.exe` (single asset — HARD rule)
3. Submit FP report to Microsoft at https://www.microsoft.com/wdsi/filesubmission
