### PR TITLE
ci(lint): repair PSScriptAnalyzer install on newer windows runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,9 +28,33 @@ jobs:
 
       - name: Install PSScriptAnalyzer
         shell: pwsh
+        # Newer windows-latest runner images don't pre-register PSGallery
+        # for the legacy PowerShellGet v2 cmdlets (Set-PSRepository fails
+        # with "No repository with the name 'PSGallery' was found"). Prefer
+        # PowerShellGet v3 (`Install-PSResource`), which ships with the
+        # pwsh on the runner and has PSGallery baked in. Fall back to the
+        # legacy path with explicit `Register-PSRepository -Default` if v3
+        # isn't available.
         run: |
-          Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
+          $installed = $false
+          if (Get-Command Install-PSResource -ErrorAction SilentlyContinue) {
+              try {
+                  Install-PSResource -Name PSScriptAnalyzer -Scope CurrentUser `
+                      -TrustRepository -Reinstall -ErrorAction Stop
+                  $installed = $true
+              } catch {
+                  Write-Host "::warning::Install-PSResource failed: $($_.Exception.Message). Falling back to Install-Module."
+              }
+          }
+          if (-not $installed) {
+              if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+                  Register-PSRepository -Default
+              }
+              Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+              Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
+          }
+          Import-Module PSScriptAnalyzer
+          (Get-Module PSScriptAnalyzer).Version
 
       - name: Parse-validate dune-server.ps1
         shell: pwsh


### PR DESCRIPTION
## What broke

Recent windows-latest runner image bumps stopped pre-registering PSGallery for the legacy PowerShellGet v2 cmdlets, so the first step of lint.yml:

```
Set-PSRepository PSGallery -InstallationPolicy Trusted
```

now fails with `No repository with the name 'PSGallery' was found` and the entire workflow exits 1 before any parsing happens. Caught on PR #81 (`ci(lint): parse-validate helper/*.ps1`); also blocks every other open PR.

## Fix

Switch the install step to **PowerShellGet v3 (`Install-PSResource`)**, which ships with the pwsh on the runner image and has PSGallery as a baked-in default resource. `-TrustRepository` handles the prompt that `Set-PSRepository ... Trusted` used to suppress.

Keeps a fallback to the legacy `Install-Module` path (with explicit `Register-PSRepository -Default`) in case the runner image ever regresses — costs nothing and means we won't have to revisit this if MS flip-flops.

Final `Import-Module` + version print gives a cheap signal in the CI log that the install actually worked.

## Verified locally

Same pwsh build the runner uses:

- `Get-Command Install-PSResource` -> exists
- `Get-PSResourceRepository -Name PSGallery` -> registered (Trusted=False, hence the `-TrustRepository` flag)
- PSScriptAnalyzer 1.25.0 installable and importable

## Scope

Only `.github/workflows/lint.yml`. No code changes. Once this lands, the other open PRs (#81, plus the upcoming `coastal-ms/rename-friend-exe`) can be rebased and re-checked.