### PR TITLE
Game Config: apply client-side settings to local client Game.ini

### DIFF
--- a/app/server/lib/Config.ps1
+++ b/app/server/lib/Config.ps1
@@ -14,7 +14,8 @@ $script:DuneConfigKeys = @(
     'ConsolePresenceVersion',
     'MarketBotAddr',
     'MarketBotToken',
-    'DecoupleNoticeAck'
+    'DecoupleNoticeAck',
+    'ClientConfigPath'
 )
 
 # Keys that ONLY a pre-decouple (<= 11.4.13) build ever wrote into

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -94,10 +94,10 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecConsole; Key='SecurityZones.PvpResourceMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='PvP Resource Multiplier'; Help='Resource yield multiplier inside PvP zones.'; Category='Resources & Economy' }
 
     # --- Building ---
-    @{ Section=$script:DuneGcSecBuilding; Key='m_MaxNumLandclaimSegments'; File='game'; Type='int'; Min=1; Default='6'; Label='Max Landclaim Segments'; Help='Maximum territory claim segments. Also needs client-side apply.'; Category='Building' }
+    @{ Section=$script:DuneGcSecBuilding; Key='m_MaxNumLandclaimSegments'; File='game'; Type='int'; Min=1; Default='6'; Label='Max Landclaim Segments'; Help='Maximum territory claim segments. Also needs client-side apply.'; ClientApply=$true; Category='Building' }
     @{ Section=$script:DuneGcSecBuilding; Key='m_BuildingBlueprintMaxExtensions'; File='game'; Type='int'; Min=0; Default='4'; Label='Blueprint Max Extensions'; Help='Maximum blueprint extension slots.'; Category='Building' }
     @{ Section=$script:DuneGcSecBuilding; Key='m_BaseBackupMaxExtensions'; File='game'; Type='int'; Min=0; Default='8'; Label='Base Backup Max Extensions'; Help='Backup (reconstruction) extension slots per base.'; Category='Building' }
-    @{ Section=$script:DuneGcSecBuilding; Key='m_bBuildingRestrictionLimitsEnabled'; File='game'; Type='bool'; Default='True'; Label='Building Restriction Limits'; Help='Enforce building restriction limits. Also needs client-side apply.'; Category='Building' }
+    @{ Section=$script:DuneGcSecBuilding; Key='m_bBuildingRestrictionLimitsEnabled'; File='game'; Type='bool'; Default='True'; Label='Building Restriction Limits'; Help='Enforce building restriction limits. Also needs client-side apply.'; ClientApply=$true; Category='Building' }
     @{ Section=$script:DuneGcSecBuilding; Key='m_GlobalBuildingDamageMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Building Damage Multiplier'; Help='Scales damage dealt to player buildings.'; Category='Building' }
 
     # --- Inventory ---
@@ -188,6 +188,180 @@ $script:DuneGameConfigTplGamePath    = '/home/dune/.dune/download/scripts/setup/
 $script:DuneGameConfigTplEnginePath  = '/home/dune/.dune/download/scripts/setup/config/UserEngine.ini'
 $script:DuneGameConfigResolvedGame   = $null
 $script:DuneGameConfigResolvedEngine = $null
