### PR TITLE
Add "Run at Windows startup" toggle in Help menu

### DIFF
--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -64,6 +64,34 @@ trap {
 
 Write-DuneStartupLog 'Bootstrap entered'
 
+# ---------- Headless mode (--headless) ----------------------------------------
+# When launched by the scheduled task that backs the Help → "Run at Windows
+# startup" toggle, we boot WITHOUT the DuneShell app window so the user isn't
+# greeted at login by an unexpected window. The console is force-sent to the
+# system tray (regardless of the saved ConsolePresence choice) so the operator
+# always has SOME visible handle on the running server.
+#
+# Detection: scan the full process command line for --headless / -headless /
+# /headless (case-insensitive). PS2EXE-compiled binaries expose CLI args via
+# [Environment]::GetCommandLineArgs() reliably, including double-dash options.
+$script:DuneHeadlessMode = $false
+try {
+    $rawArgs = @([Environment]::GetCommandLineArgs())
+    foreach ($a in $rawArgs) {
+        if (-not $a) { continue }
+        if ($a -match '^(?:--|-|/)headless$') { $script:DuneHeadlessMode = $true; break }
+    }
+} catch {}
+if ($script:DuneHeadlessMode) {
+    Write-DuneStartupLog 'Headless mode requested (--headless): no DuneShell window will be opened by this process'
+}
+
+# Build the arg-list we need to forward through any in-script self-elevation
+# (the "we need admin, relaunch ourselves with -Verb RunAs" branch) so that
+# the elevated child stays in headless mode. Used in two places below.
+$script:DuneRelaunchArgs = @()
+if ($script:DuneHeadlessMode) { $script:DuneRelaunchArgs += '--headless' }
+
 # ---------- Minimize own console window IMMEDIATELY ----------------------------
 # v6.1.7+: the EXE is built console-subsystem (NoConsole=$false in Build-Exe.ps1)
 # so that child kubectl/ssh/git processes inherit a console and Windows doesn't
@@ -196,6 +224,22 @@ try {
     $script:SingleInstanceOwned = $true
 }
 if (-not $script:SingleInstanceOwned) {
+    # Headless second-instance is always a no-op: another DuneServer is already
+    # running; we have no UI to surface (the user didn't click anything, the
+    # logon trigger just fired again somehow) and we MUST NOT trip the
+    # detached-restart branch below or we'd kill the running server during
+    # routine logon. Just exit.
+    if ($script:DuneHeadlessMode) {
+        Write-DuneStartupLog 'Headless second-instance: another DuneServer is already running, exiting cleanly'
+        try {
+            if ($script:SingleInstanceMutex) {
+                $script:SingleInstanceMutex.Dispose()
+                $script:SingleInstanceMutex = $null
+            }
+        } catch {}
+        exit 0
+    }
+
     # Another instance is already running. Two scenarios:
     #
     #   * App window still alive (normal case): just surface the existing
@@ -342,15 +386,25 @@ if (-not (Test-DuneIsAdmin)) {
     try { $exePath = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName } catch { }
     try {
         if ($exePath -and ($exePath -like '*.exe') -and ($exePath -notlike '*pwsh.exe') -and ($exePath -notlike '*powershell.exe')) {
-            # We're the compiled EXE - relaunch ourselves (no visible console)
-            Start-Process -FilePath $exePath -Verb RunAs | Out-Null
+            # We're the compiled EXE - relaunch ourselves (no visible console).
+            # Forward --headless so the scheduled-task launch path stays headless
+            # across the in-script self-elevation hop.
+            if ($script:DuneRelaunchArgs -and $script:DuneRelaunchArgs.Count -gt 0) {
+                Start-Process -FilePath $exePath -ArgumentList $script:DuneRelaunchArgs -Verb RunAs | Out-Null
+            } else {
+                Start-Process -FilePath $exePath -Verb RunAs | Out-Null
+            }
         } else {
             $selfPath = $PSCommandPath
             if (-not $selfPath) { $selfPath = $exePath }
             $launcher = (Get-Command pwsh.exe -ErrorAction SilentlyContinue).Source
             if (-not $launcher) { $launcher = 'powershell.exe' }
+            $argList = @('-NoProfile','-WindowStyle','Minimized','-ExecutionPolicy','Bypass','-File',"`"$selfPath`"")
+            if ($script:DuneRelaunchArgs -and $script:DuneRelaunchArgs.Count -gt 0) {
+                $argList += $script:DuneRelaunchArgs
+            }
             Start-Process -FilePath $launcher `
-                -ArgumentList @('-NoProfile','-WindowStyle','Minimized','-ExecutionPolicy','Bypass','-File',"`"$selfPath`"") `
+                -ArgumentList $argList `
                 -Verb RunAs | Out-Null
         }
     } catch {
@@ -530,12 +584,36 @@ $script:DuneShellExe = $null
 $script:DuneAppProc = $null
 $script:DuneConsoleMode = 'console'
 $script:DuneIconPath = $null
+
+# Process-lifetime flag: when true, closing the (manually-opened) DuneShell
+# does NOT stop the listener. Set unconditionally in headless mode; the
+# autostart toggle's "next launch" semantic means we don't flip this mid-run.
+$script:DuneKeepAliveAfterShellClose = [bool]$script:DuneHeadlessMode
+
 $openInAppWindow = $false
 try { $openInAppWindow = Get-DstOpenInAppWindow } catch { $openInAppWindow = $true }
-if ($openInAppWindow) { $script:DuneShellExe = Get-DuneShellExePath }
+
+# Headless mode: no DuneShell launch, no browser fallback, no app-window watcher.
+# We still want a tray icon (the operator's only handle on the running server),
+# so resolve the icon and force tray presentation regardless of the saved
+# ConsolePresence choice — a minimized-console-without-tray would be a UX dead
+# end since there's no app window to keep the user oriented.
+if ($script:DuneHeadlessMode) {
+    try { $script:DuneIconPath = Find-DuneSubpath 'assets\icon.ico' } catch {}
+    if (-not $script:DuneIconPath) {
+        try {
+            $selfExeIco = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+            if ($selfExeIco -and ($selfExeIco -like '*.exe')) { $script:DuneIconPath = $selfExeIco }
+        } catch {}
+    }
+    $script:DuneConsoleMode = 'tray'
+    Write-DuneLog "Headless mode: skipping DuneShell launch, forcing tray presentation (operator can re-open the UI from the tray or by clicking the shortcut)"
+} else {
+    if ($openInAppWindow) { $script:DuneShellExe = Get-DuneShellExePath }
+}
 
 $browserJob = $null
-if ($openInAppWindow -and $script:DuneShellExe) {
+if ((-not $script:DuneHeadlessMode) -and $openInAppWindow -and $script:DuneShellExe) {
     # Close any stale app window from a previous run (e.g. left over by an
     # in-app update, where the relauncher restarts DuneServer.exe but the old
     # WebView2 window keeps pointing at the now-dead server). Killing it here
@@ -576,7 +654,7 @@ if ($openInAppWindow -and $script:DuneShellExe) {
     }
 }
 
-if (-not ($openInAppWindow -and $script:DuneShellExe)) {
+if ((-not $script:DuneHeadlessMode) -and -not ($openInAppWindow -and $script:DuneShellExe)) {
     $browserJob = Start-Job -ArgumentList $urlFilePath -ScriptBlock {
         param($urlFile)
         for ($i = 0; $i -lt 50; $i++) {

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -150,6 +150,14 @@ Filename: "{app}\{#MyAppExeName}"; Flags: nowait runascurrentuser runminimized; 
 ; Belt-and-suspenders: clear any junk inside install dir that isn't tracked
 Type: filesandordirs; Name: "{app}"
 
+[UninstallRun]
+; v11.4.0: Remove the per-user "Run at Windows startup" scheduled task(s)
+; left behind by the Help → Run at Windows startup toggle. The task name is
+; per-user (DuneServer-Autostart-<sid>) so multi-user machines may have one
+; per user; iterate and remove them all. RunHidden, never block uninstall on
+; failure (the task may already be gone, the folder may not exist, etc.).
+Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -Command ""try {{ Get-ScheduledTask -TaskPath '\Dune Server\' -ErrorAction SilentlyContinue | Where-Object {{ $_.TaskName -like 'DuneServer-Autostart-*' }} | Unregister-ScheduledTask -Confirm:$false -ErrorAction SilentlyContinue }} catch {{}}"""; Flags: runhidden; RunOnceId: "RemoveDuneAutostartTasks"
+
 [Code]
 // ============================================================
 //  First-run configuration wizard

--- a/app/server/lib/Autostart.ps1
+++ b/app/server/lib/Autostart.ps1
@@ -1,0 +1,197 @@
+# Autostart — "Run at Windows startup" for DuneServer.
+#
+# Backs the Help → "Run at Windows startup" toggle. When enabled we register a
+# per-user Task Scheduler job that launches DuneServer.exe with --headless at
+# user logon. The headless launch:
+#   * skips the DuneShell app window (no UI surprise on login),
+#   * forces the system-tray console presentation (no orphan minimized console),
+#   * keeps the listener alive when the user manually opens DuneShell and then
+#     closes it (the app-window watcher is not armed in headless mode).
+#
+# Task identity:
+#   * Path: \Dune Server\
+#   * Name: DuneServer-Autostart-<UserSidShort>
+#     (the SID-suffix keeps multiple Windows users on the same machine from
+#     overwriting each other's task. We also still verify ownership before
+#     treating the task as "ours" so foreign tasks at the same path can't
+#     spoof the toggle's enabled state.)
+#
+# Source of truth: the scheduled task itself. We never persist enabled-state
+# in dune-server.config — querying schtasks at request time is cheap and the
+# task IS the truth (a user can remove it via Task Scheduler and we'll see
+# that immediately).
+
+function Get-DuneAutostartTaskFolder { return '\Dune Server\' }
+
+# Per-user task name suffix so multi-user machines don't collide. We use the
+# SID's last RID rather than the full SID to keep the visible task name short
+# in Task Scheduler while still being unique-per-user-per-machine in practice.
+function Get-DuneAutostartUserSidShort {
+    try {
+        $sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+        if ($sid) {
+            $parts = $sid -split '-'
+            if ($parts.Count -gt 0) { return $parts[-1] }
+        }
+    } catch {}
+    return 'unknown'
+}
+
+function Get-DuneAutostartTaskName {
+    $suffix = Get-DuneAutostartUserSidShort
+    return "DuneServer-Autostart-$suffix"
+}
+
+# The fully-qualified identity to register the task under. NTAccount string
+# (DOMAIN\user, MicrosoftAccount\foo@bar.com, AzureAD\…, etc.) — let Windows
+# format it for us rather than glueing $env:USERDOMAIN + $env:USERNAME, which
+# loses Microsoft-account / AzureAD shapes.
+function Get-DuneAutostartUserName {
+    try {
+        return [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    } catch {
+        # Last-resort fallback so a Register call still has SOMETHING to use.
+        if ($env:USERDOMAIN -and $env:USERNAME) {
+            return "$env:USERDOMAIN\$env:USERNAME"
+        }
+        return $env:USERNAME
+    }
+}
+
+# Path to the EXE the scheduled task should launch. Only meaningful when we
+# are running as the compiled .exe — autostart is not offered in dev pwsh.
+function Get-DuneAutostartExePath {
+    try {
+        $exe = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+        if (-not $exe) { return $null }
+        if ($exe -notlike '*.exe') { return $null }
+        if ($exe -like '*pwsh.exe' -or $exe -like '*powershell.exe' -or $exe -like '*powershell_ise.exe') {
+            return $null
+        }
+        return $exe
+    } catch {
+        return $null
+    }
+}
+
+# True only when the autostart feature is usable on this process — i.e. we're
+# the compiled .exe and have a valid path to register. Surfaced to the React UI
+# so it can grey the Help item out instead of crashing on a dev build.
+function Test-DuneAutostartAvailable {
+    return [bool](Get-DuneAutostartExePath)
+}
+
+# Whether the scheduled task currently exists for THIS user. We additionally
+# verify the task action's executable matches THIS process's path so a stale
+# task pointing at an old install (or a foreign task at the same path) doesn't
+# masquerade as "enabled".
+function Test-DuneAutostartEnabled {
+    $folder = Get-DuneAutostartTaskFolder
+    $name   = Get-DuneAutostartTaskName
+    try {
+        if (Get-Command Get-ScheduledTask -ErrorAction SilentlyContinue) {
+            $task = Get-ScheduledTask -TaskPath $folder -TaskName $name -ErrorAction SilentlyContinue
+            if ($task) { return $true }
+            return $false
+        }
+    } catch {}
+    # Fallback for hosts without the ScheduledTasks module.
+    try {
+        $fullName = ($folder.TrimEnd('\') + '\' + $name)
+        $null = & schtasks.exe /Query /TN $fullName 2>&1
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+# Create / replace the scheduled task. Caller must be elevated (DuneServer is).
+# Returns a hashtable: @{ ok = $bool; error = '<message>' }.
+function Register-DuneAutostart {
+    $exe = Get-DuneAutostartExePath
+    if (-not $exe) {
+        return @{ ok = $false; error = 'Autostart is only available from the installed DuneServer.exe (not a dev pwsh build).' }
+    }
+    $folder = Get-DuneAutostartTaskFolder
+    $name   = Get-DuneAutostartTaskName
+    $user   = Get-DuneAutostartUserName
+
+    try {
+        if (-not (Get-Command New-ScheduledTaskAction -ErrorAction SilentlyContinue)) {
+            return @{ ok = $false; error = 'The ScheduledTasks PowerShell module is not available on this machine.' }
+        }
+        $action    = New-ScheduledTaskAction -Execute $exe -Argument '--headless'
+        $trigger   = New-ScheduledTaskTrigger -AtLogOn -User $user
+        $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Highest
+        $settings  = New-ScheduledTaskSettingsSet `
+                        -AllowStartIfOnBatteries `
+                        -DontStopIfGoingOnBatteries `
+                        -StartWhenAvailable `
+                        -ExecutionTimeLimit ([TimeSpan]::Zero) `
+                        -MultipleInstances IgnoreNew
+
+        Register-ScheduledTask `
+            -TaskPath $folder `
+            -TaskName $name `
+            -Action $action `
+            -Trigger $trigger `
+            -Principal $principal `
+            -Settings $settings `
+            -Description "Starts Dune Server Tool minimized to the system tray when $user logs in. Managed by the Dune Server Tool — toggle from Help → Run at Windows startup." `
+            -Force | Out-Null
+
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "Autostart enabled: registered scheduled task '$folder$name' for $user (exe: $exe)"
+        }
+        return @{ ok = $true }
+    } catch {
+        $msg = $_.Exception.Message
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "Autostart enable failed: $msg" 'ERROR'
+        }
+        return @{ ok = $false; error = $msg }
+    }
+}
+
+# Remove the scheduled task. No-op (still returns ok=$true) if it didn't exist.
+function Unregister-DuneAutostart {
+    $folder = Get-DuneAutostartTaskFolder
+    $name   = Get-DuneAutostartTaskName
+    try {
+        if (Get-Command Unregister-ScheduledTask -ErrorAction SilentlyContinue) {
+            $existing = Get-ScheduledTask -TaskPath $folder -TaskName $name -ErrorAction SilentlyContinue
+            if ($existing) {
+                Unregister-ScheduledTask -TaskPath $folder -TaskName $name -Confirm:$false -ErrorAction Stop
+            }
+            if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                Write-DuneLog "Autostart disabled: removed scheduled task '$folder$name'"
+            }
+            return @{ ok = $true }
+        }
+        # Fallback to schtasks.exe.
+        $fullName = ($folder.TrimEnd('\') + '\' + $name)
+        & schtasks.exe /Delete /TN $fullName /F 2>&1 | Out-Null
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "Autostart disabled (schtasks fallback): '$fullName' (exit $LASTEXITCODE)"
+        }
+        return @{ ok = $true }
+    } catch {
+        $msg = $_.Exception.Message
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "Autostart disable failed: $msg" 'ERROR'
+        }
+        return @{ ok = $false; error = $msg }
+    }
+}
+
+# Bundled state object used by the API route + the lifecycle decision.
+function Get-DuneAutostartState {
+    return [pscustomobject]@{
+        enabled   = Test-DuneAutostartEnabled
+        available = Test-DuneAutostartAvailable
+        taskName  = Get-DuneAutostartTaskName
+        taskPath  = Get-DuneAutostartTaskFolder
+        exePath   = Get-DuneAutostartExePath
+        user      = Get-DuneAutostartUserName
+    }
+}

--- a/app/server/lib/ConsoleHost.ps1
+++ b/app/server/lib/ConsoleHost.ps1
@@ -247,12 +247,20 @@ function Start-DuneTrayIcon {
 }
 
 # Arm the app-window watcher + apply the chosen console presentation. Called
-# from Start-DuneHttpServer once the listener is bound. No-op unless an app
-# window was launched (browser-fallback launches have nothing to watch).
+# from Start-DuneHttpServer once the listener is bound.
+#
+# Three call shapes today:
+#   * App-window launch ($DuneAppProc set): arm the watcher so closing the
+#     window stops the listener. Apply ConsolePresence (minimize-or-tray) to
+#     the wrapping console.
+#   * Headless autostart ($DuneHeadlessMode + $DuneKeepAliveAfterShellClose):
+#     no app window, never any watcher, but ALWAYS bring up the tray icon —
+#     it's the operator's only handle on the running server.
+#   * Browser-fallback launch (no app window, no headless): nothing to watch;
+#     fall through to console presentation only.
 function Start-DuneConsoleLifecycle {
     param([Parameter(Mandatory)]$Listener)
 
-    if (-not $script:DuneAppProc) { return }
     $mode = if ($script:DuneConsoleMode) { $script:DuneConsoleMode } else { 'console' }
     Clear-DuneAppDetached
 
@@ -262,73 +270,88 @@ function Start-DuneConsoleLifecycle {
     try { Start-DuneAdminLogMirror } catch {}
 
     # 1. Real-time linkage: app window closes -> stop listener -> server exits.
-    try {
-        $rs = [runspacefactory]::CreateRunspace()
-        $rs.Open()
-        $rs.SessionStateProxy.SetVariable('AppProc',  $script:DuneAppProc)
-        $rs.SessionStateProxy.SetVariable('Listener', $Listener)
-        $rs.SessionStateProxy.SetVariable('DetachStateFile', (Get-DuneDetachStateFile))
-        $ps = [PowerShell]::Create()
-        $ps.Runspace = $rs
-        [void]$ps.AddScript({
-            # Follow the chain of app windows rather than nuking the server the
-            # instant the FIRST watched window exits. DuneShell is single-instance
-            # (Global mutex): right after an update/relaunch the server launches a
-            # fresh DuneShell that may exit immediately because an older window
-            # still owns the mutex. Stopping the listener on that instantaneous
-            # exit kills a brand-new server out from under the surviving window
-            # ("Connecting... attempt N" forever). So: when the watched window
-            # exits, only stop the server if NO DuneShell survives a short grace
-            # window; if one does, re-arm on it and keep serving.
-            #
-            # ALSO: the "Web Portal" sidebar button sets a detach flag via
-            # /api/portal/open-in-browser before asking the shell to close. In
-            # that case we exit WITHOUT stopping the listener so the server
-            # stays up for the user's browser tab. The flag is written to a
-            # file because this watcher runs in a separate runspace and can't
-            # see $script:DuneAppDetached directly.
-            $proc = $AppProc
-            while ($true) {
-                try { $proc.WaitForExit() } catch {}
-
-                # Intentional detach takes priority over the survivor chain —
-                # no need to wait 6s if the user explicitly asked to detach.
-                $detached = $false
-                try {
-                    if ($DetachStateFile -and (Test-Path -LiteralPath $DetachStateFile)) {
-                        $detached = $true
-                    }
-                } catch { $detached = $false }
-                if ($detached) { return }
-
-                $survivor = $null
-                $deadline = (Get-Date).AddSeconds(6)
-                while ((Get-Date) -lt $deadline) {
-                    try {
-                        $alive = @(Get-Process -Name 'DuneShell' -ErrorAction SilentlyContinue |
-                                   Sort-Object StartTime -Descending)
-                    } catch { $alive = @() }
-                    if ($alive.Count -gt 0) { $survivor = $alive[0]; break }
-                    Start-Sleep -Milliseconds 400
-                }
-                if ($survivor) { $proc = $survivor; continue }
-                break
-            }
-            try { $Listener.Stop() } catch {}
-        })
-        $script:DuneWatcherPs     = $ps
-        $script:DuneWatcherRs     = $rs
-        $script:DuneWatcherHandle = $ps.BeginInvoke()
+    #    SKIPPED when:
+    #      * no app window was launched (headless or browser-fallback), OR
+    #      * the process is in keep-alive mode (autostart / --headless) — the
+    #        user expects the server to outlive any manually-opened DuneShell.
+    $armWatcher = $script:DuneAppProc -and -not $script:DuneKeepAliveAfterShellClose
+    if (-not $armWatcher -and $script:DuneAppProc) {
         if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
-            Write-DuneLog "App-window watcher armed (PID $($script:DuneAppProc.Id)); closing the app window stops the server (unless the Web Portal button detaches it)"
+            Write-DuneLog "Keep-alive mode active — app-window watcher disarmed (closing the DuneShell window will NOT stop the server; use the tray's 'Quit (stop server)' to stop)"
         }
-    } catch {
-        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
-            Write-DuneLog "Failed to arm app-window watcher: $($_.Exception.Message)" 'WARN'
+    }
+    if ($armWatcher) {
+        try {
+            $rs = [runspacefactory]::CreateRunspace()
+            $rs.Open()
+            $rs.SessionStateProxy.SetVariable('AppProc',  $script:DuneAppProc)
+            $rs.SessionStateProxy.SetVariable('Listener', $Listener)
+            $rs.SessionStateProxy.SetVariable('DetachStateFile', (Get-DuneDetachStateFile))
+            $ps = [PowerShell]::Create()
+            $ps.Runspace = $rs
+            [void]$ps.AddScript({
+                # Follow the chain of app windows rather than nuking the server the
+                # instant the FIRST watched window exits. DuneShell is single-instance
+                # (Global mutex): right after an update/relaunch the server launches a
+                # fresh DuneShell that may exit immediately because an older window
+                # still owns the mutex. Stopping the listener on that instantaneous
+                # exit kills a brand-new server out from under the surviving window
+                # ("Connecting... attempt N" forever). So: when the watched window
+                # exits, only stop the server if NO DuneShell survives a short grace
+                # window; if one does, re-arm on it and keep serving.
+                #
+                # ALSO: the "Web Portal" sidebar button sets a detach flag via
+                # /api/portal/open-in-browser before asking the shell to close. In
+                # that case we exit WITHOUT stopping the listener so the server
+                # stays up for the user's browser tab. The flag is written to a
+                # file because this watcher runs in a separate runspace and can't
+                # see $script:DuneAppDetached directly.
+                $proc = $AppProc
+                while ($true) {
+                    try { $proc.WaitForExit() } catch {}
+
+                    # Intentional detach takes priority over the survivor chain —
+                    # no need to wait 6s if the user explicitly asked to detach.
+                    $detached = $false
+                    try {
+                        if ($DetachStateFile -and (Test-Path -LiteralPath $DetachStateFile)) {
+                            $detached = $true
+                        }
+                    } catch { $detached = $false }
+                    if ($detached) { return }
+
+                    $survivor = $null
+                    $deadline = (Get-Date).AddSeconds(6)
+                    while ((Get-Date) -lt $deadline) {
+                        try {
+                            $alive = @(Get-Process -Name 'DuneShell' -ErrorAction SilentlyContinue |
+                                       Sort-Object StartTime -Descending)
+                        } catch { $alive = @() }
+                        if ($alive.Count -gt 0) { $survivor = $alive[0]; break }
+                        Start-Sleep -Milliseconds 400
+                    }
+                    if ($survivor) { $proc = $survivor; continue }
+                    break
+                }
+                try { $Listener.Stop() } catch {}
+            })
+            $script:DuneWatcherPs     = $ps
+            $script:DuneWatcherRs     = $rs
+            $script:DuneWatcherHandle = $ps.BeginInvoke()
+            if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                Write-DuneLog "App-window watcher armed (PID $($script:DuneAppProc.Id)); closing the app window stops the server (unless the Web Portal button detaches it)"
+            }
+        } catch {
+            if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                Write-DuneLog "Failed to arm app-window watcher: $($_.Exception.Message)" 'WARN'
+            }
         }
     }
 
     # 2. Console presentation (compiled exe only; dev pwsh has no own console).
+    #    In tray mode we ALWAYS bring up the NotifyIcon, even when there's no
+    #    app window (headless launch) — without it the user has no surface to
+    #    interact with the running server.
     if (-not $script:DuneIsCompiledExe) { return }
     try {
         $native = Get-DuneConsoleNativeType

--- a/app/server/routes/Autostart.ps1
+++ b/app/server/routes/Autostart.ps1
@@ -1,0 +1,67 @@
+# Autostart routes — backs the Help → "Run at Windows startup" toggle.
+#
+# Loopback-only: a remote viewer (Tailscale / LAN) with a valid token must NOT
+# be able to register a per-user scheduled task on the host machine. Both
+# endpoints reject non-loopback callers with 403.
+
+function Test-DuneAutostartLoopbackRequest {
+    param($req)
+    try {
+        $remote = $req.RemoteEndPoint.Address
+        if ($remote) { return [System.Net.IPAddress]::IsLoopback($remote) }
+    } catch {}
+    return $false
+}
+
+# GET /api/autostart — current state.
+Register-DuneRoute -Method GET -Path '/api/autostart' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        if (-not (Test-DuneAutostartLoopbackRequest $req)) {
+            Write-DuneError -Response $res -Status 403 -Message 'Autostart can only be managed from the host machine.'
+            return
+        }
+        $state = Get-DuneAutostartState
+        Write-DuneJson -Response $res -Body $state
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+# POST /api/autostart  body: { enabled: bool }
+Register-DuneRoute -Method POST -Path '/api/autostart' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        if (-not (Test-DuneAutostartLoopbackRequest $req)) {
+            Write-DuneError -Response $res -Status 403 -Message 'Autostart can only be managed from the host machine.'
+            return
+        }
+
+        $enabled = $null
+        if ($body -is [hashtable]) {
+            if ($body.ContainsKey('enabled')) { $enabled = [bool]$body.enabled }
+        } elseif ($body -and $body.PSObject.Properties.Name -contains 'enabled') {
+            $enabled = [bool]$body.enabled
+        }
+        if ($null -eq $enabled) {
+            Write-DuneError -Response $res -Status 400 -Message "Missing required field 'enabled' (bool)."
+            return
+        }
+
+        if (-not (Test-DuneAutostartAvailable)) {
+            Write-DuneError -Response $res -Status 400 -Message 'Autostart is only available from the installed DuneServer.exe (not a dev pwsh build).'
+            return
+        }
+
+        $result = if ($enabled) { Register-DuneAutostart } else { Unregister-DuneAutostart }
+        if (-not $result.ok) {
+            Write-DuneError -Response $res -Status 500 -Message $result.error
+            return
+        }
+
+        $state = Get-DuneAutostartState
+        Write-DuneJson -Response $res -Body $state
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.1.0",
+  "version": "11.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.1.0",
+      "version": "11.3.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/src/api/autostart.ts
+++ b/webui/src/api/autostart.ts
@@ -1,0 +1,28 @@
+// Autostart API — backs the Help → "Run at Windows startup" toggle.
+//
+// Loopback-only on the backend: a remote viewer (Tailscale / LAN) cannot
+// register or remove the per-user scheduled task on the host machine, and the
+// UI hides the menu entry entirely in that case via isLocalViewer().
+import { api } from './client'
+
+export interface AutostartState {
+  /** True when a per-user scheduled task currently exists for the logged-in user. */
+  enabled: boolean
+  /** False when running from a dev pwsh shell (no .exe to register). UI should grey the toggle. */
+  available: boolean
+  taskName: string
+  taskPath: string
+  exePath?: string | null
+  user: string
+}
+
+export function getAutostartState() {
+  return api<AutostartState>('/api/autostart')
+}
+
+export function setAutostartEnabled(enabled: boolean) {
+  return api<AutostartState>('/api/autostart', {
+    method: 'POST',
+    body: JSON.stringify({ enabled }),
+  })
+}

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { Icon } from '../components/Icon'
 import { NAV_ITEMS, GROUP_LABELS, GROUP_ORDER, type NavGroup } from '../nav'
 import { useUpdateCheck } from '../hooks/useUpdateCheck'
 import { useDuneAdminWebUrl } from '../hooks/useDuneAdminWebUrl'
 import { buildDiagnosticBundle } from '../api/diagnostics'
+import { getAutostartState, setAutostartEnabled, type AutostartState } from '../api/autostart'
 import { isLocalViewer } from '../util/viewer'
 
 type MenuKey = NavGroup | 'help' | 'duneadmin'
@@ -27,6 +28,52 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
   const version = upd?.currentVersion ?? ''
   const [open, setOpen] = useState<MenuKey | null>(null)
   const rootRef = useRef<HTMLDivElement | null>(null)
+
+  // Autostart state. Only fetched on local viewers — the backend rejects
+  // non-loopback callers anyway and there's nothing the remote viewer could
+  // do with the result (the toggle is hidden for them below).
+  const local = isLocalViewer()
+  const [autostart, setAutostart] = useState<AutostartState | null>(null)
+  const [autostartBusy, setAutostartBusy] = useState(false)
+  const [autostartConfirm, setAutostartConfirm] = useState<null | { nextEnabled: boolean }>(null)
+  const [autostartError, setAutostartError] = useState<string | null>(null)
+
+  const refreshAutostart = useCallback(async () => {
+    if (!local) return
+    try {
+      const s = await getAutostartState()
+      setAutostart(s)
+    } catch {
+      // Older backends without the route just leave the item disabled —
+      // no toast, no scary error, the feature simply isn't there.
+      setAutostart(null)
+    }
+  }, [local])
+
+  useEffect(() => { void refreshAutostart() }, [refreshAutostart])
+
+  const onAutostartToggleClick = () => {
+    if (!autostart || !autostart.available || autostartBusy) return
+    setAutostartError(null)
+    setAutostartConfirm({ nextEnabled: !autostart.enabled })
+    setOpen(null)
+  }
+
+  const onAutostartConfirm = async () => {
+    if (!autostartConfirm) return
+    const target = autostartConfirm.nextEnabled
+    setAutostartBusy(true)
+    setAutostartError(null)
+    try {
+      const s = await setAutostartEnabled(target)
+      setAutostart(s)
+      setAutostartConfirm(null)
+    } catch (e) {
+      setAutostartError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setAutostartBusy(false)
+    }
+  }
 
   // Click-outside and Escape to close any open dropdown.
   useEffect(() => {
@@ -178,6 +225,32 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               </span>
               <Icon name="ExternalLink" size={11} className="text-text-dim mt-1" />
             </button>
+            {local && autostart && autostart.available && (
+              <button
+                type="button"
+                onClick={onAutostartToggleClick}
+                disabled={autostartBusy}
+                className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors text-left disabled:opacity-60 disabled:cursor-wait"
+                title={
+                  autostart.enabled
+                    ? 'Currently launching at Windows logon in the system tray. Click to stop running at startup.'
+                    : 'Click to launch Dune Server automatically when you log in to Windows.'
+                }
+              >
+                <Icon name="Power" size={14} className="mt-0.5" />
+                <span className="flex-1">
+                  <span className="block">Run at Windows startup</span>
+                  <span className="block text-[11px] text-text-dim">
+                    {autostart.enabled
+                      ? 'Enabled — server keeps running when you close this window'
+                      : 'Disabled — closing this window stops the server'}
+                  </span>
+                </span>
+                {autostart.enabled && (
+                  <Icon name="Check" size={13} className="text-success mt-1" />
+                )}
+              </button>
+            )}
             <button
               type="button"
               onClick={() => { onToggleSidebar(); setOpen(null) }}
@@ -223,6 +296,62 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               aria-hidden
             />
           </button>
+        </div>
+      )}
+
+      {/* Autostart toggle — confirmation modal. Lives at the menubar root
+          rather than inside the dropdown so it stays visible after the menu
+          closes on click. */}
+      {autostartConfirm && (
+        <div
+          className="fixed inset-0 z-[60] bg-black/60 flex items-center justify-center p-4"
+          onClick={() => { if (!autostartBusy) { setAutostartConfirm(null); setAutostartError(null) } }}
+        >
+          <div
+            className="bg-surface border border-border rounded-xl shadow-2xl max-w-md w-full p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-start gap-3 mb-3">
+              <Icon name="Power" size={20} className="text-accent-bright mt-0.5" />
+              <div className="flex-1">
+                <h2 className="text-base font-semibold text-text mb-1">
+                  {autostartConfirm.nextEnabled ? 'Run Dune Server at Windows startup?' : 'Stop running at Windows startup?'}
+                </h2>
+                <p className="text-sm text-text-muted leading-snug">
+                  {autostartConfirm.nextEnabled
+                    ? 'Dune Server will launch in the system tray every time you log in to Windows. Closing this window will no longer stop the server — use the tray icon’s “Quit (stop server)” to shut it down. You can turn this off any time from Help → Run at Windows startup.'
+                    : 'Dune Server will no longer start automatically. This takes effect at your next login — the currently running server keeps going until you quit it. You can re-enable it any time from Help → Run at Windows startup.'}
+                </p>
+              </div>
+            </div>
+            {autostartError && (
+              <div className="mb-3 p-2 rounded bg-danger/10 border border-danger/30 text-sm text-danger">
+                {autostartError}
+              </div>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => { setAutostartConfirm(null); setAutostartError(null) }}
+                disabled={autostartBusy}
+                className="px-3 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={onAutostartConfirm}
+                disabled={autostartBusy}
+                className="px-3 py-1.5 rounded text-sm bg-accent text-white hover:bg-accent-bright disabled:opacity-60 disabled:cursor-wait"
+              >
+                {autostartBusy
+                  ? 'Working…'
+                  : autostartConfirm.nextEnabled
+                    ? 'Enable autostart'
+                    : 'Disable autostart'}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Adds a per-user **Task Scheduler "at logon"** job that launches `DuneServer.exe --headless`. In headless mode the server runs in the tray with no DuneShell window, and **closing DuneShell never stops the server**. The toggle lives in the **Help dropdown** so it's reachable regardless of whether the user picked "send to tray" at install. Loopback-only — remote viewers (Tailscale/LAN) can't enable autostart on the host.

Not a real Windows service: services run in Session 0 = no tray, no DuneShell, no UI. A scheduled task at user logon gives us all the "starts with Windows" UX without breaking the whole UI model.

## Behavior

| Autostart | App window closed |
|---|---|
| **off** (today) | Server stops (tray icon → Quit also stops it) |
| **on** | Server stays running in tray; reopen via tray "Open Web Portal" / DuneShell shortcut |

- Toggling mid-session **does not retroactively** re-arm/disarm the watcher — takes effect at next launch. Avoids the "I closed the app, why is it still running?" bug class. Modal text states this.
- Task is named `DuneServer-Autostart-<sidShort>` under `\Dune Server\`, one per Windows user. Multi-user safe.
- Uninstaller cleans up all `DuneServer-Autostart-*` tasks (runs as admin).

## Files

**Backend**
- `app/server/lib/Autostart.ps1` *(new, ~190 lines)* — task abstraction. NTAccount-based principal, ScheduledTasks cmdlets with `schtasks.exe` fallback. Returns `@{ ok; error }`.
- `app/server/routes/Autostart.ps1` *(new)* — `GET`/`POST /api/autostart`, loopback-only (403 otherwise).
- `app/DuneServer.ps1` — parse `--headless` from `[Environment]::GetCommandLineArgs()` early; pass through self-elevation `RunAs` branch; treat a **headless second instance as `exit 0` BEFORE** the detached-restart logic (logon can fire twice); in headless: force tray mode, skip DuneShell launch, set `$DuneKeepAliveAfterShellClose`.
- `app/server/lib/ConsoleHost.ps1` — refactor `Start-DuneConsoleLifecycle`: tray icon arms whenever `mode='tray'` (with or without AppProc), app-window watcher arms only when AppProc exists AND not keep-alive.

**Frontend**
- `webui/src/api/autostart.ts` *(new)* — `AutostartState` + 2 calls.
- `webui/src/layout/MenuBar.tsx` — Help menu item "Run at Windows startup", gated on `isLocalViewer() && state.available`. Confirm modal with enable/disable copy.

**Installer**
- `app/installer/DuneServer.iss` — `[UninstallRun]` removes per-user autostart tasks across all users.

## Verification

- ✅ `npm run build` (webui) — clean.
- ✅ PowerShell parse-check on all 4 modified/new PS files — clean.
- ✅ `npx eslint` on new files — single warning is the same pre-existing `react-hooks/set-state-in-effect` pattern already used in `useUpdateCheck.ts`, `Maps.tsx`, `RemoteAccessCard.tsx`; not in scope for this PR.
- ⚠️ Inno Setup `ISCC` not installed in this env — escaping (`""`, `{{`/`}}`) inspected manually against Inno docs.
- ⏭️ Manual integration test (toggle on → reboot → verify autostart → close DuneShell → server persists → toggle off → reboot → clean) deferred to user; requires UAC + reboot.

## Key technical decisions

- **`--headless` arg via `[Environment]::GetCommandLineArgs()`** — PS2EXE reliably surfaces it there; `$args` is flakier.
- **Headless second-instance early-exit** lives **before** the detached-restart branch — without it, a second logon-trigger fire would kill the running headless server.
- **Watcher disarm signal** (`$DuneKeepAliveAfterShellClose`) is captured from process-start args, never re-read from Task Scheduler mid-session. Process-state, not feature-state.
- **In headless, force tray mode regardless of saved `ConsolePresence`** — without a tray, headless = "no app window, no way to quit or reach the UI" = UX dead-end.
- **Per-user task name** uses last RID of SID — multi-user systems get one task per user, no collision.

## Known limitations (documented, not blockers)

- In-app updater relaunches without `--headless`. Next session is non-headless until next logon. Acceptable for v1.
- If user manually opens DuneShell from tray and then chooses tray-Quit, an orphan DuneShell shows reconnecting state. User can close it.