### PR TITLE
feat(security): hide free-form PowerShell page from remote viewers (v11.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.3.3] - 2026-06-05
+
+### Security
+- **Free-form PowerShell page is now local-only.** The `/terminal` page
+  (and its `/ws/terminal` WebSocket) lets anyone with the page open type
+  arbitrary commands that run as the DuneServer service user on the
+  host. That's fine when the only viewer is the host's own WebView2,
+  but DST's remote-portal bridge (v11.2.0) now lets a friend reach the
+  same UI over Tailscale — at which point a typo, accidental click, or
+  anyone else on the friend's computer can run arbitrary host-side
+  PowerShell with no audit trail. The page is now hidden from the
+  sidebar / menu bar for any viewer that isn't on loopback, the
+  `/terminal` route redirects to Server Health for them, and the
+  `/ws/terminal` endpoint server-side returns 403 on non-loopback
+  upgrade (defense in depth). The curated **Commands** page is
+  unaffected — friends can still drive Restart Battlegroup, Clear
+  Partitions, Spin Up Map, etc.
+
 ## [11.3.2] - 2026-06-05
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -120,7 +120,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.3.2'
+$script:DuneToolVersion = '11.3.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.3.2',
+    [string]$Version = '11.3.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.3.2</Version>
+    <Version>11.3.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.3.2"
+#define MyAppVersion "11.3.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/HttpServer.ps1
+++ b/app/server/HttpServer.ps1
@@ -80,13 +80,20 @@ function Register-DuneRoute {
 function Register-DuneWebSocket {
     param(
         [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][scriptblock]$Handler
+        [Parameter(Mandatory)][scriptblock]$Handler,
+        # When set, this WS endpoint is reachable ONLY from a loopback
+        # connection on the host itself. Any remote viewer (friend reaching
+        # the portal over Tailscale, LAN client, etc.) gets a 403 on upgrade.
+        # Use for endpoints that drive arbitrary host-side execution — the
+        # free-form Terminal is the canonical case.
+        [switch]$LocalOnly
     )
     $pattern = '^' + ([regex]::Escape($Path) -replace '\\\{([^/}]+)}', '(?<$1>[^/]+)') + '$'
     $script:DuneWsRoutes.Add([pscustomobject]@{
-        Path    = $Path
-        Regex   = [regex]$pattern
-        Handler = $Handler
+        Path      = $Path
+        Regex     = [regex]$pattern
+        Handler   = $Handler
+        LocalOnly = [bool]$LocalOnly
     }) | Out-Null
 }
 
@@ -721,6 +728,20 @@ function Invoke-DuneContext {
         foreach ($r in $script:DuneWsRoutes) {
             $m = $r.Regex.Match($rawPath)
             if ($m.Success) {
+                if ($r.LocalOnly) {
+                    $remote = $null
+                    try { $remote = $req.RemoteEndPoint.Address } catch {}
+                    $isLoopback = $false
+                    if ($remote) {
+                        try { $isLoopback = [System.Net.IPAddress]::IsLoopback($remote) } catch { $isLoopback = $false }
+                    }
+                    if (-not $isLoopback) {
+                        Write-Host "[ws] 403 local-only path '$rawPath' from $remote" -ForegroundColor Yellow
+                        $res.StatusCode = 403
+                        $res.OutputStream.Close()
+                        return
+                    }
+                }
                 $routeParams = @{}
                 foreach ($g in $r.Regex.GetGroupNames()) {
                     if ($g -notmatch '^\d+$') { $routeParams[$g] = $m.Groups[$g].Value }

--- a/app/server/routes/Terminal.ps1
+++ b/app/server/routes/Terminal.ps1
@@ -27,7 +27,7 @@
 # Runs in a runspace from $script:DuneWsPool — no PS functions from
 # lib/*.ps1 are visible. Pure .NET / built-in cmdlets.
 
-Register-DuneWebSocket -Path '/ws/terminal' -Handler {
+Register-DuneWebSocket -Path '/ws/terminal' -LocalOnly -Handler {
     param($ws, $routeParams)
 
     $CT  = [System.Threading.CancellationToken]::None

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.3.2"
+$script:ToolVersion = "11.3.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.3.2",
+  "version": "11.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, Navigate } from 'react-router-dom'
 import { AppShell } from './layout/AppShell'
 import { Dashboard } from './pages/Dashboard'
 import { Commands } from './pages/Commands'
@@ -13,15 +13,26 @@ import { TerminalPage } from './pages/Terminal'
 import { DuneAdmin } from './pages/DuneAdmin'
 import { PageStub } from './pages/PageStub'
 import { StatusProvider } from './hooks/useStatus'
+import { isLocalViewer } from './util/viewer'
 
 export default function App() {
+  // The free-form PowerShell page can run arbitrary commands on the host
+  // as the DuneServer service user. It's safe locally (you're already on
+  // the host with admin) but a foot-gun for remote viewers (friend over
+  // Tailscale), so we redirect /terminal to Server Health for them. The
+  // backend /ws/terminal route enforces this too — this is just the UX
+  // half so the page doesn't render an empty failing terminal.
+  const showTerminal = isLocalViewer()
   return (
     <StatusProvider>
       <AppShell>
         <Routes>
           <Route path="/"           element={<Dashboard />} />
           <Route path="/commands"   element={<Commands />} />
-          <Route path="/terminal"   element={<TerminalPage />} />
+          <Route
+            path="/terminal"
+            element={showTerminal ? <TerminalPage /> : <Navigate to="/" replace />}
+          />
           <Route path="/gameconfig" element={<GameConfig />} />
           <Route path="/database"   element={<Database />} />
           <Route path="/sietches"   element={<Sietches />} />

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -5,6 +5,7 @@ import { NAV_ITEMS, GROUP_LABELS, GROUP_ORDER, type NavGroup } from '../nav'
 import { useUpdateCheck } from '../hooks/useUpdateCheck'
 import { useDuneAdminWebUrl } from '../hooks/useDuneAdminWebUrl'
 import { buildDiagnosticBundle } from '../api/diagnostics'
+import { isLocalViewer } from '../util/viewer'
 
 type MenuKey = NavGroup | 'help' | 'duneadmin'
 
@@ -79,7 +80,9 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
       className="h-8 shrink-0 border-b border-border bg-surface flex items-center px-1 text-[13px] select-none relative z-40"
     >
       {GROUP_ORDER.map(g => {
-        const items = NAV_ITEMS.filter(i => i.group === g)
+        const items = NAV_ITEMS
+          .filter(i => i.group === g)
+          .filter(i => !i.localOnly || isLocalViewer())
         if (items.length === 0) return null
         // Single-item group (e.g. Server Health, which has only one page):
         // a dropdown with one entry is pure friction. Render the group

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import { NAV_ITEMS, GROUP_LABELS, GROUP_ORDER } from '../nav'
 import { useUpdateCheck } from '../hooks/useUpdateCheck'
 import { api } from '../api/client'
 import { fmtToolVersion } from '../format'
+import { isLocalViewer } from '../util/viewer'
 
 // WebView2 host bridge — present only when the portal is rendered inside the
 // native DuneShell.exe app window (not in a regular browser tab). We use it to
@@ -63,7 +64,9 @@ export function Sidebar({ collapsed }: Props) {
   const groups = GROUP_ORDER.map(g => ({
     key: g,
     label: GROUP_LABELS[g],
-    items: NAV_ITEMS.filter(i => i.group === g),
+    items: NAV_ITEMS
+      .filter(i => i.group === g)
+      .filter(i => !i.localOnly || isLocalViewer()),
   })).filter(g => g.items.length > 0)
 
   // Shared row renderer for a single nav item, in either layout mode.

--- a/webui/src/nav.ts
+++ b/webui/src/nav.ts
@@ -5,12 +5,18 @@ export type NavItem = {
   label: string
   icon: string  // lucide-react icon name
   group?: NavGroup
+  // When true, this item is hidden from the sidebar / menubar for any
+  // viewer that isn't on the host machine itself (e.g. a friend reaching
+  // the portal over Tailscale). The corresponding /api or /ws routes
+  // MUST also enforce loopback-only on the server — the client filter is
+  // just a UX hide, not a security boundary.
+  localOnly?: boolean
 }
 
 export const NAV_ITEMS: NavItem[] = [
   { to: '/',            label: 'Server Health', icon: 'LayoutDashboard', group: 'overview' },
   { to: '/commands',    label: 'Commands',     icon: 'Zap',             group: 'terminal' },
-  { to: '/terminal',    label: 'PowerShell',   icon: 'SquareTerminal',  group: 'terminal' },
+  { to: '/terminal',    label: 'PowerShell',   icon: 'SquareTerminal',  group: 'terminal', localOnly: true },
   { to: '/gameconfig',  label: 'Game Config',  icon: 'Sliders',         group: 'data' },
   { to: '/dd-map',      label: 'DD Map',       icon: 'Map',             group: 'data' },
   { to: '/database',    label: 'Database',     icon: 'Database',        group: 'database' },

--- a/webui/src/pages/DuneAdmin.tsx
+++ b/webui/src/pages/DuneAdmin.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { Icon } from '../components/Icon'
 import { api, ApiError } from '../api/client'
 import { getDuneAdminWebUrl, type DuneAdminWebUrl } from '../api/duneAdmin'
+import { isLocalViewer } from '../util/viewer'
 
 // While we're waiting for dune-admin to come up after a "Start" click, poll
 // fast so the iframe swaps in as soon as the port is listening.
@@ -107,8 +108,7 @@ export function DuneAdmin() {
     // friend's own 127.0.0.1. Requires host-side firewall to allow inbound on
     // dune-admin's port over the Tailscale interface (see helper/bridge).
     const viewerHost = typeof window !== 'undefined' ? window.location.hostname : ''
-    const isLocalViewer = viewerHost === '127.0.0.1' || viewerHost === 'localhost' || viewerHost === ''
-    const iframeUrl = isLocalViewer
+    const iframeUrl = isLocalViewer()
       ? info.url
       : `http://${viewerHost}:${info.port}`
     return (

--- a/webui/src/util/viewer.ts
+++ b/webui/src/util/viewer.ts
@@ -1,0 +1,16 @@
+// Detect whether the DST web UI is currently being viewed from the host
+// machine itself (a local WebView2 / browser tab on the same box) vs from
+// a remote viewer reaching the portal over Tailscale (friend's
+// DSTConsole.exe, or any other tailnet client).
+//
+// "Local" means window.location.hostname is loopback. Anything else —
+// tailnet name, LAN IP, public hostname — is treated as remote.
+//
+// Used to gate access to surfaces that must NEVER be drivable from a
+// remote viewer (the free-form PowerShell page, for example) while still
+// letting curated remote surfaces (Commands, Dune Admin) render normally.
+export function isLocalViewer(): boolean {
+  if (typeof window === 'undefined') return true
+  const host = window.location.hostname
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === ''
+}


### PR DESCRIPTION
## Why

The `/terminal` page is a free-form PowerShell prompt that runs anything-you-type as the DuneServer service user on the host. That's fine when the only viewer is the host's own WebView2, but the friend remote-portal bridge (v11.2.0) now lets a friend reach the same UI over Tailscale — one accidental click or anyone else at the friend's keyboard can run arbitrary host-side commands with no audit trail.

## Cut

**Frontend (UX):**
- `nav.ts` — `NavItem` gains `localOnly?: boolean`; `/terminal` flagged.
- `Sidebar.tsx` + `MenuBar.tsx` — filter out `localOnly` items when not on loopback.
- `App.tsx` — `/terminal` redirects to `/` for non-local viewers.
- New shared `util/viewer.ts` with `isLocalViewer()`; `DuneAdmin.tsx` switched from its inline copy.

**Backend (security boundary):**
- `Register-DuneWebSocket` gains `-LocalOnly` switch.
- Dispatcher returns **403** on upgrade when the request's `RemoteEndPoint.Address` isn't `IsLoopback`.
- `/ws/terminal` marked `-LocalOnly`.

The client filter is just a UX hide. The server gate is the actual security boundary — direct WS pokes from a remote viewer get rejected.

## Unchanged

- `/commands` (curated buttons) — friend can still drive Restart Battlegroup, Clear Partitions, Spin Up Map.
- `/dune-admin` (embed tab) — friend can still use dune-admin over Tailscale.
- Local viewer's PowerShell tab — fully functional, unchanged.

Bumped 11.3.2 → 11.3.3 + CHANGELOG.