### PR TITLE
Dashboard: add per-visit "Show raw output" toggle to Battlegroup info

### DIFF
--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -39,6 +39,28 @@ function healthClass(v: string | undefined): string {
   return 'text-text'
 }
 
+// BG state shown under Battlegroup Info is the Funcom operator's "Status"
+// column — a kube-operator reconcile phase. It normally sits in
+// "Reconciling" / "Reconciling Ready" while the battlegroup is perfectly
+// healthy, so both healthy and reconciling are surfaced as a green "Healthy".
+// Yellow/red are reserved for genuine transitions or faults — the per-component
+// Database / Gateway / Director rows below show real component health.
+function bgStateDisplay(v: string | undefined): { cls: string; label: string } {
+  const raw = (v ?? '').trim()
+  const s = raw.toLowerCase()
+  if (!s) return { cls: 'text-text-dim', label: '—' }
+  // Genuine fault → red.
+  if (/(fail|error|unhealthy|crash|degraded|fault|stopp|\bfalse\b)/.test(s)) {
+    return { cls: 'text-danger', label: raw }
+  }
+  // Healthy or reconciling → green "Healthy".
+  if (/(healthy|ready|reconcil|running|\btrue\b)/.test(s)) {
+    return { cls: 'text-success', label: 'Healthy' }
+  }
+  // Anything else (starting / updating / pending …) is an in-progress transition.
+  return { cls: 'text-warning', label: raw }
+}
+
 function GameServerRow({ s }: { s: BgGameServer }) {
   return (
     <tr className="border-t border-border/30">
@@ -251,13 +273,13 @@ export function Dashboard() {
             <p className="text-sm text-text-dim italic">No battlegroup info yet.</p>
           ) : (
             <dl className="grid grid-cols-[110px_1fr] gap-x-3 gap-y-1 text-sm leading-snug">
-              <dt className="text-text-dim" title="Funcom BG operator's overall reconcile state. Goes 'Reconciling' briefly whenever a Game Server is added or removed.">BG state</dt>
-              <dd className={healthClass(bgInfo.status)}>
-                {bgInfo.status || '—'}
-                {bgInfo.status === 'Reconciling' && (
+              <dt className="text-text-dim" title="Funcom BG operator's overall state. 'Reconciling' is the operator's normal steady state while it manages the battlegroup, so it's reported as Healthy. The DB / Gateway / Director rows below show actual component health.">BG state</dt>
+              <dd className={bgStateDisplay(bgInfo.status).cls} title={`Operator status: ${bgInfo.status || 'unknown'}`}>
+                {bgStateDisplay(bgInfo.status).label}
+                {/reconcil/i.test(bgInfo.status || '') && (
                   <span className="ml-2 text-[10px] uppercase tracking-wider text-text-dim font-normal"
-                        title="The BG operator is settling changes — usually because a map just spun up or down. The DB / Gateway / Director rows below show actual component health.">
-                    map churn
+                        title="The BG operator is reconciling — its steady state while managing the battlegroup, usually settling a map spin-up/down. The DB / Gateway / Director rows below show actual component health.">
+                    reconciling
                   </span>
                 )}
               </dd>

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -130,6 +130,10 @@ export function Dashboard() {
   // Deep Desert / Arakeen / Harko Village — on-demand map pods.
   const bgReady = bgState === 'running'
 
+  // Per-visit toggle for the raw `battlegroup status` text. Local state only,
+  // so it resets to hidden whenever the user navigates away from the page.
+  const [showRawBg, setShowRawBg] = useState(false)
+
   // Web Interfaces (File Browser + Director URLs)
   const [links, setLinks] = useState<LinksResponse | null>(null)
   const [linksLoading, setLinksLoading] = useState(false)
@@ -292,6 +296,21 @@ export function Dashboard() {
               <dt className="text-text-dim">Uptime</dt>
               <dd className="font-mono">{bgInfo.uptime || '—'}</dd>
             </dl>
+          )}
+          {bgReady && status?.bg?.output && (
+            <div className="mt-2 flex justify-end">
+              <button
+                type="button"
+                onClick={() => setShowRawBg(v => !v)}
+                className="text-[10px] uppercase tracking-wider text-text-dim hover:text-text border border-border/40 hover:border-border rounded px-2 py-0.5 transition-colors"
+                title="Show the raw `battlegroup status` output from the VM. Resets when you leave this page."
+              >
+                {showRawBg ? 'Hide raw output' : 'Show raw output'}
+              </button>
+            </div>
+          )}
+          {showRawBg && status?.bg?.output && (
+            <pre className="mt-2 text-[10px] font-mono bg-bg-dim border border-border rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap break-words text-text-dim">{status.bg.output}</pre>
           )}
           <BgSpiceSummary enabled={bgReady} />
         </div>


### PR DESCRIPTION
## What

Adds a small **Show raw output** button at the bottom-right of the Battlegroup Info card on the main portal Dashboard. Clicking it reveals the raw `battlegroup status` text from the VM (already serialized to the frontend as `status.bg.output`), and **Hide raw output** collapses it again.

## Behavior

- Per-visit only: the toggle uses local component state, so it resets to hidden whenever the user navigates away from the page.
- The button only appears when the battlegroup is running and raw output is present.
- Raw text renders in a scrollable, monospace `<pre>` (max-height capped) below the info rows, above Active Spice.

Pairs with the earlier change that relabels reconciling/healthy BG state as a green "Healthy" — this gives a quick way to inspect the underlying operator output on demand.

## Verification

- `tsc -b` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>