### PR TITLE
hotfix(v11.4.1): restore DuneServer.exe boot (UTF-8 BOM on lib files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.1] - 2026-06-05
+
+### Fixed
+- **DuneServer.exe failed to boot on every v11.4.0 install** with a parse
+  error in `Autostart.ps1`. PS2EXE compiles against Windows PowerShell
+  5.1, which reads BOM-less `.ps1` files as the system ANSI codepage
+  (Windows-1252 on en-US) rather than UTF-8 — and `Autostart.ps1` plus
+  the v11.4.0 changes to `ConsoleHost.ps1` contained UTF-8 multi-byte
+  characters (em-dashes, right-arrows) without a UTF-8 BOM. PS 5.1
+  mis-tokenized those bytes and the parser counted `{` and `}` wrong,
+  producing a bogus "Missing closing '}'" error even though PowerShell
+  7 (used during development) parsed the same files cleanly. Adds a
+  UTF-8 BOM to the affected files, and adds a PS 5.1 parse pre-flight
+  to `Build-Installer.ps1` so this entire class of bug cannot ship
+  silently again — the installer build now refuses to compile if any
+  bundled `.ps1` fails to parse under PS 5.1.
+
 ## [11.4.0] - 2026-06-05
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.0'
+$script:DuneToolVersion = '11.4.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.0',
+    [string]$Version = '11.4.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.0</Version>
+    <Version>11.4.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/Build-Installer.ps1
+++ b/app/installer/Build-Installer.ps1
@@ -87,6 +87,65 @@ if (-not $iscc) {
     throw "ISCC.exe not found. Install Inno Setup 6: winget install --id JRSoftware.InnoSetup"
 }
 
