### PR TITLE
feat(console): merge dune-admin into DuneServer's console window (v11.3.0)

### DIFF
--- a/.github/PARKED-console-merge.md
+++ b/.github/PARKED-console-merge.md
@@ -1,0 +1,51 @@
+# v11.3.0 — Merge backend + dune-admin into one combined console window
+
+## Decision
+
+User picked "merge into one combined console window" when asked how to handle the multiple console windows that pop up when DST + dune-admin run side by side. Currently:
+
+- `DuneServer.exe` — visible console (minimized at startup, owned by PS2EXE-wrapped backend)
+- `dune-admin.exe` — separate console window when launched
+- `DuneShell.exe` — main WPF window (the DST UI)
+
+Goal: one combined console window showing both backend AND dune-admin output, interleaved with `[backend]` / `[admin]` line prefixes.
+
+## Approach (parked design)
+
+The cleanest implementation that avoids re-architecting elevation:
+
+1. **Hide dune-admin's own console window.** Change the scheduled-task launch in `dune-server.ps1` (around line 2260) from `New-ScheduledTaskAction -Execute $duneAdminExe` to a `cmd.exe` wrapper that redirects stdout/stderr to a known log file:
+   ```powershell
+   $logPath = Join-Path $env:LOCALAPPDATA 'DuneServer\logs\dune-admin.log'
+   $wrappedCmd = "/c `"`"$duneAdminExe`" 1>>`"$logPath`" 2>&1`""
+   $action = New-ScheduledTaskAction -Execute 'cmd.exe' -Argument $wrappedCmd -WorkingDirectory $duneAdminDir
+   $settings = New-ScheduledTaskSettingsSet -Hidden -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+   ```
+
+2. **Tail the log file from the main DuneServer process.** Add a helper in `app/server/lib/ConsoleHost.ps1` that creates a dedicated runspace which runs `Get-Content -Wait` on the dune-admin log file and calls `[Console]::WriteLine("[admin] $_")` for every new line. `[Console]` is process-static so writes from the runspace land in DuneServer's existing console window.
+
+3. **Lifecycle.** Start the mirror runspace from `Start-DuneHttpServer` (right after the listener is bound, alongside `Start-DuneConsoleLifecycle`). Tear it down from `Stop-DuneConsoleLifecycle` the same way the watcher + tray runspaces are torn down.
+
+4. **Prefix the backend's own output too.** Wrap `Write-DuneLog` (or `Write-Host`) calls so they print `[backend] ...` to console, matching the `[admin]` prefix. Optional but makes the merged stream readable.
+
+## Why this approach
+
+- No elevation surgery. dune-admin still runs unelevated via scheduled task; DuneServer stays elevated.
+- No need to restructure the spawn/IPC architecture.
+- Both streams visibly merge in ONE existing console window (DuneServer's). Zero extra windows. dune-admin's console is gone.
+- Log file at `%LOCALAPPDATA%\DuneServer\logs\dune-admin.log` is also durable for diagnostics.
+
+## Out of scope
+
+- True multiplexed-pipe approach with prefix-per-line in real time (would require dropping the scheduled-task launch and re-architecting elevation; not worth it for the marginal UX win over file-tail).
+- An in-app web console page (separate idea — could be a v11.4.0 add-on layered on top of this).
+
+## Files to touch (when ready)
+
+- `dune-server.ps1` ~line 2260: scheduled-task action change
+- `app/server/lib/ConsoleHost.ps1`: add `Start-DuneAdminLogMirror` + `Stop-DuneAdminLogMirror`
+- `app/server/HttpServer.ps1`: call mirror start/stop alongside existing lifecycle hooks
+
+## Status
+
+**PARKED** as of 2026-06-05. Branch exists; not implemented. To pick up: branch off `coastal-ms/console-merge`, follow the plan above, ship as v11.3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.3.0] - 2026-06-05
+
+### Changed
+- **Combined console window — backend + dune-admin streams in one place.**
+  Previously DST and dune-admin each opened their own Windows console
+  window, so the desktop had two consoles to track. dune-admin now
+  launches with its console hidden (scheduled task wrapped in `cmd.exe`
+  with stdout/stderr redirected to
+  `%LOCALAPPDATA%\DuneServer\logs\dune-admin.log`) and the DuneServer
+  process tails that log in a background runspace, mirroring every line
+  into its own console with an `[admin]` prefix. Net result: one console
+  window showing backend output and dune-admin output interleaved, with
+  the dune-admin lines clearly labelled. The dune-admin web UI (and the
+  Dune Admin embed tab inside DST) is unaffected — only the on-host
+  console window changes.
+
 ## [11.2.0] - 2026-06-05
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.2.0'
+$script:DuneToolVersion = '11.3.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.2.0',
+    [string]$Version = '11.3.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.2.0</Version>
+    <Version>11.3.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.2.0"
+#define MyAppVersion "11.3.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/ConsoleHost.ps1
+++ b/app/server/lib/ConsoleHost.ps1
@@ -256,6 +256,11 @@ function Start-DuneConsoleLifecycle {
     $mode = if ($script:DuneConsoleMode) { $script:DuneConsoleMode } else { 'console' }
     Clear-DuneAppDetached
 
+    # Mirror dune-admin stdout/stderr into THIS console so the operator sees
+    # one combined stream. Safe to call eagerly: it's a no-op if dune-admin
+    # never runs, and the tail loop re-attaches if the log file appears later.
+    try { Start-DuneAdminLogMirror } catch {}
+
     # 1. Real-time linkage: app window closes -> stop listener -> server exits.
     try {
         $rs = [runspacefactory]::CreateRunspace()
@@ -380,9 +385,122 @@ function Stop-DuneConsoleLifecycle {
     $script:DuneWatcherPs = $null; $script:DuneWatcherRs = $null; $script:DuneWatcherHandle = $null
     $script:DuneTrayPs    = $null; $script:DuneTrayRs    = $null; $script:DuneTrayHandle    = $null
 
+    # Tear down the dune-admin -> console mirror runspace if armed.
+    try { Stop-DuneAdminLogMirror } catch {}
+
     # Clear the detach marker on a clean shutdown so the next launch starts
     # from a known state. The next launch ALSO clears it after handling, so
     # this is just defense-in-depth (the marker is only meaningful while a
     # detached server is alive in the background).
     Clear-DuneAppDetached
+}
+
+# ---------------------------------------------------------------------------
+# Dune-admin log mirror — merge dune-admin's stdout/stderr into THIS console
+# so the user sees backend + dune-admin output in one window instead of two.
+#
+# Architecture:
+#   dune-server.ps1's `dune-admin` command launches dune-admin via a HIDDEN
+#   scheduled task whose action is `cmd.exe /c "<exe> 1>>"<log>" 2>&1"`. That
+#   redirects dune-admin's stdout/stderr to a well-known log file AND hides
+#   its window. The mirror runspace below tails that log file in real time
+#   and writes each new line to DuneServer's console with an `[admin]` prefix,
+#   so the user sees both streams in DuneServer's existing console window.
+#
+# This is the v11.3.0 "merge backend + dune-admin into one combined console
+# window" feature — the design parked in .github/PARKED-console-merge.md.
+# ---------------------------------------------------------------------------
+
+function Get-DuneAdminMirrorLogPath {
+    $dir = Join-Path $env:LOCALAPPDATA 'DuneServer\logs'
+    return (Join-Path $dir 'dune-admin.log')
+}
+
+function Start-DuneAdminLogMirror {
+    # No-op if a mirror is already running for this DuneServer process — the
+    # lifecycle hook may be called more than once across restart cycles.
+    if ($script:DuneAdminMirrorPs -and $script:DuneAdminMirrorHandle -and -not $script:DuneAdminMirrorHandle.IsCompleted) {
+        return
+    }
+    $logPath = Get-DuneAdminMirrorLogPath
+    $logDir  = Split-Path -Parent $logPath
+    try {
+        if (-not (Test-Path -LiteralPath $logDir)) {
+            New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+        }
+        # Touch the file so Get-Content -Wait has something to attach to from
+        # the start; otherwise it errors until dune-admin runs for the first
+        # time. The mirror's loop is also resilient to the file being deleted.
+        if (-not (Test-Path -LiteralPath $logPath)) {
+            New-Item -ItemType File -Path $logPath -Force | Out-Null
+        }
+    } catch {
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "Could not prep dune-admin mirror log dir: $($_.Exception.Message)" 'WARN'
+        }
+        return
+    }
+
+    try {
+        $rs = [runspacefactory]::CreateRunspace()
+        $rs.Open()
+        $rs.SessionStateProxy.SetVariable('LogPath', $logPath)
+        $ps = [PowerShell]::Create()
+        $ps.Runspace = $rs
+        [void]$ps.AddScript({
+            # Long-running tail loop. Get-Content -Wait blocks until killed by
+            # PowerShell.Stop() during shutdown. Wrapped so a transient file
+            # disappearance (e.g. user deletes the log while dune-admin is
+            # restarting) doesn't kill the mirror — we re-attach when the file
+            # reappears.
+            while ($true) {
+                try {
+                    if (-not (Test-Path -LiteralPath $LogPath)) {
+                        Start-Sleep -Seconds 2
+                        continue
+                    }
+                    # -Tail 0 = "stream only NEW lines from now on", so a
+                    # restart doesn't dump a huge historical replay into the
+                    # console. -Wait blocks waiting for additions until the
+                    # runspace is stopped.
+                    Get-Content -LiteralPath $LogPath -Wait -Tail 0 -ErrorAction Stop | ForEach-Object {
+                        if ($null -ne $_ -and $_ -ne '') {
+                            # [Console] is process-static, so this writes to
+                            # DuneServer's visible console window even though
+                            # we're inside a separate runspace.
+                            [Console]::WriteLine("[admin] $_")
+                        }
+                    }
+                } catch {
+                    # File got rotated / deleted / locked — back off briefly
+                    # and re-attach. Stop only happens via PowerShell.Stop()
+                    # which throws PipelineStoppedException out of this loop.
+                    Start-Sleep -Seconds 2
+                }
+            }
+        })
+        $script:DuneAdminMirrorPs     = $ps
+        $script:DuneAdminMirrorRs     = $rs
+        $script:DuneAdminMirrorHandle = $ps.BeginInvoke()
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "Dune-admin console mirror armed (tailing $logPath -> [admin] prefix)"
+        }
+    } catch {
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "Failed to start dune-admin log mirror: $($_.Exception.Message)" 'WARN'
+        }
+    }
+}
+
+function Stop-DuneAdminLogMirror {
+    try {
+        if ($script:DuneAdminMirrorPs -and $script:DuneAdminMirrorHandle -and -not $script:DuneAdminMirrorHandle.IsCompleted) {
+            try { $script:DuneAdminMirrorPs.Stop() } catch {}
+        }
+        try { if ($script:DuneAdminMirrorPs) { $script:DuneAdminMirrorPs.Dispose() } } catch {}
+        try { if ($script:DuneAdminMirrorRs) { $script:DuneAdminMirrorRs.Dispose() } } catch {}
+    } catch {}
+    $script:DuneAdminMirrorPs     = $null
+    $script:DuneAdminMirrorRs     = $null
+    $script:DuneAdminMirrorHandle = $null
 }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.2.0"
