### PR TITLE
v11.4.9 — show "Update available" banner immediately on new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.9] - 2026-06-10
+
+### Fixed
+- **The "Update available" banner now appears as soon as a new release is
+  detected — including right after you click "Check now" in Settings.**
+  Previously the global banner and the Settings update card each kept their
+  own independent copy of the update-check result. The banner only checked
+  once at startup and then every 6 hours, so if a new version was published
+  while the app was already open, the banner stayed hidden — even though
+  Settings → "Check now" correctly showed the update was available. Clicking
+  "Check now" updated only the Settings card, never the banner. The
+  update-check result is now a single shared source: any check (the periodic
+  poll, the startup check, or a manual "Check now") updates the banner
+  immediately, with no full page reload required.
+
 ## [11.4.8] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v11.4.8**. The in-app version label and the
-website show plain semver tags (e.g. `v11.4.8`) — the previous
+The current release is **v11.4.9**. The in-app version label and the
+website show plain semver tags (e.g. `v11.4.9`) — the previous
 Roman-numeral stylization has been removed.
 It runs as a single-window Windows app (native WebView2 shell) that hosts a
 local web portal (React + Vite + Tailwind) on `127.0.0.1` with a per-launch

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.8'
+$script:DuneToolVersion = '11.4.9'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.8',
+    [string]$Version = '11.4.9',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.8</Version>
+    <Version>11.4.9</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.8"
+#define MyAppVersion "11.4.9"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.8"
+$script:ToolVersion = "11.4.9"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.8",
+  "version": "11.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.8",
+      "version": "11.4.9",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.8",
+  "version": "11.4.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webui/src/hooks/useUpdateCheck.ts
+++ b/webui/src/hooks/useUpdateCheck.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 import type { UpdateCheck } from '../api/update'
 import { checkForUpdate } from '../api/update'
 
@@ -11,33 +11,87 @@ export interface UpdateState {
   refresh: () => Promise<void>
 }
 
-export function useUpdateCheck(): UpdateState {
-  const [data, setData] = useState<UpdateCheck | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const inflight = useRef(false)
+// ---------------------------------------------------------------------------
+// Shared, module-level store.
+//
+// Every consumer of useUpdateCheck() reads from this single source of truth.
+// Previously each call kept its own isolated useState, so a forced "Check now"
+// on the Settings page updated only that component's copy while the global
+// UpdateBanner kept its own stale result and stayed hidden until a full page
+// reload or the next 6-hour poll. With a shared store, any update found by any
+// consumer (or pushed via publishUpdateCheck) surfaces in the banner instantly.
+// ---------------------------------------------------------------------------
 
-  const run = useCallback(async (force = false) => {
-    if (inflight.current) return
-    inflight.current = true
-    setLoading(true)
-    setError(null)
-    try {
-      const res = await checkForUpdate({ force })
-      setData(res)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      inflight.current = false
-      setLoading(false)
-    }
-  }, [])
+interface Snapshot {
+  data: UpdateCheck | null
+  loading: boolean
+  error: string | null
+}
 
-  useEffect(() => {
+let snapshot: Snapshot = { data: null, loading: false, error: null }
+const listeners = new Set<() => void>()
+let inflight = false
+let started = false
+let pollId: number | null = null
+let mountCount = 0
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+function setState(patch: Partial<Snapshot>) {
+  snapshot = { ...snapshot, ...patch }
+  emit()
+}
+
+async function run(force = false): Promise<void> {
+  if (inflight) return
+  inflight = true
+  setState({ loading: true, error: null })
+  try {
+    const res = await checkForUpdate({ force })
+    setState({ data: res })
+  } catch (e) {
+    setState({ error: e instanceof Error ? e.message : String(e) })
+  } finally {
+    inflight = false
+    setState({ loading: false })
+  }
+}
+
+// Lets other components (e.g. the Settings update card, which runs its own
+// force-check) feed a fresh result into the shared store so the global banner
+// updates immediately — no page reload required.
+export function publishUpdateCheck(data: UpdateCheck): void {
+  setState({ data })
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb)
+  mountCount += 1
+  if (!started) {
+    started = true
     void run(false)
-    const id = window.setInterval(() => { void run(false) }, POLL_MS)
-    return () => window.clearInterval(id)
-  }, [run])
+    pollId = window.setInterval(() => { void run(false) }, POLL_MS)
+  }
+  return () => {
+    listeners.delete(cb)
+    mountCount -= 1
+    if (mountCount <= 0 && pollId !== null) {
+      window.clearInterval(pollId)
+      pollId = null
+      started = false
+      mountCount = 0
+    }
+  }
+}
 
