### PR TITLE
Commands menu: prevent click-freeze + friendly display labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.7] - 2026-06-07
+
+### Fixed
+- **Commands launched from the web UI can no longer freeze on a stray
+  mouse click.** Each command opens in a new elevated console, which
+  inherited Windows' default **QuickEdit Mode** — clicking or dragging
+  inside the window enters text-selection ("mark") mode and *suspends* the
+  running script until a key is pressed. Long flows like **Start Full
+  Stack** / **Reboot Full Stack** (VM → cluster → battlegroup → map pods)
+  could silently stall mid-boot (e.g. parked at "Settling 10s before
+  starting battlegroup…" without ever issuing the battlegroup start) with
+  no error or timeout — the only tell was a `Select` prefix on the console
+  title bar. `dune-server.ps1` now clears `ENABLE_QUICK_EDIT_INPUT` on its
+  console at startup, so every Commands-menu action is click-proof.
+
+### Changed
+- **Command menu entries now show plain-language labels instead of raw
+  command ids**, making the scope of each action obvious at a glance:
+  `start-vm` → **Start VM Only**, `startup` → **Start Full Stack**,
+  `start` → **Start BG Only**, `restart` → **Restart BG Only**,
+  `reboot` → **Reboot Full Stack**, `stop` → **Stop BG Only**,
+  `shutdown` → **Stop Full Stack**, `edit-advanced` → **Edit Director**.
+  The underlying command ids are unchanged, so saved layouts and
+  shortcuts keep working.
+
 ## [11.4.6] - 2026-06-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v11.4.6**. The in-app version label and the
-website show plain semver tags (e.g. `v11.4.6`) — the previous
+The current release is **v11.4.7**. The in-app version label and the
+website show plain semver tags (e.g. `v11.4.7`) — the previous
 Roman-numeral stylization has been removed.
 It runs as a single-window Windows app (native WebView2 shell) that hosts a
 local web portal (React + Vite + Tailwind) on `127.0.0.1` with a per-launch
@@ -585,7 +585,7 @@ so it can be tracked and fixed:
 
 The bug report form asks for:
 
-- **Tool version** — shown in the portal footer (e.g. `v11.4.6 · coastal-ms`).
+- **Tool version** — shown in the portal footer (e.g. `v11.4.7 · coastal-ms`).
 - **Surface** — which portal page (Server Health, Commands, PowerShell,
   Game Config, DD Map, Map SpinUp, Database, Sietches, Settings, Setup
   Wizard) or whether it was the CLI / installer / auto-updater.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.6'
+$script:DuneToolVersion = '11.4.7'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.6',
+    [string]$Version = '11.4.7',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.6</Version>
+    <Version>11.4.7</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.6"
+#define MyAppVersion "11.4.7"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Commands.ps1
+++ b/app/server/lib/Commands.ps1
@@ -14,19 +14,19 @@
 
 $script:DuneCommands = @(
     @{ Section='VM'; Key='a';  Name='initial-setup';   Mode='Console'; Requires='none';    DisabledWhen='core-pods-running'; Desc='Run the initial VM setup wizard' }
-    @{ Section='VM'; Key='c';  Name='start-vm';        Mode='InApp';   Requires='exists';  DisabledWhen='vm-running';  Desc='Power on the VM only (no battlegroup)' }
-    @{ Section='VM'; Key='d';  Name='startup';         Mode='Console'; Requires='exists';  DisabledWhen='bg-running';  Desc='Power on VM, start battlegroup, wait for maps Ready' }
-    @{ Section='VM'; Key='e';  Name='shutdown';        Mode='Console'; Requires='running'; Desc='Stop battlegroup, power off VM' }
-    @{ Section='VM'; Key='f';  Name='reboot';          Mode='Console'; Requires='running'; Desc='Stop battlegroup, reboot VM, start battlegroup' }
+    @{ Section='VM'; Key='c';  Name='start-vm';        Label='Start VM Only';      Mode='InApp';   Requires='exists';  DisabledWhen='vm-running';  Desc='Power on the VM only (no battlegroup)' }
+    @{ Section='VM'; Key='d';  Name='startup';         Label='Start Full Stack';   Mode='Console'; Requires='exists';  DisabledWhen='bg-running';  Desc='Power on VM, start battlegroup, wait for maps Ready' }
+    @{ Section='VM'; Key='e';  Name='shutdown';        Label='Stop Full Stack';    Mode='Console'; Requires='running'; Desc='Stop battlegroup, power off VM' }
+    @{ Section='VM'; Key='f';  Name='reboot';          Label='Reboot Full Stack';  Mode='Console'; Requires='running'; Desc='Stop battlegroup, reboot VM, start battlegroup' }
     @{ Section='VM'; Key='g';  Name='rotate-ssh-key';  Mode='Console'; Requires='running'; Desc='Generate a new SSH key and authorize it on the VM' }
     @{ Section='VM'; Key='h';  Name='change-password'; Mode='Console'; Requires='running'; Desc="Change the password of the 'dune' user on the VM" }
 
-    @{ Section='Battlegroup'; Key='2';  Name='start';                    Mode='Console'; Requires='running'; DisabledWhen='bg-running';  Desc='Start the selected battlegroup' }
-    @{ Section='Battlegroup'; Key='3';  Name='restart';                  Mode='Console'; Requires='running'; DisabledWhen='bg-stopped';  Desc='Restart the selected battlegroup' }
-    @{ Section='Battlegroup'; Key='4';  Name='stop';                     Mode='Console'; Requires='running'; DisabledWhen='bg-stopped';  Desc='Stop the selected battlegroup' }
+    @{ Section='Battlegroup'; Key='2';  Name='start';                    Label='Start BG Only';   Mode='Console'; Requires='running'; DisabledWhen='bg-running';  Desc='Start the selected battlegroup' }
+    @{ Section='Battlegroup'; Key='3';  Name='restart';                  Label='Restart BG Only'; Mode='Console'; Requires='running'; DisabledWhen='bg-stopped';  Desc='Restart the selected battlegroup' }
+    @{ Section='Battlegroup'; Key='4';  Name='stop';                     Label='Stop BG Only';    Mode='Console'; Requires='running'; DisabledWhen='bg-stopped';  Desc='Stop the selected battlegroup' }
     @{ Section='Battlegroup'; Key='5';  Name='update';                   Mode='Console'; Requires='running'; Desc='Check for new versions and apply them' }
     @{ Section='Battlegroup'; Key='6';  Name='edit';                     Mode='Console'; Requires='running'; External=$true; Desc='Edit battlegroup via utilities interface' }
-    @{ Section='Battlegroup'; Key='7';  Name='edit-advanced';            Mode='Console'; Requires='running'; External=$true; Desc='(Advanced) Edit battlegroup YAML directly' }
+    @{ Section='Battlegroup'; Key='7';  Name='edit-advanced';            Label='Edit Director';   Mode='Console'; Requires='running'; External=$true; Desc='(Advanced) Edit battlegroup YAML directly' }
     @{ Section='Battlegroup'; Key='8';  Name='enable-experimental-swap'; Mode='Console'; Requires='running'; Desc='(Experimental) Enable experimental swap memory' }
     @{ Section='Battlegroup'; Key='9';  Name='backup';                   Mode='Console'; Requires='running'; DisabledWhen='bg-stopped';  Desc="Back up the battlegroup's database" }
     @{ Section='Battlegroup'; Key='10'; Name='import';                   Mode='Console'; Requires='running'; DisabledWhen='bg-running';  Desc='Import a database backup' }

--- a/app/server/routes/Commands.ps1
+++ b/app/server/routes/Commands.ps1
@@ -12,6 +12,7 @@ Register-DuneRoute -Method GET -Path '/api/commands' -Handler {
             section      = $c.Section   # original catalogue section, kept as a hint
             key          = $c.Key
             name         = $c.Name
+            label        = $(if ($c.Label) { $c.Label } else { $c.Name })
             mode         = $c.Mode
             requires     = $c.Requires
             disabledWhen = $c.DisabledWhen

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1232,22 +1232,22 @@ function Invoke-OnDemandPartitionClear {
 
 $vmCommands = @(
     [pscustomobject]@{ Key = "a"; Name = "initial-setup";      Desc = "Run the initial VM setup" }
-    [pscustomobject]@{ Key = "c"; Name = "start-vm";           Desc = "Power on the VM only (no battlegroup) - useful for maintenance" }
-    [pscustomobject]@{ Key = "d"; Name = "startup";            Desc = "Power on VM -> start battlegroup -> wait for overmap + survival maps" }
-    [pscustomobject]@{ Key = "e"; Name = "shutdown";           Desc = "Stop battlegroup -> power off VM (e.g. shut down for the night)" }
-    [pscustomobject]@{ Key = "f"; Name = "reboot";             Desc = "Stop battlegroup -> restart VM -> start battlegroup (clean cycle)" }
+    [pscustomobject]@{ Key = "c"; Name = "start-vm";           Label = "Start VM Only";    Desc = "Power on the VM only (no battlegroup) - useful for maintenance" }
+    [pscustomobject]@{ Key = "d"; Name = "startup";            Label = "Start Full Stack"; Desc = "Power on VM -> start battlegroup -> wait for overmap + survival maps" }
+    [pscustomobject]@{ Key = "e"; Name = "shutdown";           Label = "Stop Full Stack";  Desc = "Stop battlegroup -> power off VM (e.g. shut down for the night)" }
+    [pscustomobject]@{ Key = "f"; Name = "reboot";             Label = "Reboot Full Stack"; Desc = "Stop battlegroup -> restart VM -> start battlegroup (clean cycle)" }
     [pscustomobject]@{ Key = "g"; Name = "rotate-ssh-key";     Desc = "Generate a new SSH key and replace the one authorized on the VM" }
     [pscustomobject]@{ Key = "h"; Name = "change-password";    Desc = "Change the password of the 'dune' user on the VM" }
 )
 
 $bgCommands = @(
     [pscustomobject]@{ Key = "1";  SubSection = $null;          Name = "status";                    Desc = "Shows the status of the selected battlegroup" }
-    [pscustomobject]@{ Key = "2";  SubSection = $null;          Name = "start";                     Desc = "Starts the selected battlegroup" }
-    [pscustomobject]@{ Key = "3";  SubSection = $null;          Name = "restart";                   Desc = "Restarts the selected battlegroup" }
-    [pscustomobject]@{ Key = "4";  SubSection = $null;          Name = "stop";                      Desc = "Stops the selected battlegroup" }
+    [pscustomobject]@{ Key = "2";  SubSection = $null;          Name = "start";                     Label = "Start BG Only";   Desc = "Starts the selected battlegroup" }
+    [pscustomobject]@{ Key = "3";  SubSection = $null;          Name = "restart";                   Label = "Restart BG Only"; Desc = "Restarts the selected battlegroup" }
+    [pscustomobject]@{ Key = "4";  SubSection = $null;          Name = "stop";                      Label = "Stop BG Only";    Desc = "Stops the selected battlegroup" }
     [pscustomobject]@{ Key = "5";  SubSection = $null;          Name = "update";                    Desc = "Checks for new versions and applies them" }
     [pscustomobject]@{ Key = "6";  SubSection = $null;          Name = "edit";                      Desc = "Edit the battlegroup with the utilities interface" }
-    [pscustomobject]@{ Key = "7";  SubSection = $null;          Name = "edit-advanced";             Desc = "(Advanced) Manually edit battlegroup directly with YAML" }
+    [pscustomobject]@{ Key = "7";  SubSection = $null;          Name = "edit-advanced";             Label = "Edit Director";   Desc = "(Advanced) Manually edit battlegroup directly with YAML" }
     [pscustomobject]@{ Key = "8";  SubSection = $null;          Name = "enable-experimental-swap";  Desc = "(Experimental) Enable experimental swap memory feature" }
     [pscustomobject]@{ Key = "9";  SubSection = "Database";     Name = "backup";                    Desc = "Take a backup of the battlegroup's database" }
     [pscustomobject]@{ Key = "10"; SubSection = "Database";     Name = "import";                    Desc = "Import a database backup into the selected battlegroup" }
@@ -1368,15 +1368,15 @@ while ($true) {
 
     foreach ($c in $vmCommands) {
         $avail = Get-VmCmdAvailability -cmdName $c.Name -info $info
-        $entries += [pscustomobject]@{ Section = 'vm'; SubSection = $null; Key = $c.Key; Name = $c.Name; Desc = $c.Desc; Available = $avail.Available; Reason = $avail.Reason }
+        $entries += [pscustomobject]@{ Section = 'vm'; SubSection = $null; Key = $c.Key; Name = $c.Name; Label = $(if ($c.Label) { $c.Label } else { $c.Name }); Desc = $c.Desc; Available = $avail.Available; Reason = $avail.Reason }
     }
     foreach ($c in $bgCommands) {
         $avail = Get-BgCmdAvailability -info $info
-        $entries += [pscustomobject]@{ Section = 'battlegroup'; SubSection = $c.SubSection; Key = $c.Key; Name = $c.Name; Desc = $c.Desc; Available = $avail.Available; Reason = $avail.Reason }
+        $entries += [pscustomobject]@{ Section = 'battlegroup'; SubSection = $c.SubSection; Key = $c.Key; Name = $c.Name; Label = $(if ($c.Label) { $c.Label } else { $c.Name }); Desc = $c.Desc; Available = $avail.Available; Reason = $avail.Reason }
     }
     foreach ($c in $toolCommands) {
         $avail = Get-ToolCmdAvailability -cmdName $c.Name -info $info
-        $entries += [pscustomobject]@{ Section = 'tools'; SubSection = $null; Key = $c.Key; Name = $c.Name; Desc = $c.Desc; Available = $avail.Available; Reason = $avail.Reason }
+        $entries += [pscustomobject]@{ Section = 'tools'; SubSection = $null; Key = $c.Key; Name = $c.Name; Label = $(if ($c.Label) { $c.Label } else { $c.Name }); Desc = $c.Desc; Available = $avail.Available; Reason = $avail.Reason }
     }
 
     foreach ($e in $entries) { $entryByKey[$e.Key.ToLower()] = $e }
@@ -1442,7 +1442,7 @@ while ($true) {
                 }
             }
             $color = if ($e.Available) { 'White' } else { 'DarkGray' }
-            Write-Host ("  {0,2}. {1,-30} {2}" -f $e.Key, $e.Name, $e.Desc) -ForegroundColor $color
+            Write-Host ("  {0,2}. {1,-30} {2}" -f $e.Key, $e.Label, $e.Desc) -ForegroundColor $color
             $prevSection = $e.Section
         }
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.6"
+$script:ToolVersion = "11.4.7"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -61,6 +61,42 @@ try {
     $Host.UI.RawUI.WindowSize = New-Object System.Management.Automation.Host.Size($winWidth, $winHeight)
 } catch {}
 
+# ============================================================
+#  DISABLE CONSOLE QUICKEDIT MODE  (click-freeze guard)
+# ============================================================
+# Windows consoles enable QuickEdit Mode by default: a single click or drag
+# inside the window enters text-selection ("mark") mode and SUSPENDS the
+# running process until a key is pressed. Long flows (startup/reboot: VM ->
+# cluster -> battlegroup -> map pods) would otherwise freeze silently on a
+# stray click with no error and no timeout - the title bar just gains a
+# "Select" prefix. Clear ENABLE_QUICK_EDIT_INPUT (0x40) while setting
+# ENABLE_EXTENDED_FLAGS (0x80) so the change actually applies. Best-effort:
+# any failure (no console, redirected stdin) is swallowed.
+function Disable-DuneConsoleQuickEdit {
+    try {
+        if (-not ('Dune.ConsoleMode' -as [type])) {
+            Add-Type -Namespace Dune -Name ConsoleMode -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError=true)]
+public static extern System.IntPtr GetStdHandle(int nStdHandle);
+[System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError=true)]
+public static extern bool GetConsoleMode(System.IntPtr hConsoleHandle, out uint lpMode);
+[System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError=true)]
+public static extern bool SetConsoleMode(System.IntPtr hConsoleHandle, uint dwMode);
+'@ -ErrorAction Stop
+        }
+        $STD_INPUT_HANDLE        = -10
+        $ENABLE_QUICK_EDIT_INPUT = 0x0040
+        $ENABLE_EXTENDED_FLAGS   = 0x0080
+        $h = [Dune.ConsoleMode]::GetStdHandle($STD_INPUT_HANDLE)
+        if ($h -eq [System.IntPtr]::Zero -or $h -eq [System.IntPtr](-1)) { return }
+        $mode = [uint32]0
+        if (-not [Dune.ConsoleMode]::GetConsoleMode($h, [ref]$mode)) { return }
+        $new = ($mode -band (-bnot $ENABLE_QUICK_EDIT_INPUT)) -bor $ENABLE_EXTENDED_FLAGS
+        [void][Dune.ConsoleMode]::SetConsoleMode($h, $new)
+    } catch { }
+}
+Disable-DuneConsoleQuickEdit
+
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 # ============================================================

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.6",
+  "version": "11.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.6",
+      "version": "11.4.7",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.6",
+  "version": "11.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -74,6 +74,7 @@ export type Command = {
   section: 'VM' | 'Battlegroup' | 'Tools'  // original catalogue hint — not used for layout
   key: string
   name: string