+
+# Where each player applies the "client-side too" settings. These keys are read
+# by BOTH server and client; changing them server-side only takes full effect
+# once each player mirrors them in their LOCAL client config (Funcom flags these
+# in DefaultGame.ini as "!Needs to also be applied to each client!").
+$script:DuneGameConfigClientPath = '%LOCALAPPDATA%\DuneSandbox\Saved\Config\WindowsClient\Game.ini'
+
+# Build the post-save "apply this on each client too" reminder from a set of
+# structured updates (@{ file; section; key; value }). Returns @{ path; items }
+# where items = the saved keys whose schema entry is flagged ClientApply. Empty
+# items means nothing client-side to do.
+function Get-DuneGameConfigClientApplyNotice {
+    param([object[]]$Updates)
+    $byKey = @{}
+    foreach ($f in $script:DuneGameConfigSchema) {
+        if ($f.ContainsKey('ClientApply') -and $f.ClientApply) { $byKey[$f.Key] = $f }
+    }
+    $items = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($u in $Updates) {
+        $k = "$($u.key)"
+        if ($byKey.ContainsKey($k)) {
+            $f = $byKey[$k]
+            $items.Add(@{ key = $k; label = $f.Label; section = $f.Section; value = "$($u.value)" })
+        }
+    }
+    return @{ path = $script:DuneGameConfigClientPath; items = $items.ToArray() }
+}
+
+# -----------------------------------------------------------------------------
+# LOCAL CLIENT CONFIG (admin's own machine; no SSH). DST runs locally, so it can
+# read/write the player's client Game.ini directly. Used by the optional
+# "apply to my client too" flow + the read-only client viewer.
+# -----------------------------------------------------------------------------
+$script:DuneGameConfigClientDirDefault = '%LOCALAPPDATA%\DuneSandbox\Saved\Config\WindowsClient'
+$script:DuneGameConfigClientFileName   = 'Game.ini'
+
+# The admin's configured client-config FOLDER (persisted as ClientConfigPath in
+# dune-server.config). Falls back to the per-user default. Returned UNEXPANDED so
+# the UI box round-trips the literal value the user typed.
+function Get-DuneGameConfigClientDir {
+    $configured = ''
+    if (Get-Command Read-DuneConfig -ErrorAction SilentlyContinue) {
+        try {
+            $cfg = Read-DuneConfig
+            if ($cfg -and $cfg.ContainsKey('ClientConfigPath')) { $configured = "$($cfg['ClientConfigPath'])".Trim() }
+        } catch { }
+    }
+    if ($configured) { return $configured }
+    return $script:DuneGameConfigClientDirDefault
+}
+
+# Expand env tokens (%LOCALAPPDATA% etc.) to a concrete filesystem path.
+function Resolve-DuneGameConfigClientDir {
+    param([string]$Dir = '')
+    if (-not $Dir) { $Dir = Get-DuneGameConfigClientDir }
+    return [Environment]::ExpandEnvironmentVariables($Dir)
+}
+
+# Full path to the client Game.ini under the configured (or given) folder.
+function Get-DuneGameConfigClientFilePath {
+    param([string]$Dir = '')
+    $resolved = Resolve-DuneGameConfigClientDir -Dir $Dir
+    return (Join-Path $resolved $script:DuneGameConfigClientFileName)
+}
+
+# Read the LOCAL client Game.ini and project it the same way the VM read does.
+function Get-DuneGameConfigClient {
+    param([string]$Dir = '')
+    $dirRaw      = if ($Dir) { $Dir } else { Get-DuneGameConfigClientDir }
+    $dirResolved = Resolve-DuneGameConfigClientDir -Dir $dirRaw
+    $path        = Get-DuneGameConfigClientFilePath -Dir $dirRaw
+    $exists      = Test-Path -LiteralPath $path -PathType Leaf
+    $raw         = ''
+    if ($exists) { try { $raw = [IO.File]::ReadAllText($path) } catch { $raw = '' } }
+    return @{
+        dir             = $dirRaw
+        dirResolved     = $dirResolved
+        path            = $path
+        exists          = [bool]$exists
+        dirExists       = [bool](Test-Path -LiteralPath $dirResolved)
+        default         = $script:DuneGameConfigClientDirDefault
+        raw             = $raw
+        sections        = (ConvertTo-DuneIniSectionsApi -Raw $raw)
+        effective       = (Get-DuneIniEffective -Raw $raw)
+        managedSections = (Get-DuneIniManagedSectionNames -Raw $raw)
+    }
+}
+
+# Surgically upsert scalar keys into raw INI, preserving everything else. Used
+# for the LOCAL client file so we touch only the requested keys (no whole-section
+# absorption like the server-side managed-block writer). $Updates = array of
+# @{ section; key; value }. Returns the new raw text (LF-joined).
+function Set-DuneIniValuesInPlace {
+    param([string]$Raw, [object[]]$Updates, [hashtable]$QuotedKeys)
+    if ($null -eq $Raw) { $Raw = '' }
+    $doc = ConvertFrom-DuneIniDoc -Raw $Raw
+    foreach ($u in $Updates) {
+        $secName = "$($u.section)"
+        $key     = "$($u.key)"
+        if (-not $secName -or -not $key) { continue }
+        $valLine = "$key=" + (Format-DuneIniValue -Key $key -Value $u.value -QuotedKeys $QuotedKeys)
+        # Target the LAST section with this name (UE5 last-wins ordering).
+        $target = $null
+        foreach ($s in $doc.sections) { if ($s.name -eq $secName) { $target = $s } }
+        if ($null -eq $target) {
+            $target = @{ name = $secName; header = "[$secName]"; body = (New-Object 'System.Collections.Generic.List[string]'); managed = $false }
+            $doc.sections.Add($target)
+        }
+        $replaced = $false
+        for ($i = 0; $i -lt $target.body.Count; $i++) {
+            $info = Get-DuneIniLineKey $target.body[$i]
+            if ($info -and -not $info.isArray -and $info.key -eq $key) {
+                $target.body[$i] = $valLine
+                $replaced = $true
+                break
+            }
+        }
+        if (-not $replaced) { $target.body.Add($valLine) }
+    }
+    $out = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($l in $doc.preamble) { $out.Add($l) }
+    foreach ($s in $doc.sections) {
+        $out.Add($s.header)
+        foreach ($l in $s.body) { $out.Add($l) }
+    }
+    return (($out -join "`n") + "`n")
+}
+
+# Apply client-apply updates to the LOCAL client Game.ini. Validates that every
+# key is schema-flagged ClientApply (blocks arbitrary local writes), backs the
+# file up next to itself (.dstbak-<ts>) before writing, and upserts in place.
+# Returns @{ ok; path; backup; created; applied; items }.
+function Save-DuneGameConfigClient {
+    param([object[]]$Updates, [string]$Dir = '')
+    if (-not $Updates -or $Updates.Count -eq 0) { throw 'No updates supplied.' }
+
+    $allowed = @{}
+    foreach ($f in $script:DuneGameConfigSchema) {
+        if ($f.ContainsKey('ClientApply') -and $f.ClientApply) { $allowed[$f.Key] = $f }
+    }
+    $clean = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($u in $Updates) {
+        $k = "$($u.key)"
+        if (-not $allowed.ContainsKey($k)) { continue }
+        $f = $allowed[$k]
+        $clean.Add(@{ section = $f.Section; key = $k; value = "$($u.value)" })
+    }
+    if ($clean.Count -eq 0) { throw 'No client-applicable keys in the supplied updates.' }
+
+    $dirResolved = Resolve-DuneGameConfigClientDir -Dir $Dir
+    if (-not (Test-Path -LiteralPath $dirResolved)) { throw "Client config folder not found: $dirResolved" }
+    $path = Get-DuneGameConfigClientFilePath -Dir $Dir
+
+    $existing = ''
+    $created  = $true
+    if (Test-Path -LiteralPath $path -PathType Leaf) {
+        $existing = [IO.File]::ReadAllText($path)
+        $created  = $false
+    }
+
+    $quoted = Get-DuneGameConfigQuotedKeys
+    $new    = Set-DuneIniValuesInPlace -Raw $existing -Updates $clean.ToArray() -QuotedKeys $quoted
+    $new    = $new -replace "`r?`n", "`r`n"   # local file is Windows CRLF
+
+    $backup = ''
+    if (-not $created) {
+        $ts     = (Get-Date).ToString('yyyyMMddHHmmss')
+        $backup = "$path.dstbak-$ts"
+        Copy-Item -LiteralPath $path -Destination $backup -Force
+    }
+    [IO.File]::WriteAllText($path, $new, (New-Object System.Text.UTF8Encoding($false)))
+
+    return @{ ok = $true; path = $path; backup = $backup; created = $created; applied = $clean.Count; items = $clean.ToArray() }
+}
 
 # =============================================================================
 # INI ENGINE (pure functions, no SSH - unit-testable)
