### PR TITLE
feat(remote-portal): v11.1.0 mobile portal behind Cloudflare Access (#74)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,3 +57,57 @@ jobs:
           } else {
               Write-Host "No issues found."
           }
+
+      - name: Guard remote-portal isolation
+        shell: pwsh
+        # Issue #74 (v11.1.0): the CF-Access-gated route module MUST NOT
+        # touch console-requiring or destructive surface area. The
+        # dispatcher already partitions URLs by prefix, but the runspace
+        # pool dot-sources every lib + route into every worker, so any
+        # function is technically reachable. This guard is the third
+        # safety net (after dispatcher and code review): if Remote.ps1
+        # mentions any of these names in EXECUTABLE code (comments are
+        # intentionally allowed to document the rule), the build fails so
+        # the PR can't land.
+        run: |
+          $path = 'app/server/routes/Remote.ps1'
+          if (-not (Test-Path -LiteralPath $path)) {
+              Write-Host "::warning::$path not present; skipping guard."
+              exit 0
+          }
+          $tokens = $null; $parseErrors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+              (Resolve-Path $path).Path, [ref]$tokens, [ref]$parseErrors) | Out-Null
+          if ($parseErrors -and $parseErrors.Count -gt 0) {
+              $parseErrors | ForEach-Object {
+                  Write-Host "::error file=$path,line=$($_.Extent.StartLineNumber)::$($_.Message)"
+              }
+              exit 1
+          }
+          $banned = @(
+              'Setup','ConsoleHost','Database','Browse-','EditDuneIni','Edit-DuneIni',
+              'Invoke-DuneCommand','Get-DuneCommandByName','Start-DuneTerminal',
+              'Invoke-DuneSshShell','DuneAdmin'
+          )
+          # Walk every token that is NOT a comment and check its text.
+          $bad = @()
+          foreach ($tok in $tokens) {
+              if ($tok.Kind -eq 'Comment') { continue }
+              foreach ($pat in $banned) {
+                  if ($tok.Text -match [regex]::Escape($pat)) {
+                      $bad += [pscustomobject]@{
+                          line = $tok.Extent.StartLineNumber
+                          text = $tok.Text
+                          pat  = $pat
+                      }
+                      break
+                  }
+              }
+          }
+          if ($bad) {
+              foreach ($h in $bad) {
+                  Write-Host "::error file=$path,line=$($h.line)::Remote.ps1 must not reference '$($h.pat)' in code (found: '$($h.text)')."
+              }
+              exit 1
+          }
+          Write-Host "Remote.ps1 isolation guard OK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,46 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.1.0] - 2026-06-05
+
+### Added
+- **Remote portal — mobile-friendly subset of DST behind Cloudflare Tunnel + Access.**
+  A new top-level SPA tree under `/remote/*` (Dashboard + Maps) lets you
+  view VM/battlegroup state, check the last 3 backups, and run safe
+  one-click actions (spin-up / spin-down on-demand maps, fix partitions)
+  from a phone — without ever exposing console, edit, shell, or DB
+  surfaces. **DST still binds 127.0.0.1**; cloudflared proxies the
+  Cloudflare edge to your loopback, so no port-forwarding or inbound
+  firewall changes are required. Per-email ACL gate
+  (`%APPDATA%\DuneServer\remote-acl.json`) on top of CF Access magic-link
+  / IdP auth — owner sees everything, admins get reads + safe writes.
+
+- **Settings → Remote Access card.** Toggle the remote portal,
+  configure owner + admin allowlist, see cloudflared status, view the
+  audit log. cloudflared installation/setup itself is documented (see
+  the `/remote` page on the marketing site) — this card focuses on
+  managing access once the tunnel is up.
+
+- **Audit log** at `%APPDATA%\DuneServer\.logs\remote-audit.log` — every
+  remote write action is appended with timestamp, role, email, path,
+  and HTTP status, plus every auth denial. Visible in the Settings card.
+
+- **Setup guide** at <https://coastal-ms.github.io/DST-DuneServerTool/remote>
+  covering cloudflared install, tunnel create, hostname mapping, and
+  CF Access policy setup.
+
+### Security
+- The remote portal requires **both** Cloudflare Access (per-email or
+  IdP allowlist enforced at the edge) **and** the existing DuneToken
+  (injected into the served `index.html` for `/remote/*` paths so a
+  same-Windows-box CF-header-spoofing attempt still hits a token wall).
+  Fail-closed: missing CF header, malformed ACL, or empty `owner`
+  field all return 401 and the remote portal stays disabled.
+
+### Deferred to v11.2.0
+- `restart-bg`, `backup-now`, player-kick, WebSocket live-log tail,
+  desktop push notifications, browser-side CF Access JWT validation.
+
 ## [11.0.0] - 2026-06-04
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.0.0'
+$script:DuneToolVersion = '11.1.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.0.0',
+    [string]$Version = '11.1.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.0.0</Version>
+    <Version>11.1.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.0.0"
+#define MyAppVersion "11.1.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/HttpServer.ps1
+++ b/app/server/HttpServer.ps1
@@ -278,6 +278,17 @@ function Invoke-DuneApiHandlerAsync {
     # UI gets a fast, honest error instead of an unbounded wait.
     if (-not $script:DuneApiGate.Wait(0)) {
         try { Write-DuneError -Response $Response -Status 503 -Message 'Server busy: handler pool saturated. Try again shortly.' } catch {}
+        # Remote portal audit (issue #74): saturation on a remote write
+        # never reaches the worker's finally block, so log here.
+        try {
+            if ($RouteParams -and $RouteParams.ContainsKey('remoteEmail') -and $RouteParams.remoteEmail) {
+                $m = ''; try { $m = [string]$Request.HttpMethod } catch {}
+                if ($m -and $m -ne 'GET' -and $m -ne 'HEAD') {
+                    $p = ''; try { $p = [string]$Request.Url.AbsolutePath } catch {}
+                    Write-DuneRemoteAudit -Role ([string]$RouteParams.remoteRole) -Email ([string]$RouteParams.remoteEmail) -Method $m -Path $p -Status 503 -Note 'pool-saturated'
+                }
+            }
+        } catch {}
         return
     }
 
@@ -343,6 +354,26 @@ function Invoke-DuneApiHandlerAsync {
             } catch {}
         } finally {
             try { $res.OutputStream.Close() } catch {}
+            # Remote portal audit log (issue #74): when this worker handled
+            # a write (non-GET) /api/remote/* request, append one line with
+            # the final status code. Reads are NOT audit-logged. Listener-
+            # thread denials (401/403/503) are logged in Invoke-DuneContext
+            # directly because the worker never starts for those.
+            try {
+                if ($routeParams -and $routeParams.ContainsKey('remoteEmail') -and $routeParams.remoteEmail) {
+                    $m = ''
+                    try { $m = [string]$req.HttpMethod } catch {}
+                    if ($m -and $m -ne 'GET' -and $m -ne 'HEAD') {
+                        $p = ''
+                        try { $p = [string]$req.Url.AbsolutePath } catch {}
+                        $sc = 0
+                        try { $sc = [int]$res.StatusCode } catch {}
+                        if (Get-Command Write-DuneRemoteAudit -ErrorAction SilentlyContinue) {
+                            Write-DuneRemoteAudit -Role ([string]$routeParams.remoteRole) -Email ([string]$routeParams.remoteEmail) -Method $m -Path $p -Status $sc
+                        }
+                    }
+                }
+            } catch {}
             try { $res.Close() } catch {}
             # Release the gate permit (idempotent with the main-loop sweep).
             try {
@@ -445,7 +476,16 @@ function Write-DuneError {
 }
 
 function Write-DuneFile {
-    param($Response, [string]$Path)
+    param(
+        $Response,
+        [string]$Path,
+        # When set, treat the file as the remote-portal index.html and
+        # string-replace the <!-- DUNE_REMOTE_BOOTSTRAP --> marker with a
+        # tiny <script> tag that exposes the per-launch DuneToken to the
+        # remote SPA. Issue #74: this is how the SPA gets the token without
+        # the user having to paste it on a phone.
+        [switch]$InjectRemoteToken
+    )
     if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
         Write-DuneError -Response $Response -Status 404 -Message 'Not found'
         return
@@ -458,6 +498,20 @@ function Write-DuneFile {
         $Response.Headers['Cache-Control'] = 'public, max-age=31536000, immutable'
     } else {
         $Response.Headers['Cache-Control'] = 'no-cache'
+    }
+
+    if ($InjectRemoteToken) {
+        # index.html is small (~1 KB); read it as text, do the replacement,
+        # then emit UTF-8 bytes. Never cached (we already set no-cache above).
+        $html = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+        $tokenLiteral = if ($script:DuneToken) { ($script:DuneToken -replace '"','\"') } else { '' }
+        $script = '<script>window.__duneRemoteToken="' + $tokenLiteral + '";</script>'
+        $html = $html -replace '<!--\s*DUNE_REMOTE_BOOTSTRAP\s*-->', $script
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($html)
+        $Response.ContentLength64 = $bytes.Length
+        $Response.OutputStream.Write($bytes, 0, $bytes.Length)
+        $Response.OutputStream.Close()
+        return
     }
 
     $stream = [System.IO.File]::OpenRead($Path)
@@ -677,6 +731,101 @@ function Invoke-DuneContext {
         }
         $res.StatusCode = 404
         $res.OutputStream.Close()
+        return
+    }
+
+    # ---------- Remote portal (issue #74) ------------------------------------
+    # Two distinct surfaces gated by Cloudflare Access:
+    #   /api/remote/*  — JSON API, requires CF Access header + ACL match
+    #                    AND DuneToken (defense in depth).
+    #   /remote/*      — SPA HTML/assets, requires CF Access header + ACL.
+    #                    Token reaches the SPA via index.html injection.
+    # All other /api/* and /api/remote-access/* fall through to the
+    # standard DuneToken gate below.
+    $isRemoteApi = $rawPath.StartsWith('/api/remote/')
+    $isRemoteSpa = $rawPath.StartsWith('/remote/') -or $rawPath -eq '/remote'
+    if ($isRemoteApi -or $isRemoteSpa) {
+        $auth = $null
+        try { $auth = Test-DuneRemoteRequest -Request $req } catch {
+            $auth = @{ ok = $false; status = 500; message = "Auth middleware error: $($_.Exception.Message)" }
+        }
+        if (-not $auth.ok) {
+            $note = if ($auth.status -eq 401) { 'auth-required' } elseif ($auth.status -eq 403) { 'not-authorized' } else { 'auth-error' }
+            $emailHdr = ''
+            try { $emailHdr = ($req.Headers['Cf-Access-Authenticated-User-Email']) } catch {}
+            try {
+                Write-DuneRemoteAudit -Role '-' -Email $emailHdr -Method $method -Path $rawPath -Status $auth.status -Note $note
+            } catch {}
+            Write-DuneError -Response $res -Status $auth.status -Message $auth.message
+            return
+        }
+
+        if ($isRemoteApi) {
+            # /api/remote/* — also require the per-launch DuneToken (defense
+            # in depth — a same-Windows-box attacker forging the CF header
+            # still hits this wall because the token only lives in DST's RAM).
+            if (-not (Test-DuneToken -Request $req)) {
+                try { Write-DuneRemoteAudit -Role $auth.role -Email $auth.email -Method $method -Path $rawPath -Status 401 -Note 'token-missing' } catch {}
+                Write-DuneError -Response $res -Status 401 -Message 'Invalid or missing token'
+                return
+            }
+            foreach ($r in $script:DuneRoutes) {
+                if ($r.Method -ne $method) { continue }
+                $m = $r.Regex.Match($rawPath)
+                if ($m.Success) {
+                    $routeParams = @{}
+                    foreach ($g in $r.Regex.GetGroupNames()) {
+                        if ($g -notmatch '^\d+$') { $routeParams[$g] = $m.Groups[$g].Value }
+                    }
+                    $routeParams['remoteEmail'] = $auth.email
+                    $routeParams['remoteRole']  = $auth.role
+                    if ($script:DuneApiPoolEnabled -and -not $r.Inline) {
+                        Invoke-DuneApiHandlerAsync -Handler $r.Handler -Request $req -Response $res -RouteParams $routeParams
+                        return
+                    }
+                    $body = $null
+                    if ($req.HasEntityBody) {
+                        $reader = [System.IO.StreamReader]::new($req.InputStream, $req.ContentEncoding)
+                        try { $body = $reader.ReadToEnd() } finally { $reader.Dispose() }
+                        if ($body -and $req.ContentType -like 'application/json*') {
+                            $body = ConvertFrom-DuneRequestJson -Raw $body
+                        }
+                    }
+                    & $r.Handler $req $res $routeParams $body
+                    # Inline path also gets audit-logged for writes (the
+                    # worker path is handled in Invoke-DuneApiHandlerAsync).
+                    if ($method -ne 'GET' -and $method -ne 'HEAD') {
+                        try { Write-DuneRemoteAudit -Role $auth.role -Email $auth.email -Method $method -Path $rawPath -Status ([int]$res.StatusCode) } catch {}
+                    }
+                    return
+                }
+            }
+            try { Write-DuneRemoteAudit -Role $auth.role -Email $auth.email -Method $method -Path $rawPath -Status 404 -Note 'no-route' } catch {}
+            Write-DuneError -Response $res -Status 404 -Message "No route for $method $rawPath"
+            return
+        }
+
+        # /remote/* SPA serving (GET/HEAD only). Token injection happens in
+        # Write-DuneFile when the served file is index.html.
+        if ($method -ne 'GET' -and $method -ne 'HEAD') {
+            Write-DuneError -Response $res -Status 405 -Message 'Method not allowed'
+            return
+        }
+        $filePath = Resolve-DuneStaticPath -UrlPath $rawPath
+        $serveIndex = $false
+        if ($filePath -and (Test-Path -LiteralPath $filePath -PathType Leaf)) {
+            $serveIndex = ($filePath -match '\\index\.html$')
+            Write-DuneFile -Response $res -Path $filePath -InjectRemoteToken:$serveIndex
+            return
+        }
+        # SPA fallback (client-side router URLs like /remote/maps) — serve
+        # the SPA's index.html with the token injection.
+        $indexPath = Join-Path $script:DuneDistRoot 'index.html'
+        if (Test-Path -LiteralPath $indexPath -PathType Leaf) {
+            Write-DuneFile -Response $res -Path $indexPath -InjectRemoteToken
+            return
+        }
+        Write-DuneError -Response $res -Status 404 -Message 'Static asset not found'
         return
     }
 

--- a/app/server/lib/RemoteAccess.ps1
+++ b/app/server/lib/RemoteAccess.ps1
@@ -1,0 +1,280 @@
+﻿# RemoteAccess.ps1 — Cloudflare-Access-gated remote portal subset (issue #74).
+#
+# DST today is loopback + per-launch DuneToken. The remote portal lets Neil and
+# 1..3 trusted admins reach a mobile-friendly read+safe-write subset via a
+# Cloudflare Tunnel + Cloudflare Access policy. This file owns:
+#
+#   * The ACL file (%APPDATA%\DuneServer\remote-acl.json) — schema:
+#       { "owner": "neil@example", "admins": ["friend@example", ...] }
+#     Empty "owner" == remote portal disabled (fail-closed).
+#
+#   * The middleware (Test-DuneRemoteRequest) called by the listener for any
+#     /api/remote/* or /remote/* path BEFORE route matching. Reads the
+#     Cf-Access-Authenticated-User-Email header, looks the address up, and
+#     returns either an OK result with email + role or a fail result with the
+#     HTTP status to send.
+#
+#   * The audit log (%APPDATA%\DuneServer\.logs\remote-audit.log) — one line
+#     per write attempt (success or failure) and one line per auth denial,
+#     so revoking a misbehaving admin is a single Settings-card edit.
+#
+# Public functions:
+#   Get-DuneRemoteAclPath
+#   Get-DuneRemoteAcl                    -> hashtable {owner; admins[]}
+#   Save-DuneRemoteAcl -Acl <ht>         atomic write (temp + Move-Item -Force)
+#   Get-DuneRemoteRole -Email <e>        -> 'owner' | 'admin' | $null
+#   Test-DuneRemoteRequest -Request <r>  -> @{ok=$true; email; role}
+#                                          | @{ok=$false; status; message}
+#   Write-DuneRemoteAudit -Role -Email -Method -Path -Status [-Note]
+#   Get-DuneRemoteAuditTail -Lines N     -> string[] last N lines (newest last)
+#   Test-DuneCloudflaredPresent          -> @{installed; path; version}
+#
+# Isolation guarantee (see plan.md): this file is intentionally NOT imported
+# anywhere — every lib/*.ps1 is dot-sourced into every API-pool runspace by
+# Initialize-DuneApiPool, so any function is reachable from any handler.
+# The real isolation boundary is the dispatcher prefix in Invoke-DuneContext
+# plus the code-review rule that routes/Remote.ps1 calls only the allow-list
+# of helpers documented in plan.md.
+
+# ---------- Paths ------------------------------------------------------------
+
+function Get-DuneRemoteAclPath {
+    $dir = Join-Path $env:APPDATA 'DuneServer'
+    return (Join-Path $dir 'remote-acl.json')
+}
+
+function Get-DuneRemoteAuditLogPath {
+    $dir = Join-Path $env:APPDATA 'DuneServer\.logs'
+    return (Join-Path $dir 'remote-audit.log')
+}
+
+# ---------- ACL --------------------------------------------------------------
+
+# Returns a hashtable {owner=''; admins=@()} even when the file is missing or
+# unreadable so callers don't have to nil-check. NEVER writes to disk — a
+# malformed file deliberately stays untouched so a transient parse error can't
+# silently nuke the allowlist.
+function Get-DuneRemoteAcl {
+    $default = @{ owner = ''; admins = @(); hostname = '' }
+    $path = Get-DuneRemoteAclPath
+    if (-not (Test-Path -LiteralPath $path)) { return $default }
+    try {
+        $raw = Get-Content -LiteralPath $path -Raw -Encoding UTF8 -ErrorAction Stop
+        if ([string]::IsNullOrWhiteSpace($raw)) { return $default }
+        $obj = $raw | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        # Malformed JSON → fail closed without touching the file. The caller
+        # (middleware) will deny the request; Get-DuneRemoteAuditTail still
+        # works on the (separate) audit log so the operator can investigate.
+        try {
+            if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                Write-DuneLog "remote-acl.json malformed; remote portal denied. $($_.Exception.Message)" 'WARN'
+            }
+        } catch {}
+        return $default
+    }
+
+    $owner = ''
+    if ($obj.PSObject.Properties.Name -contains 'owner' -and $obj.owner) {
+        $owner = ([string]$obj.owner).Trim().ToLowerInvariant()
+    }
+    $admins = @()
+    if ($obj.PSObject.Properties.Name -contains 'admins' -and $obj.admins) {
+        foreach ($a in @($obj.admins)) {
+            $norm = ([string]$a).Trim().ToLowerInvariant()
+            if ($norm) { $admins += $norm }
+        }
+        $admins = $admins | Select-Object -Unique
+    }
+    $hostname = ''
+    if ($obj.PSObject.Properties.Name -contains 'hostname' -and $obj.hostname) {
+        $hostname = ([string]$obj.hostname).Trim()
+    }
+    return @{ owner = $owner; admins = @($admins); hostname = $hostname }
+}
+
+# Atomic write: temp + Move-Item -Force. A SIGKILL between Set-Content and
+# Move-Item leaves the previous ACL intact (instead of half-written / empty),
+# so a crash can never silently lock the owner out.
+function Save-DuneRemoteAcl {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][hashtable]$Acl)
+
+    $owner = ''
+    if ($Acl.ContainsKey('owner') -and $Acl.owner) {
+        $owner = ([string]$Acl.owner).Trim().ToLowerInvariant()
+    }
+    $admins = @()
+    if ($Acl.ContainsKey('admins') -and $Acl.admins) {
+        foreach ($a in @($Acl.admins)) {
+            $norm = ([string]$a).Trim().ToLowerInvariant()
+            if ($norm) { $admins += $norm }
+        }
+        $admins = @($admins | Select-Object -Unique)
+    }
+    $hostname = ''
+    if ($Acl.ContainsKey('hostname') -and $Acl.hostname) {
+        $hostname = ([string]$Acl.hostname).Trim()
+    }
+
+    $out = [ordered]@{ owner = $owner; admins = $admins; hostname = $hostname }
+
+    $path = Get-DuneRemoteAclPath
+    $dir  = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    $tmp = "$path.tmp"
+    $json = ($out | ConvertTo-Json -Depth 4)
+    Set-Content -LiteralPath $tmp -Value $json -Encoding UTF8 -Force
+    Move-Item -LiteralPath $tmp -Destination $path -Force
+    return $out
+}
+
+function Get-DuneRemoteRole {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Email)
+    $e = $Email.Trim().ToLowerInvariant()
+    if (-not $e) { return $null }
+    $acl = Get-DuneRemoteAcl
+    if (-not $acl.owner) { return $null }       # remote disabled
+    if ($e -eq $acl.owner) { return 'owner' }
+    if ($acl.admins -contains $e) { return 'admin' }
+    return $null
+}
+
+# ---------- Middleware -------------------------------------------------------
+
+# Called by the listener BEFORE route matching for any /api/remote/* or
+# /remote/* path. Returns:
+#   @{ ok = $true;  email = '...'; role = 'owner'|'admin' }
+#   @{ ok = $false; status = 401|403; message = '...' }
+#
+# Fail-closed cases (401, generic message — don't leak path validity):
+#   * No Cf-Access-Authenticated-User-Email header
+#   * ACL missing or owner unset (remote disabled)
+#   * ACL malformed (Get-DuneRemoteAcl returns the default)
+# Forbidden case (403):
+#   * Valid header but email not in owner+admins list
+function Test-DuneRemoteRequest {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)]$Request)
+
+    $rawEmail = $null
+    try { $rawEmail = $Request.Headers['Cf-Access-Authenticated-User-Email'] } catch {}
+    if ([string]::IsNullOrWhiteSpace($rawEmail)) {
+        return @{ ok = $false; status = 401; message = 'Authentication required.' }
+    }
+    $email = $rawEmail.Trim().ToLowerInvariant()
+
+    $acl = Get-DuneRemoteAcl
+    if (-not $acl.owner) {
+        # Remote portal explicitly off (default for fresh installs). We deny
+        # with 401 (not 403) so a misconfigured tunnel does not advertise
+        # which paths are gated by which ACL.
+        return @{ ok = $false; status = 401; message = 'Remote portal not enabled.' }
+    }
+
+    if ($email -eq $acl.owner) {
+        return @{ ok = $true; email = $email; role = 'owner' }
+    }
+    if ($acl.admins -contains $email) {
+        return @{ ok = $true; email = $email; role = 'admin' }
+    }
+    return @{ ok = $false; status = 403; message = 'Not authorized for remote portal.' }
+}
+
+# ---------- Audit log --------------------------------------------------------
+
+# Append a single line to %APPDATA%\DuneServer\.logs\remote-audit.log.
+# Schema (tab-separated for easy splitting; UTC ISO-8601 timestamp):
+#
+#   2026-06-05T12:34:56Z\towner\tnbroome@me.com\tPOST\t/api/remote/maps/spin-up/deepdesert\t200\t<note>
+#
+# Note is optional — used by the listener to record the reason for an auth
+# denial ('no-header', 'unknown-email', 'remote-disabled', 'pool-saturated').
+function Write-DuneRemoteAudit {
+    [CmdletBinding()]
+    param(
+        [string]$Role    = '',
+        [string]$Email   = '',
+        [string]$Method  = '',
+        [string]$Path    = '',
+        [int]   $Status  = 0,
+        [string]$Note    = ''
+    )
+
+    $path = Get-DuneRemoteAuditLogPath
+    $dir  = Split-Path -Parent $path
+    try {
+        if (-not (Test-Path -LiteralPath $dir)) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        }
+        # 1 MB rollover (same pattern as Initialize-DuneLog).
+        if (Test-Path -LiteralPath $path) {
+            $sz = (Get-Item -LiteralPath $path).Length
+            if ($sz -gt 1MB) {
+                $bak = "$path.old"
+                if (Test-Path -LiteralPath $bak) { Remove-Item -LiteralPath $bak -Force }
+                Move-Item -LiteralPath $path -Destination $bak -Force
+            }
+        }
+        $ts = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        $r  = if ($Role)   { $Role }   else { '-' }
+        $e  = if ($Email)  { $Email }  else { '-' }
+        $m  = if ($Method) { $Method } else { '-' }
+        $p  = if ($Path)   { $Path }   else { '-' }
+        $s  = if ($Status -gt 0) { $Status.ToString() } else { '-' }
+        $n  = if ($Note)   { $Note }   else { '' }
+        $line = "{0}`t{1}`t{2}`t{3}`t{4}`t{5}`t{6}" -f $ts, $r, $e, $m, $p, $s, $n
+        Add-Content -LiteralPath $path -Value $line -Encoding UTF8
+    } catch {
+        # Audit-log write failure must NOT take down the request — log to the
+        # main DST log if available, otherwise swallow silently.
+        try {
+            if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                Write-DuneLog "remote-audit write failed: $($_.Exception.Message)" 'WARN'
+            }
+        } catch {}
+    }
+}
+
+# Returns the last N lines of the audit log (newest LAST — same order as the
+# file on disk) as an array of strings. Returns @() when the log is absent.
+function Get-DuneRemoteAuditTail {
+    [CmdletBinding()]
+    param([int]$Lines = 50)
+    if ($Lines -lt 1)   { $Lines = 1 }
+    if ($Lines -gt 500) { $Lines = 500 }
+    $path = Get-DuneRemoteAuditLogPath
+    if (-not (Test-Path -LiteralPath $path)) { return @() }
+    try {
+        return @(Get-Content -LiteralPath $path -Tail $Lines -Encoding UTF8 -ErrorAction Stop)
+    } catch {
+        return @()
+    }
+}
+
+# ---------- cloudflared detection (status pill, NEVER runs it) ---------------
+
+# The Settings card surfaces an "installed / not installed" pill so the user
+# knows whether they still need to install cloudflared per the setup guide.
+# We DELIBERATELY do not run `cloudflared --version` here — we resolve the
+# command via Get-Command and read the file version off the .exe so we don't
+# spawn a process every time Settings loads.
+function Test-DuneCloudflaredPresent {
+    $result = @{ installed = $false; path = ''; version = '' }
+    try {
+        $cmd = Get-Command 'cloudflared.exe' -ErrorAction SilentlyContinue
+        if (-not $cmd) { $cmd = Get-Command 'cloudflared' -ErrorAction SilentlyContinue }
+        if ($cmd -and $cmd.Source) {
+            $result.installed = $true
+            $result.path = $cmd.Source
+            try {
+                $vi = (Get-Item -LiteralPath $cmd.Source).VersionInfo
+                if ($vi -and $vi.FileVersion) { $result.version = $vi.FileVersion }
+            } catch {}
+        }
+    } catch {}
+    return $result
+}

