### PR TITLE
refactor(helper): rename friend exe to DSTConsole.exe

### DIFF
--- a/helper/README.md
+++ b/helper/README.md
@@ -1,9 +1,10 @@
 # DST Friend Helper
 
-A standalone Windows app a trusted friend double-clicks on **his** PC to
-get into Neil's full DST desktop portal running on **Neil's** PC. Built as
-a purely additive scaffold on top of the released DST surface — **zero
-changes to `app/`, `webui/`, `site/`, or `dune-server.ps1`.**
+A standalone Windows app (`DSTConsole.exe`) a trusted friend double-clicks
+on **his** PC to get into Neil's full DST desktop portal running on
+**Neil's** PC. Built as a purely additive scaffold on top of the released
+DST surface — **zero changes to `app/`, `webui/`, `site/`, or
+`dune-server.ps1`.**
 
 ## Components
 
@@ -15,13 +16,13 @@ helper/
 │   ├── Uninstall-Bridge.ps1
 │   └── README.md
 └── friend/                 # Ships to the friend (single .exe + config.json)
-    ├── DstFriendHelper.csproj
+    ├── DSTConsole.csproj
     ├── App.xaml(.cs)
     ├── MainWindow.xaml(.cs)
     ├── Config.cs
     ├── app.manifest
     ├── config.sample.json
-    ├── Build-FriendHelper.ps1
+    ├── Build-DstConsole.ps1
     └── README.md
 ```
 
@@ -32,7 +33,7 @@ See each subdirectory's `README.md` for the install / build steps.
 ```mermaid
 sequenceDiagram
   autonumber
-  participant F as Friend's PC<br/>(DstFriendHelper.exe)
+  participant F as Friend's PC<br/>(DSTConsole.exe)
   participant TS as Tailscale tailnet
   participant B as Neil's PC<br/>(bridge :47900)
   participant D as Neil's PC<br/>(DST :random/?t=token)
@@ -93,17 +94,17 @@ current DuneToken — which is rotated on every DST launch.
 - [ ] Tag the host device `tag:dst-host` in the Tailscale admin panel.
 - [ ] Add the friend's device, tag it `tag:dst-friend`, and add the ACL
       stanza shown in `helper/bridge/README.md`.
-- [ ] Build the friend .exe: `helper\friend\Build-FriendHelper.ps1`.
-- [ ] Send `dist\DstFriendHelper.exe` + `dist\config.json` to the friend
+- [ ] Build the friend .exe: `helper\friend\Build-DstConsole.ps1`.
+- [ ] Send `dist\DSTConsole.exe` + `dist\config.json` to the friend
       (set `bridgeHost` to your Tailscale hostname first, or let the
       friend do it).
 
 ### Friend's side
 
 - [ ] Install Tailscale and accept Neil's invite.
-- [ ] Drop `DstFriendHelper.exe` and `config.json` in any folder.
+- [ ] Drop `DSTConsole.exe` and `config.json` in any folder.
 - [ ] Open `config.json`, set `bridgeHost` if Neil didn't pre-fill it.
-- [ ] Double-click `DstFriendHelper.exe`.
+- [ ] Double-click `DSTConsole.exe`.
 
 ## Known limitations (scaffold scope)
 

--- a/helper/friend/Build-DstConsole.ps1
+++ b/helper/friend/Build-DstConsole.ps1
@@ -1,11 +1,11 @@
 <#
 .SYNOPSIS
-    Builds the DstFriendHelper.exe as a self-contained single-file Windows
+    Builds DSTConsole.exe as a self-contained single-file Windows
     executable, ready to hand to a friend.
 
 .DESCRIPTION
     Wraps `dotnet publish` with the publish-time properties locked in. Output
-    lands in helper/friend/dist/. Drop DstFriendHelper.exe plus a populated
+    lands in helper/friend/dist/. Drop DSTConsole.exe plus a populated
     config.json into the same folder on the friend's PC.
 
 .PARAMETER Configuration
@@ -26,11 +26,11 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 $here = $PSScriptRoot
-$proj = Join-Path $here 'DstFriendHelper.csproj'
+$proj = Join-Path $here 'DSTConsole.csproj'
 $dist = Join-Path $here 'dist'
 
 if (-not (Test-Path -LiteralPath $proj)) {
-    throw "DstFriendHelper.csproj not found at $proj"
+    throw "DSTConsole.csproj not found at $proj"
 }
 
 # Clean previous dist so single-file size doesn't accumulate stale baggage.
