### PR TITLE
Release v11.4.6 — Start/Restart Dune Admin Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.6] - 2026-06-07
+
+### Changed
+- **Server Health → "Start the Dune Admin Tool" card now restarts the
+  service in place instead of opening the embed tab.** The button is renamed
+  **Start/Restart Dune Admin Service** and, instead of navigating to the
+  Dune Admin tab (or popping a browser), it re-kicks off the merged-console
+  reattachment process — it relaunches the `dune-admin` process and re-mirrors
+  its `[admin]`-prefixed output back into DST's wrapping console. Use it after
+  a dune-admin update (which was crashing the embedded console) or if the embed
+  drops out; view the panel itself in the dedicated **Dune Admin** menu-bar tab.
+  The card shows a "Relaunching…" spinner and a confirmation message, and stays
+  disabled until dune-admin is installed and the VM is running.
+
 ## [11.4.5] - 2026-06-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v11.4.5**. The in-app version label and the
-website show plain semver tags (e.g. `v11.4.5`) — the previous
+The current release is **v11.4.6**. The in-app version label and the
+website show plain semver tags (e.g. `v11.4.6`) — the previous
 Roman-numeral stylization has been removed.
 It runs as a single-window Windows app (native WebView2 shell) that hosts a
 local web portal (React + Vite + Tailwind) on `127.0.0.1` with a per-launch
@@ -160,7 +160,10 @@ order auto-saves to `%APPDATA%\DuneServer\button-order.json` and persists
 across launches. The header has a **Reset layout** button to revert to
 the default arrangement.
 
-The **dune-admin** launch tile carries an inline
+The **dune-admin** launch tile (**Start/Restart Dune Admin Service**) restarts
+dune-admin in place — it relaunches the process and reattaches its output to
+DST's shared console rather than opening anything; view the panel in the
+**Dune Admin** menu-bar tab. The tile carries an inline
 "by [Icehunter](https://github.com/Icehunter)" credit badge linking to
 the upstream project.
 
@@ -582,7 +585,7 @@ so it can be tracked and fixed:
 
 The bug report form asks for:
 
-- **Tool version** — shown in the portal footer (e.g. `v11.4.5 · coastal-ms`).
+- **Tool version** — shown in the portal footer (e.g. `v11.4.6 · coastal-ms`).
 - **Surface** — which portal page (Server Health, Commands, PowerShell,
   Game Config, DD Map, Map SpinUp, Database, Sietches, Settings, Setup
   Wizard) or whether it was the CLI / installer / auto-updater.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.5'
+$script:DuneToolVersion = '11.4.6'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.5',
+    [string]$Version = '11.4.6',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.5</Version>
+    <Version>11.4.6</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.5"
+#define MyAppVersion "11.4.6"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.5"
+$script:ToolVersion = "11.4.6"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.5",
+  "version": "11.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.5",
+      "version": "11.4.6",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.5",
+  "version": "11.4.6",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release v11.4.6

Cuts the release for the in-place **Start/Restart Dune Admin Service** change merged in #111.

### Included
- Bumps all version stamps `11.4.5` → `11.4.6` (`app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/installer/DuneServer.iss`, `dune-server.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `webui/package.json` + lockfile).
- Adds the `CHANGELOG.md` `[11.4.6]` entry.
- README: updates the current-release version strings and rewrites the dune-admin launch-tile description to reflect the new restart-in-place behavior.

### Notes
- The functional change itself (Dashboard button) already merged in #111.
- Server Health screenshot intentionally **not** refreshed in this release — Coastal will recapture it after upgrading (the new button only appears post-install).
- Installer built locally: `DuneServerSetup.exe` (45.46 MB). Release + asset upload happen after merge, gated on Coastal's final publish confirmation.