### PR TITLE
chore(release): bump version 11.3.1 -> 11.3.2 so in-app updater fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ here cover everything those tags shipped.
   (Private + Domain profiles — Tailscale's tun adapter is Private)
   whenever it launches dune-admin. Both ops are idempotent and run
   every launch. dune-admin's own auth still gates the surface.
+- **dune-admin console window is now actually hidden.** v11.3.0 shipped
+  the cmd.exe + `-Hidden` settings approach for hiding dune-admin's
+  console window, but `-Hidden` on `New-ScheduledTaskSettingsSet` only
+  hides the task in Task Scheduler's UI — the spawned cmd.exe console
+  still appeared on screen (just empty, because stdout/stderr were
+  redirected to the log file). dune-admin is now launched via a tiny
+  `launch-dune-admin.vbs` invoking `WScript.Shell.Run` with
+  `intWindowStyle=0` (SW_HIDE) — a Windows-subsystem host with no
+  window of its own, which then spawns cmd hidden with the same
+  redirection. Result: one console window for the whole stack
+  (DuneServer's), with `[admin]`-prefixed dune-admin lines mirrored in.
 
 ## [11.3.0] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.3.2] - 2026-06-05
+
+### Fixed
+- **dune-admin console window now actually hidden.** v11.3.0 shipped the
+  cmd.exe + `-Hidden` settings approach for hiding dune-admin's console
+  window, but `-Hidden` on `New-ScheduledTaskSettingsSet` only hides the
+  task in Task Scheduler's UI — the spawned cmd.exe console still
+  appeared on screen (just empty, because stdout/stderr were redirected
+  to the log file). dune-admin is now launched via a tiny
+  `launch-dune-admin.vbs` invoking `WScript.Shell.Run` with
+  `intWindowStyle=0` (SW_HIDE) — a Windows-subsystem host with no
+  window of its own, which then spawns cmd hidden with the same
+  redirection. Result: one console window for the whole stack
+  (DuneServer's), with `[admin]`-prefixed dune-admin lines mirrored in
+  exactly as v11.3.0 advertised.
+
 ## [11.3.1] - 2026-06-05
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.3.1'
+$script:DuneToolVersion = '11.3.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.3.1',
+    [string]$Version = '11.3.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.3.1</Version>
+    <Version>11.3.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.3.1"
+#define MyAppVersion "11.3.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.3.1"
+$script:ToolVersion = "11.3.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -2323,23 +2323,50 @@ while ($true) {
             try { Set-DuneAdminBindAllInterfaces | Out-Null } catch { Write-Warning "Bind-all pre-flight failed: $($_.Exception.Message)" }
             try { Add-DuneAdminFirewallRule } catch { Write-Warning "Firewall pre-flight failed: $($_.Exception.Message)" }
             # Launch as the logged-in user via scheduled task (avoids admin elevation).
-            # Wrap in cmd.exe with stdout/stderr redirected to %LOCALAPPDATA%\DuneServer\logs\dune-admin.log
-            # AND mark the task settings -Hidden so dune-admin's own console
-            # window never appears. The DuneServer process tails that log and
-            # mirrors each line into THIS console with an [admin] prefix, giving
-            # the operator one combined console window instead of two. See
-            # Start-DuneAdminLogMirror in app/server/lib/ConsoleHost.ps1.
+            # Hiding the spawned console window is harder than it sounds:
+            #   * `-Hidden` on New-ScheduledTaskSettingsSet only hides the TASK
+            #     in Task Scheduler's UI — the spawned cmd.exe still shows a
+            #     console window.
+            #   * `-WindowStyle Hidden` on powershell.exe does work but flashes
+            #     a visible console for ~50ms while PS itself starts up.
+            # The reliable zero-flash trick on Windows 10/11 is to invoke the
+            # process via WScript.Shell.Run with intWindowStyle=0 (SW_HIDE).
+            # wscript.exe is a Windows-subsystem host (no console of its own)
+            # and CreateProcess inherits SW_HIDE through to cmd's spawn of
+            # dune-admin. We drop a tiny .vbs to %LOCALAPPDATA%\DuneServer\,
+            # then schedule wscript.exe <vbs> <exe> <log>. cmd's redirection
+            # captures both streams into the log file the DuneServer mirror
+            # runspace tails into THIS console with an [admin] prefix.
             try {
                 $duneAdminLogDir  = Join-Path $env:LOCALAPPDATA 'DuneServer\logs'
                 $duneAdminLogPath = Join-Path $duneAdminLogDir 'dune-admin.log'
+                $duneAdminVbsPath = Join-Path (Join-Path $env:LOCALAPPDATA 'DuneServer') 'launch-dune-admin.vbs'
                 if (-not (Test-Path -LiteralPath $duneAdminLogDir)) {
                     New-Item -ItemType Directory -Path $duneAdminLogDir -Force | Out-Null
                 }
-                # cmd.exe argument string: /c "<exe>" 1>>"<log>" 2>&1
-                # The whole /c value is wrapped in outer quotes so cmd treats
-                # the redirected paths as one logical command.
-                $cmdArgs = '/c "' + '"' + $duneAdminExe + '"' + ' 1>>' + '"' + $duneAdminLogPath + '"' + ' 2>&1' + '"'
-                $action    = New-ScheduledTaskAction -Execute 'cmd.exe' -Argument $cmdArgs -WorkingDirectory $duneAdminDir
+                $vbsDir = Split-Path -Parent $duneAdminVbsPath
+                if (-not (Test-Path -LiteralPath $vbsDir)) {
+                    New-Item -ItemType Directory -Path $vbsDir -Force | Out-Null
+                }
+                # VBS contents — q is the literal ASCII double-quote, used to
+                # build a cmd.exe command line with the magic-quote pattern:
+                #   cmd /c ""<exe>" 1>>"<log>" 2>&1"
+                # The outer "" pair is consumed by cmd /c's tokenizer per its
+                # documented quoting rules. Style 0 = SW_HIDE (no window).
+                # True (3rd arg) = wait for completion so cmd's redirection
+                # file handles stay alive for dune-admin's whole lifetime.
+                $vbsContent = @'
+Dim args, q, cmd
+Set args = WScript.Arguments
+If args.Count < 2 Then WScript.Quit 1
+q = Chr(34)
+cmd = "cmd.exe /c " & q & q & args(0) & q & " 1>>" & q & args(1) & q & " 2>&1" & q
+CreateObject("WScript.Shell").Run cmd, 0, True
+'@
+                [System.IO.File]::WriteAllText($duneAdminVbsPath, $vbsContent, [System.Text.UTF8Encoding]::new($false))
+
+                $wscriptArgs = '"' + $duneAdminVbsPath + '" "' + $duneAdminExe + '" "' + $duneAdminLogPath + '"'
+                $action    = New-ScheduledTaskAction -Execute 'wscript.exe' -Argument $wscriptArgs -WorkingDirectory $duneAdminDir
                 $settings  = New-ScheduledTaskSettingsSet -Hidden -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
                 $principal = New-ScheduledTaskPrincipal -UserId $windowsUser -LogonType Interactive -RunLevel Limited
                 Register-ScheduledTask -TaskName "DuneAdminLaunch" -Action $action -Principal $principal -Settings $settings -Force | Out-Null

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.3.1",
+  "version": "11.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Why

v11.3.1 was re-released yesterday with the wscript SW_HIDE launcher that actually hides dune-admin's console window, but the version stamps were left at 11.3.1. DST's in-app updater compares version stamps — installed v11.3.1 hosts see "up to date" and never pull the fixed asset.

## What

Bump 6 standard stamps `11.3.1 → 11.3.2`:
- `webui/package.json`
- `app/installer/DuneServer.iss`
- `app/DuneServer.ps1`
- `dune-server.ps1`
- `app/build/Build-Exe.ps1`
- `app/desktop/DuneShell/DuneShell.csproj`

Plus CHANGELOG split — `[11.3.2]` gets the wscript fix bullet (which is what users will install with this version), `[11.3.1]` keeps just the remote-bind fix (which is what that tag genuinely shipped at first).