--- a/app/server/routes/Remote.ps1
+++ b/app/server/routes/Remote.ps1
@@ -1,0 +1,218 @@
+﻿# Remote.ps1 — Cloudflare-Access-gated public remote portal routes (issue #74).
+#
+# IMPORTANT: Every handler in this file runs in the API runspace pool and so
+# has access to ALL lib + route functions (Initialize-DuneApiPool dot-sources
+# them all). The safety boundary is NOT this file's import surface — it's:
+#
+#   1. The dispatcher branch in Invoke-DuneContext: anything under /api/remote/*
+#      only matches routes registered HERE. The CF-Access namespace cannot
+#      reach /api/maps, /api/db, /api/sietch, /api/portal, /api/setup, etc.
+#
+#   2. A code-review rule (and CI grep guard) that this file only calls the
+#      following lib functions:
+#
+#         Get-DuneVmStatus, Get-DuneBattlegroupSnapshot,
+#         Get-DunePortStatus, Get-DunePublicIp,
+#         Get-DuneOnDemandMapState, Start-DuneOnDemandMap,
+#         Stop-DuneOnDemandMap, Invoke-DuneFixOnDemandPartitions,
+#         Get-DuneBackupContext, Get-DuneBackupHistory,
+#         Invoke-WithDuneLock, Register-DuneRoute,
+#         Write-DuneJson, Write-DuneError.
+#
+#      Adding anything from lib/Setup.ps1, lib/Database.ps1,
+#      lib/ConsoleHost.ps1, lib/Commands.ps1 (Get-DuneCommandByName /
+#      Invoke-DuneCommand*), or any other routes/* module is forbidden
+#      and the CI guard fails the PR.
+#
+# Each handler receives the authenticated email + role on $routeParams as
+# remoteEmail / remoteRole (injected by Test-DuneRemoteRequest in the
+# dispatcher) — handlers do NOT need to re-check auth, but MAY use the role
+# to gate owner-only actions (none in v11.1.0; deferred to v11.2.0).
+#
+# Audit logging of completed write actions happens automatically in the
+# worker's finally block in HttpServer.ps1 — handlers should NOT call
+# Write-DuneRemoteAudit directly (would double-log).
+
+# ---------- GET /api/remote/status -------------------------------------------
+# Compact dashboard snapshot: VM up/down, battlegroup health, public IP,
+# port-forward summary.
+Register-DuneRoute -Method GET -Path '/api/remote/status' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $vm = Get-DuneVmStatus
+        $bg = $null
+        if ($vm -and $vm.running) {
+            try { $bg = Get-DuneBattlegroupSnapshot } catch { $bg = @{ available=$false; reason=$_.Exception.Message } }
+        }
+        $ports = $null
+        try { $ports = Get-DunePortStatus } catch { $ports = $null }
+        $publicIp = $null
+        try { $publicIp = Get-DunePublicIp } catch {}
+
+        Write-DuneJson -Response $res -Body @{
+            vm       = $vm
+            bg       = $bg
+            ports    = $ports
+            publicIp = $publicIp
+            ts       = (Get-Date).ToString('o')
+            role     = $routeParams.remoteRole
+            email    = $routeParams.remoteEmail
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+# ---------- GET /api/remote/maps ---------------------------------------------
+# Per-map state for every on-demand map (deepdesert, arakeen, harkovillage).
+# Surfaces the partition-pin flag so the SPA can prompt "Fix partitions" when
+# the operator has drifted.
+Register-DuneRoute -Method GET -Path '/api/remote/maps' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $maps = @()
+        foreach ($def in $script:DuneOnDemandMaps) {
+            $entry = @{
+                key                     = $def.Key
+                label                   = $def.Label
+                ok                      = $false
+                running                 = $false
+                present                 = $false
+                totalReplicas           = 0
+                playersOnline           = 0
+                hasDisabledPart         = $false
+                missingPartitionBinding = $false
+                stuckDedicatedScaling   = $false
+                error                   = $null
+            }
+            try {
+                $state = Get-DuneOnDemandMapState -Key $def.Key
+                if ($state.ok) {
+                    $entry.ok                      = $true
+                    $entry.running                 = [bool]$state.running
+                    $entry.present                 = [bool]$state.present
+                    $entry.totalReplicas           = [int]($state.totalReplicas)
+                    $entry.playersOnline           = if ($null -eq $state.playersOnline) { $null } else { [int]$state.playersOnline }
+                    $entry.hasDisabledPart         = [bool]$state.hasDisabledPart
+                    $entry.missingPartitionBinding = [bool]$state.missingPartitionBinding
+                    $entry.stuckDedicatedScaling   = [bool]$state.stuckDedicatedScaling
+                } else {
+                    $entry.error = $state.message
+                }
+            } catch {
+                $entry.error = $_.Exception.Message
+            }
+            $maps += $entry
+        }
+        Write-DuneJson -Response $res -Body @{
+            maps  = $maps
+            ts    = (Get-Date).ToString('o')
+            role  = $routeParams.remoteRole
+            email = $routeParams.remoteEmail
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+# ---------- GET /api/remote/backups ------------------------------------------
+# Last 3 .backup files with size + age. LogLines=0 keeps this cheap; the
+# remote portal doesn't surface the log tail (desktop portal still does).
+Register-DuneRoute -Method GET -Path '/api/remote/backups' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $ctx = Get-DuneBackupContext
+        if (-not $ctx.ok) {
+            Write-DuneError -Response $res -Status $ctx.status -Message $ctx.message
+            return
+        }
+        $history = Get-DuneBackupHistory -Ip $ctx.ip -Recent 3 -LogLines 1
+        $now = (Get-Date).ToUniversalTime()
+        $entries = @()
+        foreach ($f in @($history.recent)) {
+            $age = $null
+            try {
+                $dt = [datetimeoffset]::FromUnixTimeSeconds([long]$f.mtimeEpoch).UtcDateTime
+                $age = [int]([math]::Round(($now - $dt).TotalMinutes))
+            } catch {}
+            $entries += @{
+                name       = [System.IO.Path]::GetFileName([string]$f.path)
+                path       = $f.path
+                sizeBytes  = $f.sizeBytes
+                mtimeEpoch = $f.mtimeEpoch
+                mtimeIso   = $f.mtimeIso
+                ageMinutes = $age
+            }
+        }
+        Write-DuneJson -Response $res -Body @{
+            recent      = $entries
+            dumpDirSize = $history.dumpDirSize
+            ts          = (Get-Date).ToString('o')
+            role        = $routeParams.remoteRole
+            email       = $routeParams.remoteEmail
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 502 -Message "Backup history read failed: $($_.Exception.Message)"
+    }
+}
+
+# ---------- POST /api/remote/maps/spin-up/{key} -----------------------------
+# Owner + admin both allowed in v11.1.0 (deferred owner-only gating to v11.2.0).
+Register-DuneRoute -Method POST -Path '/api/remote/maps/spin-up/{key}' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $result = Invoke-WithDuneLock -Name 'ondemand-maps' -Script { Start-DuneOnDemandMap -Key $routeParams.key }
+        if (-not $result.ok -and $result.status) {
+            Write-DuneError -Response $res -Status $result.status -Message $result.message
+            return
+        }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+# ---------- POST /api/remote/maps/spin-down/{key} ---------------------------
+# Stop WITHOUT -Force: if players are online, the lib returns 409 with the
+# count + ids. The remote SPA surfaces that as a "N players online — try
+# later" message; player-kick is intentionally NOT exposed in v11.1.0
+# (issue #74 deferred list).
+Register-DuneRoute -Method POST -Path '/api/remote/maps/spin-down/{key}' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $result = Invoke-WithDuneLock -Name 'ondemand-maps' -Script { Stop-DuneOnDemandMap -Key $routeParams.key }
+        if (-not $result.ok -and $result.status) {
+            if ($result.status -eq 409) {
+                # Surface the players-online payload so the SPA can render
+                # the count. 409 = "conflict" — same shape as the desktop
+                # portal's /api/maps/{key}/stop response.
+                $res.StatusCode = 409
+                Write-DuneJson -Response $res -Body $result
+                return
+            }
+            Write-DuneError -Response $res -Status $result.status -Message $result.message
+            return
+        }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+# ---------- POST /api/remote/maps/fix-partitions ----------------------------
+# Re-run the remote dune-clear-partitions.start helper. Idempotent — skips
+# any map with a running pod. Safe to invoke whenever a map refuses to
+# launch on demand.
+Register-DuneRoute -Method POST -Path '/api/remote/maps/fix-partitions' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $result = Invoke-WithDuneLock -Name 'ondemand-maps' -Script { Invoke-DuneFixOnDemandPartitions }
+        if (-not $result.ok -and $result.status) {
+            Write-DuneError -Response $res -Status $result.status -Message $result.message
+            return
+        }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}

