### PR TITLE
v11.5.2 \u2014 Blueprints owner fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.5.2] - 2026-06-11
+
+### Fixed
+- **Gameplay → Blueprints: offline players' blueprints now show their
+  owner.** The list query previously joined `player_state` through the
+  *live pawn* (`player_state.player_pawn_id = actors.id`), which only
+  matches a player whose pawn is currently spawned, so every offline
+  player's blueprints rendered with a blank owner — making it look like
+  "blueprints only show for the host." Owner is now resolved through the
+  persistent account link (`player_state.account_id =
+  actors.owner_account_id`, the same pattern the Storage view uses), with
+  the original pawn-based link kept as a COALESCE fallback for parity.
+  Read-only change, only affects the `owner_name` column.
+
 ## [11.5.1] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v11.5.1**. The in-app version label and the
-website show plain semver tags (e.g. `v11.5.1`) — the previous
+The current release is **v11.5.2**. The in-app version label and the
+website show plain semver tags (e.g. `v11.5.2`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.5.0**
-> DST **v11.5.1** is verified working against the **latest Funcom release** —
+> DST **v11.5.2** is verified working against the **latest Funcom release** —
 > both the game **client** and the **self-hosted server** software — as of the
 > **1.4.5.0** patch (June 10, 2026). Compatibility was checked live against a
 > running self-hosted server on that build (server image `1988751-0-shipping`),

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.5.1'
+$script:DuneToolVersion = '11.5.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.5.1',
+    [string]$Version = '11.5.2',
     [switch]$Quiet
 )
 

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.5.1"
+#define MyAppVersion "11.5.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.5.1"
+$script:ToolVersion = "11.5.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Patch release that bumps stamps + docs for the blueprints owner fix already merged via PR #128 (squash `e6aff50`).

### Fixed
- Gameplay -> Blueprints: offline players' blueprints now show their owner. Resolves owner through `player_state.account_id = actors.owner_account_id` (same pattern Storage view uses), with the original pawn-based link kept as a COALESCE fallback for parity.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>