@@ -39,7 +39,7 @@ if (Test-Path -LiteralPath $dist) {
 }
 New-Item -ItemType Directory -Path $dist | Out-Null
 
-Write-Host "Building DstFriendHelper ($Configuration / $Runtime) ..."
+Write-Host "Building DSTConsole ($Configuration / $Runtime) ..."
 
 & dotnet publish $proj `
     --configuration $Configuration `
@@ -66,5 +66,5 @@ Write-Host "Build complete." -ForegroundColor Green
 Write-Host "  Output:  $dist"
 Get-ChildItem $dist | Select-Object Name, Length | Format-Table -AutoSize
 Write-Host "Hand the friend:"
-Write-Host "  $dist\DstFriendHelper.exe"
+Write-Host "  $dist\DSTConsole.exe"
 Write-Host "  $dist\config.json   (edit bridgeHost to Neil's Tailscale hostname first)"

--- a/helper/friend/DSTConsole.csproj
+++ b/helper/friend/DSTConsole.csproj
@@ -15,12 +15,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <RootNamespace>DstFriendHelper</RootNamespace>
-    <AssemblyName>DstFriendHelper</AssemblyName>
+    <AssemblyName>DSTConsole</AssemblyName>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
     <Version>0.1.0</Version>
-    <Product>DST Friend Helper</Product>
-    <AssemblyTitle>DST Friend Helper</AssemblyTitle>
+    <Product>DST Console</Product>
+    <AssemblyTitle>DST Console</AssemblyTitle>
     <Company>Coastal</Company>
 
     <!-- Self-contained single-file publish: friend can just double-click. -->

--- a/helper/friend/MainWindow.xaml
+++ b/helper/friend/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
-        Title="Dune Server Tool — Friend Helper"
+        Title="Dune Server Tool — Console"
         Width="1280" Height="800"
         WindowStartupLocation="CenterScreen"
         Background="#0B0B0F">

--- a/helper/friend/MainWindow.xaml.cs
+++ b/helper/friend/MainWindow.xaml.cs
@@ -95,7 +95,7 @@ public partial class MainWindow : Window
         // collide with any other Edge install on the friend's PC.
         var userDataDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "DstFriendHelper",
+            "DSTConsole",
             "WebView2");
         Directory.CreateDirectory(userDataDir);
 

--- a/helper/friend/README.md
+++ b/helper/friend/README.md
@@ -20,7 +20,7 @@ Double-click to launch.
 - **Microsoft Edge WebView2 Runtime** (most systems already have it; if
   not, helper shows a dialog with the install link).
 - **Tailscale** signed in to the same tailnet as Neil's PC.
-- The shipped `DstFriendHelper.exe` and `config.json`.
+- The shipped `DSTConsole.exe` and `config.json`.
 
 That's it. No .NET install required (self-contained publish bundles the
 runtime), no admin rights required (manifest is `asInvoker`).
@@ -29,21 +29,21 @@ runtime), no admin rights required (manifest is `asInvoker`).
 
 1. Install Tailscale: <https://tailscale.com/download/windows>
 2. Sign in with the account Neil added you to.
-3. Drop `DstFriendHelper.exe` and `config.json` into any folder
+3. Drop `DSTConsole.exe` and `config.json` into any folder
    (e.g. `Documents\DstHelper`).
 4. Open `config.json` in Notepad and set `bridgeHost` to the Tailscale
    hostname Neil sent you (something like `neilpc.tailXXXX.ts.net`).
-5. Double-click `DstFriendHelper.exe`. Neil's portal opens in the
+5. Double-click `DSTConsole.exe`. Neil's portal opens in the
    window.
 
 ## Building from source (Neil side)
 
 ```powershell
 # from the repo root
-.\helper\friend\Build-FriendHelper.ps1
+.\helper\friend\Build-DstConsole.ps1
 ```
 
