### PR TITLE
Sidebar: brand title as "DST - Dune Server Tool"

### DIFF
--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -117,7 +117,7 @@ export function Sidebar({ collapsed }: Props) {
         />
         {!collapsed && (
           <div className="flex-1 min-w-0">
-            <div className="text-sm font-semibold tracking-wide">Dune Server Tool</div>
+            <div className="text-sm font-semibold tracking-wide">DST - Dune Server Tool</div>
             <div className="text-[10px] text-text-dim uppercase tracking-widest">Management Portal</div>
             <div className="text-[11px] font-bold tracking-wide mt-1 flex items-center gap-1">
               <Icon name="ThumbsUp" size={11} className="text-emerald-400" />


### PR DESCRIPTION
Renames the sidebar title next to the logo from "Dune Server Tool" to **"DST - Dune Server Tool"** to build brand recognition for the DST name.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>