-  return { data, loading, error, refresh: () => run(true) }
+function getSnapshot(): Snapshot {
+  return snapshot
+}
+
+export function useUpdateCheck(): UpdateState {
+  const snap = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const refresh = useCallback(() => run(true), [])
+  return { data: snap.data, loading: snap.loading, error: snap.error, refresh }
 }

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -5,6 +5,7 @@ import { Icon } from '../components/Icon'
 import { api } from '../api/client'
 import type { ConfigResponse } from '../api/types'
 import { checkForUpdate, installUpdate, type UpdateCheck } from '../api/update'
+import { publishUpdateCheck } from '../hooks/useUpdateCheck'
 import {
   checkDuneAdminUpdate,
   installDuneAdminUpdate,
@@ -299,7 +300,10 @@ export function Settings() {
     setUpdErr(null)
     setUpdMsg(null)
     try {
-      setUpdCheck(await checkForUpdate({ force: true }))
+      const res = await checkForUpdate({ force: true })
+      setUpdCheck(res)
+      // Share the result so the global UpdateBanner reflects it immediately.
+      publishUpdateCheck(res)
     } catch (e) {
       setUpdErr(e instanceof Error ? e.message : String(e))
     } finally {
@@ -610,7 +614,9 @@ export function Settings() {
     void (async () => {
       try {
         setUpdChecking(true)
-        setUpdCheck(await checkForUpdate({ force: false }))
+        const res = await checkForUpdate({ force: false })
+        setUpdCheck(res)
+        publishUpdateCheck(res)
       } catch (e) {
         setUpdErr(e instanceof Error ? e.message : String(e))
       } finally {


### PR DESCRIPTION
## Problem

After publishing v11.4.8, the global **"Update available"** banner never appeared — even ~10 minutes later and after refreshing — while Settings → "Check now" correctly showed "v11.4.8 available."

## Root cause (frontend only — backend was fine)

A live non-forced `/api/update/check` already returns `available: true, installable: true` (the 60-min backend cache was refreshed by the forced "Check now"). The bug was entirely in the UI:

- `useUpdateCheck()` kept **isolated local state per call site**. The `UpdateBanner` and the Settings update card each had their own independent copy.
- The banner checks **once at mount, then only every 6 hours**. The app was already open (on v11.4.7) when v11.4.8 published, so the banner's startup check saw v11.4.7, hid itself, and wouldn't re-check for 6h.
- Clicking Settings "Check now" did a forced check but updated **only the Settings component's** state — the banner's separate hook instance never heard about it.
- The "refresh" was the in-app status refresh (not a full SPA reload), so the banner hook never re-ran.

## Fix

- Convert `useUpdateCheck` into a **shared, module-level store** backed by `useSyncExternalStore`: one result, one in-flight request, one poll timer shared by every consumer. Any check (poll, startup, or manual) now updates the banner.
- Add `publishUpdateCheck(data)` and call it from the Settings update card (both its force "Check now" and its initial load) so a found update lights up the global banner **instantly, with no page reload**.

## Validation
- `npm run build` (tsc -b + vite) passes clean.
- Live backend confirmed returning `available:true` on a non-forced check, proving the defect was UI state isolation.
- Version bumped 11.4.8 → 11.4.9 across all stamps; CHANGELOG + README updated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>