### PR TITLE
feat(ui): full-bleed Dune Admin embed below the menu bar

### DIFF
--- a/webui/src/layout/AppShell.tsx
+++ b/webui/src/layout/AppShell.tsx
@@ -1,12 +1,32 @@
 import type { ReactNode } from 'react'
+import { useLocation } from 'react-router-dom'
 import { MenuBar } from './MenuBar'
 import { Sidebar } from './Sidebar'
 import { StatusBar } from './StatusBar'
 import { UpdateBanner } from '../components/UpdateBanner'
 import { useSidebarCollapsed } from '../hooks/useSidebarCollapsed'
 
+// Routes that should render full-bleed below the menu bar — no sidebar, no
+// status bar, no update banner, no max-width / padding. Keep the top menu bar
+// because that's how the user navigates back out of the immersive view.
+const IMMERSIVE_ROUTES = new Set<string>(['/dune-admin'])
+
 export function AppShell({ children }: { children: ReactNode }) {
   const { collapsed, toggle } = useSidebarCollapsed()
+  const { pathname } = useLocation()
+  const immersive = IMMERSIVE_ROUTES.has(pathname)
+
+  if (immersive) {
+    return (
+      <div className="h-full flex flex-col overflow-hidden">
+        <MenuBar sidebarCollapsed={collapsed} onToggleSidebar={toggle} />
+        <main className="flex-1 min-h-0 overflow-hidden">
+          {children}
+        </main>
+      </div>
+    )
+  }
+
   return (
     <div className="h-full flex flex-col overflow-hidden">
       <MenuBar sidebarCollapsed={collapsed} onToggleSidebar={toggle} />


### PR DESCRIPTION
Folds into v11.2.0 — installer rebuild after merge.

When /dune-admin is active, AppShell hides the sidebar + status bar + update banner + max-width padding. Only the top menu bar stays so the user can click off (Server Health, PowerShell, etc.) to leave the immersive view.