### PR TITLE
ci(lint): parse-validate helper/*.ps1 on every PR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,37 @@ jobs:
           }
           Write-Host "Parse OK"
 
+      - name: Parse-validate helper/*.ps1
+        shell: pwsh
+        # Helper is an additive scaffold (`helper/bridge/`, `helper/friend/`)
+        # and is not loaded by dune-server.ps1, so it isn't covered by the
+        # main parse step. But these scripts ship to Neil's PC (bridge) and
+        # build the friend's .exe, so a parse regression here would silently
+        # break the helper without anyone noticing. Cheap to guard.
+        run: |
+          $any = Get-ChildItem -Path .\helper -Recurse -Filter *.ps1 -ErrorAction SilentlyContinue
+          if (-not $any) {
+              Write-Host "::warning::no helper/*.ps1 files found; skipping."
+              exit 0
+          }
+          $bad = 0
+          foreach ($f in $any) {
+              $errors = $null
+              [System.Management.Automation.Language.Parser]::ParseFile(
+                  $f.FullName, [ref]$null, [ref]$errors) | Out-Null
+              if ($errors -and $errors.Count -gt 0) {
+                  $rel = Resolve-Path -Relative $f.FullName
+                  foreach ($e in $errors) {
+                      Write-Host "::error file=$rel,line=$($e.Extent.StartLineNumber)::$($e.Message)"
+                  }
+                  $bad++
+              } else {
+                  Write-Host "  $($f.FullName) OK"
+              }
+          }
+          if ($bad -gt 0) { exit 1 }
+          Write-Host "All $($any.Count) helper script(s) parse OK"
+
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |


### PR DESCRIPTION
Tiny CI gap surfaced while smoke-testing the freshly-merged friend helper (#79 / #80): the `lint.yml` workflow only parse-validates `dune-server.ps1`. The four PowerShell scripts under `helper/` (`DstHelperBridge.ps1`, `Install-Bridge.ps1`, `Uninstall-Bridge.ps1`, `Build-FriendHelper.ps1`) aren't checked at all — so a syntax break here would land silently on a feature PR and only show up the next time someone tried to run the bridge.

## Change

Adds a new step "Parse-validate helper/*.ps1" between the dune-server parse and the PSScriptAnalyzer step. It walks `helper/` recursively, runs `[Parser]::ParseFile` on every `.ps1`, and emits GitHub-annotated errors with file + line.

```yaml
- name: Parse-validate helper/*.ps1
  shell: pwsh
  run: |
    $any = Get-ChildItem -Path .\helper -Recurse -Filter *.ps1 -ErrorAction SilentlyContinue
    ...
```

## Verification

Ran the same logic locally:

```
OK  : DstHelperBridge.ps1
OK  : Install-Bridge.ps1
OK  : Uninstall-Bridge.ps1
OK  : Build-FriendHelper.ps1
all 4 clean
```

## Scope

- Doesn't touch `dune-server.ps1`, PSScriptAnalyzer step, or the Remote.ps1 isolation guard.
- Doesn't bring in Pester or any new test framework.
- Skips gracefully (with a warning, not a failure) if `helper/` is ever removed.