### PR TITLE
feat: embed dune-admin web UI inside DST (v11.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,34 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.2.0] - 2026-06-05
+
 ### Added
+- **dune-admin embedded inside DST.** When DST detects a configured
+  dune-admin install (its `config.yaml` is parseable), a new **Dune
+  Admin** menu item appears immediately to the right of Help — with a
+  small green/grey dot indicating whether dune-admin is currently
+  listening. Clicking it routes to `/dune-admin`, which renders
+  dune-admin's full web UI in a flush iframe under a slim DST header
+  (Reload + "Open in browser" actions). When dune-admin isn't yet
+  listening, the page offers a one-click **Start** button that runs
+  the existing `dune-admin` command; the page then polls fast (1.5s)
+  until the UI is up, then drops back to a 15s heartbeat. The
+  Dashboard's "Start the Dune Admin Tool" button and the Settings page's
+  post-install launcher now route to this embed page instead of
+  spawning the dune-admin process into its own browser tab, so the user
+  experience is "click → see dune-admin inside DST" with no external
+  windows.
+
+- **Friend access to dune-admin via the bridge.** The embed page is
+  bridge-aware: when DST is being viewed through the Tailscale friend
+  bridge (i.e. `window.location.hostname` is the host's tailnet name
+  rather than 127.0.0.1), the iframe `src` is rewritten to
+  `http://<host-tailnet>:<dune-admin-port>` so the friend's WebView2
+  hits the host's dune-admin instance directly, reusing the existing
+  Tailscale ACL as the trust boundary. dune-admin's default listener
+  binds all interfaces, so no bridge proxy logic is needed.
+
 - **Friend helper — WebSocket proxy.** The bridge now transparently
   proxies WebSocket upgrades (`/ws/terminal` and friends) in addition
   to plain HTTP, so the friend gets a working Terminal page in
@@ -39,6 +66,29 @@ here cover everything those tags shipped.
   defense-in-depth. Explicit "no changes to released DST surface
   area" guarantee — `app/`, `webui/`, `site/`, and `dune-server.ps1`
   are untouched.
+
+### Changed
+- **Closing the DST window now stops the whole stack.** Previously,
+  closing the portal window left the elevated PowerShell backend
+  (`DuneServer.exe`) and any spawned `dune-admin` terminal silently
+  running in the background, which surprised users — especially now
+  that dune-admin renders inside the portal. The shell's `FormClosing`
+  handler now (1) fires a graceful `POST /api/shutdown` to the backend
+  using the same loopback URL+token the WebView is on (750ms hard
+  timeout so window close isn't perceptibly delayed), (2) terminates
+  any `dune-admin*` processes, and (3) sweeps up any remaining
+  `DuneServer.exe` as a safety net. Skipped when the shell is launched
+  standalone (`--no-wait-file`), where no paired backend is assumed.
+
+### Security
+- **CI PII guard** (`.github/workflows/pii-guard.yml`). After the
+  2026-06-05 incident in which a personal name was committed to
+  documentation and required a full filter-repo history rewrite, every
+  push and pull request is now scanned by GitHub Actions for a small
+  list of banned personal identifiers. The pattern is built at runtime
+  from per-character concatenation so the workflow file itself
+  doesn't trip the scan. Scan covers tracked files only (`.git/` and
+  `node_modules/` excluded). Required check on PRs.
 
 ## [11.1.0] - 2026-06-05
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.1.0</Version>
+    <Version>11.2.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Drawing;
+using System.Net.Http;
+using System.Text;
 using System.Windows.Forms;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.WinForms;
@@ -34,7 +36,11 @@ internal sealed class MainForm : Form
         BackColor = Color.FromArgb(17, 19, 24);
         TryLoadIcon();
 
-        FormClosing += (_, _) => SaveWindowState();
+        FormClosing += (_, _) =>
+        {
+            SaveWindowState();
+            StopCompanionProcesses();
+        };
 
         // The React portal owns its own top menu bar, so the native window has
         // just the WebView and a transient status label — no MenuStrip.
@@ -410,5 +416,113 @@ internal sealed class MainForm : Form
         {
             // best-effort; ignore
         }
