### PR TITLE
Add Funcom BattleGroup.bat button to Settings (v11.4.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.4.13] - 2026-06-11
+
+### Added
+- **Open Funcom's battlegroup.bat from Settings.** A new **"Funcom
+  BattleGroup.bat"** button sits above the Browse button on the Steam install
+  path field (Settings → Tool configuration). It opens the original
+  `battlegroup.bat` in the root of your configured Steam install folder in an
+  elevated window — handy for running Funcom's own setup/management menu
+  without hunting for the file. The button confirms first, then launches the
+  `.bat` (which itself runs `battlegroup.ps1` and pauses on exit) with
+  administrator rights.
+
 ## [11.4.12] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v11.4.12**. The in-app version label and the
-website show plain semver tags (e.g. `v11.4.12`) — the previous
+The current release is **v11.4.13**. The in-app version label and the
+website show plain semver tags (e.g. `v11.4.13`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.5.0**
-> DST **v11.4.12** is verified working against the **latest Funcom release** —
+> DST **v11.4.13** is verified working against the **latest Funcom release** —
 > both the game **client** and the **self-hosted server** software — as of the
 > **1.4.5.0** patch (June 10, 2026). Compatibility was checked live against a
 > running self-hosted server on that build (server image `1988751-0-shipping`),

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.4.12'
+$script:DuneToolVersion = '11.4.13'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -1,4 +1,4 @@
-﻿# Build-Exe.ps1 - Compiles app/DuneServer.ps1 into DuneServer.exe via ps2exe.
+# Build-Exe.ps1 - Compiles app/DuneServer.ps1 into DuneServer.exe via ps2exe.
 #
 # Output: app/build/output/DuneServer.exe
 #
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.4.12',
+    [string]$Version = '11.4.13',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.4.12</Version>
+    <Version>11.4.13</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -1,4 +1,4 @@
-﻿; ============================================================
+; ============================================================
 ;  Dune Server - Inno Setup installer script
 ;  Output: app/installer/output/DuneServerSetup.exe
 ; ============================================================
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.4.12"
+#define MyAppVersion "11.4.13"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/routes/Config.ps1
+++ b/app/server/routes/Config.ps1
@@ -107,3 +107,43 @@ Register-DuneRoute -Method POST -Path '/api/config/rotate-ssh-key' -Handler {
         Write-DuneError -Response $res -Status 500 -Message "SSH key rotation failed: $($_.Exception.Message)"
     }
 }
