### PR TITLE
docs: document Help → Run at Windows startup toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,35 @@ You can also check manually from **Settings → Updates → Check now**.
 
 ---
 
+## Run at Windows startup *(optional)*
+
+The **Help** menu (top toolbar) has a **Run at Windows startup** toggle.
+Turn it on and DuneServer launches automatically every time you sign in to
+Windows — in the system tray with no app window — and **closing the
+DuneShell window no longer stops the server**.
+
+- Reopen the portal any time from the **tray icon → Open Web Portal**, or
+  just launch the Start Menu shortcut again (the running background server
+  stays where it is; the shortcut brings the app window back).
+- Toggling on or off takes effect at the **next launch**. Flipping mid-
+  session doesn't change the current session's close behavior — that's
+  intentional, so closing the app window always does what you just saw it
+  do, not what a setting says it should do.
+- **Loopback-only**: remote viewers (Tailscale / LAN / the SSH-tunneled
+  co-admin pattern below) cannot enable autostart on your host. The menu
+  entry is hidden for non-local viewers and the backend route refuses
+  non-loopback callers.
+- Implemented as a per-user Task Scheduler "at logon" job named
+  `DuneServer-Autostart-<sid>` under the `Dune Server` folder. The
+  uninstaller removes it automatically.
+
+**Off by default — opt-in only.** If the toggle is missing from the Help
+menu you're either viewing remotely (expected) or running from a dev
+`pwsh` shell rather than the installed `DuneServer.exe` (also expected —
+the feature needs the .exe path to schedule).
+
+---
+
 ## CLI launcher *(`dune-server.bat`)*
 
 The repo also ships a menu-driven PowerShell CLI for scripting one-off

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -96,6 +96,7 @@ const features = [
         <div>✓ dune-admin integration (optional)</div>
         <div>✓ Setup wizard (Hyper-V, SSH, firewall)</div>
         <div>✓ Built-in auto-updater</div>
+        <div>✓ Optional auto-start at Windows sign-in</div>
         <div>✓ Six built-in themes + custom color picker</div>
       </div>
       <div class="mt-8 flex flex-wrap gap-4">

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -113,6 +113,18 @@ import DownloadButton from "../components/DownloadButton.astro";
       </li>
     </ul>
 
+    <h2 class="text-2xl font-semibold mb-4">Optional: run at Windows startup</h2>
+    <p class="text-dune-muted leading-relaxed mb-4">
+      Off by default. Open <strong class="text-dune-text">Help → Run at
+      Windows startup</strong> in the top toolbar to toggle it on. After
+      that, DST launches automatically at every Windows sign-in — in the
+      system tray with no app window — and closing the DuneShell window no
+      longer stops the server. Toggle it back off the same way; takes
+      effect at the next launch. The toggle is loopback-only — remote
+      viewers can't enable it on your host. The uninstaller cleans up the
+      scheduled task automatically.
+    </p>
+
     <h2 class="text-2xl font-semibold mb-4">Where things live</h2>
     <div
       class="rounded-lg border border-dune-border bg-dune-surface overflow-hidden text-sm"


### PR DESCRIPTION
Follow-up to #98. Documents the new **Help → Run at Windows startup** toggle.

## Changes

- **`README.md`** — new "Run at Windows startup *(optional)*" subsection between Auto-update and CLI launcher. Covers: where the toggle lives, what enabling it changes (tray-only autostart, close-app-window no longer stops the server), the "takes effect at next launch" semantic, loopback-only enforcement, per-user task name + uninstaller cleanup, off-by-default + when the menu entry is hidden.
- **`site/src/pages/index.astro`** — added `✓ Optional auto-start at Windows sign-in` to the "What's in the box" checklist.
- **`site/src/pages/install.astro`** — short paragraph between the requirements list and "Where things live" so install-page readers see it.

## Not included

- **No screenshot update.** It's a single menu item inside a dropdown, not a page. None of the existing `docs/img/*.png` shots show the Help dropdown; a dedicated screenshot of the open menu would be the cleanest addition but is best captured manually rather than from a CLI session (timing an open dropdown reliably is fragile). Existing screenshots remain valid.
- **No `features.astro` entry.** That page is a per-screen tour and every entry pairs with a screenshot in the alternating-grid layout — adding an entry without an image would break the layout. Revisit once a Help-menu screenshot exists.

## Verification

- ✅ `npm run build` in `site/` clean — 7 pages emitted.