+    }
+
+    /// <summary>
+    /// When the portal window closes, also stop the helper processes the user
+    /// thinks of as "DST": the elevated PowerShell backend (DuneServer.exe)
+    /// and the bundled dune-admin terminal window. Closing the visible window
+    /// used to leave both running silently in the background, which surprised
+    /// users — especially now that dune-admin can render inside this window
+    /// via the in-app embed, removing the last reason to keep its console
+    /// window alive separately.
+    ///
+    /// Order matters:
+    ///   1. Ask the backend to shut down gracefully via POST /api/shutdown.
+    ///      That endpoint flushes the response, stops the HttpListener, and
+    ///      lets the script exit cleanly, releasing its mutex and the
+    ///      battlegroup VM is left in a known state.
+    ///   2. Kill any dune-admin.exe processes. dune-admin has no graceful
+    ///      stop hook, but it's a stateless watcher — terminating it just
+    ///      closes the terminal window.
+    ///   3. Schedule a short fallback that force-kills DuneServer.exe a few
+    ///      seconds later in case the HTTP shutdown didn't take (backend
+    ///      hung, port already moved, etc.). The fallback runs on a thread
+    ///      pool task so we don't block the UI close.
+    ///
+    /// Skipped when the shell was launched standalone (`--no-wait-file`):
+    /// in that mode the shell wasn't started by the backend launcher and we
+    /// must not assume there's a paired DuneServer process to stop.
+    /// </summary>
+    private void StopCompanionProcesses()
+    {
+        if (!_useWaitFile) return;
+
+        // 1) Graceful backend shutdown via the same loopback URL + token the
+        //    WebView is using. Send synchronously with a tight timeout so we
+        //    don't drag out window close past ~750ms in the worst case.
+        try
+        {
+            string? url = _targetUrl;
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                try
+                {
+                    string file = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        "DuneServer", "last-url.txt");
+                    if (File.Exists(file)) url = File.ReadAllText(file).Trim();
+                }
+                catch { /* fall through to direct kill */ }
+            }
+
+            if (!string.IsNullOrWhiteSpace(url) &&
+                Uri.TryCreate(url, UriKind.Absolute, out var u))
+            {
+                using var http = new HttpClient { Timeout = TimeSpan.FromMilliseconds(750) };
+                var shutdownUri = new Uri(u, "/api/shutdown" + u.Query);
+                var content = new StringContent("{}", Encoding.UTF8, "application/json");
+                try { _ = http.PostAsync(shutdownUri, content).GetAwaiter().GetResult(); }
+                catch { /* expected when listener tears down before responding */ }
+            }
+        }
+        catch { /* best-effort */ }
+
+        // 2) Always terminate dune-admin terminal windows — they have no
+        //    graceful stop and are safe to nuke. Two binary names are possible
+        //    depending on the dune-admin build (Go binary or wrapper).
+        foreach (var name in new[] { "dune-admin", "dune-admin-windows-amd64" })
+        {
+            try
+            {
+                foreach (var p in Process.GetProcessesByName(name))
+                {
+                    try
+                    {
+                        if (!p.HasExited) p.Kill(entireProcessTree: true);
+                    }
+                    catch { /* access denied / already gone */ }
+                }
+            }
+            catch { /* defensive */ }
+        }
+
+        // 3) Sweep up any remaining DuneServer.exe. If /api/shutdown succeeded
+        //    above the process is already gone (or has HasExited=true) and
+        //    this is a no-op; if the listener was hung or the token expired,
+        //    this is the safety net that guarantees the user's intent ("close
+        //    the window, stop the service") actually happens. The name
+        //    "DuneServer" is unique to DST so killing by name is safe.
+        //
+        //    This MUST run synchronously inside FormClosing — scheduling it
+        //    on a background Task would not work because our own process
+        //    exits within milliseconds of this method returning, killing the
+        //    scheduled task before its delay elapses. We skip the current
+        //    process defensively in case a future build ever renames our own
+        //    exe to something that overlaps.
+        try
+        {
+            int me = Environment.ProcessId;
+            foreach (var p in Process.GetProcessesByName("DuneServer"))
+            {
+                try
+                {
+                    if (p.Id == me) continue;
+                    if (!p.HasExited) p.Kill(entireProcessTree: true);
+                }
+                catch { /* best-effort */ }
+            }
+        }
+        catch { /* defensive */ }
     }
 }

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.1.0"
+#define MyAppVersion "11.2.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.1.0"
+$script:ToolVersion = "11.2.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.1.0",
+  "version": "11.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -10,6 +10,7 @@ import { MapSpinUp } from './pages/MapSpinUp'
 import { SetupWizard } from './pages/SetupWizard'
 import { Settings } from './pages/Settings'
 import { TerminalPage } from './pages/Terminal'