--- a/app/server/routes/RemoteAccess.ps1
+++ b/app/server/routes/RemoteAccess.ps1
@@ -1,0 +1,94 @@
+﻿# RemoteAccess.ps1 — DuneToken-gated LOCAL management routes (issue #74).
+#
+# These routes back the desktop portal's Settings → Remote Access card.
+# They live under /api/remote-access/* (NOT /api/remote/*) so the dispatcher
+# can branch on prefix alone — /api/remote-access/* is gated by DuneToken
+# only (same as the rest of /api/*), and is unreachable through the
+# Cloudflare tunnel by design (the desktop portal sets the token; the
+# remote SPA does not).
+#
+#   GET  /api/remote-access/acl                    -> {owner; admins[]; hostname}
+#   PUT  /api/remote-access/acl                    body: {owner; admins[]; hostname}
+#   GET  /api/remote-access/audit-log?lines=N      -> {lines: [parsed entries...]}
+#   GET  /api/remote-access/cloudflared-status     -> {installed; path; version}
+
+Register-DuneRoute -Method GET -Path '/api/remote-access/acl' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $acl = Get-DuneRemoteAcl
+        Write-DuneJson -Response $res -Body @{
+            owner    = $acl.owner
+            admins   = $acl.admins
+            hostname = $acl.hostname
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+Register-DuneRoute -Method PUT -Path '/api/remote-access/acl' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $owner = ''
+        $admins = @()
+        $hostname = ''
+        if ($body -is [hashtable]) {
+            if ($body.ContainsKey('owner'))    { $owner    = [string]$body['owner'] }
+            if ($body.ContainsKey('admins'))   { $admins   = @($body['admins']) }
+            if ($body.ContainsKey('hostname')) { $hostname = [string]$body['hostname'] }
+        } elseif ($null -ne $body) {
+            if ($body.PSObject.Properties.Name -contains 'owner')    { $owner    = [string]$body.owner }
+            if ($body.PSObject.Properties.Name -contains 'admins')   { $admins   = @($body.admins) }
+            if ($body.PSObject.Properties.Name -contains 'hostname') { $hostname = [string]$body.hostname }
+        }
+        $saved = Save-DuneRemoteAcl -Acl @{ owner = $owner; admins = $admins; hostname = $hostname }
+        Write-DuneJson -Response $res -Body @{
+            owner    = $saved.owner
+            admins   = $saved.admins
+            hostname = $saved.hostname
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Save failed: $($_.Exception.Message)"
+    }
+}
+
+Register-DuneRoute -Method GET -Path '/api/remote-access/audit-log' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $lines = 50
+        try {
+            if ($req -and $req.QueryString -and $req.QueryString['lines']) {
+                $lines = [int]$req.QueryString['lines']
+            }
+        } catch {}
+        $raw = Get-DuneRemoteAuditTail -Lines $lines
+        $entries = @()
+        foreach ($ln in @($raw)) {
+            if (-not $ln) { continue }
+            $parts = $ln -split "`t", 7
+            $entries += @{
+                ts     = if ($parts.Count -gt 0) { $parts[0] } else { '' }
+                role   = if ($parts.Count -gt 1) { $parts[1] } else { '' }
+                email  = if ($parts.Count -gt 2) { $parts[2] } else { '' }
+                method = if ($parts.Count -gt 3) { $parts[3] } else { '' }
+                path   = if ($parts.Count -gt 4) { $parts[4] } else { '' }
+                status = if ($parts.Count -gt 5) { $parts[5] } else { '' }
+                note   = if ($parts.Count -gt 6) { $parts[6] } else { '' }
+                raw    = $ln
+            }
+        }
+        Write-DuneJson -Response $res -Body @{ entries = $entries; count = $entries.Count }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+Register-DuneRoute -Method GET -Path '/api/remote-access/cloudflared-status' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $status = Test-DuneCloudflaredPresent
+        Write-DuneJson -Response $res -Body $status
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.0.0"
+$script:ToolVersion = "11.1.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -101,6 +101,16 @@ import DownloadButton from "../components/DownloadButton.astro";
         — community admin panel for player and inventory tooling. Launches
         from the Commands page if you point DST at its install path.
       </li>
