### PR TITLE
fix(shell): autostart keep-alive (real fix) + dune-admin "Open in browser" (v11.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.3] - 2026-06-05
+
+### Fixed
+- **dune-admin's "Open in browser" link now actually opens in the OS
+  browser** instead of replacing the portal inside the DST app window.
+  The shell's new-window handler used to treat any loopback URL as
+  "stay in this WebView" — but dune-admin runs on its own loopback
+  port, so clicking dune-admin's "Open in browser" link navigated the
+  shell away from the DST portal into the standalone dune-admin view.
+  Now only URLs whose loopback port matches the portal's own port stay
+  in the shell; every other loopback port (dune-admin's port, any
+  localhost helper tool) is handed to the OS default browser, the
+  same as non-localhost links.
+
 ## [11.4.2] - 2026-06-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ here cover everything those tags shipped.
 ## [11.4.3] - 2026-06-05
 
 ### Fixed
+- **Autostart keep-alive now actually keeps the backend running when you
+  close DuneShell.** v11.4.2 disarmed the backend's app-window watcher
+  when autostart was registered, but the DuneShell viewer's own
+  `FormClosing` handler was still firing its full teardown sequence:
+  `POST /api/shutdown`, kill `dune-admin.exe`, then sweep up
+  `DuneServer.exe` by name. The end result was the backend going down
+  anyway -- "Shutdown requested via /api/shutdown" in `dune-server.log`
+  even though the watcher had logged "Keep-alive mode active." The
+  backend now writes a live `keep-alive.flag` sentinel (refreshed on
+  startup AND on every Help -> Run at Windows startup toggle), and
+  DuneShell's `StopCompanionProcesses` returns early when the sentinel
+  is present -- no shutdown POST, no dune-admin kill, no DuneServer.exe
+  sweep. Toggling autostart at runtime now also takes effect without a
+  restart: the watcher consults the same sentinel before stopping the
+  listener.
 - **dune-admin's "Open in browser" link now actually opens in the OS
   browser** instead of replacing the portal inside the DST app window.
   The shell's new-window handler used to treat any loopback URL as

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.2'
+$script:DuneToolVersion = '11.4.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -619,6 +619,13 @@ $script:DuneKeepAliveAfterShellClose = [bool]$script:DuneHeadlessMode -or $scrip
 if ($script:DuneAutostartRegistered -and -not $script:DuneHeadlessMode) {
     Write-DuneLog "Autostart task registered for this user - closing the DuneShell window will leave the backend console running; click the shortcut again to re-open the viewer, or stop the backend explicitly via the tray / console window"
 }
+# Sync the on-disk keep-alive sentinel so DuneShell's FormClosing teardown
+# knows to skip its /api/shutdown + dune-admin kill + DuneServer.exe sweep
+# when keep-alive is active. Refreshed at runtime by Register-/Unregister-
+# DuneAutostart so toggling the Help menu takes effect without restart.
+if (Get-Command Update-DuneKeepAliveFlag -ErrorAction SilentlyContinue) {
+    try { [void](Update-DuneKeepAliveFlag) } catch {}
+}
 
 $openInAppWindow = $false
 try { $openInAppWindow = Get-DstOpenInAppWindow } catch { $openInAppWindow = $true }

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.2',
+    [string]$Version = '11.4.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.2</Version>
+    <Version>11.4.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -151,16 +151,32 @@ internal sealed class MainForm : Form
 
     private void OnNewWindowRequested(object? sender, CoreWebView2NewWindowRequestedEventArgs e)
     {
-        // window.open / target=_blank: keep loopback (the portal itself) in the
-        // shell, send everything else (websites, dune-admin web UI) to the OS browser.
+        // window.open / target=_blank routing:
+        //   * Same-origin as the portal's own URL (loopback + same port) -> keep
+        //     in this shell. Covers in-portal "open in new tab" flows like the
+        //     updater's safe-to-close page or any future window.open from React.
+        //   * Anything else, including OTHER loopback ports (e.g. dune-admin's
+        //     own HTTP port via the iframe's "Open in browser" link, or any
+        //     localhost game-tool URL) -> hand to the OS default browser. Just
+        //     checking `IsLoopback` here was too broad and caused dune-admin's
+        //     "Open in browser" to navigate the shell off the portal instead.
         e.Handled = true;
-        if (Uri.TryCreate(e.Uri, UriKind.Absolute, out var u))
+        if (!Uri.TryCreate(e.Uri, UriKind.Absolute, out var u)) return;
+
+        bool keepInShell = false;
+        if (u.IsLoopback &&
+            Uri.TryCreate(_targetUrl, UriKind.Absolute, out var portal) &&
+            portal.IsLoopback &&
+            u.Port == portal.Port &&
+            string.Equals(u.Scheme, portal.Scheme, StringComparison.OrdinalIgnoreCase))
         {
-            if (u.IsLoopback)
-                _web.CoreWebView2?.Navigate(e.Uri);
-            else
-                OpenExternal(e.Uri.ToString());
+            keepInShell = true;
         }
+
+        if (keepInShell)
+            _web.CoreWebView2?.Navigate(e.Uri);
+        else
+            OpenExternal(e.Uri.ToString());
     }
 
     /// <summary>

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -464,6 +464,24 @@ internal sealed class MainForm : Form
     {
         if (!_useWaitFile) return;
 
+        // Keep-alive opt-out: when the backend wrote keep-alive.flag, the
+        // user has registered DST autostart (or launched --headless), and
+        // closing the viewer must NOT take the backend + wrapped dune-admin
+        // console down with it. They re-attach to the live backend by
+        // clicking the shortcut again, and stop it explicitly via the
+        // tray's "Quit (stop server)" or the console window. The flag is
+        // refreshed live by the backend on startup AND on every autostart
+        // toggle, so this reflects current intent rather than launch-time
+        // state.
+        try
+        {
+            string keepAliveFlag = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "DuneServer", "keep-alive.flag");
+            if (File.Exists(keepAliveFlag)) return;
+        }
+        catch { /* defensive -- fall through to the normal teardown */ }
+
         // 1) Graceful backend shutdown via the same loopback URL + token the
         //    WebView is using. Send synchronously with a tight timeout so we
         //    don't drag out window close past ~750ms in the worst case.

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.2"
+#define MyAppVersion "11.4.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Autostart.ps1
+++ b/app/server/lib/Autostart.ps1
@@ -143,6 +143,11 @@ function Register-DuneAutostart {
         if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
             Write-DuneLog "Autostart enabled: registered scheduled task '$folder$name' for $user (exe: $exe)"
         }