+import { DuneAdmin } from './pages/DuneAdmin'
 import { PageStub } from './pages/PageStub'
 import { StatusProvider } from './hooks/useStatus'
 
@@ -28,6 +29,7 @@ export default function App() {
           <Route path="/map-spinup" element={<MapSpinUp />} />
           <Route path="/settings"   element={<Settings />} />
           <Route path="/setup"      element={<SetupWizard />} />
+          <Route path="/dune-admin" element={<DuneAdmin />} />
           {/* /monitoring merged into Dashboard in v6.1 — redirect old path */}
           <Route path="/monitoring" element={<Dashboard />} />
           <Route path="*"           element={<PageStub title="Not Found"   icon="HelpCircle"      description="No page at that path." phase="—" />} />

--- a/webui/src/hooks/useDuneAdminWebUrl.ts
+++ b/webui/src/hooks/useDuneAdminWebUrl.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getDuneAdminWebUrl, type DuneAdminWebUrl } from '../api/duneAdmin'
+
+const POLL_MS = 30_000
+
+export interface DuneAdminWebUrlState {
+  data: DuneAdminWebUrl | null
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+}
+
+/** Polls /api/dune-admin/web-url so anything that wants to react to whether
+ *  dune-admin is installed + currently listening can do so without each
+ *  consumer running its own poller. Default cadence is 30 s, which is fine
+ *  for menu visibility; the DuneAdmin page itself runs a faster local poller
+ *  (every couple seconds) while waiting for the process to come up after a
+ *  "Start dune-admin" click. */
+export function useDuneAdminWebUrl(intervalMs: number = POLL_MS): DuneAdminWebUrlState {
+  const [data, setData] = useState<DuneAdminWebUrl | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const inflight = useRef(false)
+
+  const run = useCallback(async () => {
+    if (inflight.current) return
+    inflight.current = true
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await getDuneAdminWebUrl()
+      setData(res)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      inflight.current = false
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void run()
+    const id = window.setInterval(() => { void run() }, intervalMs)
+    return () => window.clearInterval(id)
+  }, [run, intervalMs])
+
+  return { data, loading, error, refresh: run }
+}

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -3,9 +3,10 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import { Icon } from '../components/Icon'
 import { NAV_ITEMS, GROUP_LABELS, GROUP_ORDER, type NavGroup } from '../nav'
 import { useUpdateCheck } from '../hooks/useUpdateCheck'
+import { useDuneAdminWebUrl } from '../hooks/useDuneAdminWebUrl'
 import { buildDiagnosticBundle } from '../api/diagnostics'
 
-type MenuKey = NavGroup | 'help'
+type MenuKey = NavGroup | 'help' | 'duneadmin'
 
 type Props = {
   sidebarCollapsed: boolean
@@ -21,6 +22,7 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
   const navigate = useNavigate()
   const location = useLocation()
   const { data: upd } = useUpdateCheck()
+  const { data: da } = useDuneAdminWebUrl()
   const version = upd?.currentVersion ?? ''
   const [open, setOpen] = useState<MenuKey | null>(null)
   const rootRef = useRef<HTMLDivElement | null>(null)
@@ -161,6 +163,40 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
           </div>
         )}
       </div>