+  label: string
   mode: 'InApp' | 'Console'
   requires: 'none' | 'exists' | 'running'
   disabledWhen?: string

--- a/webui/src/pages/Commands.tsx
+++ b/webui/src/pages/Commands.tsx
@@ -96,7 +96,7 @@ function CommandButtonInner({
                             group-hover:text-text-muted group-hover:border-border-bright">
               {cmd.key}
             </kbd>
-            <span className="font-mono text-sm truncate text-text">{cmd.name}</span>
+            <span className="font-medium text-sm truncate text-text">{cmd.label || cmd.name}</span>
           </div>
           <span className={cmd.mode === 'Console' ? 'pill-info shrink-0' : 'pill-muted shrink-0'}>
             <Icon name={cmd.mode === 'Console' ? 'SquareTerminal' : 'Zap'} size={10} />


### PR DESCRIPTION
Two related Commands-menu improvements.

## 1. Disable console QuickEdit Mode (click-freeze guard)

Commands launched from the web Commands menu spawn a fresh **elevated console** via `Start-Process pwsh -Verb RunAs -WindowStyle Normal` (`app/server/lib/Commands.ps1`). That console inherits Windows' default **QuickEdit Mode**, where a single click or drag inside the window enters text-selection ("mark") mode and **suspends the running process** until a key is pressed.

For long flows like `startup`/`reboot` (VM → cluster readiness → battlegroup → map pods), a stray click silently freezes the entire pipeline — no error, no timeout, the only tell being a `Select` prefix on the console title bar. Observed live: spinup parked at "Settling 10s before starting battlegroup…" and never issued the battlegroup `start` SSH call because the script was frozen.

`dune-server.ps1` now clears `ENABLE_QUICK_EDIT_INPUT` (keeping `ENABLE_EXTENDED_FLAGS`) on its console input handle at startup via a small `GetConsoleMode`/`SetConsoleMode` P/Invoke. Because **every** Commands-menu action runs through this script, all of them become click-proof. Best-effort: failures (no console / redirected stdin) are swallowed.

## 2. Friendly display labels

The Commands page and console menu showed each command's raw canonical id, which is ambiguous about scope (VM vs battlegroup vs full stack). Added a display-only `Label`:

| id | label |
|----|-------|
| `start-vm` | Start VM Only |
| `startup` | Start Full Stack |
| `start` | Start BG Only |
| `restart` | Restart BG Only |
| `reboot` | Reboot Full Stack |
| `stop` | Stop BG Only |
| `shutdown` | Stop Full Stack |
| `edit-advanced` | Edit Director |

`Name` (the canonical id) is **unchanged**, so `/api/commands/run/{name}`, `-Cmd` dispatch, availability predicates, and persisted layouts all keep working. The API serializes `label` (falling back to `Name`); the `Command` type and card render it; the console menu renders `Label` with the same fallback. Commands without a custom label are unaffected.

## Verification
- `Parser::ParseFile` clean under pwsh 7 for all changed `.ps1` files.
- `npm run build` (`tsc -b && vite build`) passes — `label` type change compiles.
- QuickEdit P/Invoke smoke-tested: console mode `0x1F7` → `0x1B7` (QuickEdit bit cleared), no exceptions.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>