### PR TITLE
Dashboard: enlarge Game Servers refresh button

### DIFF
--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -306,10 +306,10 @@ export function Dashboard() {
                 type="button"
                 onClick={() => { void forceRefresh() }}
                 disabled={loading}
-                className="text-text-dim hover:text-text transition-colors disabled:opacity-50"
+                className="p-1.5 rounded-md border border-border text-text-muted hover:text-text hover:bg-bg-dim transition-colors disabled:opacity-50"
                 title="Refresh server status"
               >
-                <Icon name="RefreshCw" size={13} className={loading ? 'animate-spin' : ''} />
+                <Icon name="RefreshCw" size={18} className={loading ? 'animate-spin' : ''} />
               </button>
             </div>
           </div>


### PR DESCRIPTION
Enlarges the Game Servers refresh control so it's clearly visible: 18px icon (was 13px) inside a padded, bordered 32×32 hit-area with a hover background, at the far-right of the header.

- Verified live: deployed bundle `index-DcVA_MiW.js`, backend 200.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>