### PR TITLE
fix(autostart): keep backend alive across DuneShell close when autostart is on (v11.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.2] - 2026-06-05
+
+### Changed
+- **Autostart now means "background service" immediately, not just at the
+  next logon.** Toggling Help -> Run at Windows startup ON previously
+  only changed behaviour at the next logon (the scheduled task launched
+  DST with `--headless`, which keeps the backend console alive when
+  DuneShell closes). A DST you launched manually the same day still
+  treated the close-DuneShell button as "stop everything", surprising
+  users who expected the toggle to mean "DST is a service from now on,
+  the GUI just attaches / detaches." The backend now stays alive across
+  a DuneShell close whenever the autostart task is registered for the
+  current user -- manual launches and the scheduled-task `--headless`
+  launches both behave the same way. Click the desktop shortcut to
+  re-open a viewer against the running backend; stop it explicitly via
+  the tray icon's Quit, or by closing the DuneServer console window
+  itself. Toggling autostart OFF mid-run is unchanged (the next launch
+  reverts to the old "close = stop" semantic).
+
 ## [11.4.1] - 2026-06-05
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.1'
+$script:DuneToolVersion = '11.4.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the
@@ -588,7 +588,37 @@ $script:DuneIconPath = $null
 # Process-lifetime flag: when true, closing the (manually-opened) DuneShell
 # does NOT stop the listener. Set unconditionally in headless mode; the
 # autostart toggle's "next launch" semantic means we don't flip this mid-run.
-$script:DuneKeepAliveAfterShellClose = [bool]$script:DuneHeadlessMode
+# Process-lifetime flag: when true, closing the (manually-opened) DuneShell
+# does NOT stop the listener -- the backend keeps running and the user can
+# re-attach by clicking the shortcut (the single-instance branch above
+# spawns a fresh DuneShell against the live backend instead of restarting).
+#
+# True in two cases:
+#   * --headless launch (the scheduled-task autostart path): no app window
+#     is even launched; the tray icon is the only handle on the backend.
+#   * Autostart task currently registered for this user: even when DST is
+#     launched manually (shortcut click, not the scheduled-task path), the
+#     user has opted into "background service" semantics by enabling Help
+#     -> Run at Windows startup. Closing the DuneShell viewer should NOT
+#     take the merged DuneServer + dune-admin console down with it.
+#
+# Evaluated at startup only. Toggling Help -> Run at Windows startup mid-run
+# does not flip this flag; the new semantic takes effect on the next launch.
+#
+# ASCII-only on purpose: this file is BOM-less and PS2EXE compiles against
+# Windows PowerShell 5.1, which reads BOM-less files as Windows-1252. Adding
+# em-dashes or right-arrows here would risk the v11.4.0-class parse breakage
+# the v11.4.1 hotfix addressed.
+$script:DuneAutostartRegistered = $false
+try {
+    if (Get-Command Test-DuneAutostartEnabled -ErrorAction SilentlyContinue) {
+        $script:DuneAutostartRegistered = [bool](Test-DuneAutostartEnabled)
+    }
+} catch { $script:DuneAutostartRegistered = $false }
+$script:DuneKeepAliveAfterShellClose = [bool]$script:DuneHeadlessMode -or $script:DuneAutostartRegistered
+if ($script:DuneAutostartRegistered -and -not $script:DuneHeadlessMode) {
+    Write-DuneLog "Autostart task registered for this user - closing the DuneShell window will leave the backend console running; click the shortcut again to re-open the viewer, or stop the backend explicitly via the tray / console window"
+}
 
 $openInAppWindow = $false
 try { $openInAppWindow = Get-DstOpenInAppWindow } catch { $openInAppWindow = $true }

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.1',
+    [string]$Version = '11.4.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.1</Version>
+    <Version>11.4.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.1"
+#define MyAppVersion "11.4.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.1"
+$script:ToolVersion = "11.4.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.1",
+  "version": "11.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.1",
+      "version": "11.4.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.1",
+  "version": "11.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Why

Toggling **Help → Run at Windows startup** ON only changes behaviour at the next logon today. The scheduled task launches DST with `--headless`, which sets `$DuneKeepAliveAfterShellClose = $true` so closing DuneShell leaves the merged DuneServer + dune-admin console running. A DST you launched manually the same day still treats the close-DuneShell button as "stop everything", which surprises users who expected the toggle to mean "DST is a service from now on, the GUI just attaches / detaches."

## What

In `app/DuneServer.ps1`, the `DuneKeepAliveAfterShellClose` flag is now ALSO true whenever the per-user autostart scheduled task is currently registered, regardless of whether `--headless` was on the command line. Evaluated once at startup — toggling autostart mid-run takes effect on the next launch (matches the existing "next launch" semantic).

When the flag is on:
- Closing DuneShell leaves the backend running.
- Clicking the desktop shortcut spawns a fresh DuneShell against the live backend (existing single-instance branch already handles this; the `restart-requested` branch is gated on `detached.flag`, only set by the explicit "Web Portal" detach button, so it is NOT triggered here).
- The user stops the backend explicitly via the tray icon's Quit, or by closing the DuneServer console window itself.

## Stamps

All six version stamps + the webui lockfile bumped `11.4.1 → 11.4.2` so the in-app updater picks this up.

## v11.4.1-class trap avoided

Comment text added to `app/DuneServer.ps1` is **ASCII-only on purpose**. The file is BOM-less and PS2EXE compiles against PS 5.1; adding em-dashes / right-arrows here would risk the same regression the v11.4.1 hotfix addressed. Verified `app/DuneServer.ps1` still parses cleanly under `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`. The build-time pre-flight in `Build-Installer.ps1` will catch any future slip.

## Verified scenarios

| Autostart | Launch | Close DuneShell | Expected | After this PR |
|---|---|---|---|---|
| off | manual | — | backend stops | ✓ unchanged |
| on | scheduled-task (`--headless`) | — | backend stays (no shell) | ✓ unchanged |
| on | manual shortcut | close | **backend stays** | ✓ **fixed** |
| on, then toggled off mid-run | manual | close | backend stays (this run) | ✓ (next launch reverts) |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>