@@ -660,6 +834,7 @@ function Get-DuneGameConfigSchemaApi {
             default = [string]$f.Default
         }
         if ($f.ContainsKey('Help'))        { $field.help        = $f.Help }
+        if ($f.ContainsKey('ClientApply')) { $field.clientApply = [bool]$f.ClientApply }
         if ($f.ContainsKey('Unit'))        { $field.unit        = $f.Unit }
         if ($f.ContainsKey('Min'))         { $field.min         = $f.Min }
         if ($f.ContainsKey('Max'))         { $field.max         = $f.Max }

--- a/app/server/routes/GameConfig.ps1
+++ b/app/server/routes/GameConfig.ps1
@@ -240,6 +240,28 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig/client/apply' -Handler {
 }
 
 # -----------------------------------------------------------------------------
+# POST /api/gameconfig/client/open — open the local client Game.ini in Notepad
+# on this PC (DST runs locally). Body (optional): { dir }
+# -----------------------------------------------------------------------------
+Register-DuneRoute -Method POST -Path '/api/gameconfig/client/open' -Handler {
+    param($req, $res, $routeParams, $body)
+    $dir = ''
+    if ($body -is [hashtable] -and $body.Contains('dir')) { $dir = "$($body['dir'])".Trim() }
+    try {
+        $resolvedDir = Resolve-DuneGameConfigClientDir -Dir $dir
+        if (-not (Test-Path -LiteralPath $resolvedDir)) {
+            Write-DuneError -Response $res -Status 400 -Message "Client config folder not found: $resolvedDir"
+            return
+        }
+        $path = Get-DuneGameConfigClientFilePath -Dir $dir
+        Start-Process -FilePath 'notepad.exe' -ArgumentList "`"$path`""
+        Write-DuneJson -Response $res -Body @{ ok = $true; path = $path }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Opening client config failed: $($_.Exception.Message)"
+    }
+}
+
+# -----------------------------------------------------------------------------
 # GET /api/gameconfig/spicefields — list rows from dune.spicefield_types.
 # Returns: { available: true, rows: [ { spicefieldTypeId, mapName, fieldType,
 #                                       dimensionIndex,

--- a/app/server/routes/GameConfig.ps1
+++ b/app/server/routes/GameConfig.ps1
@@ -98,12 +98,14 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig' -Handler {
     try {
         Save-DuneGameConfig -Ip $ctx.ip -Updates $structured.ToArray()
         $cfg = Get-DuneGameConfig -Ip $ctx.ip
+        $clientApply = Get-DuneGameConfigClientApplyNotice -Updates $structured.ToArray()
         Write-DuneJson -Response $res -Body @{
-            ok      = $true
-            applied = $structured.Count
-            source  = $cfg.source
-            game    = $cfg.game
-            engine  = $cfg.engine
+            ok          = $true
+            applied     = $structured.Count
+            source      = $cfg.source
+            game        = $cfg.game
+            engine      = $cfg.engine
+            clientApply = $clientApply
         }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Game config save failed: $($_.Exception.Message)"
@@ -158,6 +160,82 @@ Register-DuneRoute -Method GET -Path '/api/gameconfig/backups' -Handler {
         }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Game config backup list failed: $($_.Exception.Message)"
+    }
+}
+
+# -----------------------------------------------------------------------------
+# LOCAL CLIENT CONFIG endpoints. These run on the admin's own machine (no SSH /
+# no VM context needed) and operate on the player's client Game.ini.
+#
+# GET  /api/gameconfig/client      — read the local client config + folder info.
+# PUT  /api/gameconfig/client/dir  — persist the client-config FOLDER. { dir }
+# PUT  /api/gameconfig/client/apply— upsert ClientApply keys into the local file.
+#                                     { updates: [ { key, value }, ... ], dir? }
+# -----------------------------------------------------------------------------
+Register-DuneRoute -Method GET -Path '/api/gameconfig/client' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Write-DuneJson -Response $res -Body (Get-DuneGameConfigClient)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Client config read failed: $($_.Exception.Message)"
+    }
+}
+
+Register-DuneRoute -Method PUT -Path '/api/gameconfig/client/dir' -Handler {
+    param($req, $res, $routeParams, $body)
+    $dir = ''
+    if ($body -is [hashtable] -and $body.Contains('dir')) { $dir = "$($body['dir'])".Trim() }
+    if (-not $dir) {
+        Write-DuneError -Response $res -Status 400 -Message 'Missing dir.'
+        return
+    }
+    $resolved = [Environment]::ExpandEnvironmentVariables($dir)
+    if (-not (Test-Path -LiteralPath $resolved)) {
+        Write-DuneError -Response $res -Status 400 -Message "Folder does not exist: $resolved"
+        return
+    }
+    try {
+        $null = Invoke-WithDuneLock -Name 'config' -Script { Save-DuneConfig -Config @{ ClientConfigPath = $dir } }
+        Write-DuneJson -Response $res -Body (Get-DuneGameConfigClient)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Saving client config folder failed: $($_.Exception.Message)"
+    }
+}
+
+Register-DuneRoute -Method PUT -Path '/api/gameconfig/client/apply' -Handler {
+    param($req, $res, $routeParams, $body)
+    if (-not $body -or -not ($body -is [hashtable])) {
+        Write-DuneError -Response $res -Status 400 -Message 'Missing JSON body.'
+        return
+    }
+    $dir     = if ($body.Contains('dir')) { "$($body['dir'])".Trim() } else { '' }
+    $updates = New-Object 'System.Collections.Generic.List[object]'
+    $raw = $body['updates']
+    if ($raw -is [System.Collections.IEnumerable] -and -not ($raw -is [string]) -and -not ($raw -is [hashtable])) {
+        foreach ($u in $raw) {
+            $k = if ($u -is [hashtable]) { "$($u['key'])" } else { "$($u.key)" }
+            $v = if ($u -is [hashtable]) { "$($u['value'])" } else { "$($u.value)" }
+            if ($k) { $updates.Add(@{ key = $k; value = $v }) }
+        }
+    }
+    if ($updates.Count -eq 0) {
+        Write-DuneError -Response $res -Status 400 -Message 'No updates supplied.'
+        return
+    }
+    try {
+        $r = Save-DuneGameConfigClient -Updates $updates.ToArray() -Dir $dir
+        $client = Get-DuneGameConfigClient -Dir $dir
+        Write-DuneJson -Response $res -Body @{
+            ok      = $true
+            path    = $r.path
+            backup  = $r.backup
+            created = $r.created
+            applied = $r.applied
+            items   = $r.items
+            client  = $client
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Applying to client config failed: $($_.Exception.Message)"
     }
 }
 

--- a/webui/src/api/gameconfig.ts
+++ b/webui/src/api/gameconfig.ts
@@ -64,6 +64,13 @@ export function applyGameConfigClient(items: GameConfigClientApplyItem[], dir?: 
   })
 }
 
+export function openGameConfigClientFile(dir?: string) {
+  return api<{ ok: boolean; path: string }>('/api/gameconfig/client/open', {
+    method: 'POST',
+    body: JSON.stringify(dir ? { dir } : {}),
+  })
+}
+
 export function getSpicefields() {
   return api<SpicefieldsResponse>('/api/gameconfig/spicefields')
 }

--- a/webui/src/api/gameconfig.ts
+++ b/webui/src/api/gameconfig.ts
@@ -6,6 +6,9 @@ import type {
   GameConfigSaveResponse,
   GameConfigBackupResponse,
   GameConfigBackupListResponse,
+  GameConfigClientInfo,
+  GameConfigClientApplyResult,
+  GameConfigClientApplyItem,
   SpicefieldsResponse,
   SpicefieldSaveResponse,
   SpicefieldType,
@@ -36,6 +39,29 @@ export function backupGameConfig() {
 
 export function listGameConfigBackups() {
   return api<GameConfigBackupListResponse>('/api/gameconfig/backups')
+}
+
+// --- Local client config (admin's own machine) -----------------------------
+
+export function getGameConfigClient() {
+  return api<GameConfigClientInfo>('/api/gameconfig/client')
+}
+
+export function setGameConfigClientDir(dir: string) {
+  return api<GameConfigClientInfo>('/api/gameconfig/client/dir', {
+    method: 'PUT',
+    body: JSON.stringify({ dir }),
+  })
+}
+
+export function applyGameConfigClient(items: GameConfigClientApplyItem[], dir?: string) {
+  return api<GameConfigClientApplyResult>('/api/gameconfig/client/apply', {
+    method: 'PUT',
+    body: JSON.stringify({
+      updates: items.map(i => ({ key: i.key, value: i.value })),
+      ...(dir ? { dir } : {}),
+    }),
+  })
 }
 
 export function getSpicefields() {

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -120,6 +120,7 @@ export type GameConfigField = {
   min?: number
   max?: number
   quoted?: boolean
+  clientApply?: boolean
   options?: GameConfigFieldOption[]
 }
 
@@ -160,12 +161,50 @@ export type GameConfigResponse = {
   engine: GameConfigFileBundle
 }
 
+export type GameConfigClientApplyItem = {
+  key: string
+  label: string
+  section: string
+  value: string
+}
+
+export type GameConfigClientApply = {
+  path: string
+  items: GameConfigClientApplyItem[]
+}
+
+// Local client config (admin's own machine). `bundle`-style fields mirror
+// GameConfigFileBundle so the read-only viewer can reuse the same components.
+export type GameConfigClientInfo = {
+  dir: string
+  dirResolved: string
+  path: string
+  exists: boolean
+  dirExists: boolean
+  default: string
+  raw: string
+  sections: GameConfigIniSection[]
+  effective: Record<string, string>
+  managedSections: string[]
+}
+
+export type GameConfigClientApplyResult = {
+  ok: boolean
+  path: string
+  backup: string
+  created: boolean
+  applied: number
+  items: GameConfigClientApplyItem[]
+  client: GameConfigClientInfo
+}
+
 export type GameConfigSaveResponse = {
   ok: boolean
   applied: number
   source: 'live' | 'template' | 'cache'
   game: GameConfigFileBundle
   engine: GameConfigFileBundle
+  clientApply?: GameConfigClientApply
 }
 
 export type GameConfigBackupFile = {

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -12,6 +12,7 @@ import {
   getGameConfigClient,
   setGameConfigClientDir,
   applyGameConfigClient,
+  openGameConfigClientFile,
 } from '../api/gameconfig'
 import type {
   GameConfigCategory,
@@ -161,6 +162,22 @@ export function GameConfig() {
     setClientViewOpen(true)
     await refreshClient()
   }, [refreshClient])
+
+  // Open the local client Game.ini in Notepad on this PC (DST runs locally).
+  const onOpenInEditor = useCallback(async () => {
+    setClientErr(null)
+    setClientMsg(null)
+    setClientBusy(true)
+    try {
+      const r = await openGameConfigClientFile(clientInfo?.dir)
+      setClientMsg(`Opened ${r.path} in Notepad.`)
+      window.setTimeout(() => setClientMsg(null), 5000)
+    } catch (e) {
+      setClientErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setClientBusy(false)
+    }
+  }, [clientInfo])
 
   // Explicit permission gate: the admin opts in to having DST also write the
   // client-apply settings into THEIR OWN local client Game.ini.
@@ -481,14 +498,25 @@ export function GameConfig() {
             <Icon name="MonitorSmartphone" size={15} className="text-accent-bright" />
             Your client config (this PC)
           </div>
-          <button
-            type="button"
-            onClick={() => void onViewClient()}
-            className="btn-secondary"
-            title="View the contents of your local client Game.ini"
-          >
-            <Icon name="FileSearch" size={14} /> View client config
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void onOpenInEditor()}
+              disabled={clientBusy}
+              className="btn-secondary"
+              title="Open your local client Game.ini in Notepad"
+            >
+              <Icon name="ExternalLink" size={14} /> Open in Notepad
+            </button>
+            <button
+              type="button"
+              onClick={() => void onViewClient()}
+              className="btn-secondary"
+              title="View the contents of your local client Game.ini"
+            >
+              <Icon name="FileSearch" size={14} /> View client config
+            </button>
+          </div>
         </div>
         <p className="text-xs text-text-muted mb-3">
           A few settings (landclaim limits, building restrictions) are read by the game client too. DST can mirror
@@ -815,22 +843,18 @@ export function GameConfig() {
                   first time you apply a client-side setting.
                 </div>
               )}
-              {clientInfo?.exists && clientInfo.sections.length === 0 && (
-                <pre className="text-[11px] font-mono text-text-muted bg-surface-2 rounded-lg p-3 overflow-x-auto max-h-[55vh] overflow-y-auto whitespace-pre">
+              {clientInfo?.exists && (
+                <pre className="text-xs font-mono text-text bg-[#1e1e1e] border border-border rounded-lg p-3 overflow-x-auto max-h-[60vh] overflow-y-auto whitespace-pre leading-relaxed">
                   {clientInfo.raw || '(empty file)'}
                 </pre>
               )}
-              {clientInfo?.exists && clientInfo.sections.length > 0 && (
-                <div className="space-y-3 max-h-[55vh] overflow-y-auto pr-1">
-                  {clientInfo.sections.map((s, i) => (
-                    <IniSectionBlock key={`${s.name}-${i}`} section={s} />
-                  ))}
-                </div>
-              )}
             </div>
             <div className="px-5 py-3 border-t border-border flex items-center justify-between gap-2">
-              <span className="text-[11px] text-text-dim">Read-only view of this PC&apos;s client config.</span>
+              <span className="text-[11px] text-text-dim">Read-only preview. “Open in Notepad” edits the real file.</span>
               <div className="flex items-center gap-2">
+                <button type="button" onClick={() => void onOpenInEditor()} disabled={clientBusy} className="btn-secondary" title="Open this file in Notepad">
+                  <Icon name="ExternalLink" size={14} /> Open in Notepad
+                </button>
                 <button type="button" onClick={() => void refreshClient()} className="btn-secondary" title="Reload">
                   <Icon name="RefreshCw" size={14} /> Refresh
                 </button>

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -2,12 +2,16 @@ import { useState, useEffect, useMemo, useCallback, type FormEvent } from 'react
 import { PageHeader } from '../components/PageHeader'
 import { Icon } from '../components/Icon'
 import { useStatus } from '../hooks/useStatus'
+import { api } from '../api/client'
 import {
   getGameConfigSchema,
   getGameConfig,
   saveGameConfig,
   backupGameConfig,
   listGameConfigBackups,
+  getGameConfigClient,
+  setGameConfigClientDir,
+  applyGameConfigClient,
 } from '../api/gameconfig'
 import type {
   GameConfigCategory,
@@ -16,6 +20,8 @@ import type {
   GameConfigFileBundle,
   GameConfigIniSection,
   GameConfigBackupEntry,
+  GameConfigClientApply,
+  GameConfigClientInfo,
 } from '../api/types'
 import { SpicefieldsCard } from './gameconfig/SpicefieldsCard'
 
@@ -74,6 +80,7 @@ export function GameConfig() {
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [savedMsg, setSavedMsg] = useState<string | null>(null)
+  const [clientApply, setClientApply] = useState<GameConfigClientApply | null>(null)
   const [sandwormModalOpen, setSandwormModalOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [backing, setBacking] = useState(false)
@@ -83,6 +90,97 @@ export function GameConfig() {
   const [backupsLoading, setBackupsLoading] = useState(false)
   const [backupsError, setBackupsError] = useState<string | null>(null)
   const [backups, setBackups] = useState<GameConfigBackupEntry[]>([])
+
+  // Local client config (this PC). DST runs locally, so it can read/write the
+  // player's own client Game.ini directly — gated behind explicit user action.
+  const [clientInfo, setClientInfo] = useState<GameConfigClientInfo | null>(null)
+  const [clientDirInput, setClientDirInput] = useState('')
+  const [clientBusy, setClientBusy] = useState(false)
+  const [clientMsg, setClientMsg] = useState<string | null>(null)
+  const [clientErr, setClientErr] = useState<string | null>(null)
+  const [clientViewOpen, setClientViewOpen] = useState(false)
+  const [applying, setApplying] = useState(false)
+
+  const refreshClient = useCallback(async () => {
+    try {
+      const info = await getGameConfigClient()
+      setClientInfo(info)
+      setClientDirInput(prev => (prev ? prev : info.dir))
+      return info
+    } catch (e) {
+      setClientErr(e instanceof Error ? e.message : String(e))
+      return null
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshClient()
+  }, [refreshClient])
+
+  const onBrowseClientDir = useCallback(async () => {
+    setClientErr(null)
+    setClientBusy(true)
+    try {
+      const r = await api<{ ok: boolean; cancelled: boolean; path: string }>('/api/browse-path', {
+        method: 'POST',
+        body: JSON.stringify({
+          mode: 'folder',
+          current: clientInfo?.dirResolved ?? clientDirInput,
+          title: 'Select your Dune client config folder',
+        }),
+      })
+      if (r.ok && !r.cancelled && r.path) setClientDirInput(r.path)
+    } catch (e) {
+      setClientErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setClientBusy(false)
+    }
+  }, [clientInfo, clientDirInput])
+
+  const onSaveClientDir = useCallback(async () => {
+    const dir = clientDirInput.trim()
+    if (!dir) return
+    setClientErr(null)
+    setClientMsg(null)
+    setClientBusy(true)
+    try {
+      const info = await setGameConfigClientDir(dir)
+      setClientInfo(info)
+      setClientDirInput(info.dir)
+      setClientMsg('Client config folder saved.')
+      window.setTimeout(() => setClientMsg(null), 5000)
+    } catch (e) {
+      setClientErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setClientBusy(false)
+    }
+  }, [clientDirInput])
+
+  const onViewClient = useCallback(async () => {
+    setClientErr(null)
+    setClientViewOpen(true)
+    await refreshClient()
+  }, [refreshClient])
+
+  // Explicit permission gate: the admin opts in to having DST also write the
+  // client-apply settings into THEIR OWN local client Game.ini.
+  const onApplyToClient = useCallback(async () => {
+    if (!clientApply || clientApply.items.length === 0) return
+    setClientErr(null)
+    setClientMsg(null)
+    setApplying(true)
+    try {
+      const r = await applyGameConfigClient(clientApply.items, clientInfo?.dir)
+      setClientInfo(r.client)
+      const verb = r.created ? 'Created and wrote' : 'Applied'
+      setClientMsg(`${verb} ${r.applied} setting${r.applied === 1 ? '' : 's'} to your local client (${r.path}).${r.backup ? ' Previous file backed up.' : ''}`)
+      setClientApply(null)
+    } catch (e) {
+      setClientErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setApplying(false)
+    }
+  }, [clientApply, clientInfo])
 
   const onBackup = useCallback(async () => {
     setBacking(true)
@@ -238,6 +336,10 @@ export function GameConfig() {
       const n = out.applied ?? dirtyKeys.length
       setSavedMsg(`Saved ${n} change${n === 1 ? '' : 's'} into the DST-managed block.`)
       window.setTimeout(() => setSavedMsg(null), 5000)
+      // Some settings (e.g. landclaim limits, building restrictions) are read by
+      // BOTH server and client — remind the admin to mirror them on each client.
+      const ca = out.clientApply
+      setClientApply(ca && ca.items && ca.items.length > 0 ? ca : null)
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -372,6 +474,70 @@ export function GameConfig() {
         </div>
       </div>
 
+      {/* Local client config (this PC) */}
+      <div className="card p-4 mb-4 border-border">
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <div className="flex items-center gap-2 text-sm font-semibold text-text">
+            <Icon name="MonitorSmartphone" size={15} className="text-accent-bright" />
+            Your client config (this PC)
+          </div>
+          <button
+            type="button"
+            onClick={() => void onViewClient()}
+            className="btn-secondary"
+            title="View the contents of your local client Game.ini"
+          >
+            <Icon name="FileSearch" size={14} /> View client config
+          </button>
+        </div>
+        <p className="text-xs text-text-muted mb-3">
+          A few settings (landclaim limits, building restrictions) are read by the game client too. DST can mirror
+          those into your own client&apos;s <span className="font-mono">Game.ini</span> on this machine when you save —
+          with your permission. Point this at your Dune client config folder.
+        </p>
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={clientDirInput}
+            onChange={e => setClientDirInput(e.target.value)}
+            spellCheck={false}
+            placeholder={clientInfo?.default ?? '%LOCALAPPDATA%\\DuneSandbox\\Saved\\Config\\WindowsClient'}
+            className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm font-mono placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
+          />
+          <button type="button" onClick={() => void onBrowseClientDir()} disabled={clientBusy} className="btn-secondary shrink-0">
+            <Icon name={clientBusy ? 'Loader2' : 'FolderOpen'} size={14} className={clientBusy ? 'animate-spin' : ''} /> Browse
+          </button>
+          <button
+            type="button"
+            onClick={() => void onSaveClientDir()}
+            disabled={clientBusy || !clientDirInput.trim() || clientDirInput.trim() === (clientInfo?.dir ?? '')}
+            className="btn-primary shrink-0"
+          >
+            <Icon name="Save" size={14} /> Save
+          </button>
+        </div>
+        {clientInfo && (
+          <div className="text-[11px] text-text-dim mt-2 font-mono break-all">
+            {clientInfo.path}{' '}
+            {clientInfo.exists
+              ? <span className="text-success">• found</span>
+              : clientInfo.dirExists
+                ? <span className="text-warning">• Game.ini not present yet (will be created on apply)</span>
+                : <span className="text-danger">• folder not found</span>}
+          </div>
+        )}
+      </div>
+      {clientMsg && (
+        <div className="card p-3 mb-4 border-success/40 bg-success/10 text-success text-sm flex items-center gap-2">
+          <Icon name="CheckCircle2" size={14} /> {clientMsg}
+        </div>
+      )}
+      {clientErr && (
+        <div className="card p-3 mb-4 border-danger/40 bg-danger/10 text-danger text-sm flex items-center gap-2">
+          <Icon name="AlertCircle" size={14} /> {clientErr}
+        </div>
+      )}
+
       {/* Status / error banners */}
       {loadState === 'unavailable' && (
         <div className="card p-4 mb-4 border-accent/30 bg-accent/5 text-text-muted text-sm flex items-start gap-2">
@@ -395,6 +561,61 @@ export function GameConfig() {
       {savedMsg && (
         <div className="card p-3 mb-4 border-success/40 bg-success/10 text-success text-sm flex items-center gap-2">
           <Icon name="CheckCircle2" size={14} /> {savedMsg}
+        </div>
+      )}
+      {clientApply && (
+        <div className="card p-3 mb-4 border-warning/40 bg-warning/10 text-sm">
+          <div className="flex items-start gap-2">
+            <Icon name="MonitorSmartphone" size={16} className="text-warning mt-0.5 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div className="font-medium text-text mb-1">Also apply these on each player's client</div>
+              <p className="text-text-muted mb-2">
+                The setting{clientApply.items.length === 1 ? '' : 's'} below {clientApply.items.length === 1 ? 'is' : 'are'} read by
+                both the server and the game client. The server is updated, but each player must mirror {clientApply.items.length === 1 ? 'it' : 'them'} in
+                their local client config for it to take full effect:
+              </p>
+              <ul className="space-y-1 mb-2">
+                {clientApply.items.map(it => (
+                  <li key={it.key} className="font-mono text-xs text-text">
+                    <span className="text-text-muted">[{it.section}]</span>{' '}
+                    {it.key}={it.value}
+                    <span className="text-text-muted"> — {it.label}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="text-text-muted">
+                Add {clientApply.items.length === 1 ? 'it' : 'them'} under the matching section in each client's:
+              </p>
+              <code className="block mt-1 px-2 py-1 rounded bg-surface-2 text-text text-xs break-all">{clientApply.path}</code>
+              <div className="flex items-center gap-2 mt-3">
+                <button
+                  type="button"
+                  onClick={() => void onApplyToClient()}
+                  disabled={applying}
+                  className="btn-primary"
+                  title="Let DST write these settings into your own client's Game.ini on this PC"
+                >
+                  <Icon name={applying ? 'Loader2' : 'MonitorCog'} size={14} className={applying ? 'animate-spin' : ''} />
+                  {applying ? 'Applying…' : 'Apply to my client'}
+                </button>
+                <button type="button" onClick={() => setClientApply(null)} className="btn-ghost text-xs">
+                  I&apos;ll do it manually
+                </button>
+              </div>
+              <p className="text-[11px] text-text-dim mt-2">
+                “Apply to my client” only changes <span className="font-mono break-all">{clientInfo?.path ?? 'your local client Game.ini'}</span> on
+                this machine (backed up first). Other players still apply manually.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="btn-icon shrink-0"
+              title="Dismiss"
+              onClick={() => setClientApply(null)}
+            >
+              <Icon name="X" size={14} />
+            </button>
+          </div>
         </div>
       )}
 
@@ -558,6 +779,63 @@ export function GameConfig() {
                 Refresh
               </button>
               <button type="button" className="btn-primary" onClick={() => setBackupsOpen(false)}>Close</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {clientViewOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={() => setClientViewOpen(false)}
+        >
+          <div
+            className="card w-full max-w-3xl max-h-[85vh] flex flex-col p-0 overflow-hidden"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-5 py-3 border-b border-border">
+              <h2 className="text-sm font-semibold text-text flex items-center gap-2">
+                <Icon name="MonitorSmartphone" size={16} className="text-accent-bright" />
+                Your client config
+              </h2>
+              <button type="button" className="btn-icon" title="Close" onClick={() => setClientViewOpen(false)}>
+                <Icon name="X" size={16} />
+              </button>
+            </div>
+            <div className="px-5 py-4 overflow-y-auto">
+              <div className="text-[11px] text-text-dim font-mono break-all mb-3">
+                {clientInfo?.path}{' '}
+                {clientInfo?.exists
+                  ? <span className="text-success">• found</span>
+                  : <span className="text-warning">• not present yet</span>}
+              </div>
+              {!clientInfo?.exists && (
+                <div className="text-sm text-text-muted py-4 text-center">
+                  No client <span className="font-mono">Game.ini</span> at this location yet. It will be created the
+                  first time you apply a client-side setting.
+                </div>
+              )}
+              {clientInfo?.exists && clientInfo.sections.length === 0 && (
+                <pre className="text-[11px] font-mono text-text-muted bg-surface-2 rounded-lg p-3 overflow-x-auto max-h-[55vh] overflow-y-auto whitespace-pre">
+                  {clientInfo.raw || '(empty file)'}
+                </pre>
+              )}
+              {clientInfo?.exists && clientInfo.sections.length > 0 && (
+                <div className="space-y-3 max-h-[55vh] overflow-y-auto pr-1">
+                  {clientInfo.sections.map((s, i) => (
+                    <IniSectionBlock key={`${s.name}-${i}`} section={s} />
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="px-5 py-3 border-t border-border flex items-center justify-between gap-2">
+              <span className="text-[11px] text-text-dim">Read-only view of this PC&apos;s client config.</span>
+              <div className="flex items-center gap-2">
+                <button type="button" onClick={() => void refreshClient()} className="btn-secondary" title="Reload">
+                  <Icon name="RefreshCw" size={14} /> Refresh
+                </button>
+                <button type="button" className="btn-primary" onClick={() => setClientViewOpen(false)}>Close</button>
+              </div>
             </div>
           </div>
         </div>

--- a/webui/src/pages/gameplay/BlueprintsTab.tsx
+++ b/webui/src/pages/gameplay/BlueprintsTab.tsx
@@ -89,6 +89,10 @@ export function BlueprintsTab() {
         <button className="btn-secondary" onClick={() => { void load() }} disabled={loading}>
           <Icon name="RefreshCw" size={15} className={loading ? 'animate-spin' : ''} /> Refresh
         </button>
+        <a className="btn-secondary" href="https://dune.layout.tools/" target="_blank" rel="noopener noreferrer"
+          title="Open the Dune base/blueprint layout designer in a new tab">
+          <Icon name="ExternalLink" size={15} /> Blueprint Designer
+        </a>
         <SourceBadge source={source} />
       </div>
 


### PR DESCRIPTION
Stacked on #129 (base: `coastal-ms/gameconfig-ini-accuracy`).

## What
Some Game Config settings are read by **both** the server and the game client (Funcom flags them in `DefaultGame.ini` as *"!Needs to also be applied to each client!"*) — currently `m_MaxNumLandclaimSegments` and `m_bBuildingRestrictionLimitsEnabled`. Saving them server-side only takes full effect once each player mirrors them in their local client `Game.ini`.

This PR adds, on top of the post-save reminder:

- **Client-config folder selector** — a path box on the Game Config page defaulting to `%LOCALAPPDATA%\DuneSandbox\Saved\Config\WindowsClient`, editable, with the existing native **Browse** picker (`/api/browse-path`). Persisted as `ClientConfigPath` in `dune-server.config`.
- **Permission-gated auto-apply** — when a save touches a client-side setting, the reminder now offers **"Apply to my client"**. Only on that explicit click does DST write the setting(s) into the admin's *own* client `Game.ini` on this machine. Other players still apply manually.
- **"View client config"** — a read-only modal showing the local client `Game.ini` (sections + raw), mirroring the Advanced INI browser used for the VM files.

## Safety
- Writes are **whitelisted to `ClientApply`-flagged schema keys only** — the apply route cannot write arbitrary keys/paths.
- The local file is **backed up** (`.dstbak-<ts>`) before every write; surgical in-place upsert (no whole-section absorption), preserves all other keys/sections verbatim, writes Windows CRLF.
- All three new endpoints are **local-only** (no SSH/VM context), so they work even when the battlegroup is down.

## Tests
- `webui` builds clean (`tsc -b && vite build`).
- Both PS libs + routes + Config tokenize clean (PSParser).
- Functional test: in-place update of an existing key, append of a new key within the correct section, unrelated keys/sections preserved, bogus key filtered out, backup created, CRLF verified.
- Existing non-destructive proof harness (server write path) still all-PASS.