### PR TITLE
feat(helper/bridge): proxy WebSocket upgrades so Terminal page works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ here cover everything those tags shipped.
 ## [Unreleased]
 
 ### Added
+- **Friend helper — WebSocket proxy.** The bridge now transparently
+  proxies WebSocket upgrades (`/ws/terminal` and friends) in addition
+  to plain HTTP, so the friend gets a working Terminal page in
+  WebView2. Implemented with `HttpListenerContext.AcceptWebSocketAsync`
+  + a `ClientWebSocket` toward DST on loopback, with two bidirectional
+  pumps stitched together by a `CancellationTokenSource`. Subprotocol
+  negotiation is preserved (first offered subprotocol echoed back).
+  Verified end-to-end against DST v11.0.3 with the real Terminal
+  protocol: `init` → `exec` → `output` → `done` frames carry through
+  byte-identical to a direct DST connection.
+
 - **Friend helper scaffold** (`helper/`). A net-new, additive companion
   to the released DST surface that lets a single trusted friend connect
   into Neil's full desktop portal over Tailscale, without modifying any

--- a/helper/bridge/DstHelperBridge.ps1
+++ b/helper/bridge/DstHelperBridge.ps1
@@ -185,6 +185,140 @@ function Invoke-Proxy {
     }
 }
 
