### PR TITLE
Fix diagnostics ZIP build + pause command windows on exit (v11.4.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.12] - 2026-06-11
+
+### Fixed
+- **"Report an issue" now actually produces the diagnostics ZIP.** The Help →
+  Report an issue bundle staged the archive to a `...zip.tmp` path before
+  renaming it into place. Under Windows PowerShell 5.1 — which the packaged
+  `DuneServer.exe` runs on — `Compress-Archive` rejects any destination that
+  doesn't end in `.zip` (".tmp is not a supported archive file format"), so the
+  whole bundle build threw and no ZIP was ever written. (It happened to work in
+  PowerShell 7 during development, which masked the bug.) The bundle now stages
+  to a real `.zip` name and moves it into place, so the
+  `dst-diagnostics-<timestamp>.zip` is generated reliably. Thanks to **Eqan
+  (Discord)** for reporting that no ZIP was being created.
+- **Command windows no longer slam shut before you can read the result.**
+  Console commands launched in their own window (e.g. `rotate-ssh-key`) ran to
+  completion and then closed instantly, so any final message — especially a red
+  warning or error — flashed and vanished. Those windows now pause for a
+  keypress before closing, keeping the result on screen. The pause is scoped to
+  Console-mode commands and is a no-op for the app's stdout-captured calls, so
+  it can never hang a background operation. Thanks to **Eqan (Discord)** for
+  flagging that the `rotate-ssh-key` warning was unreadable before the window
+  closed.
+
 ## [11.4.11] - 2026-06-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v11.4.11**. The in-app version label and the