+# ---------------------------------------------------------------------------
+# Pre-flight: Windows PowerShell 5.1 parse-check of every .ps1 the installer
+# will bundle.
+#
+# DuneServer.exe is compiled via PS2EXE, which produces a Windows PowerShell
+# 5.1 host. PS 5.1 reads .ps1 files WITHOUT a UTF-8 BOM as the system ANSI
+# codepage (Windows-1252 on en-US), not UTF-8. If a BOM-less file contains
+# UTF-8 multi-byte characters (em-dash, ellipsis, right-arrow, etc.) the
+# resulting byte stream can confuse PS 5.1's parser and produce bogus
+# "Missing closing '}'" errors at runtime — even though PowerShell 7 (used
+# during development) parses the file cleanly.
+#
+# This bit us in v11.4.0: Autostart.ps1 and ConsoleHost.ps1 shipped without
+# BOMs and contained em-dashes/arrows, and DuneServer.exe failed to boot on
+# every install. Catch it here, before the release ships.
+# ---------------------------------------------------------------------------
+$ps5Exe = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
+if (Test-Path $ps5Exe) {
+    $bundledPs1 = @()
+    foreach ($d in @('server', 'lib', 'data', 'resources')) {
+        $p = Join-Path $appRoot $d
+        if (Test-Path $p) { $bundledPs1 += Get-ChildItem $p -Recurse -Filter '*.ps1' -File }
+    }
+    $bundledPs1 += Get-Item (Join-Path $appRoot 'DuneServer.ps1')
+
+    $ps5ParseScript = @'
+param([string[]]$Paths)
+$exitCode = 0
+foreach ($p in $Paths) {
+  $errors = $null; $tokens = $null
+  [void][System.Management.Automation.Language.Parser]::ParseFile($p, [ref]$tokens, [ref]$errors)
+  if ($errors -and $errors.Count -gt 0) {
+    $exitCode = 1
+    Write-Host ("FAIL: " + $p)
+    foreach ($e in $errors) {
+      Write-Host ("  L" + $e.Extent.StartLineNumber + " C" + $e.Extent.StartColumnNumber + ": " + $e.Message)
+    }
+  }
+}
+exit $exitCode
+'@
+    $ps5ScriptPath = Join-Path $env:TEMP "dune-ps5-parse-check-$([guid]::NewGuid().ToString('N')).ps1"
+    Set-Content -LiteralPath $ps5ScriptPath -Value $ps5ParseScript -Encoding UTF8
+    try {
+        Write-Host "PS 5.1 parse pre-flight on $($bundledPs1.Count) .ps1 files..." -ForegroundColor Cyan
+        $paths = $bundledPs1 | ForEach-Object { $_.FullName }
+        & $ps5Exe -NoProfile -ExecutionPolicy Bypass -File $ps5ScriptPath -Paths $paths
+        if ($LASTEXITCODE -ne 0) {
+            throw "PS 5.1 parse pre-flight failed. PS2EXE compiles against PS 5.1; files that fail here will break DuneServer.exe at startup. Fix: add a UTF-8 BOM to any BOM-less .ps1 file containing non-ASCII characters."
+        }
+        Write-Host "  All .ps1 files parse under PS 5.1." -ForegroundColor Green
+        Write-Host ""
+    } finally {
+        Remove-Item -LiteralPath $ps5ScriptPath -ErrorAction SilentlyContinue
+    }
+} else {
+    Write-Warning "Windows PowerShell 5.1 not found at $ps5Exe — skipping PS 5.1 parse pre-flight. This is the runtime PS2EXE targets; missing the check means v11.4.0-class encoding bugs could ship undetected."
+}
+
 # Build the React SPA (writes webui/dist) — bundled into installer below.
 if (-not $SkipWebBuild) {
     if (-not (Test-Path $webuiDir)) { throw "webui/ folder not found at $webuiDir" }

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.0"
+#define MyAppVersion "11.4.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Autostart.ps1
+++ b/app/server/lib/Autostart.ps1
@@ -1,4 +1,4 @@
-# Autostart — "Run at Windows startup" for DuneServer.
+﻿# Autostart — "Run at Windows startup" for DuneServer.
 #
 # Backs the Help → "Run at Windows startup" toggle. When enabled we register a
 # per-user Task Scheduler job that launches DuneServer.exe with --headless at

--- a/app/server/lib/ConsoleHost.ps1
+++ b/app/server/lib/ConsoleHost.ps1
@@ -1,4 +1,4 @@
-# ConsoleHost — links the DuneServer console + the DuneShell app window so they
+﻿# ConsoleHost — links the DuneServer console + the DuneShell app window so they
 # share a single lifecycle, and lets the user pick how the console presents
 # itself (minimized vs. system tray) while the app window is open.
 #

--- a/app/server/routes/Autostart.ps1
+++ b/app/server/routes/Autostart.ps1
@@ -1,4 +1,4 @@
-# Autostart routes — backs the Help → "Run at Windows startup" toggle.
+﻿# Autostart routes — backs the Help → "Run at Windows startup" toggle.
 #
 # Loopback-only: a remote viewer (Tailscale / LAN) with a valid token must NOT
 # be able to register a per-user scheduled task on the host machine. Both

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.0"
+$script:ToolVersion = "11.4.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.0",
+  "version": "11.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.0",
+      "version": "11.4.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.0",
+  "version": "11.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Why

v11.4.0 was pulled — every install failed to boot with a parse error in `Autostart.ps1`:

> Missing closing '}' in statement block or type definition.

## Root cause

PS2EXE compiles against **Windows PowerShell 5.1**. PS 5.1 reads BOM-less `.ps1` files as the system ANSI codepage (Windows-1252 on en-US) rather than UTF-8. `Autostart.ps1` (new) and `ConsoleHost.ps1` (modified) shipped without UTF-8 BOMs and contained em-dashes / right-arrows. PS 5.1 mis-tokenized the bytes and the parser counted `{` / `}` wrong — even though PowerShell 7 (used during development) parsed the same files cleanly. The dev `[Parser]::ParseFile` pre-flight I ran in prep for v11.4.0 used PS 7 and therefore missed it.

## Fix

- **UTF-8 BOM** added to:
  - `app/server/lib/Autostart.ps1` (broken in v11.4.0)
  - `app/server/lib/ConsoleHost.ps1` (broken in v11.4.0)
  - `app/server/routes/Autostart.ps1` (also BOM-less + non-ASCII; PS 5.1 happened to parse it OK but the same class — preventive)

## Defense in depth

- New **PS 5.1 parse pre-flight** in `Build-Installer.ps1`. It locates `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, parses every bundled `.ps1` with the PS 5.1 host, and **fails the build** if any file errors. Without this, "looks fine under pwsh 7" is not proof the installed `.exe` will boot.
- Rehearsed locally — all 51 bundled `.ps1` files parse clean under PS 5.1.

## Version

`11.4.0` → `11.4.1` across all 5 enforced stamps + `webui/package.json`.

## Follow-up

Will be tagged and shipped immediately after merge with `DuneServerSetup.exe` as the sole asset (hard rule).