+
+# POST /api/config/open-battlegroup-bat — open Funcom's original battlegroup.bat
+# (located in the root of the Steam install folder) in an elevated window. The
+# .bat launches battlegroup.ps1 and pauses on exit. The API server already runs
+# elevated, so -Verb RunAs hands that elevation straight to the child (and falls
+# back to a UAC prompt if it somehow isn't). The frontend asks the user before
+# calling this.
+Register-DuneRoute -Method POST -Path '/api/config/open-battlegroup-bat' -Handler {
+    param($req, $res, $routeParams, $body)
+
+    $cfg   = Read-DuneConfigRaw
+    $steam = if ($cfg -and $cfg.SteamPath) { [string]$cfg.SteamPath } else { '' }
+    if (-not $steam) {
+        Write-DuneError -Response $res -Status 400 -Message 'Steam install path is not set. Set it in Settings first.'
+        return
+    }
+
+    $bat = Join-Path $steam 'battlegroup.bat'
+    if (-not (Test-Path -LiteralPath $bat)) {
+        Write-DuneError -Response $res -Status 404 -Message "battlegroup.bat not found at: $bat. Check that the Steam install path points at Funcom's Self-Hosted Server folder."
+        return
+    }
+
+    try {
+        $proc = Start-Process -FilePath $bat -WorkingDirectory $steam -Verb RunAs -PassThru -ErrorAction Stop
+        Write-DuneJson -Response $res -Body @{
+            ok      = $true
+            path    = $bat
+            pid     = if ($proc) { $proc.Id } else { $null }
+            message = 'Opened Funcom battlegroup.bat in an elevated window.'
+        }
+    } catch {
+        $msg = $_.Exception.Message
+        if ($msg -match 'cancell?ed by the user|operation was canceled') {
+            Write-DuneError -Response $res -Status 409 -Message 'Elevation was cancelled — battlegroup.bat was not opened.'
+        } else {
+            Write-DuneError -Response $res -Status 500 -Message "Could not open battlegroup.bat: $msg"
+        }
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.4.12"
+$script:ToolVersion = "11.4.13"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "11.4.12",
+  "version": "11.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "11.4.12",
+      "version": "11.4.13",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "11.4.12",
+  "version": "11.4.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -70,6 +70,26 @@ export function Settings() {
   // finish, then propagates the fresh key everywhere DST uses it.
   const [sshRotating, setSshRotating] = useState(false)
   const [sshRotateMsg, setSshRotateMsg] = useState<string | null>(null)
+  const [openingBat, setOpeningBat] = useState(false)
+  const [batMsg, setBatMsg] = useState<string | null>(null)
+  async function onOpenBattlegroupBat() {
+    if (!window.confirm('Open Funcom\'s original battlegroup.bat?\n\nThis launches the battlegroup.bat in the root of your Steam install folder in an ELEVATED (administrator) window. Approve the Windows UAC prompt if it appears.')) return
+    setOpeningBat(true)
+    setBatMsg(null)
+    setError(null)
+    try {
+      const r = await api<{ ok: boolean; path?: string; message?: string }>(
+        '/api/config/open-battlegroup-bat',
+        { method: 'POST' },
+      )
+      setBatMsg(r.message ?? (r.ok ? 'Opened battlegroup.bat.' : 'Could not open battlegroup.bat.'))
+      if (!r.ok && r.message) setError(r.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setOpeningBat(false)
+    }
+  }
   async function onRotateSshKey() {
     if (!window.confirm('Generate a NEW SSH key?\n\nThis regenerates the key, authorizes it on the dune-awakening VM, and copies it into the dune-admin folder. The VM must be running.\n\nA console window will open and ask for the \'dune\' user\'s password — you MUST type it there to authorize the new key on the VM. If you close that prompt without entering the password, DST will be locked out of the server until you re-run this. The console will tell you if authorization succeeded.')) return
     setSshRotating(true)
@@ -1307,7 +1327,20 @@ export function Settings() {
                 <option value="disabled">disabled — no port checks</option>
               </select>
             ) : f.browse ? (
-              <div className="flex items-stretch gap-2">
+              <>
+                {f.key === 'SteamPath' && (
+                  <button
+                    type="button"
+                    onClick={() => void onOpenBattlegroupBat()}
+                    disabled={openingBat}
+                    title="Open Funcom's battlegroup.bat (in the Steam install root) in an elevated window"
+                    className="btn-secondary mb-2"
+                  >
+                    <Icon name={openingBat ? 'Loader2' : 'SquareTerminal'} size={15} className={openingBat ? 'animate-spin' : ''} />
+                    {openingBat ? 'Opening…' : 'Funcom BattleGroup.bat'}
+                  </button>
+                )}
+                <div className="flex items-stretch gap-2">
                 <input
                   type="text"
                   value={values[f.key] ?? ''}
@@ -1342,7 +1375,8 @@ export function Settings() {
                     {sshRotating ? 'Rotating…' : 'Generate new'}
                   </button>
                 )}
-              </div>
+                </div>
+              </>
             ) : (
               <input
                 type="text"
@@ -1357,6 +1391,11 @@ export function Settings() {
             {f.key === 'SshKey' && sshRotateMsg && (
               <p className="mt-1 text-xs text-success flex items-center gap-1.5">
                 <Icon name="CheckCircle2" size={13} /> {sshRotateMsg}
+              </p>
+            )}
+            {f.key === 'SteamPath' && batMsg && (
+              <p className="mt-1 text-xs text-success flex items-center gap-1.5">
+                <Icon name="CheckCircle2" size={13} /> {batMsg}
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary

Adds a **Funcom BattleGroup.bat** button to the Steam install path field in **Settings → Tool configuration**, sitting just above the Browse button. It opens Funcom's original `battlegroup.bat` — located in the root of the configured Steam install folder — in an elevated window, so you can run Funcom's own setup/management menu without hunting for the file.

### Backend
- New `POST /api/config/open-battlegroup-bat` route (`app/server/routes/Config.ps1`):
  - Reads `SteamPath`, resolves `<SteamPath>\battlegroup.bat`.
  - Launches it via `Start-Process -FilePath $bat -WorkingDirectory $steam -Verb RunAs`. The API server already runs elevated, so elevation passes straight to the child (falls back to a UAC prompt if not).
  - `400` if `SteamPath` unset, `404` if the `.bat` is missing, `409` if elevation is cancelled.

### Frontend
- `Settings.tsx`: an auto-width **Funcom BattleGroup.bat** button rendered **above** the input + Browse row, for the `SteamPath` field only. Confirms before launching ("opens in an elevated/administrator window"), then shows a success line.

## Validation
- `Config.ps1` parses clean under `pwsh`.
- `tsc -b && vite build` succeeds.

## Version
Bumped to **11.4.13** across all 5 stamp files + `webui/package.json`/lock. CHANGELOG `[11.4.13]` added; README version callout updated.
