### PR TITLE
helper: make Friend Helper Bridge scheduled task self-healing

### DIFF
--- a/helper/bridge/Install-Bridge.ps1
+++ b/helper/bridge/Install-Bridge.ps1
@@ -8,7 +8,9 @@
       2. Creates an inbound Windows Firewall rule scoped to the Tailscale
          interface only (no LAN / no public exposure).
       3. Registers a Scheduled Task that runs DstHelperBridge.ps1 under
-         PowerShell 7 (pwsh.exe) at user logon, restarting on failure.
+         PowerShell 7 (pwsh.exe) at user logon, self-healing via a 2-minute
+         keepalive trigger (relaunches the daemon if it dies; IgnoreNew avoids
+         duplicates while it is healthy).
 
     Must be run elevated (admin) — both the URL ACL and the firewall rule
     require admin rights to create.
@@ -108,12 +110,26 @@ function Ensure-ScheduledTask {
         -Execute $pwsh `
         -Argument "-NoLogo -NoProfile -ExecutionPolicy Bypass -File `"$BridgeScriptPath`" -Port $Port"
 
-    $trigger = New-ScheduledTaskTrigger -AtLogOn -User "$env:USERDOMAIN\$env:USERNAME"
+    # Two triggers keep the daemon alive across crashes, kills, and sleep/wake:
+    #   1. AtLogOn      — start when the host user signs in.
+    #   2. Keepalive    — re-fire every 2 minutes, indefinitely. Combined with
+    #                     MultipleInstances=IgnoreNew below this is a no-op while
+    #                     the daemon is healthy, but relaunches it within ~2 min
+    #                     if it has died. RestartOnFailure alone is insufficient:
+    #                     an externally-killed daemon (exit 0xC000013A) is logged
+    #                     as a stop, not a failure, so it never restarted.
+    # A large finite RepetitionDuration is used because [TimeSpan]::MaxValue
+    # trips a known Register-ScheduledTask bug.
+    $logonTrigger = New-ScheduledTaskTrigger -AtLogOn -User "$env:USERDOMAIN\$env:USERNAME"
+    $keepAlive    = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) `
+        -RepetitionInterval (New-TimeSpan -Minutes 2) `
+        -RepetitionDuration (New-TimeSpan -Days 3650)
 
     $settings = New-ScheduledTaskSettingsSet `
         -AllowStartIfOnBatteries `
         -DontStopIfGoingOnBatteries `
         -StartWhenAvailable `
+        -MultipleInstances IgnoreNew `
         -RestartInterval (New-TimeSpan -Minutes 1) `
         -RestartCount 999 `
         -ExecutionTimeLimit (New-TimeSpan -Hours 0)
@@ -126,10 +142,10 @@ function Ensure-ScheduledTask {
     Register-ScheduledTask `
         -TaskName $TaskName `
         -Action $action `
-        -Trigger $trigger `
+        -Trigger @($logonTrigger, $keepAlive) `
         -Settings $settings `
         -Principal $principal `
-        -Description 'Reverse-proxies friend helper requests over Tailscale to the locally running DST instance.' | Out-Null
+        -Description 'Reverse-proxies friend helper requests over Tailscale to the locally running DST instance. Self-healing: a 2-minute keepalive trigger relaunches the daemon if it dies; IgnoreNew prevents duplicates while it is healthy.' | Out-Null
 }
 
 Assert-Elevated


### PR DESCRIPTION
## Problem

The DST Friend Helper Bridge runs as a Scheduled Task (`DST Friend Helper Bridge`) that hosts the `DstHelperBridge.ps1` daemon on port 47900. It was configured with `RestartOnFailure` (`RestartCount 999`, 1-min interval) only.

That doesn't cover the real-world failure modes:
- A daemon **externally terminated** exits with `0xC000013A` (`STATUS_CONTROL_C_EXIT`), which Task Scheduler logs as a *stop*, not a *failure* — so restart-on-failure never fires.
- There's **no wake/keepalive trigger**, so a sleep/resume or one-off crash leaves the task in `Ready` with nothing bound to 47900.

Hit live today: the daemon died at 15:48, the task sat idle for ~3.5 h, and the friend's `DSTConsole` got `…/_dst/token … A task was canceled` because nothing was listening.

## Fix

In `Ensure-ScheduledTask`:
- Add a **2-minute keepalive trigger** (indefinite, via a 10-year `RepetitionDuration` to dodge the `TimeSpan.MaxValue` registration bug) alongside the existing `AtLogOn` trigger.
- Set **`MultipleInstances = IgnoreNew`** so the keepalive is a no-op while the daemon is healthy, but relaunches it within ~2 min of any death — without spawning duplicate instances that would fail to bind the port.
- Keep the existing `RestartOnFailure` as belt-and-suspenders.

This was already applied to the live task on the host today; this change makes future bridge installs inherit the same self-healing config.

## Notes

- The PS 5.1 parse pre-flight flags the pre-existing `?.Source` null-conditional on line ~97 — unrelated to this change; the bridge installer always runs under pwsh/PS7 (it requires it). The added code parses clean under PS7.
- No version bump / release needed — the helper bridge is a separate component, not part of the installer payload.