### PR TITLE
Release v11.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.11] - 2026-06-10
+
 ### Fixed
 - **"Report an issue" now tells you what happened.** The Help → Report an
   issue diagnostics bundle previously built (or failed to build) silently —
@@ -25,7 +27,7 @@ here cover everything those tags shipped.
 
 ### Changed
 - **Verified compatible with Dune: Awakening 1.4.5.0.** Confirmed DST
-  v11.4.10 works against Funcom's latest release — both the game client and
+  v11.4.11 works against Funcom's latest release — both the game client and
   the self-hosted server software — tested live against the 1.4.5.0 server
   build (image `1988751-0-shipping`, June 10 2026) covering battlegroup
   management, on-demand map spin-up, game-config/database editing, and

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v11.4.10**. The in-app version label and the
-website show plain semver tags (e.g. `v11.4.10`) — the previous
+The current release is **v11.4.11**. The in-app version label and the
+website show plain semver tags (e.g. `v11.4.11`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.5.0**
-> DST **v11.4.10** is verified working against the **latest Funcom release** —
+> DST **v11.4.11** is verified working against the **latest Funcom release** —
 > both the game **client** and the **self-hosted server** software — as of the
 > **1.4.5.0** patch (June 10, 2026). Compatibility was checked live against a
 > running self-hosted server on that build (server image `1988751-0-shipping`),

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.10'
+$script:DuneToolVersion = '11.4.11'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.10',
+    [string]$Version = '11.4.11',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.10</Version>
+    <Version>11.4.11</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.10"
+#define MyAppVersion "11.4.11"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -13,7 +13,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.10"
+$script:ToolVersion = "11.4.11"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.10",
+  "version": "11.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.10",
+      "version": "11.4.11",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.10",
+  "version": "11.4.11",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump to **v11.4.11**, shipping the Help → Report an issue diagnostics-bundle feedback fix to users.

### Included
- **Fix (#119 already on main):** Help → Report an issue now surfaces the diagnostics-bundle result — saved path, file count/size, warnings (incl. the `%APPDATA%\DuneServer` fallback notice), or a clear error with manual log-attach guidance — instead of failing silently.
- Bumps the 5 version stamps + `webui/package.json`/lock to `11.4.11`.
- Rolls CHANGELOG `[Unreleased]` into `[11.4.11]`; updates README current-release/compat callout.

Installer `.exe` will be built and attached to the GitHub release after merge.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>