### PR TITLE
chore(release): bump version 11.3.3 → 11.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.0] - 2026-06-05
+
+### Added
+- **Run at Windows startup toggle (Help menu).** New opt-in toggle in
+  the Help dropdown of the top toolbar. When enabled, DuneServer launches
+  automatically at every Windows sign-in via a per-user Task Scheduler
+  "at logon" job — in the system tray with no app window — and closing
+  the DuneShell window no longer stops the server. The headless mode
+  forces tray-presence regardless of saved `ConsolePresence` so users
+  always have a way to reach the portal or quit. Toggle takes effect at
+  the next launch; mid-session flips don't change current-session close
+  behavior (intentional, avoids the "I closed the app expecting it to
+  quit, it didn't" surprise). The toggle is loopback-only — remote
+  viewers (Tailscale / LAN / SSH-tunneled co-admin) cannot enable
+  autostart on the host, and the menu entry is hidden for them. The
+  uninstaller removes all `DuneServer-Autostart-*` scheduled tasks
+  automatically. Off by default; opt-in only.
+
 ## [11.3.3] - 2026-06-05
 
 ### Security

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.3.3'
+$script:DuneToolVersion = '11.4.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.3.3',
+    [string]$Version = '11.4.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.3.3</Version>
+    <Version>11.4.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.3.3"
+#define MyAppVersion "11.4.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.3.3"
+$script:ToolVersion = "11.4.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.3.3",
+  "version": "11.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.3.3",
+      "version": "11.4.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.3.3",
+  "version": "11.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Minor bump for the new **Run at Windows startup** toggle (#98) and its docs (#99). All five enforced version stamps + `webui/package.json` now match at **11.4.0** — `Build-Installer.ps1`'s pre-flight version-sync check will pass.

Once merged, I'll tag `v11.4.0` from the merge commit, build `DuneServerSetup.exe`, and publish the release with the installer as the sole asset (per the standing hard rule).