+      <li>
+        <strong class="text-dune-text">(Optional)</strong>
+        <a
+          href="/remote"
+          class="underline decoration-dotted hover:text-dune-text"
+          >Remote portal</a
+        >
+        — phone-friendly view of status + map spin-up/down behind a
+        Cloudflare Tunnel + Access policy. Setup is BYO Cloudflare account.
+      </li>
     </ul>
 
     <h2 class="text-2xl font-semibold mb-4">Where things live</h2>

--- a/site/src/pages/remote.astro
+++ b/site/src/pages/remote.astro
@@ -1,0 +1,179 @@
+---
+import Base from "../layouts/Base.astro";
+import PageHeader from "../components/PageHeader.astro";
+---
+
+<Base
+  title="Remote portal — DST"
+  description="Set up a mobile-friendly remote view of DST behind a Cloudflare Tunnel + Cloudflare Access policy."
+>
+  <PageHeader
+    eyebrow="Remote portal (v11.1.0)"
+    title="Mobile access via Cloudflare Tunnel"
+    intro="DST stays a local-only tool by default. If you want to check status and spin maps up/down from your phone, you can expose a read-mostly subset of the portal through a Cloudflare Tunnel gated by Cloudflare Access — your email is the password."
+  />
+
+  <section class="mx-auto max-w-3xl px-6 pb-16 space-y-12 text-dune-text">
+    <!-- What it gives you ------------------------------------------------- -->
+    <div>
+      <h2 class="text-2xl font-semibold mb-4">What the remote portal does</h2>
+      <ul class="space-y-2 text-dune-muted leading-relaxed">
+        <li><strong class="text-dune-text">Dashboard</strong> — VM up/down, battlegroup state, public IP, port-forward summary, last few backups.</li>
+        <li><strong class="text-dune-text">Maps</strong> — spin a configured map up or down, run a one-click <em>fix partitions</em> if a worker pin drifts.</li>
+        <li>That's it. No initial-setup wizard, no <span class="font-mono">.ini</span> editor, no SSH/shell, no DB import or restore, no dune-admin, no Settings. The remote route module physically cannot reach those handlers.</li>
+      </ul>
+    </div>
+
+    <!-- Security model --------------------------------------------------- -->
+    <div>
+      <h2 class="text-2xl font-semibold mb-4">Security model</h2>
+      <p class="text-dune-muted leading-relaxed mb-3">
+        Three layers, all of which must pass for any remote request:
+      </p>
+      <ol class="list-decimal list-inside space-y-2 text-dune-muted leading-relaxed">
+        <li><strong class="text-dune-text">Cloudflare Tunnel</strong> — outbound-only TCP from your PC to Cloudflare's edge. No inbound port-forward, no public IP. <span class="font-mono">cloudflared</span> sees your DST listener at <span class="font-mono">http://127.0.0.1:&lt;port&gt;</span> and proxies it to a hostname like <span class="font-mono">dune.example.com</span>.</li>
+        <li><strong class="text-dune-text">Cloudflare Access</strong> — a per-hostname policy that requires a verified identity (Google / GitHub / one-time PIN). The request arrives at DST with an <span class="font-mono">Cf-Access-Authenticated-User-Email</span> header that only Cloudflare can sign.</li>
+        <li><strong class="text-dune-text">DST allow-list</strong> — DST reads that email and looks it up in <span class="font-mono">%APPDATA%\DuneServer\remote-acl.json</span>. Owner + 0–3 admins, all explicitly added by you in <strong>Settings → Remote Access</strong>. Anything else is a 401/403.</li>
+      </ol>
+      <p class="text-dune-muted leading-relaxed mt-3">
+        DST's per-launch GUID token (<span class="font-mono">DuneToken</span>) is still
+        enforced on every request as a defense-in-depth, so even an attacker on
+        your Windows box who forges the Cloudflare header without going through
+        the tunnel can't reach the remote API.
+      </p>
+      <p class="text-dune-muted leading-relaxed mt-3">
+        Every successful write (spin up / spin down / fix partitions) appends a
+        line to <span class="font-mono">%APPDATA%\DuneServer\.logs\remote-audit.log</span>
+        with timestamp, role, email, path, and status. Revoking a misbehaving
+        admin is one toggle in Settings.
+      </p>
+    </div>
+
+    <!-- Setup steps ------------------------------------------------------ -->
+    <div>
+      <h2 class="text-2xl font-semibold mb-4">One-time setup</h2>
+      <p class="text-dune-muted leading-relaxed mb-6">
+        You'll need a Cloudflare account and a domain you control on it (any
+        free plan works). The whole thing takes about 15 minutes.
+      </p>
+
+      <ol class="space-y-6">
+        <!-- Step 1 -->
+        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">1 · Install <span class="font-mono">cloudflared</span></h3>
+          <p class="text-dune-muted text-sm mb-3">From an admin PowerShell window:</p>
+          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">winget install --id Cloudflare.cloudflared</pre>
+          <p class="text-dune-muted text-xs mt-2">DST detects whether <span class="font-mono">cloudflared.exe</span> is on PATH and surfaces it in the Settings card. DST never runs it for you — you keep ownership of the tunnel.</p>
+        </li>
+
+        <!-- Step 2 -->
+        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">2 · Authenticate</h3>
+          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">cloudflared tunnel login</pre>
+          <p class="text-dune-muted text-xs mt-2">Browser opens — pick the zone you want to use. A cert is saved to <span class="font-mono">%USERPROFILE%\.cloudflared\cert.pem</span>.</p>
+        </li>
+
+        <!-- Step 3 -->
+        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">3 · Create a tunnel</h3>
+          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">cloudflared tunnel create dune-portal</pre>
+          <p class="text-dune-muted text-xs mt-2">Writes a credentials JSON for the tunnel; copy the tunnel UUID it prints — you'll need it in step 4.</p>
+        </li>
+
+        <!-- Step 4 -->
+        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">4 · Map your hostname</h3>
+          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">cloudflared tunnel route dns dune-portal dune.example.com</pre>
+          <p class="text-dune-muted text-xs mt-2">Creates a proxied <span class="font-mono">CNAME</span> in Cloudflare DNS pointing your hostname at the tunnel.</p>
+        </li>
+
+        <!-- Step 5 -->
+        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">5 · Configure ingress</h3>
+          <p class="text-dune-muted text-sm mb-3">
+            Edit <span class="font-mono">%USERPROFILE%\.cloudflared\config.yml</span>:
+          </p>
+          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">tunnel: dune-portal
+credentials-file: C:\Users\You\.cloudflared\&lt;UUID&gt;.json
+
+ingress:
+  - hostname: dune.example.com
+    service: http://127.0.0.1:47823
+  - service: http_status:404</pre>
+          <div class="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs leading-relaxed">
+            <strong>Port caveat:</strong> DST prefers port <span class="font-mono">47823</span> but
+            roams to <span class="font-mono">47824–47872</span> if it's in use. If you suspect a
+            port collision, free 47823 (so DST always takes it) or read the
+            actual port from <span class="font-mono">%LOCALAPPDATA%\DuneServer\last-url.txt</span>
+            and update the <span class="font-mono">service:</span> line above to match. The Settings
+            page status bar also shows the current port.
+          </div>
+        </li>
+
+        <!-- Step 6 -->
+        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">6 · Add the Access policy</h3>
+          <p class="text-dune-muted text-sm mb-3">
+            In the Cloudflare Zero Trust dashboard → <strong>Access → Applications →
+            Add a self-hosted app</strong>:
+          </p>
+          <ul class="list-disc list-inside text-dune-muted text-sm space-y-1 mb-3">
+            <li>Application domain: <span class="font-mono">dune.example.com</span></li>
+            <li>Session duration: 24 h (or whatever feels right)</li>
+            <li>Add a policy → Action <strong>Allow</strong> → Include <strong>Emails</strong>
+              → list yourself plus each trusted admin.</li>
+          </ul>
+          <p class="text-dune-muted text-xs">
+            Cloudflare injects the verified email as <span class="font-mono">Cf-Access-Authenticated-User-Email</span>.
+            DST's middleware compares it to <span class="font-mono">remote-acl.json</span>
+            — the Access list and DST's allow-list are independent, so the
+            principle of least privilege applies twice.
+          </p>
+        </li>
+
+        <!-- Step 7 -->
+        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">7 · Run the tunnel</h3>
+          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">cloudflared tunnel run dune-portal</pre>
+          <p class="text-dune-muted text-xs mt-2">Or install it as a Windows service so it survives reboots:</p>
+          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto mt-1">cloudflared service install</pre>
+        </li>
+
+        <!-- Step 8 -->
+        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">8 · Enable in DST</h3>
+          <p class="text-dune-muted text-sm">
+            In DST: <strong>Settings → Remote Access</strong>. Tick <strong>Enable
+            remote portal</strong>, fill in the same email Cloudflare authenticates
+            you with, add any admins, save. Visit
+            <span class="font-mono">https://dune.example.com/remote/</span> on your phone.
+            You'll get a Cloudflare login, then the mobile portal.
+          </p>
+        </li>
+      </ol>
+    </div>
+
+    <!-- Disabling / revoking --------------------------------------------- -->
+    <div>
+      <h2 class="text-2xl font-semibold mb-4">Disabling or revoking access</h2>
+      <ul class="space-y-2 text-dune-muted leading-relaxed">
+        <li><strong class="text-dune-text">Pause everything:</strong> untick <strong>Enable remote portal</strong> in Settings. Every <span class="font-mono">/remote/*</span> request is refused immediately (the owner field is cleared, so DST fails closed).</li>
+        <li><strong class="text-dune-text">Revoke an admin:</strong> remove their email from the allow-list and save. The next request they make returns 403 and gets logged.</li>
+        <li><strong class="text-dune-text">Kill the tunnel:</strong> stop the <span class="font-mono">cloudflared</span> service (or just close its window).</li>
+        <li><strong class="text-dune-text">Audit:</strong> Settings → Remote Access → <strong>View audit log</strong> shows the last 50 mutating actions with timestamp, role, email, path, and HTTP status.</li>
+      </ul>
+    </div>
+
+    <!-- What this PR does NOT do ----------------------------------------- -->
+    <div>
+      <h2 class="text-2xl font-semibold mb-4">What v11.1.0 does <em>not</em> include</h2>
+      <p class="text-dune-muted leading-relaxed">
+        Phase 1 is intentionally read-mostly. <strong>Restart battlegroup</strong>,
+        <strong>backup now</strong>, and <strong>kick player</strong> are scoped for v11.2.0
+        once we've seen real mobile usage. <span class="font-mono">cloudflared</span>
+        install / config is your job, not DST's — DST detects whether it's present
+        and surfaces a status pill, but never modifies tunnel state.
+      </p>
+    </div>
+  </section>
+</Base>

--- a/webui/index.html
+++ b/webui/index.html
@@ -35,6 +35,7 @@
         } catch (e) { /* corrupted storage — fall through to default palette */ }
       })();
     </script>