+
+      {/* Dune Admin appears immediately to the right of Help only when DST
+          detects a configured dune-admin install (config.yaml present). The
+          item itself is shown whether or not dune-admin is currently
+          listening — clicking it routes to /dune-admin, which then either
+          embeds the live web UI or offers a Start button. The whole entry
+          stays hidden for users who don't have the companion tool. */}
+      {da?.configured && (
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => { setOpen(null); navigate('/dune-admin') }}
+            onMouseEnter={() => { if (open !== null) setOpen(null) }}
+            className={`px-3 h-7 rounded-md transition-colors flex items-center gap-1.5 ${
+              isActive('/dune-admin')
+                ? 'bg-surface-3 text-text'
+                : 'text-text-muted hover:text-text hover:bg-surface-2/80'
+            }`}
+            title={
+              da.listening
+                ? `dune-admin live at ${da.url || `:${da.port}`}`
+                : `dune-admin installed but not running`
+            }
+          >
+            <span>Dune Admin</span>
+            <span
+              className={`w-1.5 h-1.5 rounded-full ${
+                da.listening ? 'bg-success' : 'bg-text-dim'
+              }`}
+              aria-hidden
+            />
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { PageHeader } from '../components/PageHeader'
 import { Icon } from '../components/Icon'
 import { useStatus } from '../hooks/useStatus'
@@ -92,6 +93,7 @@ function HeartbeatSensor({ servers, loading }: { servers: BgGameServer[]; loadin
 }
 
 export function Dashboard() {
+  const navigate = useNavigate()
   const { status, forceRefresh, loading } = useStatus()
 
   const vm = status?.vm
@@ -131,10 +133,7 @@ export function Dashboard() {
   const [exportMsg,  setExportMsg]  = useState<string | null>(null)
   const [exportErr,  setExportErr]  = useState<string | null>(null)
 
-  // Start the Dune Admin Tool — same action as the Commands "dune-admin" entry.
-  const [daBusy, setDaBusy] = useState(false)
-  const [daMsg,  setDaMsg]  = useState<string | null>(null)
-  const [daErr,  setDaErr]  = useState<string | null>(null)
+  // Start the Dune Admin Tool — navigates to the in-app embed page.
   // null = still checking; true/false = whether dune-admin.exe is located.
   const [daInstalled, setDaInstalled] = useState<boolean | null>(null)
 
@@ -146,17 +145,15 @@ export function Dashboard() {
     return () => { alive = false }
   }, [])
 
-  const startDuneAdmin = useCallback(async () => {
-    setDaBusy(true); setDaErr(null); setDaMsg(null)
-    try {
-      await api('/api/commands/run/dune-admin', { method: 'POST' })
-      setDaMsg('dune-admin launched — its web UI will open in your browser.')
-    } catch (e) {
-      setDaErr(e instanceof ApiError ? e.message : String(e))
-    } finally {
-      setDaBusy(false)
-    }
-  }, [])
+  const startDuneAdmin = useCallback(() => {
+    // Route to the in-app embed page instead of launching dune-admin's
+    // separate browser window. The embed page itself offers a Start button
+    // when dune-admin isn't yet listening, so the user flow becomes:
+    //   click "Open dune-admin" → embed page mounts → if not running, click
+    //   Start in the embed header. That replaces the prior detour through an
+    //   external browser tab.
+    navigate('/dune-admin')
+  }, [navigate])
 
   const runExport = useCallback(async (name: string, label: string) => {
     setExportBusy(name); setExportErr(null); setExportMsg(null)
@@ -330,32 +327,29 @@ export function Dashboard() {
             </a>
           </div>
           <p className="text-xs text-text-dim mb-3">
-            Launches dune-admin and opens its web UI. The VM must be running.
+            Opens dune-admin inside this window. The VM must be running.
           </p>
           <div className="flex flex-wrap gap-2">
             <button
               className="btn-primary"
-              disabled={daInstalled !== true || !vm?.running || daBusy}
+              disabled={daInstalled !== true || !vm?.running}
               onClick={() => { void startDuneAdmin() }}
               title={
                 daInstalled === false ? 'dune-admin.exe not found — install it from Settings first'
                   : daInstalled === null ? 'Checking dune-admin install…'
                   : !vm?.running ? 'VM must be running'
-                  : 'Launch dune-admin and open its web UI'
+                  : 'Open the dune-admin web UI inside DST'
               }
             >
               <Icon
-                name={daBusy ? 'Loader2' : daInstalled === false ? 'XCircle' : 'Play'}
+                name={daInstalled === false ? 'XCircle' : 'ExternalLink'}
                 size={14}
-                className={daBusy ? 'animate-spin' : ''}
               />
               {daInstalled === null ? 'Checking…'
                 : daInstalled === false ? 'Not installed'
-                : 'Start the Dune Admin Tool'}
+                : 'Open Dune Admin'}
             </button>
           </div>
-          {daMsg && <p className="mt-3 text-xs text-text-muted border-l-2 border-accent pl-2">{daMsg}</p>}
-          {daErr && <p className="mt-3 text-xs text-danger break-words">{daErr}</p>}
         </div>
 
         <div className="card p-5">

--- a/webui/src/pages/DuneAdmin.tsx
+++ b/webui/src/pages/DuneAdmin.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { Icon } from '../components/Icon'
+import { api, ApiError } from '../api/client'
+import { getDuneAdminWebUrl, type DuneAdminWebUrl } from '../api/duneAdmin'
+
+// While we're waiting for dune-admin to come up after a "Start" click, poll
+// fast so the iframe swaps in as soon as the port is listening.
+const FAST_POLL_MS = 1500
+// Once dune-admin is up and the iframe is rendered, slow the poll right down
+// — we only need to know if it goes away (e.g. crashes / killed manually) so
+// we can swap back to the start card.
+const SLOW_POLL_MS = 15_000
+
+export function DuneAdmin() {
+  const [info, setInfo] = useState<DuneAdminWebUrl | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [starting, setStarting] = useState(false)
+  const [startErr, setStartErr] = useState<string | null>(null)
+  const [iframeKey, setIframeKey] = useState(0)
+  const inflight = useRef(false)
+
+  const probe = useCallback(async () => {
+    if (inflight.current) return
+    inflight.current = true
+    try {
+      const res = await getDuneAdminWebUrl()
+      setInfo(res)
+    } catch {
+      // Backend hiccup; keep last known state, poll loop will retry.
+    } finally {
+      inflight.current = false
+      setLoading(false)
+    }
+  }, [])
+
+  // Initial probe + adaptive poll: fast while waiting for the port, slow once up.
+  useEffect(() => {
+    void probe()
+    const tick = () => { void probe() }
+    const ms = info?.listening ? SLOW_POLL_MS : FAST_POLL_MS
+    const id = window.setInterval(tick, ms)
+    return () => window.clearInterval(id)
+  }, [probe, info?.listening])
+
+  const startDuneAdmin = useCallback(async () => {
+    setStarting(true)
+    setStartErr(null)
+    try {
+      await api('/api/commands/run/dune-admin', { method: 'POST' })
+      // Give the process a beat to bind the port, then probe immediately so
+      // the user sees the iframe appear without waiting for the next poll.
+      window.setTimeout(() => { void probe() }, 500)
+    } catch (e) {
+      setStartErr(e instanceof ApiError ? e.message : String(e))
+    } finally {
+      setStarting(false)
+    }
+  }, [probe])
+
+  // Header bar with title + actions, shown above both the iframe and any
+  // status card so the page chrome doesn't jump around between states.
+  const header = (
+    <div className="h-9 shrink-0 border-b border-border bg-surface flex items-center gap-2 px-3 text-[12px]">
+      <Icon name="LayoutGrid" size={14} className="text-text-muted" />
+      <span className="text-text">Dune Admin</span>
+      {info?.listening && info.url && (
+        <span className="text-text-dim font-mono">{info.url}</span>
+      )}
+      <div className="flex-1" />
+      {info?.listening && (
+        <>
+          <button
+            type="button"
+            onClick={() => setIframeKey(k => k + 1)}
+            className="px-2 h-6 rounded text-text-muted hover:text-text hover:bg-surface-2 transition-colors flex items-center gap-1"
+            title="Reload the embedded dune-admin view"
+          >
+            <Icon name="RotateCw" size={12} />
+            <span>Reload</span>
+          </button>
+          {info.url && (
+            <a
+              href={info.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-2 h-6 rounded text-text-muted hover:text-text hover:bg-surface-2 transition-colors flex items-center gap-1"
+              title="Open dune-admin in your default browser"
+            >
+              <Icon name="ExternalLink" size={12} />
+              <span>Open in browser</span>
+            </a>
+          )}
+        </>
+      )}
+    </div>
+  )
+
+  // 1) Listening: render the iframe full-bleed below the header.
+  if (info?.configured && info.listening && info.url) {
+    // Build the iframe URL based on where the DST portal is currently being
+    // viewed FROM. On the host, window.location.hostname is 127.0.0.1 / localhost
+    // and the backend's url (also 127.0.0.1:<port>) works. When the portal is
+    // reached through the Tailscale friend bridge, window.location.hostname is
+    // the host's tailnet name — so we swap the iframe's hostname to match,
+    // pointing the friend's WebView2 at the host's dune-admin instead of the
+    // friend's own 127.0.0.1. Requires host-side firewall to allow inbound on
+    // dune-admin's port over the Tailscale interface (see helper/bridge).
+    const viewerHost = typeof window !== 'undefined' ? window.location.hostname : ''
+    const isLocalViewer = viewerHost === '127.0.0.1' || viewerHost === 'localhost' || viewerHost === ''
+    const iframeUrl = isLocalViewer
+      ? info.url
+      : `http://${viewerHost}:${info.port}`
+    return (
+      <div className="h-full flex flex-col">
+        {header}
+        <iframe
+          key={iframeKey}
+          src={iframeUrl}
+          title="dune-admin"
+          className="flex-1 w-full border-0 bg-white"
+        />
+      </div>
+    )
+  }
+
+  // 2) Not yet listening — render one of three status cards in the middle.
+  let body: ReactNode
+  if (loading && !info) {
+    body = (
+      <div className="text-center text-text-muted">
+        <Icon name="Loader2" size={20} className="animate-spin mx-auto mb-2" />
+        Checking dune-admin status…
+      </div>
+    )
+  } else if (!info?.configured) {
+    body = (
+      <div className="max-w-md text-center">
+        <Icon name="PackageOpen" size={28} className="text-text-muted mx-auto mb-3" />
+        <h2 className="text-base text-text mb-1">dune-admin isn't set up</h2>
+        <p className="text-sm text-text-muted mb-4">
+          DST didn't find a dune-admin install path in your config. Point Settings at a
+          dune-admin.exe (or run the Setup Wizard) and this page will embed it here.
+        </p>
+        <div className="flex items-center justify-center gap-2">
+          <Link
+            to="/settings"
+            className="px-3 h-8 rounded-md bg-accent text-accent-contrast hover:opacity-90 transition-opacity text-sm flex items-center gap-1.5"
+          >
+            <Icon name="Settings" size={13} />
+            Open Settings
+          </Link>
+          <Link
+            to="/setup"
+            className="px-3 h-8 rounded-md border border-border text-text-muted hover:text-text hover:bg-surface-2 transition-colors text-sm flex items-center gap-1.5"
+          >
+            <Icon name="Wand2" size={13} />
+            Setup Wizard
+          </Link>
+        </div>
+      </div>
+    )
+  } else {
+    body = (
+      <div className="max-w-md text-center">
+        <Icon name="Power" size={28} className="text-text-muted mx-auto mb-3" />
+        <h2 className="text-base text-text mb-1">dune-admin isn't running</h2>
+        <p className="text-sm text-text-muted mb-4">
+          Found at <span className="font-mono text-text">{info.listenAddr || `:${info.port}`}</span>{' '}
+          but nothing is listening yet. Start it and the web UI will load right here.
+        </p>
+        <button
+          type="button"
+          onClick={() => void startDuneAdmin()}
+          disabled={starting}
+          className="px-3 h-8 rounded-md bg-accent text-accent-contrast hover:opacity-90 transition-opacity text-sm flex items-center gap-1.5 mx-auto disabled:opacity-60"
+        >
+          <Icon name={starting ? 'Loader2' : 'Play'} size={13} className={starting ? 'animate-spin' : ''} />
+          {starting ? 'Starting…' : 'Start dune-admin'}
+        </button>
+        {startErr && (
+          <p className="mt-3 text-xs text-error">{startErr}</p>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      {header}
+      <div className="flex-1 flex items-center justify-center p-6">{body}</div>
+    </div>
+  )
+}

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { PageHeader } from '../components/PageHeader'
 import { Icon } from '../components/Icon'
 import { api } from '../api/client'
@@ -56,6 +57,7 @@ const FIELDS: {
 ]
 
 export function Settings() {
+  const navigate = useNavigate()
   const [cfg, setCfg] = useState<ConfigResponse | null>(null)
   const [values, setValues] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(true)
@@ -426,14 +428,14 @@ export function Settings() {
   } | null>(null)
 
   const pendingDaLaunchRef = useRef(false)
-  const launchDuneAdminApp = useCallback(async () => {
-    try {
-      await api('/api/commands/run/dune-admin', { method: 'POST' })
-      setDaMsg(prev => (prev ? prev + ' ' : '') + 'Opened dune-admin so you can re-setup the market bot.')
-    } catch (e) {
-      setDaErr(prev => (prev ? prev + ' ' : '') + `Could not open dune-admin automatically: ${e instanceof Error ? e.message : String(e)}`)
-    }
-  }, [])
+  const launchDuneAdminApp = useCallback(() => {
+    // Reroute to the in-app embed page (see Dashboard.startDuneAdmin for the
+    // rationale). The pricing-patch / setup flow that previously spawned the
+    // dune-admin executable in a separate console window now lands the user
+    // inside the iframe, which keeps the "everything inside DST" promise of
+    // the embed feature.
+    navigate('/dune-admin')
+  }, [navigate])
 
   async function onInstallDuneAdmin(skipDepCheck = false) {
     setDaInstalling(true)


### PR DESCRIPTION
## Summary

Bundles three user-facing changes into v11.2.0:

### 1. dune-admin embedded inside DST

- New conditional **Dune Admin** menu item appears immediately to the right of Help **only** when DST detects a configured dune-admin install (`config.yaml` parseable). A small green/grey dot indicates whether dune-admin is currently listening.
- Clicking routes to `/dune-admin`, which renders dune-admin's full web UI in a flush iframe under a slim DST header (Reload + "Open in browser" actions).
- When dune-admin isn't yet listening: page offers one-click **Start**, polls fast (1.5s) until up, then drops to 15s heartbeat.
- Dashboard's "Start the Dune Admin Tool" button and Settings page's post-install launcher now route to the embed page — no more external browser tabs.

### 2. Friend access to dune-admin via the bridge

- Embed page is bridge-aware: when DST is viewed through the Tailscale friend bridge (i.e. `window.location.hostname` is the host's tailnet name, not 127.0.0.1), the iframe `src` is rewritten to `http://<host-tailnet>:<dune-admin-port>` so the friend's WebView2 hits the host's dune-admin instance directly.
- dune-admin defaults to binding all interfaces, so no bridge proxy logic is needed — trust boundary is the Tailscale ACL (same as the existing helper).

### 3. Closing DST stops the whole stack

- `FormClosing` now fires graceful `POST /api/shutdown` (750ms timeout) → kills `dune-admin*` processes → sweeps any surviving `DuneServer.exe`.
- Skipped when shell launched standalone (`--no-wait-file`).
- Rationale: now that dune-admin renders inside the portal, leaving its separate terminal window running silently after the user closes DST is exactly the kind of "why does the company require this, where AI has to fix it" UX the user called out earlier.

## Files

| File | Change |
|---|---|
| `webui/src/hooks/useDuneAdminWebUrl.ts` | NEW — 30s poll for dune-admin web URL status |
| `webui/src/pages/DuneAdmin.tsx` | NEW — embed page with adaptive polling + bridge-aware iframe URL |
| `webui/src/App.tsx` | + `/dune-admin` route |
| `webui/src/layout/MenuBar.tsx` | + conditional menu item right of Help |
| `webui/src/pages/Dashboard.tsx` | repoint launcher to `navigate('/dune-admin')` |
| `webui/src/pages/Settings.tsx` | repoint launcher to `navigate('/dune-admin')` |
| `app/desktop/DuneShell/MainForm.cs` | `FormClosing` → stop backend + dune-admin |
| `dune-server.ps1`, `DuneShell.csproj`, `webui/package.json`, `DuneServer.iss` | version bump 11.1.0 → 11.2.0 |
| `CHANGELOG.md` | new 11.2.0 entry (rolled up from Unreleased) |

## Verification

- `webui` builds clean (`npm run build`)
- `DuneShell.csproj` builds clean (`dotnet build -c Release`)
- PII guard self-scan: 0 hits
- Installer will be built and uploaded via the standard `app\installer\Build-Installer.ps1` flow after merge.