+        # Refresh the keep-alive sentinel so closing the shell from this
+        # point on leaves the backend running (no need to restart DST).
+        if (Get-Command Update-DuneKeepAliveFlag -ErrorAction SilentlyContinue) {
+            try { [void](Update-DuneKeepAliveFlag) } catch {}
+        }
         return @{ ok = $true }
     } catch {
         $msg = $_.Exception.Message
@@ -166,6 +171,9 @@ function Unregister-DuneAutostart {
             if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
                 Write-DuneLog "Autostart disabled: removed scheduled task '$folder$name'"
             }
+            if (Get-Command Update-DuneKeepAliveFlag -ErrorAction SilentlyContinue) {
+                try { [void](Update-DuneKeepAliveFlag) } catch {}
+            }
             return @{ ok = $true }
         }
         # Fallback to schtasks.exe.
@@ -173,6 +181,9 @@ function Unregister-DuneAutostart {
         & schtasks.exe /Delete /TN $fullName /F 2>&1 | Out-Null
         if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
             Write-DuneLog "Autostart disabled (schtasks fallback): '$fullName' (exit $LASTEXITCODE)"
+        }
+        if (Get-Command Update-DuneKeepAliveFlag -ErrorAction SilentlyContinue) {
+            try { [void](Update-DuneKeepAliveFlag) } catch {}
         }
         return @{ ok = $true }
     } catch {

--- a/app/server/lib/ConsoleHost.ps1
+++ b/app/server/lib/ConsoleHost.ps1
@@ -63,6 +63,61 @@ function Clear-DuneAppDetached {
     } catch { }
 }
 