+    <!-- DUNE_REMOTE_BOOTSTRAP -->
   </head>
   <body>
     <div id="root"></div>

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "0.0.0",
+  "version": "11.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "0.0.0",
+      "version": "11.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.0.0",
+  "version": "11.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webui/src/api/remote.ts
+++ b/webui/src/api/remote.ts
@@ -1,0 +1,150 @@
+// Remote portal API client — for /api/remote/* endpoints reached through the
+// Cloudflare tunnel. Mirrors the shape of api/client.ts but reads the per-
+// launch DuneToken from window.__duneRemoteToken (injected into index.html
+// by HttpServer.ps1's Write-DuneFile when the path starts with /remote/).
+//
+// Issue #74 (v11.1.0). Defense-in-depth: requests carry BOTH the CF Access
+// header (set automatically by Cloudflare on the edge) AND the X-Dune-Token
+// header so a same-Windows-box attacker forging the CF header still fails.
+
+declare global {
+  interface Window {
+    __duneRemoteToken?: string
+  }
+}
+
+export class RemoteApiError extends Error {
+  status: number
+  body?: unknown
+  constructor(status: number, message: string, body?: unknown) {
+    super(message)
+    this.status = status
+    this.body = body
+  }
+}
+
+function getRemoteToken(): string {
+  return (typeof window !== 'undefined' && window.__duneRemoteToken) || ''
+}
+
+async function remoteFetch<T = unknown>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const headers = new Headers(init.headers)
+  headers.set('Accept', 'application/json')
+  if (init.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+  const token = getRemoteToken()
+  if (token) headers.set('X-Dune-Token', token)
+
+  const res = await fetch(path, { ...init, headers })
+  const text = await res.text()
+  let body: unknown = undefined
+  if (text) {
+    try { body = JSON.parse(text) } catch { body = text }
+  }
+  if (!res.ok) {
+    const msg = (typeof body === 'object' && body && 'error' in body)
+      ? String((body as { error: unknown }).error)
+      : `${res.status} ${res.statusText}`
+    throw new RemoteApiError(res.status, msg, body)
+  }
+  return body as T
+}
+
+// ---- Types ----
+
+export interface RemoteVmStatus {
+  exists: boolean
+  running: boolean
+  state?: string
+  ip?: string
+}
+
+export interface RemoteStatusResponse {
+  vm: RemoteVmStatus | null
+  bg: Record<string, unknown> | null
+  ports: {
+    mode: string
+    publicIp: string | null
+    results: Array<{ port: number; protocol: string; label: string; status: string }>
+  } | null
+  publicIp: string | null
+  ts: string
+  role: 'owner' | 'admin'
+  email: string
+}
+
+export interface RemoteMapEntry {
+  key: string
+  label: string
+  ok: boolean
+  running: boolean
+  present: boolean
+  totalReplicas: number
+  playersOnline: number | null
+  hasDisabledPart: boolean
+  missingPartitionBinding: boolean
+  stuckDedicatedScaling: boolean
+  error: string | null
+}
+
+export interface RemoteMapsResponse {
+  maps: RemoteMapEntry[]
+  ts: string
+  role: 'owner' | 'admin'
+  email: string
+}
+
+export interface RemoteBackupEntry {
+  name: string
+  path: string
+  sizeBytes: number
+  mtimeEpoch: number
+  mtimeIso: string
+  ageMinutes: number | null
+}
+
+export interface RemoteBackupsResponse {
+  recent: RemoteBackupEntry[]
+  dumpDirSize: string
+  ts: string
+  role: 'owner' | 'admin'
+  email: string
+}
+
+export interface RemoteActionResult {
+  ok: boolean
+  message?: string
+  [k: string]: unknown
+}
+
+// ---- Reads ----
+
+export function getRemoteStatus(): Promise<RemoteStatusResponse> {
+  return remoteFetch<RemoteStatusResponse>('/api/remote/status')
+}
+
+export function getRemoteMaps(): Promise<RemoteMapsResponse> {
+  return remoteFetch<RemoteMapsResponse>('/api/remote/maps')
+}
+
+export function getRemoteBackups(): Promise<RemoteBackupsResponse> {
+  return remoteFetch<RemoteBackupsResponse>('/api/remote/backups')
+}
+
+// ---- Writes ----
+
+export function spinUpMap(key: string): Promise<RemoteActionResult> {
+  return remoteFetch<RemoteActionResult>(`/api/remote/maps/spin-up/${encodeURIComponent(key)}`, { method: 'POST' })
+}
+
+export function spinDownMap(key: string): Promise<RemoteActionResult> {
+  return remoteFetch<RemoteActionResult>(`/api/remote/maps/spin-down/${encodeURIComponent(key)}`, { method: 'POST' })
+}
+
+export function fixPartitions(): Promise<RemoteActionResult> {
+  return remoteFetch<RemoteActionResult>('/api/remote/maps/fix-partitions', { method: 'POST' })
+}

--- a/webui/src/api/remoteAccess.ts
+++ b/webui/src/api/remoteAccess.ts
@@ -1,0 +1,50 @@
+// Local-only management client for the Settings → Remote Access card.
+// Targets /api/remote-access/*  (NOT /api/remote/*) — these endpoints are
+// gated by DuneToken (same as the rest of the desktop portal), and are
+// intentionally unreachable through the Cloudflare tunnel.
+//
+// Issue #74 (v11.1.0).
+
+import { api } from './client'
+
+export interface RemoteAcl {
+  owner: string
+  admins: string[]
+  hostname: string
+}
+
+export interface CloudflaredStatus {
+  installed: boolean
+  path: string
+  version: string
+}
+
+export interface RemoteAuditEntry {
+  ts: string
+  role: string
+  email: string
+  method: string
+  path: string
+  status: string
+  note: string
+  raw: string
+}
+
+export function getAcl(): Promise<RemoteAcl> {
+  return api<RemoteAcl>('/api/remote-access/acl')
+}
+
+export function saveAcl(acl: RemoteAcl): Promise<RemoteAcl> {
+  return api<RemoteAcl>('/api/remote-access/acl', {
+    method: 'PUT',
+    body: JSON.stringify(acl),
+  })
+}
+
+export function getAuditLog(lines = 50): Promise<{ entries: RemoteAuditEntry[]; count: number }> {
+  return api(`/api/remote-access/audit-log?lines=${encodeURIComponent(String(lines))}`)
+}
+
+export function getCloudflaredStatus(): Promise<CloudflaredStatus> {
+  return api<CloudflaredStatus>('/api/remote-access/cloudflared-status')
+}

--- a/webui/src/main.tsx
+++ b/webui/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
+import RemoteApp from './pages/remote/RemoteApp'
 import { ThemeProvider } from './theme/ThemeContext'
 
 // Capture install prompt as early as possible so it's not lost before the
@@ -19,11 +20,19 @@ if ('serviceWorker' in navigator) {
   })
 }
 
+// Top-level routing split (issue #74): /remote/* renders the mobile-first
+// remote portal tree, everything else renders the desktop portal. The split
+// happens HERE (not inside <App />) so the remote tree doesn't pull in the
+// desktop <StatusProvider> / <AppShell> chrome and doesn't poll local-only
+// status APIs that would 401 over the CF tunnel.
+const isRemote = window.location.pathname === '/remote'
+  || window.location.pathname.startsWith('/remote/')
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ThemeProvider>
       <BrowserRouter>
-        <App />
+        {isRemote ? <RemoteApp /> : <App />}
       </BrowserRouter>
     </ThemeProvider>
   </StrictMode>,

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -22,6 +22,7 @@ import { fmtToolVersion } from '../format'
 import { DependencyInstallModal } from '../components/DependencyInstallModal'
 import { getDependencies, type SystemDependency } from '../api/dependencies'
 import { AppearanceCard } from './settings/AppearanceCard'
