### PR TITLE
v11.4.8 — zombie-backend self-heal, change-vm-ip command, faster Start BG settle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ here cover everything those tags shipped.
 
 ## [11.4.8] - 2026-06-10
 
+### Added
+- **New VM command: `change-vm-ip` ("Change VM IP").** Lets you change the
+  VM's network address — or switch how it gets one — without leaving DST.
+  Choose DHCP (automatic from your router) or a static IP (simple, or
+  advanced with custom CIDR / gateway / DNS); the change is applied to the
+  VM over SSH and networking is restarted in place. Available in the VM
+  section of the Commands page (and the CLI menu) whenever the VM is running.
+
+### Changed
+- **"Start BG Only" no longer waits 45s before clearing on-demand map
+  partition pins.** On a plain `start` the VM is already up and the operator
+  pins the on-demand ServerSets quickly, so the post-start settle is now
+  **9s** instead of 45s — the window closes much sooner. `restart`, `reboot`,
+  and `startup` keep their existing settle times.
+
 ### Fixed
 - **The app no longer gets stuck on "Connecting to Dune Server Tool…
   (attempt N)" after the backend's listener silently dies.** A prior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.8] - 2026-06-10
+
+### Fixed
+- **The app no longer gets stuck on "Connecting to Dune Server Tool…
+  (attempt N)" after the backend's listener silently dies.** A prior
+  DuneServer process can keep running (and keep holding the single-instance
+  mutex) while its HTTP listener has stopped accepting — observed after a
+  sleep/resume cycle, a network-stack reset, or http.sys dropping the URL
+  registration. The process stays alive but nothing is bound to the port.
+  Previously every subsequent shortcut click just re-attached the WebView2
+  viewer to that dead "zombie" backend, so the window retried forever and
+  never recovered. The launcher now **probes the recorded portal URL before
+  adopting an already-running instance**: if it doesn't answer at the HTTP
+  level, the instance is treated exactly like a stale "Web Portal" detach —
+  the zombie is killed and a fresh server (new listener, token, and app
+  window) is started automatically. Clicking the shortcut now self-heals the
+  stuck state instead of compounding it.
+
 ## [11.4.7] - 2026-06-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v11.4.7**. The in-app version label and the
-website show plain semver tags (e.g. `v11.4.7`) — the previous
+The current release is **v11.4.8**. The in-app version label and the
+website show plain semver tags (e.g. `v11.4.8`) — the previous
 Roman-numeral stylization has been removed.
 It runs as a single-window Windows app (native WebView2 shell) that hosts a
 local web portal (React + Vite + Tailwind) on `127.0.0.1` with a per-launch
@@ -585,7 +585,7 @@ so it can be tracked and fixed:
 
 The bug report form asks for:
 
-- **Tool version** — shown in the portal footer (e.g. `v11.4.7 · coastal-ms`).
+- **Tool version** — shown in the portal footer (e.g. `v11.4.8 · coastal-ms`).
 - **Surface** — which portal page (Server Health, Commands, PowerShell,
   Game Config, DD Map, Map SpinUp, Database, Sietches, Settings, Setup
   Wizard) or whether it was the CLI / installer / auto-updater.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.7'
+$script:DuneToolVersion = '11.4.8'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the
@@ -204,6 +204,46 @@ try {
     }
 } catch {
     Write-DuneStartupLog "Restart-on-detach handler failed: $($_.Exception.Message)"
+}
+
+# ---------- Health probe for an already-running instance ----------------------
+# A prior DuneServer can keep its process (and the single-instance mutex) alive
+# while its HttpListener has silently stopped accepting - observed after a
+# sleep/resume cycle, a network-stack reset, or http.sys dropping the URL
+# registration. The log then shows the process still running but nothing bound
+# to the port. Without a liveness check, every subsequent shortcut click just
+# re-attaches the viewer to that dead backend, stranding the user forever on
+# "Connecting to Dune Server Tool... (attempt N)".
+#
+# Probe the recorded portal URL: ANY HTTP-level response (200/302/401/404)
+# proves the listener is accepting; a connection failure / timeout means it's a
+# zombie. Used by the already-running branch below to decide focus-vs-restart.
+function Test-DuneExistingServerHealthy {
+    param([int]$TimeoutMs = 1500, [int]$Attempts = 3)
+    $urlFile = Join-Path $env:LOCALAPPDATA 'DuneServer\last-url.txt'
+    $u = ''
+    try { if (Test-Path -LiteralPath $urlFile) { $u = (Get-Content -LiteralPath $urlFile -Raw).Trim() } } catch {}
+    # No recorded URL -> there is no running server we can confirm is serving.
+    if (-not $u) { return $false }
+    $probe = $u
+    try { $uri = [Uri]$u; $probe = "$($uri.Scheme)://$($uri.Authority)/" } catch {}
+    for ($i = 0; $i -lt $Attempts; $i++) {
+        try {
+            $req = [System.Net.HttpWebRequest]::Create($probe)
+            $req.Timeout          = $TimeoutMs
+            $req.Method           = 'GET'
+            $req.AllowAutoRedirect = $false
+            $resp = $req.GetResponse()
+            try { $resp.Close() } catch {}
+            return $true
+        } catch [System.Net.WebException] {
+            # A protocol error still carries an HTTP response => listener alive.
+            if ($_.Exception.Response) { return $true }
+            # ConnectFailure / Timeout / NameResolutionFailure => not serving.
+        } catch {}
+        Start-Sleep -Milliseconds 250
+    }
+    return $false
 }
 
 # ---------- Single-instance gate ----------------------------------------------
