### PR TITLE
Release v11.4.5: BG state Healthy-when-reconciling + raw output toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.5] - 2026-06-07
+
+### Changed
+- **Server Health → Battlegroup info: "BG state" now reads "Healthy" (green)
+  while the operator is reconciling.** The Funcom battlegroup operator sits in
+  its `Reconciling` / `Reconciling Ready` phase as its normal steady state
+  while managing a healthy battlegroup, so the field used to show a permanent
+  yellow "Reconciling" that read like a fault. Healthy and reconciling states
+  are now both surfaced as a green **Healthy**; yellow/red are reserved for
+  genuine transitions (starting/updating/pending) and faults
+  (failed/error/unhealthy/stopped). The raw operator status stays in the
+  field's hover tooltip and a dim "reconciling" hint still appears while the
+  operator settles map churn. The Database / Gateway / Director rows and the
+  Game Servers table keep their literal per-component colouring.
+
+### Added
+- **Server Health → Battlegroup info: a "Show raw output" toggle.** A small
+  button at the bottom-right of the Battlegroup Info card reveals the raw
+  `battlegroup status` text from the VM on demand ("Hide raw output" collapses
+  it again). It's per-visit — the panel resets to hidden when you navigate
+  away from the page.
+
 ## [11.4.4] - 2026-06-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v11.4.4**. The in-app version label and the
-website show plain semver tags (e.g. `v11.4.4`) — the previous
+The current release is **v11.4.5**. The in-app version label and the
+website show plain semver tags (e.g. `v11.4.5`) — the previous
 Roman-numeral stylization has been removed.
 It runs as a single-window Windows app (native WebView2 shell) that hosts a
 local web portal (React + Vite + Tailwind) on `127.0.0.1` with a per-launch
@@ -120,7 +120,11 @@ The default landing page. Cards for everything you usually want to glance at:
 - **TCP Ports Open** — live verdict for each public TCP port (Game first,
   Game last, RabbitMQ).
 - **Battlegroup Info** — typed view of `kubectl get bg` (BG state, DB,
-  Gateway, Director, Uptime).
+  Gateway, Director, Uptime). **BG state** reports a green **Healthy** while
+  the operator is healthy *or* reconciling (the operator's normal steady
+  state), so yellow/red only show for genuine transitions or faults; a
+  per-visit **Show raw output** toggle reveals the raw `battlegroup status`
+  text on demand.
 - **Game Servers** — per-pod phase, readiness, player count, age.
 - **Active Spice** — per-map / per-size-class active vs primed counts,
   pulled live from `dune.public_spicefields` over psql. Tiered colors
@@ -578,7 +582,7 @@ so it can be tracked and fixed:
 
 The bug report form asks for:
 
-- **Tool version** — shown in the portal footer (e.g. `v11.4.4 · coastal-ms`).
+- **Tool version** — shown in the portal footer (e.g. `v11.4.5 · coastal-ms`).
 - **Surface** — which portal page (Server Health, Commands, PowerShell,
   Game Config, DD Map, Map SpinUp, Database, Sietches, Settings, Setup
   Wizard) or whether it was the CLI / installer / auto-updater.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.4'
+$script:DuneToolVersion = '11.4.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.4',
+    [string]$Version = '11.4.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.4</Version>
+    <Version>11.4.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.4"
+#define MyAppVersion "11.4.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.4"
+$script:ToolVersion = "11.4.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -10,7 +10,7 @@ const sections = [
     id: "health",
     title: "Server Health",
     img: "server-health.png",
-    body: "Default landing page. Combined battlegroup + VM state, live TCP port verdicts, per-pod game-server status, active spice-field counts pulled live from Postgres with tiered colours and at-cap highlighting, public port checks with provider fallback, and one-click log exports.",
+    body: "Default landing page. Combined battlegroup + VM state, live TCP port verdicts, per-pod game-server status, active spice-field counts pulled live from Postgres with tiered colours and at-cap highlighting, public port checks with provider fallback, and one-click log exports. BG state reads a green 'Healthy' while the operator is healthy or reconciling (its normal steady state), with a per-visit toggle to reveal the raw battlegroup status output.",
   },
   {
     id: "commands",

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.4",
+  "version": "11.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.4",
+      "version": "11.4.5",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.4",
+  "version": "11.4.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -39,6 +39,28 @@ function healthClass(v: string | undefined): string {
   return 'text-text'
 }
 