+import { RemoteAccessCard } from './settings/RemoteAccessCard'
 
 const FIELDS: {
   key: string
@@ -1274,6 +1275,8 @@ export function Settings() {
       </div>
 
       <AppearanceCard />
+
+      <RemoteAccessCard />
 
       <form onSubmit={onSubmit} className="card p-6 space-y-5">
         {FIELDS.map(f => (

--- a/webui/src/pages/remote/Dashboard.tsx
+++ b/webui/src/pages/remote/Dashboard.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Icon } from '../../components/Icon'
+import {
+  getRemoteStatus,
+  getRemoteBackups,
+  RemoteApiError,
+  type RemoteStatusResponse,
+  type RemoteBackupsResponse,
+} from '../../api/remote'
+
+// Mobile-first dashboard: VM state, battlegroup state, public IP,
+// port-forward summary, last 3 backups. Read-only — every interaction
+// lives on the Maps tab so this view is safe for owner OR admin.
+
+function formatAge(min: number | null): string {
+  if (min === null || min === undefined) return '—'
+  if (min < 1)   return 'just now'
+  if (min < 60)  return `${min}m ago`
+  if (min < 1440) {
+    const h = Math.floor(min / 60)
+    const m = min % 60
+    return m === 0 ? `${h}h ago` : `${h}h ${m}m ago`
+  }
+  const d = Math.floor(min / 1440)
+  return `${d}d ago`
+}
+
+function formatBytes(n: number): string {
+  if (!n || n < 0) return '—'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let v = n
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++ }
+  return `${v.toFixed(v >= 100 ? 0 : 1)} ${units[i]}`
+}
+
+export function RemoteDashboard() {
+  const [status, setStatus] = useState<RemoteStatusResponse | null>(null)
+  const [backups, setBackups] = useState<RemoteBackupsResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const load = useCallback(async (showSpinner: boolean) => {
+    if (showSpinner) setLoading(true); else setRefreshing(true)
+    setError(null)
+    try {
+      const [s, b] = await Promise.allSettled([getRemoteStatus(), getRemoteBackups()])
+      if (s.status === 'fulfilled') setStatus(s.value)
+      else if (s.reason instanceof RemoteApiError && s.reason.status === 401) {
+        window.location.href = '/remote/login-required'; return
+      } else setError(s.reason instanceof Error ? s.reason.message : String(s.reason))
+      if (b.status === 'fulfilled') setBackups(b.value)
+      // Backups failing is non-fatal — VM may be down. Show what we have.
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false); setRefreshing(false)
+    }
+  }, [])
+
+  useEffect(() => { void load(true) }, [load])
+
+  // Auto-refresh every 30 s while the page is visible. Cheap because the
+  // backend caches port-status results for 5 minutes.
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      if (document.visibilityState === 'visible') void load(false)
+    }, 30_000)
+    return () => window.clearInterval(id)
+  }, [load])
+
+  if (loading && !status) {
+    return (
+      <div className="flex items-center justify-center py-16 text-text-muted">
+        <Icon name="Loader2" size={20} className="animate-spin mr-2" />
+        Loading…
+      </div>
+    )
+  }
+
+  const vmRunning = status?.vm?.running === true
+  const vmState = status?.vm?.state ?? (status?.vm?.exists ? 'unknown' : 'no VM')
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="card border-danger/40 bg-danger/10 px-4 py-3 text-sm text-danger flex items-start gap-2">
+          <Icon name="AlertTriangle" size={16} className="mt-0.5 flex-none" />
+          <div>{error}</div>
+        </div>
+      )}
+
+      <div className="card p-4">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Icon name="Server" size={18} className="text-text-muted" />
+            <h2 className="font-semibold">VM</h2>
+          </div>
+          {vmRunning
+            ? <span className="pill-success">running</span>
+            : <span className="pill-danger">{vmState}</span>}
+        </div>
+        <dl className="grid grid-cols-[8rem,1fr] gap-y-1 text-sm">
+          <dt className="text-text-muted">Internal IP</dt>
+          <dd className="font-mono">{status?.vm?.ip ?? '—'}</dd>
+          <dt className="text-text-muted">Public IP</dt>
+          <dd className="font-mono">{status?.publicIp ?? '—'}</dd>
+        </dl>
+      </div>
+
+      <div className="card p-4">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Icon name="Activity" size={18} className="text-text-muted" />
+            <h2 className="font-semibold">Battlegroup</h2>
+          </div>
+          {status?.bg
+            ? <span className="pill-success">available</span>
+            : <span className="pill-muted">offline</span>}
+        </div>
+        {status?.bg
+          ? <div className="text-sm text-text-muted">Battlegroup snapshot OK. See desktop portal for full per-set detail.</div>
+          : <div className="text-sm text-text-muted">VM is not running or the operator hasn&apos;t reported in yet.</div>}
+      </div>
+
+      <div className="card p-4">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Icon name="Globe" size={18} className="text-text-muted" />
+            <h2 className="font-semibold">Ports</h2>
+          </div>
+        </div>
+        {status?.ports?.results?.length
+          ? (
+            <ul className="space-y-1.5 text-sm">
+              {status.ports.results.map(p => (
+                <li key={`${p.port}-${p.protocol}`} className="flex items-center justify-between">
+                  <span className="font-mono">{p.protocol} {p.port}</span>
+                  <span className="text-text-muted">{p.label}</span>
+                  {p.status === 'open'      && <span className="pill-success">open</span>}
+                  {p.status === 'closed'    && <span className="pill-danger">closed</span>}
+                  {p.status === 'udp-skip'  && <span className="pill-muted">UDP — skipped</span>}
+                  {p.status === 'unknown'   && <span className="pill-muted">unknown</span>}
+                  {p.status === 'ratelimit' && <span className="pill-warning">rate-limited</span>}
+                </li>
+              ))}
+            </ul>
+          )
+          : <div className="text-sm text-text-muted">Port check disabled or unavailable.</div>}
+      </div>
+
+      <div className="card p-4">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Icon name="HardDrive" size={18} className="text-text-muted" />
+            <h2 className="font-semibold">Recent backups</h2>
+          </div>
+          {backups?.dumpDirSize ? <span className="pill-muted">{backups.dumpDirSize}</span> : null}
+        </div>
+        {backups?.recent?.length
+          ? (
+            <ul className="space-y-2 text-sm">
+              {backups.recent.map(b => (
+                <li key={b.path} className="flex items-center justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-mono text-xs">{b.name}</div>
+                    <div className="text-text-muted text-xs">{formatBytes(b.sizeBytes)}</div>
+                  </div>
+                  <div className="text-text-muted text-xs whitespace-nowrap">{formatAge(b.ageMinutes)}</div>
+                </li>
+              ))}
+            </ul>
+          )
+          : <div className="text-sm text-text-muted">No backups visible (VM offline or none taken yet).</div>}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => { void load(false) }}
+        disabled={refreshing}
+        className="btn-secondary w-full justify-center"
+      >
+        <Icon name={refreshing ? 'Loader2' : 'RefreshCw'} size={16} className={refreshing ? 'animate-spin' : ''} />
+        {refreshing ? 'Refreshing…' : 'Refresh now'}
+      </button>
+
+      <div className="text-center text-xs text-text-dim pt-2">
+        {status?.email ? <>signed in as <span className="font-mono">{status.email}</span> ({status.role})</> : null}
+      </div>
+    </div>
+  )
+}

--- a/webui/src/pages/remote/LoginRequired.tsx
+++ b/webui/src/pages/remote/LoginRequired.tsx
@@ -1,0 +1,24 @@
+import { Icon } from '../../components/Icon'
+
+// Shown when the remote portal middleware returns 401 — typically because
+// the user isn't authenticated through Cloudflare Access (header missing)
+// or the operator hasn't enabled the remote portal yet (ACL owner empty).
+//
+// Issue #74 (v11.1.0).
+export function LoginRequired() {
+  return (
+    <div className="text-center py-12 space-y-4">
+      <Icon name="ShieldAlert" size={48} className="text-warning mx-auto" />
+      <h2 className="text-xl font-semibold">Authentication required</h2>
+      <p className="text-text-muted max-w-md mx-auto">
+        Your Cloudflare Access session has expired, or your email isn&apos;t on the
+        remote-portal allow-list. Sign in again through the same hostname and
+        try once more.
+      </p>
+      <p className="text-text-dim text-xs">
+        If you&apos;re the server owner, open the desktop portal and check
+        Settings → Remote Access.
+      </p>
+    </div>
+  )
+}

