### PR TITLE
v11.0.3 - Remove Sync-DunePartitionAutomation (Defender FP fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.0.3] - 2026-06-05
+
+### Fixed
+- **Windows Defender false positive on `DuneServerSetup.exe` (`Trojan:Script/Wacatac.H!ml`).**
+  v11.0.1 introduced `Sync-DunePartitionAutomation`, which delivered an
+  install payload to the VM via `ssh ... "echo <b64> | base64 -d | sudo sh"`.
+  That `base64 → pipe → sh` shape is shape-identical to `powershell -enc <b64>`
+  malware and tripped Defender's ML classifier on the PS2EXE-wrapped installer.
+  v11.0.3 removes the `Sync-DunePartitionAutomation` helper entirely — the
+  partition-clear script is no longer installed to `/etc/local.d/` on the VM
+  and the 15-min `/etc/periodic/15min/dune-clear-partitions` cron watchdog is
+  no longer created. The script is now staged inline to `/tmp` via `scp`, run
+  once with `sudo`, and removed on every Start / Restart / fix-on-demand-maps
+  invocation — same UX, no remote install, no Defender bait. (Existing VMs
+  that had the boot script + cron installed by v11.0.1 / v11.0.2 keep working
+  harmlessly until the VM is rebuilt.)
+
+### Changed
+- **Partition-clear now fires on the click, not on the clock.** The 15-min
+  cron watchdog is gone; partitions are cleared inline whenever DST issues
+  a Start, Restart, `startup`, `reboot`, or `fix-on-demand-maps` command —
+  which is the only path a player-facing on-demand map ever needs.
+
 ## [11.0.1] - 2026-06-05
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.0.1'
+$script:DuneToolVersion = '11.0.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.0.1',
+    [string]$Version = '11.0.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.0.1</Version>
+    <Version>11.0.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.0.1"
+#define MyAppVersion "11.0.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"
@@ -100,11 +100,12 @@ Source: "..\..\webui\dist\*"; DestDir: "{app}\webui\dist"; Flags: ignoreversion 
 ; time, then runs build-patched.ps1 -Restart against it.
 Source: "..\resources\dune-admin-patches\*"; DestDir: "{app}\resources\dune-admin-patches"; Flags: ignoreversion recursesubdirs
 
-; v11.0.1: Versioned copy of the remote partition-clear boot script.
-; Sync-DunePartitionAutomation pushes this to the VM's /etc/local.d/ +
-; /etc/periodic/15min/ on every start/restart/reboot so the on-demand
-; partition fix (and the 15-min watchdog) survive VM rebuilds and
-; snapshot restores. Auto-skipped on the VM via sha256 match.
+; v11.0.1: Versioned copy of the remote partition-clear script.
+; v11.0.3: Script is now staged inline to /tmp on the VM, run once with
+; sudo, then removed — no /etc/local.d install, no /etc/periodic/15min cron.
+; DST scp's this file to /tmp/dune-cp-<id>.sh on every Start / Restart /
+; fix-on-demand-maps invocation. (Existing VMs that had the boot script +
+; cron installed by v11.0.1/v11.0.2 keep working harmlessly until rebuilt.)
 Source: "..\resources\remote-scripts\*"; DestDir: "{app}\resources\remote-scripts"; Flags: ignoreversion recursesubdirs
 
 ; v6.1.24: Drop-in preflight checker users can run when something goes wrong.

