### PR TITLE
fix(remote): bind dune-admin 0.0.0.0 + firewall rule for friend portal access (v11.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.3.1] - 2026-06-05
+
+### Fixed
+- **dune-admin reachable through the friend remote-portal bridge.**
+  v11.2.0 added the friend helper (DSTConsole.exe) and the Dune Admin
+  embed tab, but dune-admin was still bound to `127.0.0.1` only — so
+  when the friend loaded the embed tab through Tailscale, the iframe
+  pointed at the host's tailnet name on dune-admin's port and got a
+  "took too long to respond" error because nothing answered on that
+  interface. DST now rewrites dune-admin's `listen_addr` to
+  `0.0.0.0:<port>` and opens a matching Windows Firewall inbound rule
+  (Private + Domain profiles — Tailscale's tun adapter is Private)
+  whenever it launches dune-admin. Both ops are idempotent and run
+  every launch. dune-admin's own auth still gates the surface.
+
 ## [11.3.0] - 2026-06-05
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.3.0'
+$script:DuneToolVersion = '11.3.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.3.0',
+    [string]$Version = '11.3.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.3.0</Version>
+    <Version>11.3.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.3.0"
+#define MyAppVersion "11.3.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.3.0"
+$script:ToolVersion = "11.3.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a
@@ -581,11 +581,13 @@ function Set-DuneAdminOwnLoopbackPort {
         return $port
     }
 
-    # Rewrite (or add) listen_addr, pinning to 127.0.0.1 so dune-admin binds IPv4
-    # loopback ONLY — it owns this port outright (no AMP contention) and the web
-    # UI opens on a normal 'localhost' name instead of [::1].
+    # Rewrite (or add) listen_addr. Bind 0.0.0.0 so the remote-portal helper
+    # bridge (helper/) can route the friend's WebView2 to dune-admin over
+    # Tailscale. If the configured port WAS contested (e.g. AMP), we've already
+    # relocated to a free port above — binding 0.0.0.0 on that new port is safe
+    # because nothing else holds it. dune-admin still has its own auth gate.
     try {
-        $newAddr = "127.0.0.1:$freePort"
+        $newAddr = "0.0.0.0:$freePort"
         $lines = @(Get-Content -LiteralPath $cfgPath)
         $found = $false
         $lines = $lines | ForEach-Object {
@@ -594,11 +596,70 @@ function Set-DuneAdminOwnLoopbackPort {
         if (-not $found) { $lines += "listen_addr: $newAddr" }
         $utf8 = New-Object System.Text.UTF8Encoding($false)
         [System.IO.File]::WriteAllText($cfgPath, ($lines -join "`n") + "`n", $utf8)
-        Write-Host "Port $port is held by another process (likely AMP) — moved dune-admin to 127.0.0.1:$freePort." -ForegroundColor Cyan
+        Write-Host "Port $port is held by another process (likely AMP) — moved dune-admin to 0.0.0.0:$freePort." -ForegroundColor Cyan
         return $freePort
     } catch {
         Write-Warning "Could not update dune-admin listen_addr: $($_.Exception.Message)"
         return $port
+    }
+}
+
+# Force dune-admin's listen_addr to bind ALL interfaces (0.0.0.0) on its current
+# port. Needed for the friend remote-portal helper to reach dune-admin through
+# DST's bridge — a 127.0.0.1 bind only answers the host's loopback, so even
+# though DST's listener routes through Tailscale, the iframe inside DST web UI
+# pointed at the host's tailnet name:port hits dune-admin which doesn't answer
+# on that interface. Idempotent (no rewrite if already 0.0.0.0:port). Returns
+# $true if any change was made, $false otherwise.
+function Set-DuneAdminBindAllInterfaces {
+    $cfgPath = Join-Path (Join-Path $env:USERPROFILE '.dune-admin') 'config.yaml'
+    if (-not (Test-Path -LiteralPath $cfgPath)) { return $false }
+    try {
+        $port = [int](Get-DuneAdminWebState).Port
+        if (-not $port -or $port -le 0) { return $false }
+        $newAddr = "0.0.0.0:$port"
+        $lines = @(Get-Content -LiteralPath $cfgPath)
+        $found = $false
+        $changed = $false
+        $lines = $lines | ForEach-Object {
+            if ($_ -match '^\s*listen_addr\s*:\s*(\S+)') {
+                $found = $true
+                $current = $matches[1].Trim()
+                if ($current -ne $newAddr) { $changed = $true; "listen_addr: $newAddr" } else { $_ }
+            } else { $_ }
+        }
+        if (-not $found) { $changed = $true; $lines += "listen_addr: $newAddr" }
+        if ($changed) {
+            $utf8 = New-Object System.Text.UTF8Encoding($false)
+            [System.IO.File]::WriteAllText($cfgPath, ($lines -join "`n") + "`n", $utf8)
+            Write-Host "dune-admin bind set to $newAddr (all interfaces, for remote-portal friend access)." -ForegroundColor Cyan
+        }
+        return $changed
+    } catch {
+        Write-Warning "Could not set dune-admin listen_addr to all interfaces: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+# Open a Windows Firewall hole for dune-admin's port on the Private + Domain
+# profiles so the friend can reach it over Tailscale (Tailscale's tun adapter
+# is Private). Idempotent — won't add a duplicate rule on subsequent launches.
+function Add-DuneAdminFirewallRule {
+    try {
+        $port = [int](Get-DuneAdminWebState).Port
+        if (-not $port -or $port -le 0) { return }
+        $ruleName = "DST_DuneAdmin_Inbound_$port"
+        $existing = Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue
+        if ($existing) { return }
+        New-NetFirewallRule `
+            -DisplayName $ruleName `
+            -Description "Allow inbound TCP to dune-admin (managed by DST for remote-portal helper access)." `
+            -Direction Inbound -Action Allow -Protocol TCP `
+            -LocalPort $port -Profile Private,Domain `
+            -ErrorAction Stop | Out-Null
+        Write-Host "Firewall: opened inbound TCP $port for dune-admin (Private+Domain profiles)." -ForegroundColor DarkGray
+    } catch {
+        Write-Warning "Could not add dune-admin firewall rule: $($_.Exception.Message)"
     }
 }
 
@@ -2255,6 +2316,12 @@ while ($true) {
             # own free 127.0.0.1 loopback port BEFORE launch so it binds IPv4
             # cleanly and the UI opens on a normal name (no [::1]).
             try { Set-DuneAdminOwnLoopbackPort | Out-Null } catch { Write-Warning "Port pre-flight failed: $($_.Exception.Message)" }
+            # Ensure dune-admin binds all interfaces (0.0.0.0) on its port so the
+            # remote-portal helper bridge can route the friend's WebView2 to it
+            # over Tailscale. Also drop a Windows Firewall rule for the same port
+            # (Private+Domain — Tailscale's tun is Private). Both idempotent.
+            try { Set-DuneAdminBindAllInterfaces | Out-Null } catch { Write-Warning "Bind-all pre-flight failed: $($_.Exception.Message)" }
+            try { Add-DuneAdminFirewallRule } catch { Write-Warning "Firewall pre-flight failed: $($_.Exception.Message)" }
             # Launch as the logged-in user via scheduled task (avoids admin elevation).
             # Wrap in cmd.exe with stdout/stderr redirected to %LOCALAPPDATA%\DuneServer\logs\dune-admin.log
             # AND mark the task settings -Hidden so dune-admin's own console

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.3.0",
+  "version": "11.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v11.3.1 hotfix

v11.2.0 introduced the friend remote-portal helper (`DSTConsole.exe`) and the Dune Admin embed tab inside DST. The iframe's URL-rewrite logic correctly points at `http://<host-tailnet-name>:<port>` when the viewer isn't local — but dune-admin was still bound to `127.0.0.1` only, so nothing answered on the tailnet interface and the friend got "took too long to respond".

### Fix

Two new helpers in `dune-server.ps1` run on every dune-admin launch (both idempotent):

- `Set-DuneAdminBindAllInterfaces` — rewrites `listen_addr` in `~/.dune-admin/config.yaml` to `0.0.0.0:<port>`.
- `Add-DuneAdminFirewallRule` — creates a Windows Firewall inbound TCP allow rule on the same port for the Private + Domain profiles (Tailscale's tun adapter is Private).

Also flipped the existing AMP-relocate path so when dune-admin moves to a fallback port (18080–18099) it also binds 0.0.0.0, not 127.0.0.1.

dune-admin's own auth still gates the surface — this only changes which interfaces it answers on.

### Friend impact

None — friend keeps using existing `DSTConsole.exe`. After v11.3.1 runs on the host once, the friend just reloads the Dune Admin tab and it works.

### Version bumps

11.3.0 → 11.3.1 across the 6 stamps + `[11.3.1]` changelog entry.