--- a/webui/src/pages/remote/Maps.tsx
+++ b/webui/src/pages/remote/Maps.tsx
@@ -1,0 +1,235 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Icon } from '../../components/Icon'
+import {
+  getRemoteMaps,
+  spinUpMap,
+  spinDownMap,
+  fixPartitions,
+  RemoteApiError,
+  type RemoteMapEntry,
+  type RemoteMapsResponse,
+} from '../../api/remote'
+
+// Mobile-first map control surface (issue #74).
+//
+// One card per on-demand map. Each card shows running/ready state and offers
+// "Spin up" / "Spin down" buttons. A "Fix partitions" button at the bottom
+// re-runs the remote partition cleanup helper (idempotent, safe to retry).
+//
+// Spin-down without -Force: when players are connected the server returns 409
+// with the count; we surface that as a friendly "N players online — try later"
+// message. Player-kick is intentionally NOT exposed in v11.1.0 (issue #74's
+// deferred list).
+
+interface ActionState {
+  busy: 'spin-up' | 'spin-down' | 'fix' | null
+  message: string | null
+  isError: boolean
+}
+
+function statusPill(m: RemoteMapEntry) {
+  if (!m.ok) return <span className="pill-muted">offline</span>
+  if (m.running) return <span className="pill-success">running</span>
+  if (m.hasDisabledPart || m.missingPartitionBinding || m.stuckDedicatedScaling) return <span className="pill-warning">needs fix</span>
+  if (m.present) return <span className="pill-muted">stopped</span>
+  return <span className="pill-muted">not configured</span>
+}
+
+export function RemoteMaps() {
+  const [data, setData] = useState<RemoteMapsResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [actions, setActions] = useState<Record<string, ActionState>>({})
+  const [globalAction, setGlobalAction] = useState<ActionState>({ busy: null, message: null, isError: false })
+
+  const load = useCallback(async (showSpinner: boolean) => {
+    if (showSpinner) setLoading(true); else setRefreshing(true)
+    setError(null)
+    try {
+      const r = await getRemoteMaps()
+      setData(r)
+    } catch (e) {
+      if (e instanceof RemoteApiError && e.status === 401) {
+        window.location.href = '/remote/login-required'; return
+      }
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false); setRefreshing(false)
+    }
+  }, [])
+
+  useEffect(() => { void load(true) }, [load])
+
+  // Refresh after every successful write so the user sees the new state.
+  const refreshSilently = useCallback(() => { void load(false) }, [load])
+
+  const setMapAction = (key: string, s: ActionState) =>
+    setActions(prev => ({ ...prev, [key]: s }))
+
+  const onSpinUp = async (key: string) => {
+    setMapAction(key, { busy: 'spin-up', message: null, isError: false })
+    try {
+      const r = await spinUpMap(key)
+      setMapAction(key, { busy: null, message: r.message ?? 'Spin-up scheduled.', isError: !r.ok })
+      refreshSilently()
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      setMapAction(key, { busy: null, message: msg, isError: true })
+    }
+  }
+
+  const onSpinDown = async (key: string) => {
+    if (!window.confirm('Spin this map down? Any active session will end.')) return
+    setMapAction(key, { busy: 'spin-down', message: null, isError: false })
+    try {
+      const r = await spinDownMap(key)
+      setMapAction(key, { busy: null, message: r.message ?? 'Spin-down complete.', isError: !r.ok })
+      refreshSilently()
+    } catch (e) {
+      if (e instanceof RemoteApiError && e.status === 409) {
+        const body = e.body as { playersOnline?: number; message?: string } | undefined
+        const count = body?.playersOnline ?? 0
+        setMapAction(key, {
+          busy: null,
+          isError: true,
+          message: `${count} player${count === 1 ? '' : 's'} online — try again later (player-kick lives in the desktop portal).`,
+        })
+        refreshSilently()
+        return
+      }
+      setMapAction(key, { busy: null, message: e instanceof Error ? e.message : String(e), isError: true })
+    }
+  }
+
+  const onFixPartitions = async () => {
+    if (!window.confirm('Re-run the partition-cleanup helper on the VM?\n\nIdempotent — skips any map with a running pod.')) return
+    setGlobalAction({ busy: 'fix', message: null, isError: false })
+    try {
+      const r = await fixPartitions()
+      setGlobalAction({ busy: null, message: r.message ?? 'Partition cleanup ran.', isError: !r.ok })
+      refreshSilently()
+    } catch (e) {
+      setGlobalAction({ busy: null, message: e instanceof Error ? e.message : String(e), isError: true })
+    }
+  }
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center py-16 text-text-muted">
+        <Icon name="Loader2" size={20} className="animate-spin mr-2" />
+        Loading…
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="card border-danger/40 bg-danger/10 px-4 py-3 text-sm text-danger flex items-start gap-2">
+          <Icon name="AlertTriangle" size={16} className="mt-0.5 flex-none" />
+          <div>{error}</div>
+        </div>
+      )}
+
+      {data?.maps.map(m => {
+        const a = actions[m.key] ?? { busy: null, message: null, isError: false }
+        const busy = a.busy !== null
+        return (
+          <div key={m.key} className="card p-4">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <Icon name="Map" size={18} className="text-text-muted" />
+                <h2 className="font-semibold">{m.label}</h2>
+              </div>
+              {statusPill(m)}
+            </div>
+
+            <dl className="grid grid-cols-[8rem,1fr] gap-y-1 text-sm mb-3">
+              <dt className="text-text-muted">Replicas</dt>
+              <dd className="font-mono">{m.totalReplicas}</dd>
+              <dt className="text-text-muted">Players online</dt>
+              <dd className="font-mono">{m.playersOnline ?? '—'}</dd>
+            </dl>
+
+            {(m.hasDisabledPart || m.missingPartitionBinding || m.stuckDedicatedScaling) && (
+              <div className="text-xs text-warning bg-warning/10 border border-warning/30 rounded-lg px-3 py-2 mb-3">
+                Partition state drifted — use &ldquo;Fix partitions&rdquo; below.
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={() => { void onSpinUp(m.key) }}
+                disabled={busy || !m.ok || m.running}
+                className="btn-primary justify-center h-12"
+              >
+                <Icon name={a.busy === 'spin-up' ? 'Loader2' : 'Power'} size={18} className={a.busy === 'spin-up' ? 'animate-spin' : ''} />
+                Spin up
+              </button>
+              <button
+                type="button"
+                onClick={() => { void onSpinDown(m.key) }}
+                disabled={busy || !m.ok || !m.running}
+                className="btn-secondary justify-center h-12"
+              >
+                <Icon name={a.busy === 'spin-down' ? 'Loader2' : 'PowerOff'} size={18} className={a.busy === 'spin-down' ? 'animate-spin' : ''} />
+                Spin down
+              </button>
+            </div>
+
+            {m.error && (
+              <div className="text-xs text-text-muted mt-2">{m.error}</div>
+            )}
+
+            {a.message && (
+              <div className={'text-xs mt-2 ' + (a.isError ? 'text-danger' : 'text-text-muted')}>
+                {a.message}
+              </div>
+            )}
+          </div>
+        )
+      })}
+
+      <div className="card p-4 border-border-bright">
+        <div className="flex items-center gap-2 mb-2">
+          <Icon name="Wrench" size={18} className="text-text-muted" />
+          <h2 className="font-semibold">Fix partitions</h2>
+        </div>
+        <p className="text-sm text-text-muted mb-3">
+          Re-runs the remote cleanup helper if a map refuses to launch. Idempotent
+          and skips any map whose pod is already running, so it&apos;s always safe.
+        </p>
+        <button
+          type="button"
+          onClick={() => { void onFixPartitions() }}
+          disabled={globalAction.busy === 'fix'}
+          className="btn-primary w-full justify-center h-12"
+        >
+          <Icon
+            name={globalAction.busy === 'fix' ? 'Loader2' : 'Wrench'}
+            size={18}
+            className={globalAction.busy === 'fix' ? 'animate-spin' : ''}
+          />
+          {globalAction.busy === 'fix' ? 'Running…' : 'Run partition cleanup'}
+        </button>
+        {globalAction.message && (
+          <div className={'text-xs mt-2 ' + (globalAction.isError ? 'text-danger' : 'text-text-muted')}>
+            {globalAction.message}
+          </div>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => { void load(false) }}
+        disabled={refreshing}
+        className="btn-secondary w-full justify-center"
+      >
+        <Icon name={refreshing ? 'Loader2' : 'RefreshCw'} size={16} className={refreshing ? 'animate-spin' : ''} />
+        {refreshing ? 'Refreshing…' : 'Refresh now'}
+      </button>
+    </div>
+  )
+}

--- a/webui/src/pages/remote/RemoteApp.tsx
+++ b/webui/src/pages/remote/RemoteApp.tsx
@@ -1,0 +1,28 @@
+import { Routes, Route, Navigate } from 'react-router-dom'
+import { RemoteShell } from './RemoteShell'
+import { RemoteDashboard } from './Dashboard'
+import { RemoteMaps } from './Maps'
+import { LoginRequired } from './LoginRequired'
+
+// Top-level component for the remote portal tree (issue #74).
+//
+// Intentionally NOT wrapped in the desktop <StatusProvider> / <AppShell> —
+// those poll local-only APIs and render sidebar/menubar/statusbar chrome
+// that doesn't belong on a mobile remote view. The split happens in
+// main.tsx, where /remote/* paths get this component instead of <App />.
+//
+// All routes under /remote/* render here; the static handler serves this
+// index.html (with the DuneToken injected) so client-side navigation works.
+export default function RemoteApp() {
+  return (
+    <RemoteShell>
+      <Routes>
+        <Route path="/remote"                element={<RemoteDashboard />} />
+        <Route path="/remote/"               element={<RemoteDashboard />} />
+        <Route path="/remote/maps"           element={<RemoteMaps />} />
+        <Route path="/remote/login-required" element={<LoginRequired />} />
+        <Route path="*"                      element={<Navigate to="/remote" replace />} />
+      </Routes>
+    </RemoteShell>
+  )
+}

--- a/webui/src/pages/remote/RemoteShell.tsx
+++ b/webui/src/pages/remote/RemoteShell.tsx
@@ -1,0 +1,69 @@
+import { type ReactNode } from 'react'
+import { NavLink, useLocation } from 'react-router-dom'
+import { Icon } from '../../components/Icon'
+
+// Mobile-first remote-portal layout (issue #74).
+//
+// - Sticky compact header at the top (DST mark + the current view's name).
+// - Main content scrolls in the middle.
+// - Sticky bottom tab bar with two tabs (Dashboard / Maps). Big touch
+//   targets — each tab is 64px tall so thumbs land reliably on a phone.
+//
+// No sidebar, no menubar, no status bar — those belong to the desktop tree.
+//
+// Theme tokens flow through unchanged: <ThemeProvider> in main.tsx applies
+// CSS custom properties on :root, so the same palette the user picks on
+// desktop also colors the remote portal on their phone.
+
+interface TabDef {
+  to: string
+  label: string
+  icon: string
+}
+
+const TABS: TabDef[] = [
+  { to: '/remote',      label: 'Dashboard', icon: 'LayoutDashboard' },
+  { to: '/remote/maps', label: 'Maps',      icon: 'Map' },
+]
+
+export function RemoteShell({ children }: { children: ReactNode }) {
+  const loc = useLocation()
+  const active = TABS.find(t => t.to === loc.pathname || (t.to !== '/remote' && loc.pathname.startsWith(t.to))) ?? TABS[0]
+
+  return (
+    <div className="flex flex-col min-h-screen bg-base text-text">
+      <header className="sticky top-0 z-20 border-b border-border bg-surface/95 backdrop-blur-sm">
+        <div className="mx-auto max-w-2xl px-4 py-3 flex items-center gap-3">
+          <Icon name="Shield" size={20} className="text-accent" />
+          <h1 className="text-lg font-semibold tracking-tight">Dune Server · Remote</h1>
+          <div className="ml-auto pill-muted text-xs">{active.label}</div>
+        </div>
+      </header>
+
+      <main className="flex-1 mx-auto w-full max-w-2xl px-4 py-4 pb-24">
+        {children}
+      </main>
+
+      <nav className="fixed bottom-0 left-0 right-0 z-20 border-t border-border bg-surface/95 backdrop-blur-sm">
+        <div className="mx-auto max-w-2xl grid grid-cols-2">
+          {TABS.map(t => (
+            <NavLink
+              key={t.to}
+              to={t.to}
+              end={t.to === '/remote'}
+              className={({ isActive }) =>
+                'flex flex-col items-center justify-center gap-1 h-16 text-xs font-medium transition-colors '
+                + (isActive
+                    ? 'text-accent bg-surface-2/60'
+                    : 'text-text-muted hover:text-text hover:bg-surface-2/30')
+              }
+            >
+              <Icon name={t.icon} size={22} />
+              <span>{t.label}</span>
+            </NavLink>
+          ))}
+        </div>
+      </nav>
+    </div>
+  )
+}

--- a/webui/src/pages/settings/RemoteAccessCard.tsx
+++ b/webui/src/pages/settings/RemoteAccessCard.tsx
@@ -1,0 +1,330 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Icon } from '../../components/Icon'
+import {
+  getAcl,
+  saveAcl,
+  getAuditLog,
+  getCloudflaredStatus,
+  type RemoteAcl,
+  type CloudflaredStatus,
+  type RemoteAuditEntry,
+} from '../../api/remoteAccess'
+
+// Settings → Remote Access card (issue #74).
+//
+// Surfaces the ACL editor + audit-log viewer + cloudflared status pill.
+// Modeled on AppearanceCard.tsx for visual consistency. All requests go
+// to /api/remote-access/* (DuneToken-gated, desktop-portal-only).
+//
+// "Remote enabled" is implemented as a single bit on the owner field —
+// empty string = disabled, non-empty = enabled. The toggle just hides /
+// restores the owner from a buffer.
+
+export function RemoteAccessCard() {
+  const [expanded, setExpanded] = useState(false)
+  const [acl, setAcl] = useState<RemoteAcl | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [savedMsg, setSavedMsg] = useState<string | null>(null)
+  const [cf, setCf] = useState<CloudflaredStatus | null>(null)
+  const [showAudit, setShowAudit] = useState(false)
+  const [audit, setAudit] = useState<RemoteAuditEntry[] | null>(null)
+  const [auditLoading, setAuditLoading] = useState(false)
+  const [newAdmin, setNewAdmin] = useState('')
+  const [ownerBuffer, setOwnerBuffer] = useState('')   // remembered owner while toggled off
+
+  const load = useCallback(async () => {
+    setLoading(true); setError(null)
+    try {
+      const [a, c] = await Promise.allSettled([getAcl(), getCloudflaredStatus()])
+      if (a.status === 'fulfilled') {
+        setAcl(a.value)
+        if (a.value.owner) setOwnerBuffer(a.value.owner)
+      } else throw a.reason
+      if (c.status === 'fulfilled') setCf(c.value)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (expanded && !acl) void load()
+  }, [expanded, acl, load])
+
+  const enabled = !!acl?.owner
+
+  const updateAcl = (patch: Partial<RemoteAcl>) => {
+    if (!acl) return
+    setAcl({ ...acl, ...patch })
+  }
+
+  const onToggleEnabled = (v: boolean) => {
+    if (!acl) return
+    if (v) {
+      // Restoring — prefer the remembered owner; fall back to empty (user must fill in)
+      updateAcl({ owner: ownerBuffer })
+    } else {
+      // Disabling — stash the current owner so we can restore it next toggle
+      if (acl.owner) setOwnerBuffer(acl.owner)
+      updateAcl({ owner: '' })
+    }
+  }
+
+  const onAddAdmin = () => {
+    if (!acl) return
+    const e = newAdmin.trim().toLowerCase()
+    if (!e || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e)) {
+      setError('Enter a valid email address.')
+      return
+    }
+    if (acl.admins.includes(e) || e === acl.owner.toLowerCase()) {
+      setNewAdmin('')
+      return
+    }
+    updateAcl({ admins: [...acl.admins, e] })
+    setNewAdmin('')
+    setError(null)
+  }
+
+  const onRemoveAdmin = (e: string) => {
+    if (!acl) return
+    updateAcl({ admins: acl.admins.filter(x => x !== e) })
+  }
+
+  const onSave = async () => {
+    if (!acl) return
+    setSaving(true); setError(null); setSavedMsg(null)
+    try {
+      const saved = await saveAcl(acl)
+      setAcl(saved)
+      if (saved.owner) setOwnerBuffer(saved.owner)
+      setSavedMsg('Saved.')
+      window.setTimeout(() => setSavedMsg(null), 3000)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const onShowAudit = async () => {
+    setShowAudit(true)
+    setAuditLoading(true)
+    try {
+      const r = await getAuditLog(50)
+      setAudit(r.entries)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setAuditLoading(false)
+    }
+  }
+
+  return (
+    <div className="card mb-4">
+      <button
+        type="button"
+        onClick={() => setExpanded(v => !v)}
+        className="w-full flex items-center justify-between px-6 py-4 text-left hover:bg-surface-2/40 rounded-lg transition-colors"
+        aria-expanded={expanded}
+      >
+        <div className="flex items-center gap-3">
+          <Icon name={expanded ? 'ChevronDown' : 'ChevronRight'} size={16} className="text-text-dim" />
+          <Icon name="Shield" size={18} className="text-text-muted" />
+          <h2 className="text-lg font-semibold">Remote Access</h2>
+        </div>
+        <div className="flex items-center gap-2">
+          {enabled
+            ? <span className="pill-success text-xs">enabled</span>
+            : <span className="pill-muted text-xs">disabled</span>}
+          {cf?.installed
+            ? <span className="pill-info text-xs">cloudflared {cf.version || 'detected'}</span>
+            : <span className="pill-warning text-xs">cloudflared not detected</span>}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="px-6 pb-6 space-y-5">
+          {loading && (
+            <div className="flex items-center text-text-muted text-sm">
+              <Icon name="Loader2" size={16} className="animate-spin mr-2" /> Loading…
+            </div>
+          )}
+
+          {error && (
+            <div className="text-sm text-danger bg-danger/10 border border-danger/40 rounded-lg px-3 py-2 flex items-start gap-2">
+              <Icon name="AlertTriangle" size={14} className="mt-0.5 flex-none" />
+              <div>{error}</div>
+            </div>
+          )}
+
+          {acl && (
+            <>
+              <p className="text-sm text-text-muted">
+                Lets you and 1–3 trusted admins reach a mobile-friendly subset of DST
+                (Dashboard + Maps) from outside the LAN via a Cloudflare Tunnel +
+                Access policy. See the{' '}
+                <a
+                  href="https://coastal-ms.github.io/DST-DuneServerTool/remote"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-accent hover:text-accent-bright underline"
+                >
+                  setup guide
+                </a>
+                {' '}for cloudflared install + tunnel + Access policy steps.
+              </p>
+
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={enabled}
+                  onChange={e => onToggleEnabled(e.target.checked)}
+                  className="h-4 w-4"
+                />
+                <span className="text-sm">
+                  <strong>Enable remote portal</strong>
+                  <span className="block text-xs text-text-dim">
+                    Clears the owner field on disable — every /remote/* request is
+                    refused until re-enabled.
+                  </span>
+                </span>
+              </label>
+
+              <div>
+                <label htmlFor="ra-owner" className="block text-sm font-medium mb-1">Owner email</label>
+                <input
+                  id="ra-owner"
+                  type="email"
+                  value={acl.owner}
+                  onChange={e => updateAcl({ owner: e.target.value })}
+                  disabled={!enabled}
+                  className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text disabled:opacity-50"
+                  placeholder="you@example.com"
+                />
+                <p className="text-xs text-text-dim mt-1">
+                  Full read + write. This MUST match the email Cloudflare Access
+                  authenticates you with.
+                </p>
+              </div>
+
+              <div>
+                <label htmlFor="ra-hostname" className="block text-sm font-medium mb-1">Hostname (for reference)</label>
+                <input
+                  id="ra-hostname"
+                  type="text"
+                  value={acl.hostname}
+                  onChange={e => updateAcl({ hostname: e.target.value })}
+                  className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text"
+                  placeholder="dune.example.com"
+                />
+                <p className="text-xs text-text-dim mt-1">
+                  The hostname you mapped in Cloudflare. Stored for documentation —
+                  DST doesn&apos;t configure cloudflared itself.
+                </p>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium mb-2">Admin allow-list</label>
+                {acl.admins.length === 0 && (
+                  <p className="text-xs text-text-dim mb-2">No admins yet — only the owner can sign in.</p>
+                )}
+                <ul className="space-y-1 mb-2">
+                  {acl.admins.map(e => (
+                    <li key={e} className="flex items-center justify-between bg-surface-2 border border-border rounded-lg px-3 py-2 text-sm">
+                      <span className="font-mono">{e}</span>
+                      <button
+                        type="button"
+                        onClick={() => onRemoveAdmin(e)}
+                        className="btn-ghost text-xs"
+                        aria-label={`Remove ${e}`}
+                      >
+                        <Icon name="X" size={14} />
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+                <div className="flex gap-2">
+                  <input
+                    type="email"
+                    value={newAdmin}
+                    onChange={e => setNewAdmin(e.target.value)}
+                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); onAddAdmin() } }}
+                    placeholder="trusted-admin@example.com"
+                    className="flex-1 px-3 py-2 rounded-lg bg-surface-2 border border-border text-text"
+                  />
+                  <button type="button" onClick={onAddAdmin} className="btn-secondary">
+                    <Icon name="Plus" size={14} />
+                    Add
+                  </button>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3 pt-2 border-t border-border">
+                <button type="button" onClick={() => { void onSave() }} disabled={saving} className="btn-primary">
+                  <Icon name={saving ? 'Loader2' : 'Save'} size={14} className={saving ? 'animate-spin' : ''} />
+                  {saving ? 'Saving…' : 'Save changes'}
+                </button>
+                {savedMsg && <span className="text-sm text-success">{savedMsg}</span>}
+                <div className="ml-auto">
+                  <button type="button" onClick={() => { void onShowAudit() }} className="btn-ghost text-sm">
+                    <Icon name="FileText" size={14} />
+                    {showAudit ? 'Refresh audit log' : 'View audit log'}
+                  </button>
+                </div>
+              </div>
+
+              {showAudit && (
+                <div className="bg-surface-2/60 border border-border rounded-lg p-3 max-h-80 overflow-auto">
+                  {auditLoading && <div className="text-xs text-text-muted">Loading…</div>}
+                  {!auditLoading && audit && audit.length === 0 && (
+                    <div className="text-xs text-text-muted">No audit entries yet.</div>
+                  )}
+                  {!auditLoading && audit && audit.length > 0 && (
+                    <table className="w-full text-xs font-mono">
+                      <thead className="text-text-dim border-b border-border">
+                        <tr>
+                          <th className="text-left py-1 pr-2">When (UTC)</th>
+                          <th className="text-left py-1 pr-2">Role</th>
+                          <th className="text-left py-1 pr-2">Email</th>
+                          <th className="text-left py-1 pr-2">Method</th>
+                          <th className="text-left py-1 pr-2">Path</th>
+                          <th className="text-left py-1 pr-2">Status</th>
+                          <th className="text-left py-1">Note</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {audit.slice().reverse().map((e, i) => (
+                          <tr key={i} className="border-b border-border/40 last:border-0">
+                            <td className="py-1 pr-2">{e.ts}</td>
+                            <td className="py-1 pr-2">{e.role}</td>
+                            <td className="py-1 pr-2">{e.email}</td>
+                            <td className="py-1 pr-2">{e.method}</td>
+                            <td className="py-1 pr-2 break-all">{e.path}</td>
+                            <td className={'py-1 pr-2 ' + (e.status.startsWith('2') ? 'text-success' : 'text-danger')}>{e.status}</td>
+                            <td className="py-1 text-text-dim">{e.note}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              )}
+
+              <div className="text-xs text-text-dim border-t border-border pt-3">
+                cloudflared status:{' '}
+                {cf?.installed
+                  ? <>installed at <span className="font-mono">{cf.path}</span>{cf.version && <> · v{cf.version}</>}</>
+                  : <>not detected on PATH — see the setup guide for install steps.</>}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a top-level `/remote/*` SPA tree that gives the owner plus 1-3 trusted admins a phone-friendly view of DST (Dashboard + Maps) behind a Cloudflare Tunnel + Cloudflare Access policy. Read-mostly by design: status, last backups, and three safe writes (spin-up / spin-down on-demand maps, fix partitions). Console, initial-setup, edit, shell, DB import/restore, dune-admin, and Settings are physically unreachable from the remote module.

## Related issue

Fixes: #74

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (menu option removed/renamed, config key changed, etc.)
- [ ] Docs only
- [ ] Chore / CI / refactor

## Approach

Three layers of auth, all of which must pass on every request:

1. **Cloudflare Access** verifies identity at the edge and injects `Cf-Access-Authenticated-User-Email`.
2. **DST middleware** (`Test-DuneRemoteRequest` in `lib/RemoteAccess.ps1`) looks that email up in `%APPDATA%\DuneServer\remote-acl.json` (`{ owner, admins[], hostname }`) and fails closed on missing header, malformed ACL, or empty owner.
3. The existing **DuneToken** is injected into the served `/remote/*` index.html via a `<!-- DUNE_REMOTE_BOOTSTRAP -->` marker, so a same-host header-spoof attempt still hits a token wall.

Four URL namespaces, dispatched in `HttpServer.ps1` by prefix:

| Prefix | Auth |
| --- | --- |
| `/api/*` | DuneToken (untouched) |
| `/api/remote-access/*` | DuneToken local mgmt (Settings card) |
| `/api/remote/*` | CF Access + DuneToken (mobile SPA data) |
| `/remote/*` | CF Access + DuneToken (mobile SPA HTML/assets) |

Belt-and-braces isolation: the dispatcher routes by prefix, and a new CI step parses `app/server/routes/Remote.ps1` and fails the build if any non-comment token references `Setup` / `ConsoleHost` / `Database` / `Browse-` / `EditDuneIni` / `Invoke-DuneCommand` / `Get-DuneCommandByName` / `Start-DuneTerminal` / `Invoke-DuneSshShell` / `DuneAdmin`.

Every successful write (and every auth denial) appends a tab-separated line to `%APPDATA%\DuneServer\.logs\remote-audit.log` with timestamp, role, email, method, path, and HTTP status. Visible from the new **Settings -> Remote Access** card alongside the cloudflared status pill and the ACL editor.

`cloudflared` install/setup itself is documented on the marketing site at `/remote`. DST detects whether it's on `PATH` and surfaces a status pill, but never modifies tunnel state — that stays under the user's control.

## Things to watch in review

- **Token injection happens at file-serve time**, not via a service worker. The literal marker `<!-- DUNE_REMOTE_BOOTSTRAP -->` lives in `webui/index.html` (desktop portal serves it untouched; remote portal expands it). If someone removes that marker the remote SPA still loads but auth calls fail — worth a manual smoke test after any HTML refactor.
- **Runspace pool dot-sources every lib + route into every worker** by design, so the isolation contract is enforced by the dispatcher prefix + the CI guard, not by import boundaries. The CI guard is the third safety net specifically because the runspace shape can't be tightened without a bigger refactor.
- **Owner-field-as-toggle**: the "Enable remote portal" checkbox in the Settings card just clears (and remembers, for re-toggle) the owner email. Empty owner = every request 403s. This is intentional — a single source of truth in the ACL file.
- `cloudflared` is intentionally not auto-installed or auto-configured in this PR. Users follow the new `/remote` setup guide.

## Testing

- [x] `Parse-validated` the script (no syntax errors) — all 5 touched `.ps1` files parse clean
- [x] PSScriptAnalyzer is clean (`Invoke-ScriptAnalyzer -Path .\dune-server.ps1`) — also clean on the 3 new modules
- [ ] Ran end-to-end against a real Dune server VM
- [x] Tested affected build outputs: `webui` and `site` both build, isolation guard passes locally, dispatcher branches verified by file inspection

End-to-end against a real CF tunnel happens at release-validation time (needs DNS + Access policy on a real domain).

## Changelog

- [x] I added an entry to `CHANGELOG.md` under `[Unreleased]` (`[11.1.0]` section)

## Deferred to v11.2.0

`restart-bg`, `backup-now`, `player-kick`, websocket live-log tail, desktop push notifications, browser-side CF Access JWT validation. Tracked under issue #74 phase 2.

## Out of scope

The current Defender false-positive (`Trojan:Script/Wacatac.H!ml` on the freshly compiled `DuneServer.exe`) is being handled in a separate session and is **not** in this PR.