### PR TITLE
Guard SSH-key rotation against silent lockout + confirm 1.4.5.0 deployment-file compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ here cover everything those tags shipped.
 ## [11.4.11] - 2026-06-10
 
 ### Fixed
+- **Rotating the SSH key can no longer silently lock you out.** Settings →
+  SSH key → "Generate new" (the `rotate-ssh-key` command) regenerates the
+  local key and then authorizes it on the VM by SSHing in with the `dune`
+  password. If that password prompt was closed or cancelled, the local key
+  was swapped in but its public half never reached the VM's
+  `authorized_keys` — leaving DST locked out of every key-based operation
+  (server health, commands, diagnostics all failed with "Permission denied
+  (publickey)"). The command now verifies the new key actually authenticates
+  before finishing and, if it didn't, prints a loud warning with the exact
+  one-line recovery command. The in-app confirmation also now makes clear you
+  must enter the `dune` password when the console prompts.
 - **"Report an issue" now tells you what happened.** The Help → Report an
   issue diagnostics bundle previously built (or failed to build) silently —
   if the ZIP couldn't be written, or landed in the `%APPDATA%\DuneServer`
@@ -31,11 +42,22 @@ here cover everything those tags shipped.
   the self-hosted server software — tested live against the 1.4.5.0 server
   build (image `1988751-0-shipping`, June 10 2026) covering battlegroup
   management, on-demand map spin-up, game-config/database editing, and
-  backups. No DST code change was required for the patch. Added a noticeable
-  compatibility callout to the README, the marketing-site home page (hero
-  badge + banner), and the install page. The 1.4.5.0 on-demand partition
-  drift behavior is unchanged, so the `dune-clear-partitions` workaround
-  remains required.
+  backups. 1.4.5.0 updated Funcom's self-hosted deployment files, so DST's
+  dependencies were re-audited against the live build: the host helper
+  signatures DST dot-sources (`Update-SshKey`/`Set-VmPassword` in
+  `vm-utilities.ps1`, `Set-VmIp` in `vm-ip.ps1`), the `funcom-seabass-`
+  namespace prefix, every battlegroup-CRD JSON-patch path DST writes
+  (`sets[].map/replicas/partitions/dedicatedScaling`,
+  `worldPartitions[].partitions[].disable`, and the `director.ini` config
+  file), and the `sudo kubectl` shim plus the in-VM
+  `/home/dune/.dune/bin/battlegroup` binary all remain unchanged — so no DST
+  code change was required for the patch. 1.4.5.0's only command-surface delta
+  is additive (the bg binary's new `change-battlegroup-ip` for the advertised
+  player IP, alongside the existing `change-vm-ip` DST already drives), which
+  does not affect existing DST behavior. Added a noticeable compatibility
+  callout to the README, the marketing-site home page (hero badge + banner),
+  and the install page. The 1.4.5.0 on-demand partition drift behavior is
+  unchanged, so the `dune-clear-partitions` workaround remains required.
 
 ## [11.4.10] - 2026-06-10
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -2132,6 +2132,41 @@ while ($true) {
     if ($cmdName -eq "rotate-ssh-key") {
         . "$bgSetupPath\vm-utilities.ps1"
         Update-SshKey -Ip $ip | Out-Null
+
+        # --- Guard: confirm the freshly-rotated key actually authenticates -----
+        # Update-SshKey regenerates the local key, then authorizes it on the VM
+        # by SSHing in with the dune *password*. If that password prompt is
+        # closed or cancelled, the local key is replaced but its public half
+        # never reaches dune@VM:~/.ssh/authorized_keys — leaving DST locked out
+        # of every key-based operation (status, commands, diagnostics all fail
+        # with "Permission denied (publickey)"). Verify non-interactively and,
+        # if it failed, tell the user exactly how to recover instead of silently
+        # stranding them.
+        $verifyKey = Resolve-FreshSshKey -ConfiguredPath $sshKey
+        if (-not $verifyKey) { $verifyKey = $sshKey }
+        $rotateProbe = ''
+        if ($verifyKey -and (Test-Path -LiteralPath $verifyKey)) {
+            $rotateProbe = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=8 -o LogLevel=QUIET -i "$verifyKey" "$sshUser@$ip" "echo dune-ok" 2>&1
+        }
+        if ($rotateProbe -match 'dune-ok') {
+            Write-Host ""
+            Write-Host "  Verified: the new SSH key authenticates to $sshUser@$ip." -ForegroundColor Green
+        } else {
+            Write-Host ""
+            Write-Host "  WARNING: the new SSH key is NOT authorized on the VM yet." -ForegroundColor Red
+            Write-Host "  The key was regenerated locally, but its public half never reached" -ForegroundColor Yellow
+            Write-Host "  ${sshUser}@${ip}:~/.ssh/authorized_keys - usually because the dune" -ForegroundColor Yellow
+            Write-Host "  password prompt above was closed or cancelled. DST cannot manage the" -ForegroundColor Yellow
+            Write-Host "  server (status, commands, diagnostics) until this is fixed." -ForegroundColor Yellow
+            Write-Host ""
+            Write-Host "  Recover by running this and entering the '$sshUser' password when asked:" -ForegroundColor Yellow
+            Write-Host ""
+            Write-Host "    Get-Content `"$verifyKey.pub`" | ssh $sshUser@$ip `"mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys`"" -ForegroundColor Cyan
+            Write-Host ""
+            Write-Host "  ...or simply run 'rotate-ssh-key' again and be sure to type the dune" -ForegroundColor DarkGray
+            Write-Host "  password when the console asks for it." -ForegroundColor DarkGray
+        }
+
         # Keep dune-admin's copy of the SSH key in sync with the rotated one
         if ($cfg.DuneAdminExe -and (Test-Path $cfg.DuneAdminExe)) {
             try {

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -71,7 +71,7 @@ export function Settings() {
   const [sshRotating, setSshRotating] = useState(false)
   const [sshRotateMsg, setSshRotateMsg] = useState<string | null>(null)
   async function onRotateSshKey() {
-    if (!window.confirm('Generate a NEW SSH key?\n\nThis regenerates the key, authorizes it on the dune-awakening VM, and copies it into the dune-admin folder. The VM must be running. A console window will open and may ask for admin approval.')) return
+    if (!window.confirm('Generate a NEW SSH key?\n\nThis regenerates the key, authorizes it on the dune-awakening VM, and copies it into the dune-admin folder. The VM must be running.\n\nA console window will open and ask for the \'dune\' user\'s password — you MUST type it there to authorize the new key on the VM. If you close that prompt without entering the password, DST will be locked out of the server until you re-run this. The console will tell you if authorization succeeded.')) return
     setSshRotating(true)
     setSshRotateMsg(null)
     setError(null)


### PR DESCRIPTION
## Why

Two things ship here, both follow-ups to the v11.4.11 work:

### 1. SSH-key rotation can no longer silently lock you out

A user (Eqan) was stranded after clicking **Settings → SSH key → "Generate new"**. That button runs the `rotate-ssh-key` command, which regenerates the local key and then authorizes it on the VM by SSHing in with the **`dune` password**. If that password prompt is closed or cancelled, the local key is swapped in but its public half never reaches the VM's `~/.ssh/authorized_keys` — leaving DST locked out of *every* key-based operation (server health, commands, diagnostics all fail with `Permission denied (publickey)`). Funcom's own `Update-SshKey` comment confirms it only falls back to password auth when **no** local key exists, so a half-rotated key blocks recovery.

**Fix:**
- `dune-server.ps1`: after `Update-SshKey`, run a non-interactive SSH probe (`echo dune-ok`) with the freshly-rotated key. On success → green "Verified" line. On failure → loud red warning + the exact one-line recovery command + a note to re-run and type the `dune` password. (This handler runs under `pwsh` via `Invoke-DuneCommandExternal`, so the file's UTF-8 content is unaffected by the PS2EXE/PS 5.1 path.)
- `Settings.tsx`: the confirm dialog now makes explicit that the user **must** type the `dune` password in the console window or DST will be locked out.

### 2. Re-audited DST against Funcom's 1.4.5.0 self-hosted server

1.4.5.0 updated Funcom's self-hosted **deployment files**, so I re-verified every DST dependency against the live 1.4.5.0 build (`seabass-server:1988751-0-shipping`):

| DST dependency | 1.4.5.0 status |
|---|---|
| `Update-SshKey -Ip` / `Set-VmPassword -Ip -NewPassword` (`vm-utilities.ps1`) | ✅ unchanged signatures |
| `Set-VmIp -Ip -SshKey` (`vm-ip.ps1`) | ✅ unchanged |
| `funcom-seabass-` namespace prefix | ✅ |
| battlegroup-CRD paths: `sets[].map/replicas/partitions/dedicatedScaling`, `worldPartitions[].partitions[].disable`, `director.ini` | ✅ all resolve live |
| `sudo kubectl` shim + `/home/dune/.dune/bin/battlegroup` | ✅ |

**No DST code change was required for compatibility.** The only command-surface delta is additive — the bg binary's new `change-battlegroup-ip` (advertised player IP), alongside the existing `change-vm-ip` DST already drives. Recorded in the CHANGELOG under `[11.4.11]`.

## Testing
- `dune-server.ps1` parses clean under `pwsh` (its actual runtime).
- `webui` builds clean (`tsc -b && vite build`).
- CRD/host-script/binary checks run live against the 1.4.5.0 VM.