+$script:ToolVersion = "11.3.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a
@@ -2255,11 +2255,27 @@ while ($true) {
             # own free 127.0.0.1 loopback port BEFORE launch so it binds IPv4
             # cleanly and the UI opens on a normal name (no [::1]).
             try { Set-DuneAdminOwnLoopbackPort | Out-Null } catch { Write-Warning "Port pre-flight failed: $($_.Exception.Message)" }
-            # Launch as the logged-in user via scheduled task (avoids admin elevation)
+            # Launch as the logged-in user via scheduled task (avoids admin elevation).
+            # Wrap in cmd.exe with stdout/stderr redirected to %LOCALAPPDATA%\DuneServer\logs\dune-admin.log
+            # AND mark the task settings -Hidden so dune-admin's own console
+            # window never appears. The DuneServer process tails that log and
+            # mirrors each line into THIS console with an [admin] prefix, giving
+            # the operator one combined console window instead of two. See
+            # Start-DuneAdminLogMirror in app/server/lib/ConsoleHost.ps1.
             try {
-                $action = New-ScheduledTaskAction -Execute $duneAdminExe -WorkingDirectory $duneAdminDir
+                $duneAdminLogDir  = Join-Path $env:LOCALAPPDATA 'DuneServer\logs'
+                $duneAdminLogPath = Join-Path $duneAdminLogDir 'dune-admin.log'
+                if (-not (Test-Path -LiteralPath $duneAdminLogDir)) {
+                    New-Item -ItemType Directory -Path $duneAdminLogDir -Force | Out-Null
+                }
+                # cmd.exe argument string: /c "<exe>" 1>>"<log>" 2>&1
+                # The whole /c value is wrapped in outer quotes so cmd treats
+                # the redirected paths as one logical command.
+                $cmdArgs = '/c "' + '"' + $duneAdminExe + '"' + ' 1>>' + '"' + $duneAdminLogPath + '"' + ' 2>&1' + '"'
+                $action    = New-ScheduledTaskAction -Execute 'cmd.exe' -Argument $cmdArgs -WorkingDirectory $duneAdminDir
+                $settings  = New-ScheduledTaskSettingsSet -Hidden -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
                 $principal = New-ScheduledTaskPrincipal -UserId $windowsUser -LogonType Interactive -RunLevel Limited
-                Register-ScheduledTask -TaskName "DuneAdminLaunch" -Action $action -Principal $principal -Force | Out-Null
+                Register-ScheduledTask -TaskName "DuneAdminLaunch" -Action $action -Principal $principal -Settings $settings -Force | Out-Null
                 Start-ScheduledTask -TaskName "DuneAdminLaunch"
                 Start-Sleep -Seconds 1
                 Unregister-ScheduledTask -TaskName "DuneAdminLaunch" -Confirm:$false

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.2.0",
+  "version": "11.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Replaces the two-console-window experience (DuneServer + dune-admin) with one combined window.

## Behaviour change

- dune-admin's scheduled-task action is now `cmd.exe /c "<exe>" 1>>"<log>" 2>&1`, and the task settings are flagged `-Hidden`. dune-admin's own console window never appears.
- A background runspace inside `DuneServer.exe` tails `%LOCALAPPDATA%\DuneServer\logs\dune-admin.log` with `Get-Content -Wait` and writes each new line to DuneServer's existing console with an `[admin]` prefix.
- Net: one console window. Backend output and dune-admin output interleave there, with `[admin]` clearly marking dune-admin lines.

## What this does NOT change

- dune-admin's web UI is untouched — it keeps serving HTTP normally.
- The Dune Admin embed tab inside DST still iframes that web UI.
- The friend remote experience (DSTConsole.exe → Tailscale → DST web UI → Dune Admin embed) is completely unaffected — they never saw host-side console windows in the first place.

## Implementation

- `dune-server.ps1` — switched the `dune-admin` command's `Register-ScheduledTask` action to a cmd.exe wrapper with redirected stdout/stderr and `-Hidden` settings.
- `app/server/lib/ConsoleHost.ps1` — added `Get-DuneAdminMirrorLogPath`, `Start-DuneAdminLogMirror`, `Stop-DuneAdminLogMirror`. Mirror runspace is resilient to the log file disappearing (re-attaches after a backoff). Wired into `Start-DuneConsoleLifecycle` and `Stop-DuneConsoleLifecycle` so it follows the existing watcher/tray lifecycle.
- `CHANGELOG.md` — new `[11.3.0]` entry under Changed.
- Version bumps `11.2.0 → 11.3.0` in: `webui/package.json`, `app/installer/DuneServer.iss`, `app/DuneServer.ps1`, `dune-server.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`.

## Origin

Implements the design previously parked at `.github/PARKED-console-merge.md` (this branch was the parking spot).