-This produces `helper\friend\dist\DstFriendHelper.exe` (+ a stub
+This produces `helper\friend\dist\DSTConsole.exe` (+ a stub
 `config.json`) as a self-contained single-file win-x64 publish. Hand
 both files to the friend.
 
@@ -53,7 +53,7 @@ The project file targets **`net8.0-windows`** with WPF. The .NET 10
 SDK installed on Neil's machine cross-targets net8.0 fine — NuGet
 auto-resolves the WindowsDesktop reference pack on first build. If
 your environment can't reach that pack (offline / mirror), change the
-`<TargetFramework>` in `DstFriendHelper.csproj` to `net10.0-windows`
+`<TargetFramework>` in `DSTConsole.csproj` to `net10.0-windows`
 and rebuild; the source compiles unchanged.
 
 ### Code-signing
@@ -83,10 +83,10 @@ scaffold.
 
 | File                      | Role                                              |
 | ------------------------- | ------------------------------------------------- |
-| `DstFriendHelper.csproj`  | WPF + WebView2 project, single-file publish.      |
+| `DSTConsole.csproj`       | WPF + WebView2 project, single-file publish.      |
 | `app.manifest`            | `asInvoker` execution level.                      |
 | `App.xaml` / `.xaml.cs`   | WPF application entry.                            |
 | `MainWindow.xaml` / `.cs` | Window with WebView2 + status overlay.            |
 | `Config.cs`               | `config.json` loader.                             |
 | `config.sample.json`      | Template the build script copies as `config.json`.|
-| `Build-FriendHelper.ps1`  | `dotnet publish` wrapper.                         |
+| `Build-DstConsole.ps1`    | `dotnet publish` wrapper.                         |

--- a/helper/friend/app.manifest
+++ b/helper/friend/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="0.1.0.0" name="DstFriendHelper.app" />
+  <assemblyIdentity version="0.1.0.0" name="DSTConsole.app" />
 
   <!-- asInvoker: no admin rights required. The friend just double-clicks. -->
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">


### PR DESCRIPTION
Renames the built friend binary from `DstFriendHelper.exe` to `DSTConsole.exe` and propagates the brand to the user-facing surface (window title, file properties, README references, build script).

## Surgical scope

| Change | From | To |
| --- | --- | --- |
| csproj `AssemblyName` | `DstFriendHelper` | `DSTConsole` (controls the .exe filename) |
| csproj `Product` / `AssemblyTitle` | `DST Friend Helper` | `DST Console` (file properties dialog) |
| csproj filename | `DstFriendHelper.csproj` | `DSTConsole.csproj` (git rename) |
| Build script | `Build-FriendHelper.ps1` | `Build-DstConsole.ps1` (git rename) |
| app.manifest `assemblyIdentity` name | `DstFriendHelper.app` | `DSTConsole.app` |
| Window title | `Dune Server Tool — Friend Helper` | `Dune Server Tool — Console` |
| WebView2 user data folder | `%LOCALAPPDATA%\DstFriendHelper\WebView2` | `%LOCALAPPDATA%\DSTConsole\WebView2` |
| READMEs | every reference to the old exe / csproj / build script name | new name |

## Deliberately NOT renamed

- **C# namespace** `DstFriendHelper` — internal, no user impact. Renaming would churn every `.cs` and `.xaml` for zero user-visible value.
- **The `helper/friend/` folder** — architectural name describing the audience, not the brand.
- **Bridge daemon naming** (scheduled task `DST Friend Helper Bridge`, firewall rule, function descriptions) — the bridge is a separate component from the friend's exe. Renaming the task name on already-installed bridges would orphan them.
- **The `helper/README.md` `# DST Friend Helper` headline** — still the accurate architectural term for the whole system. Clarified with `(DSTConsole.exe)` in the intro paragraph instead so the binary name is obvious from line 1.

## Verified

- `dotnet build .\helper\friend\DSTConsole.csproj` → `0 Warning(s) 0 Error(s)`, output is `DSTConsole.exe` (152 KB Debug stub; full self-contained publish via `Build-DstConsole.ps1` produces the ~72 MB single-file .exe).
- Assembly metadata via reflection on the built dll: `Product = 'DST Console'`, `AssemblyTitle = 'DST Console'`, `Company = 'Coastal'`.

## CI note

Will inherit the CI lint workflow from main. PR #82 (PSGallery fix) needs to land first or this PR's CI will hit the same Set-PSRepository failure. After #82 merges I'll rebase this branch.