+# Sentinel file consumed by DuneShell's FormClosing teardown AND by the
+# app-window watcher runspace. When this file exists, neither side should
+# tear the backend down on shell close -- the user has opted into
+# "background service" semantics (autostart registered or --headless launch)
+# and the backend (+ wrapped dune-admin console) is expected to outlive any
+# manually-opened DuneShell.
+#
+# Live state: rewritten on every startup AND on every autostart toggle
+# (Register-/Unregister-DuneAutostart), so closing the shell mid-run
+# always reflects the user's current intent rather than the snapshot
+# captured at process startup.
+function Get-DuneKeepAliveStateFile {
+    $dir = Join-Path $env:LOCALAPPDATA 'DuneServer'
+    return (Join-Path $dir 'keep-alive.flag')
+}
+
+function Set-DuneKeepAliveFlag {
+    try {
+        $file = Get-DuneKeepAliveStateFile
+        $dir = Split-Path -Parent $file
+        if (-not (Test-Path -LiteralPath $dir)) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        }
+        $payload = @{
+            pid       = $PID
+            timestamp = (Get-Date).ToString('o')
+        } | ConvertTo-Json -Compress
+        Set-Content -LiteralPath $file -Value $payload -Encoding UTF8 -Force
+    } catch { }
+}
+
+function Clear-DuneKeepAliveFlag {
+    try {
+        $file = Get-DuneKeepAliveStateFile
+        if (Test-Path -LiteralPath $file) {
+            Remove-Item -LiteralPath $file -Force -ErrorAction SilentlyContinue
+        }
+    } catch { }
+}
+
+# Recompute the effective keep-alive state from live inputs (headless mode +
+# whether the autostart task is currently registered for this user) and write
+# or remove the sentinel file accordingly. Safe to call repeatedly.
+function Update-DuneKeepAliveFlag {
+    $autostart = $false
+    try {
+        if (Get-Command Test-DuneAutostartEnabled -ErrorAction SilentlyContinue) {
+            $autostart = [bool](Test-DuneAutostartEnabled)
+        }
+    } catch { $autostart = $false }
+    $keep = [bool]$script:DuneHeadlessMode -or $autostart
+    if ($keep) { Set-DuneKeepAliveFlag } else { Clear-DuneKeepAliveFlag }
+    return $keep
+}
+
 # Two-button first-run dialog. Returns 'console' or 'tray' ('console' on any
 # failure so we never end up with a hidden, unmanaged console).
 function Show-DuneConsolePresencePrompt {
@@ -287,6 +342,7 @@ function Start-DuneConsoleLifecycle {
             $rs.SessionStateProxy.SetVariable('AppProc',  $script:DuneAppProc)
             $rs.SessionStateProxy.SetVariable('Listener', $Listener)
             $rs.SessionStateProxy.SetVariable('DetachStateFile', (Get-DuneDetachStateFile))
+            $rs.SessionStateProxy.SetVariable('KeepAliveStateFile', (Get-DuneKeepAliveStateFile))
             $ps = [PowerShell]::Create()
             $ps.Runspace = $rs
             [void]$ps.AddScript({
@@ -333,6 +389,18 @@ function Start-DuneConsoleLifecycle {
                     if ($survivor) { $proc = $survivor; continue }
                     break
                 }
+                # Final gate before tearing the listener down: if keep-alive
+                # was enabled at runtime (autostart toggled on after launch,
+                # or --headless), the user expects the backend to outlive
+                # the shell. Re-read the flag here -- the value captured at
+                # startup is stale by the time we get here.
+                $keepAlive = $false
+                try {
+                    if ($KeepAliveStateFile -and (Test-Path -LiteralPath $KeepAliveStateFile)) {
+                        $keepAlive = $true
+                    }
+                } catch { $keepAlive = $false }
+                if ($keepAlive) { return }
                 try { $Listener.Stop() } catch {}
             })
             $script:DuneWatcherPs     = $ps

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.2"
+$script:ToolVersion = "11.4.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.2",
+  "version": "11.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.2",
+      "version": "11.4.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.2",
+  "version": "11.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Two related DuneShell teardown bugs bundled into v11.4.3.

---

## 1. Autostart keep-alive — really, this time

v11.4.2 only fixed **half** the close path. The backend's app-window watcher was disarmed when autostart was registered, but DuneShell's own `FormClosing` handler kept firing its full teardown:

1. `POST /api/shutdown` (graceful backend stop)
2. Kill `dune-admin.exe`
3. Sweep `DuneServer.exe` by name (safety-net force-kill)

End result: backend goes down anyway. `dune-server.log` literally reads:

```
[21:42:09] [INFO] Keep-alive mode active — app-window watcher disarmed
[21:43:30] [INFO] Shutdown requested via /api/shutdown from 127.0.0.1:63587
[21:43:31] [INFO] Dune Server stopped
```

### Fix

- Backend writes `%LOCALAPPDATA%\DuneServer\keep-alive.flag` (mirroring the existing `detached.flag` pattern) reflecting the **live** keep-alive state.
- Sentinel is refreshed at startup AND on every `Register-DuneAutostart` / `Unregister-DuneAutostart` call — so toggling Help → Run at Windows startup at runtime takes effect without restarting DST.
- `DuneShell.StopCompanionProcesses` returns early when the sentinel is present — no `/api/shutdown`, no dune-admin kill, no DuneServer.exe sweep.
- The backend's app-window watcher runspace also consults the sentinel just before `$Listener.Stop()`, so a watcher that was armed at startup (autostart off then toggled on mid-run) also honors the new intent.

### Files

- `app/server/lib/ConsoleHost.ps1` — `Get-/Set-/Clear-/Update-DuneKeepAliveFlag` helpers + watcher gate before `Stop()`
- `app/server/lib/Autostart.ps1` — toggle hooks
- `app/DuneServer.ps1` — startup sync
- `app/desktop/DuneShell/MainForm.cs` — early-return guard at top of `StopCompanionProcesses`

---

## 2. dune-admin "Open in browser" routes to the OS browser

DuneShell's `OnNewWindowRequested` treated **any** loopback URL as "stay in this WebView". dune-admin runs on its own loopback port, so clicking dune-admin's "Open in browser" link navigated the shell off the portal into the standalone dune-admin view — opposite of what the link promises.

### Fix

Only loopback URLs that match the portal's own scheme + port (compared against `_targetUrl`) stay in-shell. Every other loopback URL — dune-admin's port, any localhost helper — is handed to `Process.Start(UseShellExecute=true)`.

---

## Stamps

`11.4.2 → 11.4.3` across all 5 enforced version files + `webui/package.json` + `package-lock.json`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>