### PR TITLE
v11.2.0 UX polish: single-item menu + dune-admin browser suppress

### DIFF
--- a/app/server/lib/Commands.ps1
+++ b/app/server/lib/Commands.ps1
@@ -324,7 +324,17 @@ function Get-DuneCommandByName {
 # UI used for external commands. Phase 4 will route InApp commands through the
 # embedded terminal instead; for now everything opens a console window.
 function Invoke-DuneCommandExternal {
-    param([string]$Name)
+    param(
+        [string]$Name,
+        # When the API command runner spawns dune-admin, the DST embed tab is
+        # already showing dune-admin via iframe — so dune-server.ps1's default
+        # behavior of Start-Process'ing the URL in the user's browser would
+        # pop a redundant second window. Setting this env var on the spawned
+        # process tells dune-server.ps1's dune-admin handler to skip the
+        # browser launch. CLI users running the command directly still get
+        # the browser open as before.
+        [switch]$SuppressBrowser
+    )
     if (-not $script:PwshExe -or -not $script:MainScript) {
         throw "Command execution not configured (pwsh.exe or dune-server.ps1 missing)."
     }
@@ -345,7 +355,27 @@ function Invoke-DuneCommandExternal {
         Verb             = 'RunAs'   # dune-server.ps1 requires admin
         PassThru         = $true
     }
-    $proc = Start-Process @startArgs
+    # Default to suppressing the browser for the dune-admin command — the
+    # DST embed tab is the canonical viewer now. Callers can pass
+    # -SuppressBrowser:$false to override.
+    $shouldSuppress = if ($PSBoundParameters.ContainsKey('SuppressBrowser')) {
+        [bool]$SuppressBrowser
+    } else {
+        $cmd.Name -eq 'dune-admin'
+    }
+
+    $prevValue = $env:DST_DUNE_ADMIN_NO_BROWSER
+    try {
+        if ($shouldSuppress) { $env:DST_DUNE_ADMIN_NO_BROWSER = '1' }
+        $proc = Start-Process @startArgs
+    } finally {
+        # Restore the parent's env so subsequent commands aren't affected.
+        if ($null -eq $prevValue) {
+            Remove-Item Env:\DST_DUNE_ADMIN_NO_BROWSER -ErrorAction SilentlyContinue
+        } else {
+            $env:DST_DUNE_ADMIN_NO_BROWSER = $prevValue
+        }
+    }
     return @{
         ok      = $true
         name    = $cmd.Name

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -2312,10 +2312,19 @@ while ($true) {
             # 'localhost' (127.0.0.1-first) would open AMP's panel — use [::1].
             $urlHost = Get-DuneAdminUrlHost -Port $webState.Port -AdminProcName $adminProcName
             $openUrl = "http://${urlHost}:$($webState.Port)/#/players"
-            # Start-Process <url> uses the registered https:// protocol handler,
-            # honoring the user's default browser (avoids Win11 24H2's Edge bug).
-            Start-Process $openUrl
-            Write-Host "Done. dune-admin is listening on port $($webState.Port); web UI opened in browser ($openUrl)." -ForegroundColor Green
+            # The DST embed tab is the canonical dune-admin viewer now, so the
+            # API command runner sets DST_DUNE_ADMIN_NO_BROWSER=1 to stop us
+            # from popping a redundant second browser window over the iframe.
+            # CLI users running this command directly have the env var unset
+            # and still get the browser open.
+            if ($env:DST_DUNE_ADMIN_NO_BROWSER -eq '1') {
+                Write-Host "Done. dune-admin is listening on port $($webState.Port) ($openUrl). Browser skipped (DST embed tab is active)." -ForegroundColor Green
+            } else {
+                # Start-Process <url> uses the registered https:// protocol handler,
+                # honoring the user's default browser (avoids Win11 24H2's Edge bug).
+                Start-Process $openUrl
+                Write-Host "Done. dune-admin is listening on port $($webState.Port); web UI opened in browser ($openUrl)." -ForegroundColor Green
+            }
         } elseif ($conflictOwner) {
             Write-Host ""
             Write-Host "Port $($webState.Port) is in use by '$conflictOwner' (not dune-admin)." -ForegroundColor Yellow

--- a/webui/src/layout/AppShell.tsx
+++ b/webui/src/layout/AppShell.tsx
@@ -1,12 +1,32 @@
 import type { ReactNode } from 'react'
+import { useLocation } from 'react-router-dom'
 import { MenuBar } from './MenuBar'
 import { Sidebar } from './Sidebar'
 import { StatusBar } from './StatusBar'
 import { UpdateBanner } from '../components/UpdateBanner'
 import { useSidebarCollapsed } from '../hooks/useSidebarCollapsed'
 
+// Routes that should render full-bleed below the menu bar — no sidebar, no
+// status bar, no update banner, no max-width / padding. Keep the top menu bar
+// because that's how the user navigates back out of the immersive view.
+const IMMERSIVE_ROUTES = new Set<string>(['/dune-admin'])
+
 export function AppShell({ children }: { children: ReactNode }) {
   const { collapsed, toggle } = useSidebarCollapsed()
+  const { pathname } = useLocation()
+  const immersive = IMMERSIVE_ROUTES.has(pathname)
+
+  if (immersive) {
+    return (
+      <div className="h-full flex flex-col overflow-hidden">
+        <MenuBar sidebarCollapsed={collapsed} onToggleSidebar={toggle} />
+        <main className="flex-1 min-h-0 overflow-hidden">
+          {children}
+        </main>
+      </div>
+    )
+  }
+
   return (
     <div className="h-full flex flex-col overflow-hidden">
       <MenuBar sidebarCollapsed={collapsed} onToggleSidebar={toggle} />

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -81,6 +81,31 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
       {GROUP_ORDER.map(g => {
         const items = NAV_ITEMS.filter(i => i.group === g)
         if (items.length === 0) return null
+        // Single-item group (e.g. Server Health, which has only one page):
+        // a dropdown with one entry is pure friction. Render the group
+        // button as a direct link to that page instead. The button label
+        // stays as the group label so the menu bar's visual layout is
+        // unchanged; only the click behavior differs.
+        if (items.length === 1) {
+          const only = items[0]
+          const active = isActive(only.to)
+          return (
+            <div key={g} className="relative">
+              <button
+                type="button"
+                onClick={() => { setOpen(null); navigate(only.to) }}
+                onMouseEnter={() => { if (open !== null) setOpen(null) }}
+                className={`px-3 h-7 rounded-md transition-colors ${
+                  active
+                    ? 'bg-surface-3 text-text'
+                    : 'text-text-muted hover:text-text hover:bg-surface-2/80'
+                }`}
+              >
+                {GROUP_LABELS[g]}
+              </button>
+            </div>
+          )
+        }
         const isOpen = open === g
         return (
           <div key={g} className="relative">


### PR DESCRIPTION
Two small folds into v11.2.0 before the release ships:

1. Single-item menu groups (Server Health) render as direct links instead of one-item dropdowns.
2. Suppress dune-admin browser auto-open when launched from the DST embed tab. The embed already shows dune-admin in an iframe; the API runner now sets DST_DUNE_ADMIN_NO_BROWSER=1 to stop dune-server.ps1 from popping a redundant browser window. CLI users unaffected.