### PR TITLE
v11.4.10 — fix 15-minute reboot/start hang on DB-pod readiness wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.10] - 2026-06-10
+
+### Fixed
+- **Reboot / Start BG no longer hang for up to 15 minutes on the "Waiting for
+  DB pod(s) Ready…" step.** The readiness gate matched database pods by the
+  `-db-` name pattern, which also caught the one-shot `db-dbdepl-util` Job pod
+  (plus the `db-util-mon` / `db-util-pghero` sidecars). A finished Job pod sits
+  in `Completed` state permanently, and `kubectl wait --for=condition=Ready`
+  against a Completed pod never succeeds — it blocks for the entire 900-second
+  timeout and then gives up, so whenever that Job pod hadn't been
+  garbage-collected yet the whole reboot/start appeared to freeze for ~15
+  minutes before continuing. The gate now skips `util` / `mon` / `pghero`
+  helper pods by name and skips any terminal (`Completed` / `Succeeded`) pod by
+  status, so it only ever waits on the real database StatefulSet pod
+  (`db-dbdepl-sts-*`). Verified against the live cluster: the new filter
+  returns exactly the DB pod where the old one returned four.
+
 ## [11.4.9] - 2026-06-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v11.4.9**. The in-app version label and the
-website show plain semver tags (e.g. `v11.4.9`) — the previous
+The current release is **v11.4.10**. The in-app version label and the
+website show plain semver tags (e.g. `v11.4.10`) — the previous
 Roman-numeral stylization has been removed.
 It runs as a single-window Windows app (native WebView2 shell) that hosts a
 local web portal (React + Vite + Tailwind) on `127.0.0.1` with a per-launch

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.9'
+$script:DuneToolVersion = '11.4.10'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.9',
+    [string]$Version = '11.4.10',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.9</Version>
+    <Version>11.4.10</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.9"
+#define MyAppVersion "11.4.10"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.9"
+$script:ToolVersion = "11.4.10"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a
@@ -1656,9 +1656,19 @@ while ($true) {
         # Awk prints "namespace podname" space-separated; embedded double quotes in
         # an awk script get mangled by PowerShell when the script is in a double-
         # quoted string passed to ssh, so we split on whitespace in PS instead.
+        #
+        # Exclusions matter: the `-db-` family also contains a one-shot
+        # `db-dbdepl-util` Job pod plus `db-util-mon` / `db-util-pghero`
+        # sidecars. A finished Job pod sits in STATUS=Completed forever, and
+        # `kubectl wait --for=condition=Ready` against a Completed pod never
+        # succeeds - it blocks for the ENTIRE --timeout (900s) and then fails,
+        # so reboot/start appeared to hang for 15 minutes whenever that Job
+        # pod hadn't been garbage-collected yet. Skip util/mon/pghero by name
+        # and skip any terminal (Completed/Succeeded) pod by status ($4) so we
+        # only ever wait on the real DB StatefulSet pod (db-dbdepl-sts-*).
         $estDb = Format-PhaseEstimate 'db-pods'
         $dbPodList = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" `
-            "sudo k3s kubectl get pods -A --no-headers 2>/dev/null | awk '`$2 ~ /(-db-|postgres|^pg-|-pg-)/ && `$2 !~ /(dump|backup|fb-|migration)/ {print `$1, `$2}'"
+            "sudo k3s kubectl get pods -A --no-headers 2>/dev/null | awk '`$2 ~ /(-db-|postgres|^pg-|-pg-)/ && `$2 !~ /(dump|backup|fb-|migration|util|mon|pghero)/ && `$4 !~ /(Completed|Succeeded)/ {print `$1, `$2}'"
         $dbPodList = ($dbPodList | Out-String).Trim()
         if ($dbPodList) {
             $dbPods = $dbPodList -split "`r?`n" | Where-Object { $_.Trim() }
@@ -1931,9 +1941,15 @@ while ($true) {
         # (which would also wait on backup Jobs, file-browser deployments, etc).
         # Awk prints space-separated to avoid embedded double quotes (PowerShell
         # mangles \" inside a double-quoted string passed to ssh).
+        #
+        # Exclude util/mon/pghero helpers and terminal (Completed/Succeeded)
+        # pods: a finished `db-dbdepl-util` Job pod stays Completed forever and
+        # `kubectl wait --for=condition=Ready` against it blocks for the full
+        # --timeout (900s) before failing, which made start/reboot hang ~15
+        # min. We only want the real DB StatefulSet pod (db-dbdepl-sts-*).
         $estDb = Format-PhaseEstimate 'db-pods'
         $dbPodList = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" `
-            "sudo k3s kubectl get pods -A --no-headers 2>/dev/null | awk '`$2 ~ /(-db-|postgres|^pg-|-pg-)/ && `$2 !~ /(dump|backup|fb-|migration)/ {print `$1, `$2}'"
+            "sudo k3s kubectl get pods -A --no-headers 2>/dev/null | awk '`$2 ~ /(-db-|postgres|^pg-|-pg-)/ && `$2 !~ /(dump|backup|fb-|migration|util|mon|pghero)/ && `$4 !~ /(Completed|Succeeded)/ {print `$1, `$2}'"
         $dbPodList = ($dbPodList | Out-String).Trim()
         if ($dbPodList) {
             $dbPods = $dbPodList -split "`r?`n" | Where-Object { $_.Trim() }

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.9",
+  "version": "11.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.9",
+      "version": "11.4.10",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.9",
+  "version": "11.4.10",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Symptom

Reboot and "Start BG Only" appeared to **hang for up to ~15 minutes** on the `Waiting for DB pod(s) Ready…` step (screenshot showed it climbing past 2:00 against a historical avg of ~32s).

## Root cause (verified on the live cluster)

The DB-readiness gate selects database pods by the `-db-` / `postgres` / `pg-` name pattern. That pattern **over-matches**: besides the real DB StatefulSet pod (`db-dbdepl-sts-0`), it also catches:

- `db-dbdepl-util-*` — a **one-shot Job pod that sits in `Completed` forever**
- `db-util-mon-*`, `db-util-pghero-*` — monitoring sidecars

`kubectl wait --for=condition=Ready` waits on **all** listed pods, and a `Completed` pod's Ready condition is `False` permanently — so the wait blocks for the **entire `--timeout` (900s)** and then exits non-zero ("proceeding anyway"). On boots where the util Job pod had already been garbage-collected, the wait was fast (~32s) — which is why it only *sometimes* hung.

Empirically confirmed: `kubectl wait --for=condition=Ready` on the Completed util pod ran the full timeout then returned `error: timed out waiting for the condition`.

## Fix

Tighten the `awk` filter in **both** the reboot and start paths to additionally:
- exclude `util` / `mon` / `pghero` helper pods by name, and
- exclude any terminal (`Completed` / `Succeeded`) pod by status column.

So the gate only ever waits on the real DB StatefulSet pod.

**Live verification** — same cluster, same moment:
- Old filter → 4 pods (incl. the `Completed` `db-dbdepl-util` that caused the stall)
- New filter → exactly 1 pod: `…-db-dbdepl-sts-0`

## Validation
- `dune-server.ps1` parses clean under pwsh 7.
- Version bumped 11.4.9 → 11.4.10; CHANGELOG + README updated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>