### PR TITLE
Dashboard: move Game Servers refresh to far-right of header row

### DIFF
--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -297,6 +297,11 @@ export function Dashboard() {
           <div className="flex items-center justify-between mb-2">
             <h2 className="text-sm font-semibold uppercase tracking-wider text-text-muted flex items-center gap-2">
               <Icon name="ServerCog" size={14} className="text-accent" /> Game servers
+            </h2>
+            <div className="flex items-center gap-2">
+              {gameServers.length > 0 && (
+                <span className="text-[10px] text-text-dim">{gameServers.length} pod{gameServers.length === 1 ? '' : 's'}</span>
+              )}
               <button
                 type="button"
                 onClick={() => { void forceRefresh() }}
@@ -306,10 +311,7 @@ export function Dashboard() {
               >
                 <Icon name="RefreshCw" size={13} className={loading ? 'animate-spin' : ''} />
               </button>
-            </h2>
-            {gameServers.length > 0 && (
-              <span className="text-[10px] text-text-dim">{gameServers.length} pod{gameServers.length === 1 ? '' : 's'}</span>
-            )}
+            </div>
           </div>
           {!bgReady ? (
             <p className="text-sm text-text-dim italic">Battlegroup must be running.</p>


### PR DESCRIPTION
Relocates the Game Servers refresh control out of the card title and places it at the far-right of the header row, after the pod count (Option C from the in-chat mockups).

- Verified live: deployed bundle `index-Ffjck_uB.js`, backend 200, refresh icon renders at far-right after "3 pods".

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>