### PR TITLE
feat(helper): scaffold friend helper + bridge daemon (Tailscale + WebView2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+- **Friend helper scaffold** (`helper/`). A net-new, additive companion
+  to the released DST surface that lets a single trusted friend connect
+  into Neil's full desktop portal over Tailscale, without modifying any
+  v11.0.3 code. Two components: `helper/bridge/` (PowerShell 7
+  `HttpListener` daemon that runs on the host as a scheduled task,
+  binds port 47900 scoped to the Tailscale interface, re-reads
+  `%LOCALAPPDATA%\DuneServer\last-url.txt` per request, and
+  reverse-proxies into the current DST loopback) and `helper/friend/`
+  (.NET 8 WPF + WebView2 single-file .exe + `config.json` the friend
+  drops on their PC). Trust boundary is the Tailscale ACL; the
+  DuneToken returned by the bridge's `/_dst/token` endpoint is
+  defense-in-depth. Explicit "no changes to released DST surface
+  area" guarantee — `app/`, `webui/`, `site/`, and `dune-server.ps1`
+  are untouched.
+
 ## [11.1.0] - 2026-06-05
 
 ### Added

--- a/helper/README.md
+++ b/helper/README.md
@@ -1,0 +1,117 @@
+# DST Friend Helper
+
+A standalone Windows app a trusted friend double-clicks on **his** PC to
+get into Neil's full DST desktop portal running on **Neil's** PC. Built as
+a purely additive scaffold on top of the released DST surface — **zero
+changes to `app/`, `webui/`, `site/`, or `dune-server.ps1`.**
+
+## Components
+
+```
+helper/
+├── bridge/                 # Runs on Neil's PC (long-lived, scheduled task)
+│   ├── DstHelperBridge.ps1
+│   ├── Install-Bridge.ps1
+│   ├── Uninstall-Bridge.ps1
+│   └── README.md
+└── friend/                 # Ships to the friend (single .exe + config.json)
+    ├── DstFriendHelper.csproj
+    ├── App.xaml(.cs)
+    ├── MainWindow.xaml(.cs)
+    ├── Config.cs
+    ├── app.manifest
+    ├── config.sample.json
+    ├── Build-FriendHelper.ps1
+    └── README.md
+```
+
+See each subdirectory's `README.md` for the install / build steps.
+
+## Data flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant F as Friend's PC<br/>(DstFriendHelper.exe)
+  participant TS as Tailscale tailnet
+  participant B as Neil's PC<br/>(bridge :47900)
+  participant D as Neil's PC<br/>(DST :random/?t=token)
+
+  F->>TS: GET http://neilpc.tailnet/47900/_dst/token
+  TS->>B: encrypted via Tailscale
+  B->>B: read %LOCALAPPDATA%\DuneServer\last-url.txt
+  B-->>F: { url: "http://127.0.0.1:47823", token: "3e2f..." }
+  F->>F: WebView2.Navigate("http://neilpc.tailnet/47900/?t=3e2f...")
+
+  loop every portal request
+    F->>B: GET /api/...?t=token  (via Tailscale)
+    B->>D: GET /api/...?t=token  (127.0.0.1 loopback)
+    D-->>B: response
+    B-->>F: response
+  end
+```
+
+## Trust boundaries
+
+| Layer                | What it gates                                                  |
+| -------------------- | -------------------------------------------------------------- |
+| Tailscale tailnet    | Only devices Neil has added can route to his machine at all.   |
+| Tailscale ACL        | Friend's device tag can only reach port 47900 on Neil's host.  |
+| Windows Firewall     | Port 47900 is allowed inbound **only on the Tailscale NIC**.   |
+| DuneToken (?t=)      | Defense-in-depth — DST itself still requires a valid token.    |
+
+Defeating this requires (a) Neil-issued tailnet membership, (b) the
+friend's specific device tag in the ACL, **and** (c) capturing the
+current DuneToken — which is rotated on every DST launch.
+
+## Why this design
+
+- **Tailscale, not Cloudflare Tunnel.** The existing `/remote/*` SPA
+  already uses CF Tunnel + Access for a mobile-friendly subset. This
+  scaffold targets a *different* use case: a single trusted friend who
+  wants the **full** desktop portal (Database, Terminal, Setup Wizard,
+  everything Neil sees). Tailscale gives identity-based access without
+  per-domain edge config, and friends don't need to set up an IdP.
+- **No DST code changes.** The bridge is a pure reverse proxy that reads
+  the existing `last-url.txt` (DST already writes this for the desktop
+  shell). DST stays on the **released** v11.0.3 surface — no risk of
+  breaking the released app while iterating on the helper.
+- **WPF + WebView2, no ps2exe.** The DST v11.0.1–v11.0.3 Defender
+  saga taught us that any base64-pipe-decode-exec pattern gets
+  flagged as `Trojan:Win32/Wacatac.B!ml`. WPF compiled .NET is a
+  normal benign Windows app.
+
+## Setup checklist
+
+### Neil's side
+
+- [ ] Tailscale installed + signed in. `Get-NetIPInterface | ? InterfaceAlias -eq 'Tailscale'` returns a row.
+- [ ] PowerShell 7 (`pwsh.exe`) on PATH.
+- [ ] DST runs at least once so `%LOCALAPPDATA%\DuneServer\last-url.txt` exists.
+- [ ] Run `helper\bridge\Install-Bridge.ps1` from an **elevated** pwsh.
+- [ ] Verify locally: `curl http://127.0.0.1:47900/_dst/health` → `{"ok":true}`.
+- [ ] Tag the host device `tag:dst-host` in the Tailscale admin panel.
+- [ ] Add the friend's device, tag it `tag:dst-friend`, and add the ACL
+      stanza shown in `helper/bridge/README.md`.
+- [ ] Build the friend .exe: `helper\friend\Build-FriendHelper.ps1`.
+- [ ] Send `dist\DstFriendHelper.exe` + `dist\config.json` to the friend
+      (set `bridgeHost` to your Tailscale hostname first, or let the
+      friend do it).
+
+### Friend's side
+
+- [ ] Install Tailscale and accept Neil's invite.
+- [ ] Drop `DstFriendHelper.exe` and `config.json` in any folder.
+- [ ] Open `config.json`, set `bridgeHost` if Neil didn't pre-fill it.
+- [ ] Double-click `DstFriendHelper.exe`.
+
+## Known limitations (scaffold scope)
+
+- **No WebSocket proxy.** Terminal page won't work for the friend
+  (HttpClient-based reverse proxy doesn't speak `Upgrade: websocket`).
+  Everything else in the portal does.
+- **Single concurrent request** through the bridge. One friend, one
+  request at a time. Fine.
+- **No code-signing.** Friend's first launch will trip SmartScreen
+  unless you sign the .exe with the same EV cert used for
+  `DuneServerSetup.exe`.

--- a/helper/bridge/DstHelperBridge.ps1
+++ b/helper/bridge/DstHelperBridge.ps1
@@ -33,7 +33,12 @@
 param(
     [int]$Port = 47900,
     [string]$LastUrlPath = (Join-Path $env:LOCALAPPDATA 'DuneServer\last-url.txt'),
-    [string]$LogPath
+    [string]$LogPath,
+    # Override the listener URL prefix. Default binds all interfaces and
+    # relies on the Tailscale-scoped firewall rule for inbound filtering.
+    # For local testing without admin/URLACL, set this to
+    # 'http://localhost:<port>/' or 'http://127.0.0.1:<port>/'.
+    [string]$Prefix
 )
 
 $ErrorActionPreference = 'Stop'
@@ -228,17 +233,19 @@ function Invoke-Request {
 
 function Start-Bridge {
     $listener = [System.Net.HttpListener]::new()
-    # Bind to all interfaces; the firewall rule scopes inbound to Tailscale.
-    $prefix = "http://+:$Port/"
-    $listener.Prefixes.Add($prefix)
+    # Bind to all interfaces by default; the firewall rule scopes inbound to
+    # Tailscale. The -Prefix override lets you bind to localhost for local
+    # testing without admin / URL ACL.
+    $effectivePrefix = if ($Prefix) { $Prefix } else { "http://+:$Port/" }
+    $listener.Prefixes.Add($effectivePrefix)
 
     try {
         $listener.Start()
     } catch [System.Net.HttpListenerException] {
-        throw "Failed to bind $prefix — needs admin OR a URL ACL: `n  netsh http add urlacl url=$prefix user=$env:USERNAME`n($($_.Exception.Message))"
+        throw "Failed to bind $effectivePrefix — needs admin OR a URL ACL: `n  netsh http add urlacl url=$effectivePrefix user=$env:USERNAME`n($($_.Exception.Message))"
     }
 
-    Write-BridgeLog "DST Helper Bridge listening on $prefix"
+    Write-BridgeLog "DST Helper Bridge listening on $effectivePrefix"
     Write-BridgeLog "Watching $LastUrlPath"
 
     try {

--- a/helper/bridge/DstHelperBridge.ps1
+++ b/helper/bridge/DstHelperBridge.ps1
@@ -1,0 +1,258 @@
+<#
+.SYNOPSIS
+    DST Friend Helper bridge daemon. Runs on Neil's PC.
+
+.DESCRIPTION
+    Long-lived HTTP listener bound to a stable port (default 47900). Re-reads
+    %LOCALAPPDATA%\DuneServer\last-url.txt on every request to discover the
+    current DST loopback port + DuneToken (DST rewrites this file on every
+    launch). All non-special paths are reverse-proxied to the current DST
+    process on 127.0.0.1.
+
+    Trust boundary: this listener binds to all interfaces, but the companion
+    Windows Firewall rule (see Install-Bridge.ps1) restricts inbound traffic
+    to the Tailscale interface only. Tailscale ACLs gate which devices on
+    the tailnet can reach this port. The DuneToken returned by /_dst/token
+    is defense-in-depth.
+
+.PARAMETER Port
+    TCP port to listen on. Default 47900.
+
+.PARAMETER LastUrlPath
+    Path to DST's last-url.txt. Default %LOCALAPPDATA%\DuneServer\last-url.txt.
+
+.PARAMETER LogPath
+    Optional log file path. When set, each request is appended.
+
+.NOTES
+    PowerShell 7+ (uses [System.Net.Http.HttpClient] async patterns
+    synchronously via .GetAwaiter().GetResult()).
+#>
+
+[CmdletBinding()]
+param(
+    [int]$Port = 47900,
+    [string]$LastUrlPath = (Join-Path $env:LOCALAPPDATA 'DuneServer\last-url.txt'),
+    [string]$LogPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Hop-by-hop headers that must not be forwarded (RFC 7230 §6.1) plus a few
+# that HttpClient / HttpListener manage themselves.
+$script:HopByHop = @(
+    'connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
+    'te', 'trailers', 'transfer-encoding', 'upgrade',
+    'host', 'content-length'
+)
+
+# Shared HttpClient — keep-alive + connection pooling to localhost.
+$script:HttpClient = [System.Net.Http.HttpClient]::new()
+$script:HttpClient.Timeout = [TimeSpan]::FromSeconds(60)
+
+function Write-BridgeLog {
+    param([string]$Message)
+    $line = "{0} {1}" -f ([DateTime]::UtcNow.ToString('o')), $Message
+    Write-Host $line
+    if ($LogPath) {
+        try {
+            $dir = Split-Path -Parent $LogPath
+            if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+                New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            }
+            Add-Content -LiteralPath $LogPath -Value $line -Encoding UTF8
+        } catch {
+            # Swallow log errors — never let logging take the daemon down.
+        }
+    }
+}
+
+function Get-CurrentDst {
+    <#
+        Re-read last-url.txt and parse out the current DST loopback URL +
+        token. Cheap (single file read), so safe to call per request.
+    #>
+    if (-not (Test-Path -LiteralPath $LastUrlPath)) {
+        throw "last-url.txt not found at $LastUrlPath — is DST running?"
+    }
+    $raw = (Get-Content -LiteralPath $LastUrlPath -Raw).Trim()
+    if (-not $raw) {
+        throw "last-url.txt is empty"
+    }
+    # Expected: http://127.0.0.1:<port>/?t=<token>
+    $match = [regex]::Match($raw, '^https?://127\.0\.0\.1:(?<port>\d+)/?\?t=(?<token>[A-Za-z0-9]+)\s*$')
+    if (-not $match.Success) {
+        throw "last-url.txt does not match expected format: '$raw'"
+    }
+    return [pscustomobject]@{
+        DstPort = [int]$match.Groups['port'].Value
+        Token   = $match.Groups['token'].Value
+        BaseUrl = "http://127.0.0.1:$($match.Groups['port'].Value)"
+    }
+}
+
+function Send-JsonResponse {
+    param(
+        [System.Net.HttpListenerResponse]$Response,
+        [int]$StatusCode,
+        $Body
+    )
+    $json = $Body | ConvertTo-Json -Compress -Depth 6
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+    $Response.StatusCode = $StatusCode
+    $Response.ContentType = 'application/json; charset=utf-8'
+    $Response.ContentLength64 = $bytes.LongLength
+    $Response.OutputStream.Write($bytes, 0, $bytes.Length)
+    $Response.OutputStream.Close()
+}
+
+function Invoke-Proxy {
+    param(
+        [System.Net.HttpListenerContext]$Context,
+        [pscustomobject]$Dst
+    )
+    $req = $Context.Request
+    $res = $Context.Response
+
+    # Build the target URI: same path + query, but pointing at loopback DST.
+    $targetUri = [Uri]::new("$($Dst.BaseUrl)$($req.Url.PathAndQuery)")
+    $httpReq = [System.Net.Http.HttpRequestMessage]::new(
+        [System.Net.Http.HttpMethod]::new($req.HttpMethod),
+        $targetUri
+    )
+
+    # Copy body (POST/PUT/PATCH). Buffer to memory — DST API payloads are
+    # tiny, and HttpListener's InputStream is non-seekable.
+    $methodHasBody = @('POST', 'PUT', 'PATCH', 'DELETE') -contains $req.HttpMethod.ToUpperInvariant()
+    if ($methodHasBody -and $req.HasEntityBody) {
+        $ms = [System.IO.MemoryStream]::new()
+        $req.InputStream.CopyTo($ms)
+        $ms.Position = 0
+        $content = [System.Net.Http.StreamContent]::new($ms)
+        if ($req.ContentType) {
+            $content.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse($req.ContentType)
+        }
+        $httpReq.Content = $content
+    }
+
+    # Copy headers (skipping hop-by-hop + host/content-length).
+    foreach ($name in $req.Headers.AllKeys) {
+        if ($script:HopByHop -contains $name.ToLowerInvariant()) { continue }
+        $values = $req.Headers.GetValues($name)
+        # Try request headers first, fall back to content headers.
+        if (-not $httpReq.Headers.TryAddWithoutValidation($name, $values)) {
+            if ($httpReq.Content) {
+                [void]$httpReq.Content.Headers.TryAddWithoutValidation($name, $values)
+            }
+        }
+    }
+
+    # Send and stream the response back.
+    $httpRes = $script:HttpClient.SendAsync(
+        $httpReq,
+        [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead
+    ).GetAwaiter().GetResult()
+
+    try {
+        $res.StatusCode = [int]$httpRes.StatusCode
+
+        foreach ($h in $httpRes.Headers) {
+            if ($script:HopByHop -contains $h.Key.ToLowerInvariant()) { continue }
+            try { $res.Headers[$h.Key] = ($h.Value -join ', ') } catch { }
+        }
+        if ($httpRes.Content) {
+            foreach ($h in $httpRes.Content.Headers) {
+                if ($script:HopByHop -contains $h.Key.ToLowerInvariant()) { continue }
+                if ($h.Key -ieq 'Content-Type') {
+                    $res.ContentType = ($h.Value -join ', ')
+                    continue
+                }
+                try { $res.Headers[$h.Key] = ($h.Value -join ', ') } catch { }
+            }
+
+            $stream = $httpRes.Content.ReadAsStreamAsync().GetAwaiter().GetResult()
+            try { $stream.CopyTo($res.OutputStream) } finally { $stream.Dispose() }
+        }
+    } finally {
+        $httpRes.Dispose()
+        try { $res.OutputStream.Close() } catch { }
+    }
+}
+
+function Invoke-Request {
+    param([System.Net.HttpListenerContext]$Context)
+    $req = $Context.Request
+    $res = $Context.Response
+    $path = $req.Url.AbsolutePath
+    $client = $req.RemoteEndPoint
+
+    try {
+        if ($path -eq '/_dst/token') {
+            $dst = Get-CurrentDst
+            Send-JsonResponse -Response $res -StatusCode 200 -Body @{
+                url   = $dst.BaseUrl
+                token = $dst.Token
+            }
+            Write-BridgeLog "200 $($req.HttpMethod) $path from $client (token-handout)"
+            return
+        }
+
+        if ($path -eq '/_dst/health') {
+            try {
+                $null = Get-CurrentDst
+                Send-JsonResponse -Response $res -StatusCode 200 -Body @{ ok = $true }
+            } catch {
+                Send-JsonResponse -Response $res -StatusCode 503 -Body @{ ok = $false; error = $_.Exception.Message }
+            }
+            return
+        }
+
+        # Everything else: reverse-proxy to current DST.
+        $dst = Get-CurrentDst
+        Invoke-Proxy -Context $Context -Dst $dst
+        Write-BridgeLog "$($res.StatusCode) $($req.HttpMethod) $path from $client"
+    } catch {
+        $msg = $_.Exception.Message
+        Write-BridgeLog "ERR $($req.HttpMethod) $path from $client : $msg"
+        try {
+            Send-JsonResponse -Response $res -StatusCode 502 -Body @{
+                ok    = $false
+                error = $msg
+            }
+        } catch {
+            try { $res.OutputStream.Close() } catch { }
+        }
+    }
+}
+
+function Start-Bridge {
+    $listener = [System.Net.HttpListener]::new()
+    # Bind to all interfaces; the firewall rule scopes inbound to Tailscale.
+    $prefix = "http://+:$Port/"
+    $listener.Prefixes.Add($prefix)
+
+    try {
+        $listener.Start()
+    } catch [System.Net.HttpListenerException] {
+        throw "Failed to bind $prefix — needs admin OR a URL ACL: `n  netsh http add urlacl url=$prefix user=$env:USERNAME`n($($_.Exception.Message))"
+    }
+
+    Write-BridgeLog "DST Helper Bridge listening on $prefix"
+    Write-BridgeLog "Watching $LastUrlPath"
+
+    try {
+        while ($listener.IsListening) {
+            $ctx = $listener.GetContext()
+            # Inline (synchronous) handling. Friend helper = single user;
+            # concurrency isn't worth runspace overhead here.
+            Invoke-Request -Context $ctx
+        }
+    } finally {
+        try { $listener.Stop(); $listener.Close() } catch { }
+        try { $script:HttpClient.Dispose() } catch { }
+        Write-BridgeLog "Bridge stopped."
+    }
+}
+
+Start-Bridge

--- a/helper/bridge/Install-Bridge.ps1
+++ b/helper/bridge/Install-Bridge.ps1
@@ -1,0 +1,159 @@
+<#
+.SYNOPSIS
+    Installs the DST Friend Helper bridge as a Scheduled Task on Neil's PC.
+
+.DESCRIPTION
+    Performs three setup steps (all idempotent):
+      1. Registers a URL ACL so a non-admin user can bind http://+:<port>/.
+      2. Creates an inbound Windows Firewall rule scoped to the Tailscale
+         interface only (no LAN / no public exposure).
+      3. Registers a Scheduled Task that runs DstHelperBridge.ps1 under
+         PowerShell 7 (pwsh.exe) at user logon, restarting on failure.
+
+    Must be run elevated (admin) — both the URL ACL and the firewall rule
+    require admin rights to create.
+
+.PARAMETER Port
+    TCP port to bind. Default 47900. Must match Install/Friend config.
+
+.PARAMETER TaskName
+    Scheduled task name. Default 'DST Friend Helper Bridge'.
+
+.PARAMETER TailscaleInterfaceAlias
+    Windows interface alias for Tailscale. Default 'Tailscale'.
+#>
+
+[CmdletBinding()]
+param(
+    [int]$Port = 47900,
+    [string]$TaskName = 'DST Friend Helper Bridge',
+    [string]$TailscaleInterfaceAlias = 'Tailscale'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Assert-Elevated {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [System.Security.Principal.WindowsPrincipal]::new($id)
+    if (-not $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw "Install-Bridge.ps1 must be run from an elevated (admin) PowerShell."
+    }
+}
+
+function Ensure-UrlAcl {
+    param([int]$Port)
+    $url = "http://+:$Port/"
+    $user = "$env:USERDOMAIN\$env:USERNAME"
+    Write-Host "Registering URL ACL: $url for $user ..."
+    # `netsh http add urlacl` is idempotent-ish: it errors if the ACL exists.
+    # Delete-then-add is the simplest path to a clean state.
+    & netsh http delete urlacl url=$url 2>&1 | Out-Null
+    $out = & netsh http add urlacl url=$url user=$user 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "netsh add urlacl failed: $out"
+    }
+}
+
+function Ensure-FirewallRule {
+    param(
+        [int]$Port,
+        [string]$InterfaceAlias
+    )
+    $ruleName = "DST Friend Helper Bridge ($Port/TCP, Tailscale)"
+    Write-Host "Configuring firewall rule '$ruleName' (Tailscale only) ..."
+
+    $existing = Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue
+    if ($existing) {
+        Remove-NetFirewallRule -DisplayName $ruleName
+    }
+
+    # Resolve the interface alias to its index. Fail loudly with a helpful
+    # message if Tailscale isn't installed / interface is named differently.
+    $iface = Get-NetIPInterface -InterfaceAlias $InterfaceAlias -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $iface) {
+        throw "No network interface with alias '$InterfaceAlias' found. Is Tailscale installed and running? `nList available interfaces: Get-NetIPInterface | Select-Object InterfaceAlias"
+    }
+
+    New-NetFirewallRule `
+        -DisplayName $ruleName `
+        -Direction Inbound `
+        -Action Allow `
+        -Protocol TCP `
+        -LocalPort $Port `
+        -InterfaceAlias $InterfaceAlias `
+        -Profile Any `
+        -Description 'Allow inbound to DST Friend Helper Bridge on the Tailscale interface only.' | Out-Null
+}
+
+function Ensure-ScheduledTask {
+    param(
+        [string]$TaskName,
+        [int]$Port,
+        [string]$BridgeScriptPath
+    )
+    Write-Host "Registering scheduled task '$TaskName' ..."
+
+    $pwsh = (Get-Command pwsh.exe -ErrorAction SilentlyContinue)?.Source
+    if (-not $pwsh) {
+        throw "pwsh.exe (PowerShell 7+) not found in PATH. Install from https://aka.ms/powershell"
+    }
+
+    $existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if ($existing) {
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    }
+
+    $action = New-ScheduledTaskAction `
+        -Execute $pwsh `
+        -Argument "-NoLogo -NoProfile -ExecutionPolicy Bypass -File `"$BridgeScriptPath`" -Port $Port"
+
+    $trigger = New-ScheduledTaskTrigger -AtLogOn -User "$env:USERDOMAIN\$env:USERNAME"
+
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable `
+        -RestartInterval (New-TimeSpan -Minutes 1) `
+        -RestartCount 999 `
+        -ExecutionTimeLimit (New-TimeSpan -Hours 0)
+
+    $principal = New-ScheduledTaskPrincipal `
+        -UserId "$env:USERDOMAIN\$env:USERNAME" `
+        -LogonType Interactive `
+        -RunLevel Limited
+
+    Register-ScheduledTask `
+        -TaskName $TaskName `
+        -Action $action `
+        -Trigger $trigger `
+        -Settings $settings `
+        -Principal $principal `
+        -Description 'Reverse-proxies friend helper requests over Tailscale to the locally running DST instance.' | Out-Null
+}
+
+Assert-Elevated
+
+$bridgeScript = Join-Path $PSScriptRoot 'DstHelperBridge.ps1'
+if (-not (Test-Path -LiteralPath $bridgeScript)) {
+    throw "DstHelperBridge.ps1 not found next to installer at $bridgeScript"
+}
+
+Ensure-UrlAcl -Port $Port
+Ensure-FirewallRule -Port $Port -InterfaceAlias $TailscaleInterfaceAlias
+Ensure-ScheduledTask -TaskName $TaskName -Port $Port -BridgeScriptPath $bridgeScript
+
+Write-Host ""
+Write-Host "Bridge installed." -ForegroundColor Green
+Write-Host "  Port:          $Port/TCP (Tailscale interface only)"
+Write-Host "  Task:          $TaskName"
+Write-Host "  Script:        $bridgeScript"
+Write-Host ""
+Write-Host "Starting the task now..."
+Start-ScheduledTask -TaskName $TaskName
+Start-Sleep -Seconds 2
+$state = (Get-ScheduledTask -TaskName $TaskName).State
+Write-Host "  Task state:    $state"
+Write-Host ""
+Write-Host "Verify with:"
+Write-Host "  curl http://127.0.0.1:$Port/_dst/health"

--- a/helper/bridge/README.md
+++ b/helper/bridge/README.md
@@ -1,0 +1,122 @@
+# Bridge — runs on Neil's PC
+
+This is the half of the friend helper that lives on the **host** PC (mine).
+It exposes the locally running DST portal to a single trusted friend over
+**Tailscale**, without exposing it to the LAN or the public internet, and
+without modifying any released DST code.
+
+## What it does
+
+1. Listens on a stable port (default **47900/TCP**).
+2. The Windows Firewall rule restricts inbound to the **Tailscale interface
+   only**. Nothing on the LAN, nothing from the public internet, can reach
+   this port.
+3. On every request:
+   - Re-reads `%LOCALAPPDATA%\DuneServer\last-url.txt` (DST rewrites this
+     on every launch with `http://127.0.0.1:<port>/?t=<token>`).
+   - For `GET /_dst/token`: returns the current `{url, token}` as JSON
+     (the friend helper uses this to know where to navigate).
+   - For `GET /_dst/health`: returns `{ok: true}` if DST is currently
+     up and the token file parses.
+   - For everything else: reverse-proxies the request to the current DST
+     instance on `127.0.0.1:<DST port>` — method, headers, body, status,
+     response body all carried through.
+
+Because the URL is re-read per request, the bridge handles DST restarts
+transparently. No restart needed when DST relaunches with a new port/token.
+
+## Files
+
+| File                       | Role                                             |
+| -------------------------- | ------------------------------------------------ |
+| `DstHelperBridge.ps1`      | The daemon. PS7 `HttpListener` + reverse proxy.  |
+| `Install-Bridge.ps1`       | URL ACL + firewall rule + scheduled task setup.  |
+| `Uninstall-Bridge.ps1`     | Reverses everything Install does.                |
+
+## One-time setup
+
+Requirements:
+
+- **PowerShell 7** (`pwsh.exe`) on PATH. Install from <https://aka.ms/powershell>
+- **Tailscale** installed and signed in. Windows interface alias must be
+  `Tailscale` (the default). Verify with:
+  ```powershell
+  Get-NetIPInterface | Where-Object InterfaceAlias -eq 'Tailscale'
+  ```
+- An **admin** PowerShell to run `Install-Bridge.ps1` (URL ACL + firewall
+  rule both require admin). The daemon itself runs **unelevated**.
+
+Install:
+
+```powershell
+# from an elevated pwsh, in the repo root:
+.\helper\bridge\Install-Bridge.ps1
+```
+
+This will:
+
+1. Register `http://+:47900/` URL ACL for your user (so the unelevated
+   daemon can bind it).
+2. Create a Windows Firewall inbound rule allowing 47900/TCP **only on
+   the Tailscale interface**.
+3. Register a Scheduled Task `DST Friend Helper Bridge` that runs the
+   daemon at user logon and restarts it every minute on failure.
+4. Start the task immediately.
+
+Verify locally:
+
+```powershell
+curl http://127.0.0.1:47900/_dst/health
+# -> {"ok":true}
+```
+
+Verify from the friend's PC (after they're on the tailnet):
+
+```powershell
+curl http://<your-machine-name>.<tailnet>.ts.net:47900/_dst/health
+# -> {"ok":true}
+```
+
+## Tailscale ACL
+
+Trust boundary = Tailscale ACL. In your Tailscale admin panel, lock
+inbound to port 47900 to **only the friend's device tag**:
+
+```jsonc
+{
+  "acls": [
+    // Friend tag can only hit your bridge port, nothing else on your machine.
+    { "action": "accept", "src": ["tag:dst-friend"], "dst": ["tag:dst-host:47900"] }
+  ],
+  "tagOwners": {
+    "tag:dst-host":   ["autogroup:admin"],
+    "tag:dst-friend": ["autogroup:admin"]
+  }
+}
+```
+
+Tag your own device `tag:dst-host` and the friend's device `tag:dst-friend`
+in the admin panel.
+
+## Uninstall
+
+```powershell
+# from an elevated pwsh:
+.\helper\bridge\Uninstall-Bridge.ps1
+```
+
+Removes the scheduled task, firewall rule, and URL ACL. No leftover
+state.
+
+## Known limitations (MVP scaffold)
+
+- **No WebSocket support.** The reverse proxy uses `HttpClient`, which
+  doesn't speak the `Upgrade: websocket` handshake. The Terminal page
+  in the DST portal will not work for the friend. Everything else (REST
+  API, static assets, status polling) works fine.
+- **Single concurrent request** (synchronous loop). Fine for one friend;
+  not a public service.
+- The daemon logs to stdout; redirect or pass `-LogPath` if you want a
+  file. The scheduled-task action doesn't currently capture stdout to a
+  log file — add `> $env:LOCALAPPDATA\DuneServer\.logs\bridge.log 2>&1`
+  to the task action if you need persistent logs.

--- a/helper/bridge/Uninstall-Bridge.ps1
+++ b/helper/bridge/Uninstall-Bridge.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+    Cleanly removes the DST Friend Helper bridge from Neil's PC.
+
+.DESCRIPTION
+    Reverses every step taken by Install-Bridge.ps1: unregisters the
+    scheduled task, removes the firewall rule, and deletes the URL ACL.
+    Each step is best-effort — missing artifacts are not errors.
+
+    Must be run elevated (admin).
+#>
+
+[CmdletBinding()]
+param(
+    [int]$Port = 47900,
+    [string]$TaskName = 'DST Friend Helper Bridge'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Assert-Elevated {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [System.Security.Principal.WindowsPrincipal]::new($id)
+    if (-not $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw "Uninstall-Bridge.ps1 must be run from an elevated (admin) PowerShell."
+    }
+}
+
+Assert-Elevated
+
+$ruleName = "DST Friend Helper Bridge ($Port/TCP, Tailscale)"
+$url = "http://+:$Port/"
+
+Write-Host "Stopping + unregistering scheduled task '$TaskName' ..."
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    try { Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue } catch { }
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Host "  removed."
+} else {
+    Write-Host "  (not present)"
+}
+
+Write-Host "Removing firewall rule '$ruleName' ..."
+if (Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue) {
+    Remove-NetFirewallRule -DisplayName $ruleName
+    Write-Host "  removed."
+} else {
+    Write-Host "  (not present)"
+}
+
+Write-Host "Removing URL ACL '$url' ..."
+$out = & netsh http delete urlacl url=$url 2>&1
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "  removed."
+} else {
+    Write-Host "  (not present or already removed)"
+}
+
+Write-Host ""
+Write-Host "Bridge uninstalled." -ForegroundColor Green

--- a/helper/friend/.gitignore
+++ b/helper/friend/.gitignore
@@ -1,0 +1,7 @@
+# build/publish output
+dist/
+bin/
+obj/
+
+# Friend-specific config (don't commit a real one with a real host name)
+config.json

--- a/helper/friend/App.xaml
+++ b/helper/friend/App.xaml
@@ -1,0 +1,6 @@
+<Application x:Class="DstFriendHelper.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+  <Application.Resources />
+</Application>

--- a/helper/friend/App.xaml.cs
+++ b/helper/friend/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace DstFriendHelper;
+
+public partial class App : Application
+{
+}

--- a/helper/friend/Build-FriendHelper.ps1
+++ b/helper/friend/Build-FriendHelper.ps1
@@ -1,0 +1,70 @@
+<#
+.SYNOPSIS
+    Builds the DstFriendHelper.exe as a self-contained single-file Windows
+    executable, ready to hand to a friend.
+
+.DESCRIPTION
+    Wraps `dotnet publish` with the publish-time properties locked in. Output
+    lands in helper/friend/dist/. Drop DstFriendHelper.exe plus a populated
+    config.json into the same folder on the friend's PC.
+
+.PARAMETER Configuration
+    Build configuration. Default Release.
+
+.PARAMETER Runtime
+    Runtime identifier. Default win-x64.
+#>
+
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Release',
+    [string]$Runtime = 'win-x64'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$here = $PSScriptRoot
+$proj = Join-Path $here 'DstFriendHelper.csproj'
+$dist = Join-Path $here 'dist'
+
+if (-not (Test-Path -LiteralPath $proj)) {
+    throw "DstFriendHelper.csproj not found at $proj"
+}
+
+# Clean previous dist so single-file size doesn't accumulate stale baggage.
+if (Test-Path -LiteralPath $dist) {
+    Remove-Item -Recurse -Force -LiteralPath $dist
+}
+New-Item -ItemType Directory -Path $dist | Out-Null
+
+Write-Host "Building DstFriendHelper ($Configuration / $Runtime) ..."
+
+& dotnet publish $proj `
+    --configuration $Configuration `
+    --runtime $Runtime `
+    --self-contained true `
+    -p:PublishSingleFile=true `
+    -p:IncludeNativeLibrariesForSelfExtract=true `
+    -p:EnableCompressionInSingleFile=true `
+    --output $dist
+
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet publish failed with exit code $LASTEXITCODE"
+}
+
+# Drop a config.json next to the .exe if one isn't already shipped — friend
+# only needs to edit bridgeHost.
+$cfg = Join-Path $dist 'config.json'
+if (-not (Test-Path -LiteralPath $cfg)) {
+    Copy-Item -Path (Join-Path $here 'config.sample.json') -Destination $cfg
+}
+
+Write-Host ""
+Write-Host "Build complete." -ForegroundColor Green
+Write-Host "  Output:  $dist"
+Get-ChildItem $dist | Select-Object Name, Length | Format-Table -AutoSize
+Write-Host "Hand the friend:"
+Write-Host "  $dist\DstFriendHelper.exe"
+Write-Host "  $dist\config.json   (edit bridgeHost to Neil's Tailscale hostname first)"

--- a/helper/friend/Config.cs
+++ b/helper/friend/Config.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DstFriendHelper;
+
+/// <summary>
+/// Friend-side configuration. Loaded from <c>config.json</c> sitting next
+/// to the published .exe. The friend edits this once after dropping in the
+/// .exe; the helper re-reads it on every launch.
+/// </summary>
+public sealed class FriendConfig
+{
+    [JsonPropertyName("bridgeHost")]
+    public string BridgeHost { get; init; } = string.Empty;
+
+    [JsonPropertyName("bridgePort")]
+    public int BridgePort { get; init; } = 47900;
+
+    [JsonIgnore]
+    public string BridgeUrl => $"http://{BridgeHost}:{BridgePort}";
+
+    public static FriendConfig LoadOrThrow()
+    {
+        var path = ResolveConfigPath();
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(
+                $"config.json not found at {path}. " +
+                "Copy config.sample.json -> config.json and set bridgeHost to Neil's Tailscale hostname.",
+                path);
+        }
+
+        var json = File.ReadAllText(path);
+        var cfg = JsonSerializer.Deserialize<FriendConfig>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        }) ?? throw new InvalidDataException("config.json parsed to null.");
+
+        if (string.IsNullOrWhiteSpace(cfg.BridgeHost))
+        {
+            throw new InvalidDataException("config.json: bridgeHost is required.");
+        }
+        if (cfg.BridgePort <= 0 || cfg.BridgePort > 65535)
+        {
+            throw new InvalidDataException($"config.json: bridgePort {cfg.BridgePort} is out of range.");
+        }
+
+        return cfg;
+    }
+
+    private static string ResolveConfigPath()
+    {
+        // Resolve relative to the executable, not the current working directory.
+        // AppContext.BaseDirectory is the correct API under PublishSingleFile
+        // (Assembly.Location returns an empty string there).
+        var baseDir = AppContext.BaseDirectory;
+        if (string.IsNullOrEmpty(baseDir))
+        {
+            baseDir = Directory.GetCurrentDirectory();
+        }
+        return Path.Combine(baseDir, "config.json");
+    }
+}

--- a/helper/friend/DstFriendHelper.csproj
+++ b/helper/friend/DstFriendHelper.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <!--
+      Spec target: .NET 8 LTS. The .NET 10 SDK installed on Neil's machine
+      cross-targets net8.0-windows fine; NuGet auto-resolves the
+      Microsoft.WindowsDesktop.App.Ref pack on first build. If you need to
+      target net10 because no net8 reference pack is reachable, change the
+      TFM below — the source compiles unchanged.
+    -->
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>DstFriendHelper</RootNamespace>
+    <AssemblyName>DstFriendHelper</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
+    <Version>0.1.0</Version>
+    <Product>DST Friend Helper</Product>
+    <AssemblyTitle>DST Friend Helper</AssemblyTitle>
+    <Company>Coastal</Company>
+
+    <!-- Self-contained single-file publish: friend can just double-click. -->
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+
+    <!-- Drop debug + doc artifacts from publish output. -->
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <PublishDocumentationFiles>false</PublishDocumentationFiles>
+    <PublishReferencesDocumentationFiles>false</PublishReferencesDocumentationFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Same WebView2 pin as DuneShell so behavior matches across the two
+         WPF/WinForms entry points. -->
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
+  </ItemGroup>
+
+  <!-- Ship a sample config.json next to the published .exe so the friend
+       knows what to edit. -->
+  <ItemGroup>
+    <None Update="config.sample.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/helper/friend/MainWindow.xaml
+++ b/helper/friend/MainWindow.xaml
@@ -1,0 +1,37 @@
+<Window x:Class="DstFriendHelper.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        Title="Dune Server Tool — Friend Helper"
+        Width="1280" Height="800"
+        WindowStartupLocation="CenterScreen"
+        Background="#0B0B0F">
+  <Grid>
+    <wv2:WebView2 x:Name="Web" Visibility="Hidden" />
+    <Border x:Name="StatusOverlay" Background="#0B0B0F">
+      <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="640">
+        <TextBlock x:Name="StatusTitle"
+                   Text="Connecting to Neil's PC..."
+                   FontSize="22"
+                   Foreground="#FFB05E"
+                   HorizontalAlignment="Center"
+                   Margin="0,0,0,12" />
+        <TextBlock x:Name="StatusBody"
+                   Text=""
+                   TextWrapping="Wrap"
+                   Foreground="#D4C7B5"
+                   HorizontalAlignment="Center"
+                   TextAlignment="Center"
+                   FontSize="14" />
+        <Button x:Name="RetryButton"
+                Content="Retry"
+                Width="120"
+                Height="32"
+                Margin="0,20,0,0"
+                Visibility="Collapsed"
+                HorizontalAlignment="Center"
+                Click="RetryButton_Click" />
+      </StackPanel>
+    </Border>
+  </Grid>
+</Window>

--- a/helper/friend/MainWindow.xaml.cs
+++ b/helper/friend/MainWindow.xaml.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Microsoft.Web.WebView2.Core;
+
+namespace DstFriendHelper;
+
+public partial class MainWindow : Window
+{
+    private static readonly HttpClient Http = new()
+    {
+        Timeout = TimeSpan.FromSeconds(5),
+    };
+
+    private FriendConfig? _config;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+        Loaded += MainWindow_Loaded;
+    }
+
+    private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
+    {
+        await ConnectAsync();
+    }
+
+    private async void RetryButton_Click(object sender, RoutedEventArgs e)
+    {
+        await ConnectAsync();
+    }
+
+    private async Task ConnectAsync()
+    {
+        ShowStatus("Connecting to Neil's PC...", "Reading config and probing the bridge over Tailscale.");
+
+        try
+        {
+            _config ??= FriendConfig.LoadOrThrow();
+        }
+        catch (Exception ex)
+        {
+            ShowError("Couldn't read config.json", ex.Message + "\n\nMake sure config.json sits next to the .exe and contains bridgeHost + bridgePort.");
+            return;
+        }
+
+        TokenResponse token;
+        try
+        {
+            token = await FetchTokenAsync(_config);
+        }
+        catch (Exception ex)
+        {
+            ShowError(
+                "Can't reach Neil's PC",
+                $"Tried {_config.BridgeUrl}/_dst/token but got: {ex.Message}\n\n" +
+                "Checklist:\n" +
+                "  • Is Tailscale running on this PC?\n" +
+                "  • Is Neil's PC online and on the tailnet?\n" +
+                "  • Is the DST Friend Helper Bridge running on Neil's PC?");
+            return;
+        }
+
+        try
+        {
+            await EnsureWebViewAsync();
+        }
+        catch (Exception ex)
+        {
+            ShowError(
+                "WebView2 runtime missing",
+                $"{ex.Message}\n\nInstall the Microsoft Edge WebView2 Runtime from https://developer.microsoft.com/microsoft-edge/webview2/");
+            return;
+        }
+
+        // Navigate WebView2 through the bridge using the freshly fetched token.
+        // The bridge proxies / -> 127.0.0.1:<DSTport>/ on Neil's PC, and the
+        // token query-param is exactly what DST's portal expects to auth.
+        var targetUrl = $"{_config.BridgeUrl}/?t={Uri.EscapeDataString(token.Token)}";
+        Web.CoreWebView2.Navigate(targetUrl);
+
+        StatusOverlay.Visibility = Visibility.Collapsed;
+        Web.Visibility = Visibility.Visible;
+    }
+
+    private async Task EnsureWebViewAsync()
+    {
+        if (Web.CoreWebView2 != null) return;
+
+        // Per-friend isolated user data folder, so the WebView profile doesn't
+        // collide with any other Edge install on the friend's PC.
+        var userDataDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "DstFriendHelper",
+            "WebView2");
+        Directory.CreateDirectory(userDataDir);
+
+        var env = await CoreWebView2Environment.CreateAsync(null, userDataDir);
+        await Web.EnsureCoreWebView2Async(env);
+    }
+
+    private async Task<TokenResponse> FetchTokenAsync(FriendConfig cfg)
+    {
+        var url = $"{cfg.BridgeUrl}/_dst/token";
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var json = await Http.GetStringAsync(url, cts.Token);
+        var parsed = JsonSerializer.Deserialize<TokenResponse>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        });
+        if (parsed is null || string.IsNullOrEmpty(parsed.Token))
+        {
+            throw new InvalidDataException("Bridge returned empty / malformed token JSON.");
+        }
+        return parsed;
+    }
+
+    private void ShowStatus(string title, string body)
+    {
+        StatusTitle.Text = title;
+        StatusBody.Text = body;
+        RetryButton.Visibility = Visibility.Collapsed;
+        StatusOverlay.Visibility = Visibility.Visible;
+        Web.Visibility = Visibility.Hidden;
+    }
+
+    private void ShowError(string title, string body)
+    {
+        StatusTitle.Text = title;
+        StatusBody.Text = body;
+        RetryButton.Visibility = Visibility.Visible;
+        StatusOverlay.Visibility = Visibility.Visible;
+        Web.Visibility = Visibility.Hidden;
+    }
+
+    private sealed record TokenResponse(string Url, string Token);
+}

--- a/helper/friend/README.md
+++ b/helper/friend/README.md
@@ -1,0 +1,92 @@
+# Friend — runs on your friend's PC
+
+This is the half of the friend helper that ships **to your friend**. It's
+a single self-contained Windows .exe with one tiny `config.json` next to it.
+Double-click to launch.
+
+## What it does
+
+1. Reads `config.json` (in the same folder as the .exe).
+2. Probes `http://<bridgeHost>:<bridgePort>/_dst/token` over Tailscale
+   with a 5s timeout. If unreachable → friendly dialog, no stack trace.
+3. On success, parses `{url, token}` and navigates an embedded WebView2
+   window to the bridge URL with the token in the query string.
+4. The bridge reverse-proxies into the current DST portal on Neil's
+   loopback. You see exactly what Neil sees in his portal.
+
+## What the friend needs
+
+- **Windows 10/11 x64**
+- **Microsoft Edge WebView2 Runtime** (most systems already have it; if
+  not, helper shows a dialog with the install link).
+- **Tailscale** signed in to the same tailnet as Neil's PC.
+- The shipped `DstFriendHelper.exe` and `config.json`.
+
+That's it. No .NET install required (self-contained publish bundles the
+runtime), no admin rights required (manifest is `asInvoker`).
+
+## Setup steps (give these to the friend)
+
+1. Install Tailscale: <https://tailscale.com/download/windows>
+2. Sign in with the account Neil added you to.
+3. Drop `DstFriendHelper.exe` and `config.json` into any folder
+   (e.g. `Documents\DstHelper`).
+4. Open `config.json` in Notepad and set `bridgeHost` to the Tailscale
+   hostname Neil sent you (something like `neilpc.tailXXXX.ts.net`).
+5. Double-click `DstFriendHelper.exe`. Neil's portal opens in the
+   window.
+
+## Building from source (Neil side)
+
+```powershell
+# from the repo root
+.\helper\friend\Build-FriendHelper.ps1
+```
+
+This produces `helper\friend\dist\DstFriendHelper.exe` (+ a stub
+`config.json`) as a self-contained single-file win-x64 publish. Hand
+both files to the friend.
+
+### Toolchain
+
+The project file targets **`net8.0-windows`** with WPF. The .NET 10
+SDK installed on Neil's machine cross-targets net8.0 fine — NuGet
+auto-resolves the WindowsDesktop reference pack on first build. If
+your environment can't reach that pack (offline / mirror), change the
+`<TargetFramework>` in `DstFriendHelper.csproj` to `net10.0-windows`
+and rebuild; the source compiles unchanged.
+
+### Code-signing
+
+The unsigned single-file .exe will trigger SmartScreen on the friend's
+first launch (Windows defender + EV cert reputation kicks in over
+time). For real-world distribution you'd code-sign with the same EV
+cert used for `DuneServerSetup.exe` releases — out of scope for the
+scaffold.
+
+## Why WPF + WebView2 specifically (not ps2exe / Electron / Tauri)
+
+- **Defender / SmartScreen FP avoidance.** The DST v11.0.1–v11.0.3
+  saga showed that ANY binary that performs a base64-decode-then-pipe-
+  to-cmdline (the classic ps2exe pattern) gets flagged as
+  `Trojan:Win32/Wacatac.B!ml`. WPF is a normal compiled .NET app; the
+  reputation curve is much friendlier.
+- **No 100 MB Chromium download.** WebView2 reuses the system Edge
+  installation (or auto-installs the lightweight Evergreen runtime
+  once). Final .exe ≈ 90 MB (most of which is the self-contained
+  .NET runtime).
+- **First-party Microsoft stack.** Friend's antivirus is much less
+  likely to quarantine a signed Microsoft WebView2 host than a
+  random Electron build.
+
+## Files
+
+| File                      | Role                                              |
+| ------------------------- | ------------------------------------------------- |
+| `DstFriendHelper.csproj`  | WPF + WebView2 project, single-file publish.      |
+| `app.manifest`            | `asInvoker` execution level.                      |
+| `App.xaml` / `.xaml.cs`   | WPF application entry.                            |
+| `MainWindow.xaml` / `.cs` | Window with WebView2 + status overlay.            |
+| `Config.cs`               | `config.json` loader.                             |
+| `config.sample.json`      | Template the build script copies as `config.json`.|
+| `Build-FriendHelper.ps1`  | `dotnet publish` wrapper.                         |

--- a/helper/friend/app.manifest
+++ b/helper/friend/app.manifest
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="0.1.0.0" name="DstFriendHelper.app" />
+
+  <!-- asInvoker: no admin rights required. The friend just double-clicks. -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/helper/friend/config.sample.json
+++ b/helper/friend/config.sample.json
@@ -1,0 +1,4 @@
+{
+  "bridgeHost": "neilpc.tailXXXX.ts.net",
+  "bridgePort": 47900
+}


### PR DESCRIPTION
## Summary

Net-new scaffold under `helper/` — a standalone Windows app a trusted friend can double-click on **his** PC to get into the full DST desktop portal running on **the host's** PC, over Tailscale. **Zero changes to `app/`, `webui/`, `site/`, or `dune-server.ps1`** — DST stays on the released v11.0.3 surface area.

## Related issue

n/a — the maintainer-driven feature work spawned from the v11.1.0 session.

## Type of change

- [x] New feature (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] Breaking change
- [ ] Docs only
- [ ] Chore / CI / refactor

## What ships

```
helper/
├── README.md             # overview + mermaid data-flow + trust model
├── bridge/               # Runs on the host's PC (long-lived scheduled task)
│   ├── DstHelperBridge.ps1     PS7 HttpListener + reverse proxy
│   ├── Install-Bridge.ps1      URL ACL + Tailscale-scoped firewall + task
│   ├── Uninstall-Bridge.ps1    Clean removal
│   └── README.md
└── friend/               # Ships to the friend (single .exe + config.json)
    ├── DstFriendHelper.csproj   net8.0-windows WPF, self-contained single-file
    ├── App.xaml / .xaml.cs
    ├── MainWindow.xaml / .xaml.cs   WebView2 + status overlay + retry
    ├── Config.cs                config.json loader
    ├── app.manifest             asInvoker (no admin)
    ├── config.sample.json
    ├── Build-FriendHelper.ps1   dotnet publish wrapper -> dist/
    └── README.md
```

## Architecture

```
Friend .exe  ──Tailscale──▶  Bridge :47900  ──127.0.0.1──▶  DST :random/?t=<token>
```

1. Friend launches `DstFriendHelper.exe`.
2. It reads `config.json` (sitting next to the .exe), then probes `http://<bridgeHost>:47900/_dst/token` over the tailnet with a 5s timeout.
3. The bridge re-reads `%LOCALAPPDATA%\DuneServer\last-url.txt` on every request, parses out the current DST port + DuneToken, and returns `{url, token}` as JSON.
4. The friend helper navigates the embedded WebView2 to `http://<bridgeHost>:47900/?t=<token>`.
5. The bridge reverse-proxies every subsequent request to the current DST loopback. Because `last-url.txt` is re-read per request, DST relaunches (new port, new token) are picked up transparently — no bridge restart required.

## Trust boundaries

| Layer            | Gates                                                          |
| ---------------- | -------------------------------------------------------------- |
| Tailscale tailnet| Only devices the maintainer has added can route to his machine at all.   |
| Tailscale ACL    | Friend's device tag is restricted to port 47900 on the host.   |
| Windows Firewall | Port 47900 inbound is allowed **only on the Tailscale NIC**.   |
| DuneToken (`?t=`)| Defense-in-depth — DST itself still requires a valid token.    |

## Why this design (locked in with the maintainer before scaffolding)

- **Tailscale, not Cloudflare Tunnel.** The existing `/remote/*` SPA already uses CF Tunnel + Access for a mobile-friendly subset. This scaffold targets a different use case: a single trusted friend who wants the *full* desktop portal. Tailscale gives identity-based access without per-domain edge config.
- **WPF + WebView2, not ps2exe / Electron.** The DST v11.0.1–v11.0.3 saga taught us that any base64-pipe-decode-exec pattern gets flagged as `Trojan:Win32/Wacatac.B!ml`. WPF compiled .NET is a normal benign Windows app and reuses the system Edge / WebView2 Evergreen runtime (~90 MB final .exe, mostly the bundled .NET runtime).
- **No DST code changes.** The bridge is a pure reverse proxy that consumes the *existing* `last-url.txt` DST already writes for its desktop shell. Zero risk of breaking the released app while iterating on the helper.

## Testing

- [x] `Parse-validated` all 4 `.ps1` files via `[System.Management.Automation.Language.Parser]::ParseFile` — clean.
- [x] `dotnet build helper/friend/` succeeds on net8.0-windows (using the .NET 10 SDK installed on the host's machine — NuGet auto-resolves the WindowsDesktop ref pack). **0 warnings, 0 errors.**
- [x] `Get-ChildItem helper -Recurse` produces a sensible 16-file tree.
- [x] `git diff main --stat` shows only `helper/**` (new) and `CHANGELOG.md` (one `[Unreleased]` entry) — confirms zero released-surface changes.
- [ ] End-to-end test against a real friend on the tailnet — out of scope for this scaffold PR; will be exercised when the maintainer tests with a friend.
- [ ] PSScriptAnalyzer — would be a follow-up; the scripts compile-validate clean which is the relevant gate for this scaffold.

## Changelog

- [x] Added an entry to `CHANGELOG.md` under `[Unreleased]` (deliberately **not** under `[11.1.0]` — this is post-11.1.0 work).

## Known limitations (MVP scope)

- **No WebSocket proxy.** The bridge uses `HttpClient`, which doesn't speak `Upgrade: websocket`. The Terminal page in the portal won't work for the friend. Everything else (Dashboard, Maps, Settings, Database, Setup Wizard, etc.) does.
- **Single concurrent request** through the bridge — synchronous handling loop. Fine for one friend.
- **No code-signing.** First friend launch will trip SmartScreen until the .exe is signed with the same EV cert used for `DuneServerSetup.exe`.

## Explicit "no released-surface changes" guarantee

```
$ git diff main --name-only
CHANGELOG.md
helper/README.md
helper/bridge/DstHelperBridge.ps1
helper/bridge/Install-Bridge.ps1
helper/bridge/README.md
helper/bridge/Uninstall-Bridge.ps1
helper/friend/.gitignore
helper/friend/App.xaml
helper/friend/App.xaml.cs
helper/friend/Build-FriendHelper.ps1
helper/friend/Config.cs
helper/friend/DstFriendHelper.csproj
helper/friend/MainWindow.xaml
helper/friend/MainWindow.xaml.cs
helper/friend/README.md
helper/friend/app.manifest
helper/friend/config.sample.json
```

No `app/`, no `webui/`, no `site/`, no `dune-server.ps1`. No version bumps. v11.0.3 stays exactly v11.0.3.