+function Start-WsPumpAsync {
+    <#
+        Spawn a background PowerShell runspace that pumps WebSocket frames
+        one-way (Src -> Dst). Returns @{ PS = ..., Handle = ... } so the
+        caller can wait for completion and dispose.
+    #>
+    param(
+        [System.Net.WebSockets.WebSocket]$Src,
+        [System.Net.WebSockets.WebSocket]$Dst,
+        [System.Threading.CancellationToken]$CT
+    )
+    $ps = [System.Management.Automation.PowerShell]::Create()
+    [void]$ps.AddScript({
+        param($s, $d, $ct)
+        $buf = [byte[]]::new(16384)
+        try {
+            while (-not $ct.IsCancellationRequested -and
+                   $s.State -eq [System.Net.WebSockets.WebSocketState]::Open) {
+                $seg = [System.ArraySegment[byte]]::new($buf)
+                $r = $s.ReceiveAsync($seg, $ct).GetAwaiter().GetResult()
+                if ($r.MessageType -eq [System.Net.WebSockets.WebSocketMessageType]::Close) {
+                    if ($d.State -eq [System.Net.WebSockets.WebSocketState]::Open) {
+                        try {
+                            [void]$d.CloseOutputAsync(
+                                [System.Net.WebSockets.WebSocketCloseStatus]::NormalClosure,
+                                '', [System.Threading.CancellationToken]::None
+                            ).GetAwaiter().GetResult()
+                        } catch { }
+                    }
+                    return
+                }
+                $out = [System.ArraySegment[byte]]::new($buf, 0, $r.Count)
+                [void]$d.SendAsync($out, $r.MessageType, $r.EndOfMessage, $ct).GetAwaiter().GetResult()
+            }
+        } catch {
+            # Connection dropped / cancelled. Let the partner pump notice
+            # through its own cancellation token; nothing to log per-frame.
+        }
+    }).AddArgument($Src).AddArgument($Dst).AddArgument($CT) | Out-Null
+    return @{ PS = $ps; Handle = $ps.BeginInvoke() }
+}
+
+function Invoke-WsProxy {
+    <#
+        Bidirectional WebSocket reverse proxy. The friend's browser opens a
+        WS to the bridge (e.g. /ws/terminal?t=token); we accept it, open a
+        matching WS to DST on loopback, and bridge frames in both directions
+        until either side closes.
+
+        Trade-off: this call blocks the main HttpListener loop for the
+        lifetime of the WS session. The friend helper is single-user and
+        the DST WebUI only opens one WS at a time (from the Terminal page),
+        so this is acceptable for the scaffold scope. Periodic REST polls
+        from other tabs will queue behind the WS — close the Terminal page
+        to free the loop.
+    #>
+    param(
+        [System.Net.HttpListenerContext]$Context,
+        [pscustomobject]$Dst
+    )
+    $req = $Context.Request
+    $serverWs = $null
+    $client = $null
+    $cts = [System.Threading.CancellationTokenSource]::new()
+    $j1 = $null
+    $j2 = $null
+
+    try {
+        # Accept the inbound upgrade (subprotocol negotiation deferred to DST —
+        # pass through whatever the client requested, if anything).
+        $subprotocol = [NullString]::Value
+        $requested = $req.Headers['Sec-WebSocket-Protocol']
+        if ($requested) {
+            # Use the first offered subprotocol; AcceptWebSocketAsync requires
+            # us to pick one specifically rather than echoing the list.
+            $subprotocol = ($requested -split ',')[0].Trim()
+        }
+        $wsCtx = $Context.AcceptWebSocketAsync($subprotocol).GetAwaiter().GetResult()
+        $serverWs = $wsCtx.WebSocket
+
+        # Connect to DST on loopback. Same path + query (e.g. ?t=token).
+        $client = [System.Net.WebSockets.ClientWebSocket]::new()
+        if ($subprotocol -and $subprotocol -ne [NullString]::Value) {
+            $client.Options.AddSubProtocol($subprotocol)
+        }
+        $targetUri = [Uri]::new("ws://127.0.0.1:$($Dst.DstPort)$($req.Url.PathAndQuery)")
+        [void]$client.ConnectAsync($targetUri, [System.Threading.CancellationToken]::None).GetAwaiter().GetResult()
+
+        # Two pumps in parallel: client->DST and DST->client.
+        $j1 = Start-WsPumpAsync -Src $serverWs -Dst $client -CT $cts.Token
+        $j2 = Start-WsPumpAsync -Src $client -Dst $serverWs -CT $cts.Token
+
+        [System.Threading.WaitHandle]::WaitAny(@($j1.Handle.AsyncWaitHandle, $j2.Handle.AsyncWaitHandle)) | Out-Null
+        $cts.Cancel()
+        # WaitAll isn't supported on STA threads (PowerShell default), so
+        # wait on each handle individually with a 5s ceiling each.
+        foreach ($j in @($j1, $j2)) {
+            try { [void]$j.Handle.AsyncWaitHandle.WaitOne([TimeSpan]::FromSeconds(5)) } catch { }
+        }
+    } catch {
+        Write-BridgeLog "WS proxy error: $($_.Exception.Message)"
+    } finally {
+        foreach ($j in @($j1, $j2)) {
+            if ($null -ne $j) {
+                try { [void]$j.PS.EndInvoke($j.Handle) } catch { }
+                try { $j.PS.Dispose() } catch { }
+            }
+        }
+        if ($null -ne $serverWs) {
+            try {
+                if ($serverWs.State -eq [System.Net.WebSockets.WebSocketState]::Open) {
+                    [void]$serverWs.CloseAsync(
+                        [System.Net.WebSockets.WebSocketCloseStatus]::NormalClosure,
+                        '', [System.Threading.CancellationToken]::None
+                    ).GetAwaiter().GetResult()
+                }
+            } catch { }
+            try { $serverWs.Dispose() } catch { }
+        }
+        if ($null -ne $client) {
+            try {
+                if ($client.State -eq [System.Net.WebSockets.WebSocketState]::Open) {
+                    [void]$client.CloseAsync(
+                        [System.Net.WebSockets.WebSocketCloseStatus]::NormalClosure,
+                        '', [System.Threading.CancellationToken]::None
+                    ).GetAwaiter().GetResult()
+                }
+            } catch { }
+            try { $client.Dispose() } catch { }
+        }
+        $cts.Dispose()
+    }
+}
+
 function Invoke-Request {
     param([System.Net.HttpListenerContext]$Context)
     $req = $Context.Request
@@ -215,6 +349,15 @@ function Invoke-Request {
 
         # Everything else: reverse-proxy to current DST.
         $dst = Get-CurrentDst
+
+        if ($req.IsWebSocketRequest) {
+            # WebSocket upgrades (currently just /ws/terminal). Handled inline
+            # — see Invoke-WsProxy for the trade-off note about main-loop blocking.
+            Invoke-WsProxy -Context $Context -Dst $dst
+            Write-BridgeLog "WS  $($req.HttpMethod) $path from $client (closed)"
+            return
+        }
+
         Invoke-Proxy -Context $Context -Dst $dst
         Write-BridgeLog "$($res.StatusCode) $($req.HttpMethod) $path from $client"
     } catch {


### PR DESCRIPTION
Follow-up to #79 (now merged on main). Adds WebSocket proxying to the friend helper's bridge daemon so the Terminal page — and anything else DST runs over `/ws/*` — works from the friend's WebView2 window.

## What

The first scaffold proxied HTTP only. DST's Terminal page upgrades to a WebSocket at `/ws/terminal?t=<token>`, so when the friend opens it, the upgrade hit `HttpListener` as a plain GET and the bridge returned HTML instead of a 101. This PR teaches the bridge to detect `IsWebSocketRequest` and proxy the upgrade end-to-end.

## How

- **`HttpListenerContext.AcceptWebSocketAsync`** on the inbound side (accepts the upgrade from the friend's WebView2)
- **`ClientWebSocket`** toward DST on `127.0.0.1:<DSTport>` (carrying through the exact `PathAndQuery`, so `?t=<token>` rides through)
- **Two one-way pumps** (friend→DST, DST→friend) running in separate runspaces, each calling `ReceiveAsync` / `SendAsync`. Both share a single `CancellationTokenSource` so either side dropping tears down both.
- **Subprotocol negotiation** preserved — first subprotocol the friend offers is echoed back to DST and to the friend.
- **STA gotcha:** PowerShell defaults to STA on Windows, where `WaitHandle.WaitAll` throws `"WaitAll for multiple handles on a STA thread is not supported"`. Uses `WaitAny` to wake on first pump finishing, then `WaitOne` on each handle individually with a 5-second ceiling.
- **Finally-driven cleanup** of pumps, runspaces, and both sockets — drops on either side close cleanly.

## Trust boundary unchanged

The friend's WS request still arrives over Tailscale, still carries the DuneToken in `?t=<token>`, and DST's own auth check still gates the upgrade. The bridge is a dumb pipe.

## Verification

Live-tested against the running DST v11.0.3 instance using the actual Terminal protocol from `webui/src/api/terminal.ts`:

```
=== Through bridge  (ws://localhost:47902/ws/terminal) ===
Received 3 frames:
  {"cols":80,"cwd":"C:\\Users\\Coastal","type":"ready"}
  {"data":"WS_PROXY_TEST_12345\r\n","stream":"stdout","type":"output"}
  {"hadErrors":false,"durationMs":90,"cwd":"C:\\Users\\Coastal","type":"done"}

=== Direct to DST  (ws://127.0.0.1:47823/ws/terminal) ===
Received 3 frames:
  {"cols":80,"cwd":"C:\\Users\\Coastal","type":"ready"}
  {"data":"WS_PROXY_TEST_12345\r\n","stream":"stdout","type":"output"}
  {"hadErrors":false,"durationMs":51,"cwd":"C:\\Users\\Coastal","type":"done"}

Through bridge: match=True frames=3
Direct to DST : match=True frames=3
Frame-count parity: True
OK
```

Byte-identical frame stream, matching stdout payload, matching cwd, matching `hadErrors`. Bridge log shows a clean lifecycle:

```
WS   /ws/terminal from [::1]:64477 (closed)
```

No STA errors, no `VoidTaskResult` leakage, no leaked runspaces.

## No changes to v11.0.3 surface area

Still purely additive in `helper/`. `app/`, `webui/`, `site/`, `dune-server.ps1` untouched. CHANGELOG entry stays under `[Unreleased]`.

## Files

- `helper/bridge/DstHelperBridge.ps1` — `Start-WsPumpAsync`, `Invoke-WsProxy`, WS branch in `Invoke-Request`
- `CHANGELOG.md` — `[Unreleased]` addendum