-website show plain semver tags (e.g. `v11.4.11`) — the previous
+The current release is **v11.4.12**. The in-app version label and the
+website show plain semver tags (e.g. `v11.4.12`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.5.0**
-> DST **v11.4.11** is verified working against the **latest Funcom release** —
+> DST **v11.4.12** is verified working against the **latest Funcom release** —
 > both the game **client** and the **self-hosted server** software — as of the
 > **1.4.5.0** patch (June 10, 2026). Compatibility was checked live against a
 > running self-hosted server on that build (server image `1988751-0-shipping`),

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.11'
+$script:DuneToolVersion = '11.4.12'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.11',
+    [string]$Version = '11.4.12',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.11</Version>
+    <Version>11.4.12</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.11"
+#define MyAppVersion "11.4.12"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Commands.ps1
+++ b/app/server/lib/Commands.ps1
@@ -348,6 +348,11 @@ function Invoke-DuneCommandExternal {
         '-File',"`"$script:MainScript`""
         '-Cmd',$cmd.Name
     )
+    # Console-mode commands open in their own visible window; tell dune-server.ps1
+    # to pause for a keypress before exiting so the result (especially a warning
+    # or error) stays readable instead of the window closing instantly. InApp
+    # commands capture stdout and must never pause, so they don't get the flag.
+    if ($cmd.Mode -eq 'Console') { $argList += '-PauseOnExit' }
     $startArgs = @{
         FilePath         = $script:PwshExe
         ArgumentList     = $argList

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -142,10 +142,15 @@ function New-DstDiagnosticBundle {
     }
     $ts = (Get-Date).ToString('yyyyMMdd-HHmmss-fff')
     $finalZip = Join-Path $destInfo.path "dst-diagnostics-$ts.zip"
-    $tmpZip   = "$finalZip.tmp"
+    # NB: Compress-Archive ONLY accepts a destination ending in ".zip". Under
+    # Windows PowerShell 5.1 (which the packaged DuneServer.exe runs on) a
+    # ".tmp" destination throws ".tmp is not a supported archive file format",
+    # which silently failed the whole bundle. Stage to a real .zip name in
+    # %TEMP%, then move it onto the final path.
+    $stageZip = Join-Path $env:TEMP "dst-diagnostics-$ts.partial.zip"
 
     # Stage everything in %TEMP% so writes to the user's Desktop are atomic
-    # (we Compress-Archive into the .tmp name, then rename on success).
+    # (we Compress-Archive into the staging .zip, then move on success).
     $stageDir = Join-Path $env:TEMP "dst-diagnostics-$ts"
     [void](New-Item -ItemType Directory -Force -Path $stageDir -ErrorAction SilentlyContinue)
 
@@ -262,14 +267,14 @@ function New-DstDiagnosticBundle {
     Set-Content -LiteralPath $manPath -Value ($manLines -join "`r`n") -Encoding UTF8
     $included.Add(@{ name = 'manifest.txt'; bytes = (Get-Item -LiteralPath $manPath).Length })
 
-    # 8) Compress into .tmp then atomically rename ---------------------------
-    if (Test-Path -LiteralPath $tmpZip)   { Remove-Item -LiteralPath $tmpZip -Force -ErrorAction SilentlyContinue }
+    # 8) Compress into a staging .zip then move into place ------------------
+    if (Test-Path -LiteralPath $stageZip) { Remove-Item -LiteralPath $stageZip -Force -ErrorAction SilentlyContinue }
     if (Test-Path -LiteralPath $finalZip) { Remove-Item -LiteralPath $finalZip -Force -ErrorAction SilentlyContinue }
     try {
-        Compress-Archive -Path (Join-Path $stageDir '*') -DestinationPath $tmpZip -Force -ErrorAction Stop
-        Rename-Item -LiteralPath $tmpZip -NewName (Split-Path -Leaf $finalZip) -ErrorAction Stop
+        Compress-Archive -Path (Join-Path $stageDir '*') -DestinationPath $stageZip -Force -ErrorAction Stop
+        Move-Item -LiteralPath $stageZip -Destination $finalZip -Force -ErrorAction Stop
     } catch {
-        if (Test-Path -LiteralPath $tmpZip) { Remove-Item -LiteralPath $tmpZip -Force -ErrorAction SilentlyContinue }
+        if (Test-Path -LiteralPath $stageZip) { Remove-Item -LiteralPath $stageZip -Force -ErrorAction SilentlyContinue }
         Remove-Item -LiteralPath $stageDir -Recurse -Force -ErrorAction SilentlyContinue
         throw "Failed to build diagnostic ZIP: $($_.Exception.Message)"
     }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -5,7 +5,15 @@ param(
     # When set, skip the interactive menu and dispatch directly to the named
     # command. Used by the desktop app (app\DuneServer.ps1) to invoke commands
     # inside its embedded terminal pane.
-    [string]$Cmd
+    [string]$Cmd,
+
+    # When set, pause for a keypress before the script exits so the result
+    # stays on screen instead of the console window closing instantly. The
+    # desktop app passes this for Console-mode commands launched in their own
+    # window (Invoke-DuneCommandExternal); without it a quick command like
+    # rotate-ssh-key flashes its result/warning and vanishes before it can be
+    # read. Never passed for stdout-captured InApp runs.
+    [switch]$PauseOnExit
 )
 
 # ============================================================
@@ -13,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.11"
+$script:ToolVersion = "11.4.12"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a
@@ -44,6 +52,25 @@ function Invoke-DuneCleanup {
             $jobs | Remove-Job -Force -ErrorAction SilentlyContinue
         }
     } catch { }
+}
+
+# Pause before the script exits so a command launched in its own console
+# window doesn't slam shut before the user can read the result — especially a
+# red warning or error (a user reported rotate-ssh-key flashed a red message
+# and the window closed before they could tell whether it had worked). Only
+# active when -PauseOnExit was passed (Console-mode commands), and a no-op when
+# stdin is redirected so it can never hang a non-interactive / stdout-captured
+# caller.
+function Invoke-DunePauseBeforeClose {
+    if (-not $PauseOnExit) { return }
+    try { if ([Console]::IsInputRedirected) { return } } catch {}
+    try {
+        Write-Host ""
+        Write-Host "Press any key to close this window..." -ForegroundColor Cyan
+        $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
+    } catch {
+        try { Read-Host "Press Enter to close this window" | Out-Null } catch {}
+    }
 }
 Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {
     try {
@@ -1351,6 +1378,7 @@ trap {
     Write-Host "  at: $($_.InvocationInfo.PositionMessage)" -ForegroundColor DarkGray
     Write-Host "Cleaning up background helpers..." -ForegroundColor Yellow
     Invoke-DuneCleanup
+    Invoke-DunePauseBeforeClose
     exit 1
 }
 
@@ -1389,6 +1417,7 @@ while ($true) {
         $entry = $entries | Where-Object { $_.Name -eq $Cmd } | Select-Object -First 1
         if (-not $entry) {
             Write-Error "Unknown command: $Cmd"
+            Invoke-DunePauseBeforeClose
             exit 1
         }
     } else {
@@ -1474,7 +1503,7 @@ while ($true) {
 
     if (-not $entry.Available) {
         Write-Warning $entry.Reason
-        if ($Cmd) { exit 1 } else { continue }
+        if ($Cmd) { Invoke-DunePauseBeforeClose; exit 1 } else { continue }
     }
 
     $cmdName = $entry.Name
@@ -2713,3 +2742,4 @@ CreateObject("WScript.Shell").Run cmd, 0, True
 }
 
 Stop-Transcript | Out-Null
+Invoke-DunePauseBeforeClose

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.11",
+  "version": "11.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.11",
+      "version": "11.4.12",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.11",
+  "version": "11.4.12",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Two fixes surfaced by **Eqan (Discord)** while testing v11.4.11, plus the version bump to **11.4.12**.

### 1. Diagnostics "Report an issue" ZIP never generated
`New-DstDiagnosticBundle` staged the archive to a `...zip.tmp` path, then renamed it into place. Under **Windows PowerShell 5.1** — which the packaged `DuneServer.exe` runs on — `Compress-Archive` rejects any `-DestinationPath` that doesn't end in `.zip`:

```
.tmp is not a supported archive file format. .zip is the only supported archive file format.
```

So the whole bundle build threw and **no ZIP was ever written**. It happened to work under PowerShell 7 in dev, which masked the bug. Reproduced and verified the fix under 5.1.

**Fix:** stage to a real `.zip` name in `%TEMP%` (`dst-diagnostics-<ts>.partial.zip`) and `Move-Item` it onto the final path.

### 2. Command windows slam shut before the result is readable
Console-mode commands launched in their own window (e.g. `rotate-ssh-key`) ran to completion and closed instantly, so a final message — especially the SSH-rotate guard's red warning — flashed and vanished. Eqan reported seeing "a red message before the PowerShell closed" but couldn't read it.

**Fix:** `dune-server.ps1` now takes a `-PauseOnExit` switch and waits for a keypress at every exit point (trap, unknown-command, not-available, normal tail). `Invoke-DuneCommandExternal` passes it **only for Console-mode commands**; it's guarded by `[Console]::IsInputRedirected` so it can never hang a stdout-captured / non-interactive caller.

## Version
Bumped to **11.4.12** across all 5 stamp files + `webui/package.json`/lock. CHANGELOG `[11.4.12]` added crediting Eqan; README compatibility callout updated. Marketing site pulls version/changelog dynamically — no source edits needed.

## Validation
- All three changed PS files parse clean under `pwsh`.
- Reproduced the `.tmp` failure under PS 5.1 and confirmed the staged-`.zip` + `Move-Item` path succeeds.
- `npm run build` in `webui/` succeeds.