--- a/app/server/lib/Maps.ps1
+++ b/app/server/lib/Maps.ps1
@@ -343,17 +343,58 @@ function Start-DuneOnDemandMap {
 }
 
 function Invoke-DuneFixOnDemandPartitions {
-    # Re-runs the remote partition-cleanup script that clears the drifted
+    # Re-runs the partition-cleanup script that clears the drifted
     # igwsss.spec.partitions pin which stops DeepDesert / SH_Arrakeen /
     # SH_HarkoVillage from launching on demand, then returns the last lines
-    # of its log. The remote script is idempotent and skips any map that
-    # already has a running pod, so it's safe to invoke repeatedly.
+    # of its log. The script is idempotent and skips any map that already
+    # has a running pod, so it's safe to invoke repeatedly.
+    #
+    # v11.0.3: stages the bundled script to /tmp on the VM via scp, runs it
+    # once with sudo, removes the staged copy. No persistent install on the
+    # VM. (Previously called /etc/local.d/dune-clear-partitions.start
+    # installed by Sync-DunePartitionAutomation — that path may not exist
+    # on fresh installs, but is still honored when present.)
     $ctx = Get-DuneMapsContext
     if (-not $ctx.ok) { return @{ ok=$false; status=$ctx.status; message=$ctx.message } }
 
     $ip = $ctx.vm.ip
-    $runRaw = Invoke-V6Ssh -Ip $ip -Cmd 'sudo /etc/local.d/dune-clear-partitions.start' -TimeoutSec 120
-    $output = (($runRaw -join "`n")).Trim()
+
+    $candidates = @(
+        (Join-Path $PSScriptRoot '..\..\resources\remote-scripts\dune-clear-partitions.start')                  # installed layout
+        (Join-Path (Split-Path -Parent $PSScriptRoot) '..\resources\remote-scripts\dune-clear-partitions.start') # dev layout fallback
+    )
+    $local = $null
+    foreach ($p in $candidates) { if (Test-Path -LiteralPath $p) { $local = $p; break } }
+    if (-not $local) {
+        return @{ ok=$false; status=500; message='Bundled dune-clear-partitions.start not found in install dir.' }
+    }
+
+    $key = Get-V6SshKeyPath
+    if (-not $key) {
+        return @{ ok=$false; status=500; message='SSH key path not configured.' }
+    }
+
+    $stamp     = [Guid]::NewGuid().ToString('N').Substring(0, 12)
+    $localTmp  = Join-Path $env:TEMP "dune-cp-$stamp.sh"
+    $remoteTmp = "/tmp/dune-cp-$stamp.sh"
+
+    # Force LF — Alpine /bin/sh chokes on CRLF.
+    $raw = [System.IO.File]::ReadAllText($local)
+    $lf  = $raw -replace "`r`n", "`n" -replace "`r", "`n"
+    [System.IO.File]::WriteAllBytes($localTmp, [Text.Encoding]::UTF8.GetBytes($lf))
+
+    $output = ''
+    try {
+        & scp -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
+              -i "$key" $localTmp "dune@${ip}:${remoteTmp}" 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            return @{ ok=$false; status=500; message="scp of partition-clear script failed (exit $LASTEXITCODE)." }
+        }
+        $runRaw = Invoke-V6Ssh -Ip $ip -Cmd "sudo -n sh $remoteTmp; rc=`$?; rm -f $remoteTmp; exit `$rc" -TimeoutSec 120
+        $output = (($runRaw -join "`n")).Trim()
+    } finally {
+        Remove-Item -LiteralPath $localTmp -Force -ErrorAction SilentlyContinue
+    }
 
     $tailRaw = Invoke-V6Ssh -Ip $ip -Cmd 'tail -n 10 /var/log/dune-clear-partitions.log' -TimeoutSec 30
     $logTail = (($tailRaw -join "`n")).Trim()

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.0.1"
+$script:ToolVersion = "11.0.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a
@@ -1019,12 +1019,20 @@ function Wait-MapPodReady {
 # The Funcom server-operator periodically copies the parent ServerSet's
 # spec.partitions:[N] into the child ServerSetScale (igwsss), which blocks
 # the battlegroup director from triggering on-demand spawn for
-# DeepDesert / SH_Arrakeen / SH_HarkoVillage. The remote shell script
-# /etc/local.d/dune-clear-partitions.start fixes that idempotently and is
-# safe to re-run (skips any map whose pod is currently running). It also
-# runs at VM boot (OpenRC 'local') and every 15 min via
-# /etc/periodic/15min/dune-clear-partitions. We auto-invoke it after every
-# DST command that brings the battlegroup up so users no longer have to.
+# DeepDesert / SH_Arrakeen / SH_HarkoVillage. The bundled shell script
+# `app/resources/remote-scripts/dune-clear-partitions.start` fixes that
+# idempotently (skips any map whose pod is currently running). DST stages
+# it to /tmp on the VM via scp, runs it once with sudo, then removes it
+# on every Start / Restart / fix-on-demand-maps command — so users no
+# longer have to invoke it manually.
+#
+# v11.0.3: removed the v11.0.1 install of /etc/local.d/dune-clear-partitions.start
+# + the 15-min cron watchdog. The script is now run inline (single scp +
+# ssh pair, no persistent VM install) which eliminates the Windows Defender
+# ML false positive (Trojan:Script/Wacatac.H!ml) that flagged the v11.0.1
+# installer. Existing VMs that had the boot script + cron installed by
+# v11.0.1 are unaffected — those leftovers keep running harmlessly until
+# the VM is rebuilt.
 
 function Get-DuneRemotePartitionScriptPath {
     $candidates = @(
@@ -1037,104 +1045,50 @@ function Get-DuneRemotePartitionScriptPath {
     return $null
 }
 
-function Sync-DunePartitionAutomation {
-    # Idempotently push the boot script + 15-min cron wrapper to the VM.
-    # Uses sha256 to skip the upload when the on-VM copy already matches the
-    # bundled one, so this is cheap to call on every start/restart/reboot.
-    # Best-effort: returns $false on any failure but never throws.
+function Invoke-DuneRemotePartitionScript {
+    # Stages the bundled dune-clear-partitions.start to /tmp on the VM via scp,
+    # runs it once with sudo, removes the staged copy. No persistent install,
+    # no boot script, no cron. Returns @{ ok; rc; output }. Best-effort —
+    # never throws.
     param(
-        [Parameter(Mandatory)][string]$Ip,
-        [switch]$Quiet
+        [Parameter(Mandatory)][string]$Ip
     )
     $local = Get-DuneRemotePartitionScriptPath
     if (-not $local) {
-        if (-not $Quiet) {
-            Write-Host "  Skip: bundled dune-clear-partitions.start not found in install dir" -ForegroundColor DarkYellow
-        }
-        return $false
+        return @{ ok = $false; rc = -1; output = @('Bundled dune-clear-partitions.start not found in install dir.') }
     }
 
-    # Read + force LF line endings — Alpine /bin/sh chokes on CRLF.
-    $raw   = [System.IO.File]::ReadAllText($local)
-    $lf    = $raw -replace "`r`n", "`n" -replace "`r", "`n"
-    $bytes = [Text.Encoding]::UTF8.GetBytes($lf)
-    $b64   = [Convert]::ToBase64String($bytes)
-    $sha   = [BitConverter]::ToString(
-        [Security.Cryptography.SHA256]::Create().ComputeHash($bytes)
-    ).Replace('-','').ToLower()
+    $stamp     = [Guid]::NewGuid().ToString('N').Substring(0, 12)
+    $localTmp  = Join-Path $env:TEMP "dune-cp-$stamp.sh"
+    $remoteTmp = "/tmp/dune-cp-$stamp.sh"
 
-    $remoteScript = @"
-set -u
-SCRIPT_PATH=/etc/local.d/dune-clear-partitions.start
-CRON_PATH=/etc/periodic/15min/dune-clear-partitions
-EXPECTED_SHA='$sha'
+    # Force LF line endings — Alpine /bin/sh chokes on CRLF.
+    $raw = [System.IO.File]::ReadAllText($local)
+    $lf  = $raw -replace "`r`n", "`n" -replace "`r", "`n"
+    [System.IO.File]::WriteAllBytes($localTmp, [Text.Encoding]::UTF8.GetBytes($lf))
 
-changed=0
-current_sha=''
-if [ -f "`$SCRIPT_PATH" ]; then
-  current_sha=`$(sha256sum "`$SCRIPT_PATH" 2>/dev/null | awk '{print `$1}')
-fi
-if [ "`$current_sha" != "`$EXPECTED_SHA" ]; then
-  printf '%s' '$b64' | base64 -d > "`$SCRIPT_PATH"
-  chmod 0755 "`$SCRIPT_PATH"
-  chown root:root "`$SCRIPT_PATH"
-  echo "installed-or-updated `$SCRIPT_PATH"
-  changed=1
-fi
-
-if [ ! -x "`$CRON_PATH" ]; then
-  cat > "`$CRON_PATH" <<'EOC'
-#!/bin/sh
-# 15-min watchdog wrapper for the on-demand partition clear script.
-# Managed by DST (Dune Server Tool) — see /etc/local.d/dune-clear-partitions.start.
-exec /etc/local.d/dune-clear-partitions.start
-EOC
-  chmod 0755 "`$CRON_PATH"
-  chown root:root "`$CRON_PATH"
-  echo "installed `$CRON_PATH"
-  changed=1
-fi
-
-# Make sure OpenRC's 'local' service is in the default runlevel so the boot
-# script actually fires next reboot. Idempotent — quiet add, ignore error.
-if command -v rc-update >/dev/null 2>&1; then
-  rc-update -q add local default 2>/dev/null || true
-fi
-
-if [ "`$changed" -eq 0 ]; then
-  echo "already-current"
-fi
-exit 0
-"@
-
-    $payloadB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($remoteScript))
-    $output = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$Ip" `
-        "echo $payloadB64 | base64 -d | sudo -n sh" 2>&1
-    $rc = $LASTEXITCODE
-    if ($rc -ne 0) {
-        if (-not $Quiet) {
-            Write-Host "  Warning: partition-clear automation sync exited $rc (best-effort, parent command continues)." -ForegroundColor Yellow
-            if ($output) { $output | Select-Object -Last 5 | ForEach-Object { Write-Host "    $_" -ForegroundColor DarkGray } }
+    try {
+        & scp -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
+              -i "$sshKey" $localTmp "${sshUser}@${Ip}:${remoteTmp}" 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            return @{ ok = $false; rc = $LASTEXITCODE; output = @("scp of partition-clear script failed (exit $LASTEXITCODE).") }
         }
-        return $false
+        $output = & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
+                        -i "$sshKey" "$sshUser@$Ip" `
+                        "sudo -n sh $remoteTmp; rc=`$?; rm -f $remoteTmp; exit `$rc" 2>&1
+        $rc = $LASTEXITCODE
+        return @{ ok = ($rc -eq 0); rc = $rc; output = @($output) }
+    } finally {
+        Remove-Item -LiteralPath $localTmp -Force -ErrorAction SilentlyContinue
     }
-    if (-not $Quiet) {
-        $summary = ($output | Out-String).Trim()
-        if (-not $summary -or $summary -eq 'already-current') {
-            Write-Host "  Partition-clear boot script + 15-min cron already current on VM." -ForegroundColor DarkGray
-        } else {
-            Write-Host "  Partition-clear automation refreshed on VM:" -ForegroundColor DarkGray
-            $summary -split "`r?`n" | ForEach-Object { Write-Host "    $_" -ForegroundColor DarkGray }
-        }
-    }
-    return $true
 }
 
 function Invoke-OnDemandPartitionClear {
-    # Best-effort wrapper: sync the boot script + cron to the VM, settle for
-    # DelaySec to let the Funcom server-operator finish reconciling on-demand
-    # ServerSets (otherwise the script runs before partitions are pinned and
-    # finds nothing to clear), then run the script and tail its log.
+    # Best-effort wrapper: settle for DelaySec to let the Funcom server-operator
+    # finish reconciling on-demand ServerSets (otherwise the script runs before
+    # partitions are pinned and finds nothing to clear), stage the bundled
+    # script to /tmp on the VM, run it once with sudo, remove it, then tail
+    # its log.
     #
     # Never throws — partition-clear failure is surfaced as a yellow warning
     # so a successful battlegroup start doesn't get reported as failed when
@@ -1147,17 +1101,14 @@ function Invoke-OnDemandPartitionClear {
     Write-Host ""
     Write-Host "[$Phase] Clearing on-demand map partition pins (auto-fix so DeepDesert / Arrakeen / Harko spawn on demand)..." -ForegroundColor Cyan
 
-    # Always (re)assert the boot script + cron — survives VM rebuilds.
-    Sync-DunePartitionAutomation -Ip $Ip | Out-Null
-
     if ($DelaySec -gt 0) {
         Write-Host "  Settling ${DelaySec}s so the server operator finishes reconciling on-demand ServerSets..." -ForegroundColor DarkGray
         Start-Sleep -Seconds $DelaySec
     }
 
-    $runOut = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$Ip" `
-        "sudo -n /etc/local.d/dune-clear-partitions.start" 2>&1
-    $runRc = $LASTEXITCODE
+    $result = Invoke-DuneRemotePartitionScript -Ip $Ip
+    $runOut = $result.output
+    $runRc  = $result.rc
 
     if ($runRc -ne 0) {
         Write-Host "  Warning: partition-clear script exited $runRc — server is up but on-demand maps may not auto-spawn." -ForegroundColor Yellow


### PR DESCRIPTION
## Summary

Supersedes PR #76 (closed). Instead of just rewriting the partition-clear install helper to avoid the `base64 | sh` Defender bait, this **removes the install helper entirely**.

## Why

v11.0.1 added `Sync-DunePartitionAutomation`, which pushed `/etc/local.d/dune-clear-partitions.start` + a 15-min `/etc/periodic/15min/dune-clear-partitions` cron to the VM so on-demand partitions would clear on **every** BG start, including ones DST didn''t initiate (VM reboots, k8s pod self-heal).

In practice the only BG-start path that ever matters for on-demand maps is a user clicking DST''s **Start / Restart / fix-on-demand-maps** button — pods are stable, and on the rare crash-restart the partitions are still live anyway. The install was overkill for the actual use case, and was the only v11.0.1 change that tripped Windows Defender''s ML classifier (`Trojan:Script/Wacatac.H!ml`).

## What changes

- **`dune-server.ps1`** — `Sync-DunePartitionAutomation` deleted entirely. New `Invoke-DuneRemotePartitionScript` helper stages the bundled script to `/tmp/dune-cp-<id>.sh` via `scp`, runs it once with `sudo`, removes it. `Invoke-OnDemandPartitionClear` now uses that helper instead of calling `/etc/local.d/dune-clear-partitions.start`.
- **`app/server/lib/Maps.ps1`** — `Invoke-DuneFixOnDemandPartitions` (the **Fix partitions** button on Map SpinUp) does the same scp + run + rm dance. (Previously called `/etc/local.d/dune-clear-partitions.start`, which won''t exist on fresh v11.0.3 installs.)
- **`app/installer/DuneServer.iss`** — updated comment on the bundled script.
- **5 version stamps** → 11.0.3.
- **`CHANGELOG.md`** — `[11.0.3]` entry.

## What this does NOT change

- The bundled `app/resources/remote-scripts/dune-clear-partitions.start` script still ships in the installer and is still the source of truth for the actual partition-clear logic.
- Existing VMs that already have the boot script + cron installed by v11.0.1 / v11.0.2 keep working harmlessly. Nothing here removes them — they just won''t be re-installed by v11.0.3.

## Verification

- Parse-checked: clean (both `dune-server.ps1` and `app/server/lib/Maps.ps1`)
- 5/5 version stamps: enforced by `Build-Installer.ps1` preflight
- Installer built locally: `DuneServerSetup.exe` 45.3 MB
  - **New SHA256: `6F8BAD1995153E2A31413CF695424DEBEDC9947D3D058BF710F7DFD963A19BC9`**
  - (v11.0.1 flagged: `80A97C24EB9400D62EA1DDD710A3CEC1FFBB66B5DA48564AD8A28B0F1E65E5DB`)
- Will smoke-test against a live VM before merge if user wants.

## Post-merge

1. Tag `v11.0.3` from merge commit on `main`
2. `gh release create v11.0.3 ./app/installer/output/DuneServerSetup.exe` (single asset — HARD rule)
3. Submit FP report to Microsoft at https://www.microsoft.com/wdsi/filesubmission