@@ -266,10 +306,21 @@ if (-not $script:SingleInstanceOwned) {
             $shellAlive = @(Get-Process -Name 'DuneShell' -ErrorAction SilentlyContinue).Count -gt 0
         } catch { $shellAlive = $false }
 
-        if ($isDetached -and -not $shellAlive) {
+        # Zombie guard: confirm the already-running instance is actually serving
+        # HTTP. If it isn't (listener died but the process - typically a headless
+        # keep-alive backend - lingers holding the mutex), adopting its portal
+        # URL would strand the viewer on "Connecting..." forever. Treat a
+        # non-responding backend exactly like a stale "Web Portal" detach: kill
+        # it and start fresh, regardless of which flag (if any) was set.
+        $serverHealthy = Test-DuneExistingServerHealthy
+        if (-not $serverHealthy) {
+            Write-DuneStartupLog 'Already-running instance is not serving HTTP (zombie listener) - forcing kill-and-restart'
+        }
+
+        if ((-not $serverHealthy) -or ($isDetached -and -not $shellAlive)) {
             # Tag the flag with our PID so the elevated child knows WHICH
             # DuneServer.exe to kill (everyone-named-DuneServer-except-self
-            # is risky if the user has unrelated processes — though "DuneServer"
+            # is risky if the user has unrelated processes - though "DuneServer"
             # is specific enough that in practice we'd be fine).
             try {
                 $marker = Join-Path $env:LOCALAPPDATA 'DuneServer\restart-requested.flag'

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.7',
+    [string]$Version = '11.4.8',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.7</Version>
+    <Version>11.4.8</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.7"
+#define MyAppVersion "11.4.8"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Commands.ps1
+++ b/app/server/lib/Commands.ps1
@@ -20,6 +20,7 @@ $script:DuneCommands = @(
     @{ Section='VM'; Key='f';  Name='reboot';          Label='Reboot Full Stack';  Mode='Console'; Requires='running'; Desc='Stop battlegroup, reboot VM, start battlegroup' }
     @{ Section='VM'; Key='g';  Name='rotate-ssh-key';  Mode='Console'; Requires='running'; Desc='Generate a new SSH key and authorize it on the VM' }
     @{ Section='VM'; Key='h';  Name='change-password'; Mode='Console'; Requires='running'; Desc="Change the password of the 'dune' user on the VM" }
+    @{ Section='VM'; Key='i';  Name='change-vm-ip';    Mode='Console'; Requires='running'; Desc="Change the VM's IP address or how it gets one (DHCP/static)" }
 
     @{ Section='Battlegroup'; Key='2';  Name='start';                    Label='Start BG Only';   Mode='Console'; Requires='running'; DisabledWhen='bg-running';  Desc='Start the selected battlegroup' }
     @{ Section='Battlegroup'; Key='3';  Name='restart';                  Label='Restart BG Only'; Mode='Console'; Requires='running'; DisabledWhen='bg-stopped';  Desc='Restart the selected battlegroup' }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1238,6 +1238,7 @@ $vmCommands = @(
     [pscustomobject]@{ Key = "f"; Name = "reboot";             Label = "Reboot Full Stack"; Desc = "Stop battlegroup -> restart VM -> start battlegroup (clean cycle)" }
     [pscustomobject]@{ Key = "g"; Name = "rotate-ssh-key";     Desc = "Generate a new SSH key and replace the one authorized on the VM" }
     [pscustomobject]@{ Key = "h"; Name = "change-password";    Desc = "Change the password of the 'dune' user on the VM" }
+    [pscustomobject]@{ Key = "i"; Name = "change-vm-ip";       Desc = "Change the VM's IP address or how it gets one (DHCP/static)" }
 )
 
 $bgCommands = @(
@@ -2142,6 +2143,20 @@ while ($true) {
         continue
     }
 
+    if ($cmdName -eq "change-vm-ip") {
+        $vmIpScript = Join-Path $bgSetupPath 'vm-ip.ps1'
+        if (-not (Test-Path -LiteralPath $vmIpScript)) {
+            Write-Warning "vm-ip.ps1 not found at $vmIpScript - your self-hosted server install may be too old to change the VM IP from here."
+            continue
+        }
+        . $vmIpScript
+        if (Set-VmIp -Ip $ip -SshKey $sshKey) {
+            Write-Host "VM IP configuration updated." -ForegroundColor Green
+            Write-Host "  The VM may take a few seconds to reappear on its new address; DST will pick it up on the next status refresh." -ForegroundColor DarkGray
+        }
+        continue
+    }
+
     # ========================================================
     #  BATTLEGROUP COMMANDS
     # ========================================================
@@ -2624,7 +2639,11 @@ CreateObject("WScript.Shell").Run cmd, 0, True
     # partition pins so DD/Arrakeen/Harko spawn for the next player without
     # the user having to invoke fix-on-demand-maps manually.
     if ($bgFallbackExit -eq 0 -and ($cmdName -eq 'start' -or $cmdName -eq 'restart')) {
-        Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 45 -Phase "post-$cmdName"
+        # 'start' brings up a battlegroup that was not running, on an already-up
+        # VM; the operator pins on-demand ServerSets quickly, so a short settle
+        # is enough. 'restart' keeps the longer delay (battlegroup churn).
+        $settleSec = if ($cmdName -eq 'start') { 9 } else { 45 }
+        Invoke-OnDemandPartitionClear -Ip $ip -DelaySec $settleSec -Phase "post-$cmdName"
     }
 
     # After start/restart, resolve director port

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.7"
+$script:ToolVersion = "11.4.8"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.7",
+  "version": "11.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.7",
+      "version": "11.4.8",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.7",
+  "version": "11.4.8",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Three changes, shipping together as **v11.4.8**.

## 1. Fixed: app can no longer get stuck on "Connecting to Dune Server Tool… (attempt N)"

A prior `DuneServer` process can keep running — and keep holding the `Global\DuneServer-Portal-v6` single-instance mutex — while its `HttpListener` has silently stopped accepting (sleep/resume, network-stack reset, or http.sys dropping the URL registration). The process is alive but **nothing is bound to the port**. Diagnosed live: `DuneServer` pid present + `keep-alive.flag` held, but port 47823 actively refused.

Because the single-instance gate trusted mutex ownership + process existence alone, every subsequent shortcut click re-attached the WebView2 viewer to that dead "zombie" backend → infinite retry.

The already-running branch in `app/DuneServer.ps1` now calls a new `Test-DuneExistingServerHealthy` helper that probes the recorded portal URL before adopting an existing instance:
- **Any HTTP response** (200/302/401/404) → listener alive → normal focus-the-window path.
- **Connection failure / timeout** (zombie) → treat like a stale "Web Portal" detach: drop `restart-requested.flag`, elevate, kill the prior `DuneServer.exe`, start fresh. **Self-heals on the next click.**

## 2. Added: `change-vm-ip` command ("Change VM IP")

New VM-section command to change the VM's address — or switch DHCP ↔ static (simple/advanced: CIDR, gateway, DNS) — over SSH, with networking restarted in place. Reuses the self-hosted server's own `Set-VmIp` (`battlegroup-management/vm-ip.ps1`), exactly like `change-password` reuses `Set-VmPassword`. Wired into the CLI menu, the dispatch handler, and the web command catalogue (`app/server/lib/Commands.ps1`) as a `Console` command requiring the VM running.

## 3. Changed: "Start BG Only" settle 45s → 9s

On a plain `start` the VM is already up and the operator pins on-demand ServerSets quickly, so the post-start partition-pin clear now settles **9s** instead of 45s. `restart`, `reboot`, and `startup` keep their existing delays.

## Validation
- `Test-DuneExistingServerHealthy`: live → True, dead port → False; live machine recovered (HTTP 200).
- `app/DuneServer.ps1` + `Commands.ps1` parse clean under Windows PowerShell 5.1 (PS2EXE target); `dune-server.ps1` parses clean under pwsh 7.
- Version stamps bumped 11.4.7 → 11.4.8; CHANGELOG + README updated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>