+// BG state shown under Battlegroup Info is the Funcom operator's "Status"
+// column — a kube-operator reconcile phase. It normally sits in
+// "Reconciling" / "Reconciling Ready" while the battlegroup is perfectly
+// healthy, so both healthy and reconciling are surfaced as a green "Healthy".
+// Yellow/red are reserved for genuine transitions or faults — the per-component
+// Database / Gateway / Director rows below show real component health.
+function bgStateDisplay(v: string | undefined): { cls: string; label: string } {
+  const raw = (v ?? '').trim()
+  const s = raw.toLowerCase()
+  if (!s) return { cls: 'text-text-dim', label: '—' }
+  // Genuine fault → red.
+  if (/(fail|error|unhealthy|crash|degraded|fault|stopp|\bfalse\b)/.test(s)) {
+    return { cls: 'text-danger', label: raw }
+  }
+  // Healthy or reconciling → green "Healthy".
+  if (/(healthy|ready|reconcil|running|\btrue\b)/.test(s)) {
+    return { cls: 'text-success', label: 'Healthy' }
+  }
+  // Anything else (starting / updating / pending …) is an in-progress transition.
+  return { cls: 'text-warning', label: raw }
+}
+
 function GameServerRow({ s }: { s: BgGameServer }) {
   return (
     <tr className="border-t border-border/30">
@@ -251,13 +273,13 @@ export function Dashboard() {
             <p className="text-sm text-text-dim italic">No battlegroup info yet.</p>
           ) : (
             <dl className="grid grid-cols-[110px_1fr] gap-x-3 gap-y-1 text-sm leading-snug">
-              <dt className="text-text-dim" title="Funcom BG operator's overall reconcile state. Goes 'Reconciling' briefly whenever a Game Server is added or removed.">BG state</dt>
-              <dd className={healthClass(bgInfo.status)}>
-                {bgInfo.status || '—'}
-                {bgInfo.status === 'Reconciling' && (
+              <dt className="text-text-dim" title="Funcom BG operator's overall state. 'Reconciling' is the operator's normal steady state while it manages the battlegroup, so it's reported as Healthy. The DB / Gateway / Director rows below show actual component health.">BG state</dt>
+              <dd className={bgStateDisplay(bgInfo.status).cls} title={`Operator status: ${bgInfo.status || 'unknown'}`}>
+                {bgStateDisplay(bgInfo.status).label}
+                {/reconcil/i.test(bgInfo.status || '') && (
                   <span className="ml-2 text-[10px] uppercase tracking-wider text-text-dim font-normal"
-                        title="The BG operator is settling changes — usually because a map just spun up or down. The DB / Gateway / Director rows below show actual component health.">
-                    map churn
+                        title="The BG operator is reconciling — its steady state while managing the battlegroup, usually settling a map spin-up/down. The DB / Gateway / Director rows below show actual component health.">
+                    reconciling
                   </span>
                 )}
               </dd>

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -130,6 +130,10 @@ export function Dashboard() {
   // Deep Desert / Arakeen / Harko Village — on-demand map pods.
   const bgReady = bgState === 'running'
 
+  // Per-visit toggle for the raw `battlegroup status` text. Local state only,
+  // so it resets to hidden whenever the user navigates away from the page.
+  const [showRawBg, setShowRawBg] = useState(false)
+
   // Web Interfaces (File Browser + Director URLs)
   const [links, setLinks] = useState<LinksResponse | null>(null)
   const [linksLoading, setLinksLoading] = useState(false)
@@ -292,6 +296,21 @@ export function Dashboard() {
               <dt className="text-text-dim">Uptime</dt>
               <dd className="font-mono">{bgInfo.uptime || '—'}</dd>
             </dl>
+          )}
+          {bgReady && status?.bg?.output && (
+            <div className="mt-2 flex justify-end">
+              <button
+                type="button"
+                onClick={() => setShowRawBg(v => !v)}
+                className="text-[10px] uppercase tracking-wider text-text-dim hover:text-text border border-border/40 hover:border-border rounded px-2 py-0.5 transition-colors"
+                title="Show the raw `battlegroup status` output from the VM. Resets when you leave this page."
+              >
+                {showRawBg ? 'Hide raw output' : 'Show raw output'}
+              </button>
+            </div>
+          )}
+          {showRawBg && status?.bg?.output && (
+            <pre className="mt-2 text-[10px] font-mono bg-bg-dim border border-border rounded p-2 max-h-64 overflow-auto whitespace-pre-wrap break-words text-text-dim">{status.bg.output}</pre>
           )}
           <BgSpiceSummary enabled={bgReady} />
         </div>


### PR DESCRIPTION
## Release v11.4.5

Ships the two webui changes already merged to `main` (PRs #108, #109) as a tagged release, with version stamps and docs.

### Included changes
- **BG state reads green "Healthy" while reconciling.** The Funcom operator's `Reconciling` / `Reconciling Ready` phase is its normal steady state, so the field no longer shows a permanent yellow "Reconciling". Yellow/red are reserved for genuine transitions and faults.
- **"Show raw output" toggle** on the Battlegroup Info card — per-visit reveal of the raw `battlegroup status` text.

### Release bookkeeping
- Bumped all 7 version stamps `11.4.4 → 11.4.5` (dune-server.ps1, app/DuneServer.ps1, Build-Exe.ps1, DuneServer.iss, DuneShell.csproj, webui/package.json, webui/package-lock.json).
- Added the `[11.4.5]` CHANGELOG entry (site changelog renders from this).
- Refreshed README prose + marketing site (`features.astro`) to document the new Battlegroup Info behavior.

### Build
- `DuneServerSetup.exe` built (45.46 MB); bundled webui assets match the fresh build.

No screenshots this release (only the Battlegroup card changed; intentionally skipped).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>