### PR TITLE
v11.5.2 — native Market Bot sell side + sane-pricing port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,60 @@ here cover everything those tags shipped.
 
 ## [11.5.2] - 2026-06-11
 
+### Added
+- **Native Market Bot ("Duke") sell side — listing tick, sane-pricing
+  formula, and per-template overrides.** Duke (the native bot) used to
+  only *buy* player listings; it now also *lists* its own NPC stock on
+  the in-game market. On each list tick the bot snapshots live NPC
+  vendor inventory from `dune.dune_exchange_orders`, applies the
+  sane-pricing formula (tier base price × category factor × rarity
+  multiplier × vendor multiplier × grade multiplier), and tops every
+  (template, grade) up to a configurable per-grade quota. A hard
+  **100,000 Solari cap** is enforced for every price, every time
+  (matches the dune-admin sane-pricing patch). Stale listings priced
+  more than 20% away from the new target are purged before re-listing.
+  Buy ticks and list ticks run on independent intervals from the same
+  in-process scheduler — no extra service.
+- **Market Bot tab: full sell-side UI.** New *List side* sub-tab with
+  dry-run + live list-tick buttons, listing-tuning controls
+  (`list_tick_interval`, `listings_per_grade`, `stackables_only`,
+  `price_cap`, `default_unit_price`), a *Vendor snapshot preview*
+  table that shows what the bot **would** list (derived from the live
+  NPC vendor inventory, before writing) and the target price for each
+  row. New *Pricing rules* sub-tab with editable tier base prices,
+  stack unit prices, category factors, rarity multipliers, grade
+  multipliers, vendor multipliers, and a per-template price-override
+  table.
+- **Honest NPC listing counters.** The Market Bot status strip now
+  reports **Duke's listings** *and* **total NPC listings** separately,
+  plus a per-actor-class breakdown chip row so it's obvious when there
+  are NPC listings owned by something other than Duke (e.g. leftover
+  Revy orphans from the old external dune-admin bot integration). A
+  *Last list tick* timestamp sits next to *Last buy tick*.
+- **Wipe legacy NPC listings.** One-click cleanup button on the Market
+  Bot tab that permanently deletes any NPC `dune_exchange_orders`
+  whose actor `class` is not `Duke` (Revy orphans, etc.). Player
+  listings and Duke's own listings are never touched. Hidden when
+  there are no legacy rows; warns with the exact row count when
+  there are.
+- **Tier-1 access-point exchange detection.** `Get-DuneBotIdentity`
+  now tries to resolve Duke's exchange via
+  `dune.dune_exchange_accesspoints` (Tier 1 access point) before
+  falling back to the existing actor-name / hardcoded lookups, so the
+  bot can self-provision on a fresh server with no Duke yet.
+
+### Changed
+- **Market tab owner labels are now honest.** The Sales and Listings
+  panes previously hardcoded `Duke` for every NPC row. The SQL already
+  projected `COALESCE(player_state.character_name, actors.class,
+  'Unknown')`; the UI now actually surfaces that column, so leftover
+  Revy / other-class NPC orders are labelled correctly.
+- **Sane-pricing one-shot migration.** The first time a v11.5.2 server
+  loads its bot config, the six pricing-multiplier tables are
+  force-written to the dune-admin sane-pricing defaults (gated by
+  `sane_defaults_revision < 1`, so subsequent edits are preserved on
+  later restarts).
+
 ### Fixed
 - **Gameplay → Blueprints: offline players' blueprints now show their
   owner.** The list query previously joined `player_state` through the
@@ -26,6 +80,9 @@ here cover everything those tags shipped.
   actors.owner_account_id`, the same pattern the Storage view uses), with
   the original pawn-based link kept as a COALESCE fallback for parity.
   Read-only change, only affects the `owner_name` column.
+- **Buy-tick candidate query now returns `quality_level`.** Older
+  servers without a `quality_level` column on `dune_exchange_orders`
+  still work via a `COALESCE(o.quality_level, 0)` guard.
 
 ## [11.5.1] - 2026-06-11
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.5.0</Version>
+    <Version>11.5.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/server/lib/Gameplay.ps1
+++ b/app/server/lib/Gameplay.ps1
@@ -264,7 +264,9 @@ function Get-DuneMarketListingsLive {
             order_id    = [string]$r['id']
             template_id = [string]$r['template_id']
             owner_type  = if ($isNpc) { 'bot' } else { 'player' }
-            owner_name  = if ($isNpc) { 'Duke' } else { [string]$r['owner_name'] }
+            # owner_name = actor.class for NPCs (Duke, Revy, etc.) or the
+            # character_name fallback for players; never hard-code one bot name.
+            owner_name  = [string]$r['owner_name']
             price       = (ConvertTo-DuneInt $r['item_price']) * 10
             stock       = (ConvertTo-DuneInt $r['stock'])
             quality     = (ConvertTo-DuneInt $r['quality'])
@@ -284,7 +286,7 @@ function Get-DuneMarketSalesLive {
             order_id    = [string]$r['order_id']
             template_id = [string]$r['template_id']
             seller_type = if ($isNpc) { 'bot' } else { 'player' }
-            seller_name = if ($isNpc) { 'Duke' } else { [string]$r['seller_name'] }
+            seller_name = [string]$r['seller_name']
             price       = (ConvertTo-DuneInt $r['item_price']) * 10
             quantity    = (ConvertTo-DuneInt $r['stack_size'])
         }

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -48,6 +48,7 @@ function Get-DuneBotStatePath {
 function Get-DuneBotConfigDefaults {
     [ordered]@{
         enabled           = $false
+        # Buy side (existing — d12 gamble buy).
         buy_tick_interval = 120
         max_buys_per_tick = 25
         die_size          = 12
@@ -55,7 +56,50 @@ function Get-DuneBotConfigDefaults {
         target_balance    = 9000000000000
         maintain_balance  = $true
         disabled_items    = @()
+        # ----- Listing side (sane-pricing port of dune-admin/internal/marketbot) -----
+        list_tick_interval   = 1800          # 30 min between list ticks
+        listings_per_grade   = 5             # concurrent NPC listings per (template, grade)
+        stackables_only      = $true         # v11.5.2 scope: skip gradeable gear
+        price_cap            = 100000        # HARD ceiling in Solari (sane-pricing patch)
+        default_unit_price   = 100           # fallback for unknown templates
+        # Per-tier base prices, mirroring 0001-sane-pricing-100k-cap.patch.
+        tier_base_prices     = @{ '0' = 10; '1' = 50; '2' = 200; '3' = 800; '4' = 3000; '5' = 10000; '6' = 30000 }
+        stack_unit_prices    = @{ '0' = 1;  '1' = 1;  '2' = 5;   '3' = 20;  '4' = 75;   '5' = 250;   '6' = 800   }
+        category_factors     = @{ augment = 0.6; schematic = 1.0; gear = 0.8 }
+        grade_multipliers    = @(1.0, 1.25, 1.55, 2.0, 2.6, 3.3)
+        rarity_multipliers   = @{ common = 1.0; rare = 1.03; unique = 1.05; memento = 1.08 }
+        vendor_multipliers   = @{ all = 0.95 }
+        # Per-template manual price override (template_id -> integer Solari).
+        price_overrides      = @{}
+        # Marker for one-time sane-defaults migration on load.
+        sane_defaults_revision = 1
     }
+}
+
+# Coerce a JSON-deserialised PSCustomObject (or null) into a plain hashtable
+# whose values are numeric. Used for tier/stack/rarity/multiplier configs.
+function ConvertFrom-DuneBotJsonMap {
+    param($Value, [hashtable]$Default, [switch]$IntValues)
+    if ($null -eq $Value) { return $Default }
+    $out = @{}
+    if ($Value -is [System.Collections.IDictionary]) {
+        foreach ($k in $Value.Keys) { $out[[string]$k] = if ($IntValues) { [int]$Value[$k] } else { [double]$Value[$k] } }
+    } elseif ($Value.PSObject -and $Value.PSObject.Properties) {
+        foreach ($p in $Value.PSObject.Properties) {
+            try { $out[[string]$p.Name] = if ($IntValues) { [int]$p.Value } else { [double]$p.Value } } catch {}
+        }
+    }
+    if ($out.Count -eq 0) { return $Default }
+    return $out
+}
+
+function ConvertFrom-DuneBotJsonArray {
+    param($Value, [array]$Default)
+    if ($null -eq $Value) { return $Default }
+    $arr = @()
+    foreach ($v in @($Value)) { try { $arr += [double]$v } catch {} }
+    if ($arr.Count -eq 0) { return $Default }
+    return ,$arr
 }
 
 function Read-DuneBotConfig {
@@ -68,13 +112,36 @@ function Read-DuneBotConfig {
                 if ($null -ne $json.PSObject.Properties[$k]) {
                     $v = $json.$k
                     switch ($k) {
-                        'enabled'          { $cfg[$k] = [bool]$v }
-                        'maintain_balance' { $cfg[$k] = [bool]$v }
-                        'disabled_items'   { $cfg[$k] = @($v | ForEach-Object { [string]$_ } | Where-Object { $_ }) }
-                        'target_balance'   { $cfg[$k] = [int64]$v }
-                        default            { $cfg[$k] = [int]$v }
+                        'enabled'              { $cfg[$k] = [bool]$v }
+                        'maintain_balance'     { $cfg[$k] = [bool]$v }
+                        'stackables_only'      { $cfg[$k] = [bool]$v }
+                        'disabled_items'       { $cfg[$k] = @($v | ForEach-Object { [string]$_ } | Where-Object { $_ }) }
+                        'target_balance'       { $cfg[$k] = [int64]$v }
+                        'tier_base_prices'     { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] -IntValues }
+                        'stack_unit_prices'    { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] -IntValues }
+                        'category_factors'     { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] }
+                        'rarity_multipliers'   { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] }
+                        'vendor_multipliers'   { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] }
+                        'grade_multipliers'    { $cfg[$k] = ConvertFrom-DuneBotJsonArray -Value $v -Default $cfg[$k] }
+                        'price_overrides'      { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default @{} -IntValues }
+                        default                { $cfg[$k] = [int]$v }
                     }
                 }
+            }
+            # One-shot migration: if a pre-listing config is loaded, force-overwrite
+            # the multiplier tables to the patched sane-pricing defaults so users
+            # don't get stuck with stale legacy values.
+            $rev = 0
+            if ($json.PSObject.Properties['sane_defaults_revision']) { try { $rev = [int]$json.sane_defaults_revision } catch {} }
+            if ($rev -lt 1) {
+                $defaults = Get-DuneBotConfigDefaults
+                $cfg['tier_base_prices']    = $defaults['tier_base_prices']
+                $cfg['stack_unit_prices']   = $defaults['stack_unit_prices']
+                $cfg['category_factors']    = $defaults['category_factors']
+                $cfg['grade_multipliers']   = $defaults['grade_multipliers']
+                $cfg['rarity_multipliers']  = $defaults['rarity_multipliers']
+                $cfg['vendor_multipliers']  = $defaults['vendor_multipliers']
+                $cfg['sane_defaults_revision'] = 1
             }
         } catch {}
     }
@@ -95,16 +162,30 @@ function Save-DuneBotConfig {
     }
     $v = _Get $Incoming 'enabled';           if ($null -ne $v) { $cfg['enabled'] = [bool]$v }
     $v = _Get $Incoming 'maintain_balance';  if ($null -ne $v) { $cfg['maintain_balance'] = [bool]$v }
+    $v = _Get $Incoming 'stackables_only';   if ($null -ne $v) { $cfg['stackables_only'] = [bool]$v }
     $v = _Get $Incoming 'buy_tick_interval'; if ($null -ne $v) { $cfg['buy_tick_interval'] = [Math]::Max(10,  [int]$v) }
+    $v = _Get $Incoming 'list_tick_interval';if ($null -ne $v) { $cfg['list_tick_interval'] = [Math]::Max(60, [int]$v) }
+    $v = _Get $Incoming 'listings_per_grade';if ($null -ne $v) { $cfg['listings_per_grade'] = [Math]::Min(50, [Math]::Max(1, [int]$v)) }
+    $v = _Get $Incoming 'price_cap';         if ($null -ne $v) { $cfg['price_cap'] = [Math]::Max(1, [int]$v) }
+    $v = _Get $Incoming 'default_unit_price';if ($null -ne $v) { $cfg['default_unit_price'] = [Math]::Max(1, [int]$v) }
     $v = _Get $Incoming 'max_buys_per_tick'; if ($null -ne $v) { $cfg['max_buys_per_tick'] = [Math]::Min(500, [Math]::Max(1, [int]$v)) }
     $v = _Get $Incoming 'die_size';          if ($null -ne $v) { $cfg['die_size']   = [Math]::Min(1000, [Math]::Max(2, [int]$v)) }
     $v = _Get $Incoming 'die_target';        if ($null -ne $v) { $cfg['die_target'] = [Math]::Max(1, [int]$v) }
     $v = _Get $Incoming 'target_balance';    if ($null -ne $v) { $cfg['target_balance'] = [Math]::Max(0L, [int64]$v) }
     $v = _Get $Incoming 'disabled_items'
     if ($null -ne $v) { $cfg['disabled_items'] = @($v | ForEach-Object { [string]$_ } | Where-Object { $_ }) }
+    $v = _Get $Incoming 'tier_base_prices';  if ($null -ne $v) { $cfg['tier_base_prices']   = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['tier_base_prices']   -IntValues }
+    $v = _Get $Incoming 'stack_unit_prices'; if ($null -ne $v) { $cfg['stack_unit_prices']  = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['stack_unit_prices']  -IntValues }
+    $v = _Get $Incoming 'category_factors';  if ($null -ne $v) { $cfg['category_factors']   = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['category_factors']  }
+    $v = _Get $Incoming 'rarity_multipliers';if ($null -ne $v) { $cfg['rarity_multipliers'] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['rarity_multipliers']}
+    $v = _Get $Incoming 'vendor_multipliers';if ($null -ne $v) { $cfg['vendor_multipliers'] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['vendor_multipliers']}
+    $v = _Get $Incoming 'grade_multipliers'; if ($null -ne $v) { $cfg['grade_multipliers']  = ConvertFrom-DuneBotJsonArray -Value $v -Default $cfg['grade_multipliers'] }
+    $v = _Get $Incoming 'price_overrides';   if ($null -ne $v) { $cfg['price_overrides']    = ConvertFrom-DuneBotJsonMap -Value $v -Default @{} -IntValues }
 
     # die_target must be within 1..die_size to ever win.
     if ($cfg['die_target'] -gt $cfg['die_size']) { $cfg['die_target'] = $cfg['die_size'] }
+    # Bump the revision so a config saved through the UI is never re-migrated.
+    $cfg['sane_defaults_revision'] = 1
 
     $path = Get-DuneBotConfigPath
     $dir = Split-Path -Parent $path
@@ -115,10 +196,12 @@ function Save-DuneBotConfig {
 
 function Read-DuneBotState {
     $state = [ordered]@{
-        last_buy_tick = $null
-        last_result   = $null
-        error_count   = 0
-        last_error    = ''
+        last_buy_tick   = $null
+        last_list_tick  = $null
+        last_result     = $null
+        last_list_result = $null
+        error_count     = 0
+        last_error      = ''
     }
     $path = Get-DuneBotStatePath
     if (Test-Path -LiteralPath $path) {
@@ -183,6 +266,10 @@ function Get-DuneBotIdentity {
             # stays 0 and provisioned is false.
             $exId = 0L
             foreach ($q in @(
+                # Tier 1 (upstream parity): the access-point table is the
+                # authoritative exchange index even on virgin servers with no
+                # player orders yet.
+                'SELECT ap.exchange_id FROM dune.dune_exchange_accesspoints ap JOIN dune.dune_exchanges e ON e.id = ap.exchange_id ORDER BY ap.id LIMIT 1',
                 'SELECT exchange_id FROM dune.dune_exchange_orders WHERE is_npc_order = FALSE LIMIT 1',
                 'SELECT id FROM dune.dune_exchanges ORDER BY id LIMIT 1',
                 "SELECT dune.get_dune_exchange_id('Global')"
@@ -215,9 +302,11 @@ SELECT id FROM ins UNION ALL SELECT id FROM existing LIMIT 1;
         $null = Invoke-DuneSqlQuery -Ip $Ip -Sql "SELECT dune.dune_exchange_get_user_id($ownerId)" -ReadOnly $false -MaxRows 5 -TimeoutSec 30
     }
 
-    # Exchange id (try the same fallbacks dune-admin uses).
+    # Exchange id (try the same fallbacks dune-admin uses, with the upstream
+    # access-point cascade prepended so we always pick the canonical exchange).
     $exchangeId = 0L
     foreach ($q in @(
+        'SELECT ap.exchange_id FROM dune.dune_exchange_accesspoints ap JOIN dune.dune_exchanges e ON e.id = ap.exchange_id ORDER BY ap.id LIMIT 1',
         'SELECT exchange_id FROM dune.dune_exchange_orders WHERE is_npc_order = FALSE LIMIT 1',
         'SELECT id FROM dune.dune_exchanges ORDER BY id LIMIT 1',
         "SELECT dune.get_dune_exchange_id('Global')"
@@ -359,6 +448,7 @@ function Invoke-DuneBotBuyTick {
     $limit = $maxBuys * 10
     $candSql = @"
 SELECT o.id, o.template_id, o.item_price, COALESCE(o.item_id, 0) AS item_id, o.owner_id,
+       COALESCE(o.quality_level, 0) AS quality_level,
        COALESCE(i.stack_size, s.initial_stack_size) AS actual_stack
 FROM dune.dune_exchange_orders o
 JOIN dune.dune_exchange_sell_orders s ON s.order_id = o.id
@@ -448,6 +538,387 @@ COMMIT;
     return $summary
 }
 
+# ============================================================================
+# LISTING SIDE — port of dune-admin/internal/marketbot with the sane-pricing
+# 100k-cap patch (recovered from DST commit cf903665).
+# ----------------------------------------------------------------------------
+# Catalog source: DB-derived. We snapshot the live game's NPC vendor inventory
+# (existing is_npc_order rows) to learn per-template {vendor_price, category_
+# mask, max_stack_size}. The bot then lists items from that snapshot only,
+# applying the patched sane-pricing formula (tier base price * category factor
+# * rarity multiplier, vendor floor + 2x ceiling, hard 100k cap). This keeps
+# the bot self-bootstrapping — no out-of-band item-data.json to ship.
+# ============================================================================
+
+function Get-DuneBotVendorSnapshot {
+    param([string]$Ip, [int64]$ExchangeId)
+    $sql = @"
+SELECT o.template_id,
+       MAX(o.item_price)                                 AS max_price,
+       MAX(o.category_mask)                              AS category_mask,
+       MAX(o.category_depth)                             AS category_depth,
+       MAX(COALESCE(i.stack_size, s.initial_stack_size)) AS max_stack,
+       COUNT(*)                                          AS occurrences
+FROM dune.dune_exchange_orders o
+JOIN dune.dune_exchange_sell_orders s ON s.order_id = o.id
+LEFT JOIN dune.items i ON i.id = o.item_id
+WHERE o.is_npc_order = TRUE AND o.exchange_id = $ExchangeId
+GROUP BY o.template_id
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 50000 -TimeoutSec 60
+    if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    $snap = @{}
+    foreach ($row in (ConvertTo-DuneRowMaps -Result $r)) {
+        $tmpl = [string]$row['template_id']
+        if (-not $tmpl) { continue }
+        $snap[$tmpl] = @{
+            template_id    = $tmpl
+            vendor_price   = ConvertTo-DuneInt $row['max_price']
+            category_mask  = ConvertTo-DuneInt $row['category_mask']
+            category_depth = ConvertTo-DuneInt $row['category_depth']
+            max_stack      = ConvertTo-DuneInt $row['max_stack']
+            occurrences    = ConvertTo-DuneInt $row['occurrences']
+        }
+    }
+    return @{ ok = $true; snapshot = $snap }
+}
+
+# Pull a tier hint from a template_id like "WaterRationMk3" / "Spice_T4".
+function Get-DuneBotTierFromTemplate {
+    param([string]$Template)
+    if ($Template -match '_T(\d)') { return [int]$Matches[1] }
+    if ($Template -match 'Mk(\d)') { return [int]$Matches[1] }
+    return 0
+}
+
+# Merge vendor snapshot with bundled item metadata + DST's existing equipment
+# heuristic. Returns the eligible-to-list candidate list filtered by config.
+function Resolve-DuneBotListingCandidates {
+    param([hashtable]$Snapshot, [hashtable]$Cfg)
+    # Lazy-load gameplay-item-data.json via the Gameplay lib helpers.
+    if (Get-Command Initialize-DuneGameplayItemData -ErrorAction SilentlyContinue) {
+        Initialize-DuneGameplayItemData
+    }
+    $rules = if ($null -ne $script:DuneGameplayItemRules) { $script:DuneGameplayItemRules } else { @{} }
+    $stackablesOnly = [bool]$Cfg.stackables_only
+    $disabled = @{}; foreach ($d in @($Cfg.disabled_items)) { $disabled[[string]$d] = $true }
+    $candidates = @()
+    foreach ($tmpl in $Snapshot.Keys) {
+        if ($disabled.ContainsKey($tmpl)) { continue }
+        $sn = $Snapshot[$tmpl]
+        $rule = if ($rules.ContainsKey($tmpl)) { $rules[$tmpl] } else { $null }
+        $cat    = if ($rule) { [string]$rule.category } else { '' }
+        $tier   = if ($rule) { [int]$rule.tier } else { 0 }
+        $rarity = if ($rule) { ([string]$rule.rarity).ToLower() } else { '' }
+        if (-not $tier)   { $tier = Get-DuneBotTierFromTemplate -Template $tmpl }
+        if (-not $rarity) { $rarity = 'common' }
+        # Stackability: trust the vendor snapshot (max_stack > 1 means the game
+        # has actually stacked this template). Fall back to category prefix.
+        $isStackable = ($sn.max_stack -gt 1)
+        if (-not $isStackable -and $cat -and (Get-Command Test-DuneIsEquipmentCategory -ErrorAction SilentlyContinue)) {
+            $isStackable = -not (Test-DuneIsEquipmentCategory -Category $cat)
+        }
+        if ($stackablesOnly -and -not $isStackable) { continue }
+        # Listing requires a real category_mask — without it the item is
+        # invisible in every in-game market tab.
+        if ($sn.category_mask -le 0) { continue }
+        $candidates += @{
+            template_id    = $tmpl
+            vendor_price   = $sn.vendor_price
+            category_mask  = $sn.category_mask
+            category_depth = $sn.category_depth
+            stack_max      = if ($sn.max_stack -gt 0) { $sn.max_stack } else { 1 }
+            tier           = $tier
+            rarity         = $rarity
+            category       = $cat
+            is_stackable   = $isStackable
+        }
+    }
+    return ,$candidates
+}
+
+function Get-DuneBotCategoryFactor {
+    param([hashtable]$Cfg, [hashtable]$Cand)
+    $factors = [hashtable]$Cfg.category_factors
+    $tmplLc = $Cand.template_id.ToLower()
+    if ($tmplLc.EndsWith('_schematic')) { if ($factors.ContainsKey('schematic')) { return [double]$factors['schematic'] } }
+    $cat = ([string]$Cand.category).ToLower()
+    if ($cat -match 'augment')          { if ($factors.ContainsKey('augment'))   { return [double]$factors['augment']   } }
+    if ($factors.ContainsKey('gear'))   { return [double]$factors['gear'] }
+    return 1.0
+}
+
+function Limit-DuneBotPrice {
+    param([double]$Price, [int]$Cap)
+    if ($Price -lt 1)    { return 1 }
+    if ($Price -gt $Cap) { return $Cap }
+    return [int][Math]::Round($Price)
+}
+
+# Magnitude-aware rounding (matches sane-pricing patch's roundPrice).
+function Get-DuneBotRoundedPrice {
+    param([double]$Price)
+    if ($Price -ge 1000000) { return [int]([Math]::Round($Price / 100000) * 100000) }
+    if ($Price -ge 100000)  { return [int]([Math]::Round($Price / 10000)  * 10000)  }
+    if ($Price -ge 10000)   { return [int]([Math]::Round($Price / 1000)   * 1000)   }
+    if ($Price -ge 1000)    { return [int]([Math]::Round($Price / 100)    * 100)    }
+    if ($Price -ge 100)     { return [int]([Math]::Round($Price / 10)     * 10)     }
+    return [int][Math]::Round($Price)
+}
+
+# Per-stack listing price (returns the item_price column value — player-facing
+# Solari is item_price * 10). Respects per-template override, then sane-pricing
+# tier/category/rarity formula, vendor floor (vendor*0.95) and 2x vendor ceiling.
+function Get-DuneBotItemPrice {
+    param([hashtable]$Cfg, [hashtable]$Cand)
+    $cap = [int]$Cfg.price_cap
+    $overrides = [hashtable]$Cfg.price_overrides
+    if ($overrides -and $overrides.ContainsKey($Cand.template_id)) {
+        return Limit-DuneBotPrice -Price ([double]$overrides[$Cand.template_id]) -Cap $cap
+    }
+    $tierKey = [string]([int]$Cand.tier)
+    $rarityMult = 1.0
+    $rm = [hashtable]$Cfg.rarity_multipliers
+    if ($rm -and $rm.ContainsKey($Cand.rarity)) { $rarityMult = [double]$rm[$Cand.rarity] }
+    $price = 0.0
+    if ($Cand.is_stackable) {
+        $unit = [double]$Cfg.default_unit_price
+        $sm = [hashtable]$Cfg.stack_unit_prices
+        if ($sm -and $sm.ContainsKey($tierKey)) { $unit = [double]$sm[$tierKey] }
+        $price = $unit * $rarityMult
+    } else {
+        $base = [double]$Cfg.default_unit_price
+        $tbp = [hashtable]$Cfg.tier_base_prices
+        if ($tbp -and $tbp.ContainsKey($tierKey)) { $base = [double]$tbp[$tierKey] }
+        $factor = Get-DuneBotCategoryFactor -Cfg $Cfg -Cand $Cand
+        $price = $base * $factor * $rarityMult
+    }
+    $vp = [double]$Cand.vendor_price
+    if ($vp -ge 10) {
+        $vmAll = 0.95
+        $vm = [hashtable]$Cfg.vendor_multipliers
+        if ($vm -and $vm.ContainsKey('all')) { $vmAll = [double]$vm['all'] }
+        $floor = $vp * $vmAll
+        if ($price -lt $floor) { $price = $floor }
+        $ceil = $vp * 2.0
+        if ($price -gt $ceil) { $price = $ceil }
+    }
+    $rounded = Get-DuneBotRoundedPrice -Price $price
+    return Limit-DuneBotPrice -Price $rounded -Cap $cap
+}
+
+# Snapshot of Duke's own current listings keyed by template_id.
+function Get-DuneBotCurrentListings {
+    param([string]$Ip, [int64]$OwnerId, [int64]$ExchangeId)
+    $sql = @"
+SELECT o.id, o.template_id, COALESCE(o.item_id, 0) AS item_id, o.item_price,
+       COALESCE(i.stack_size, s.initial_stack_size) AS stack_size,
+       COALESCE(o.quality_level, 0)                 AS quality_level
+FROM dune.dune_exchange_orders o
+JOIN dune.dune_exchange_sell_orders s ON s.order_id = o.id
+LEFT JOIN dune.items i ON i.id = o.item_id
+WHERE o.owner_id = $OwnerId AND o.is_npc_order = TRUE AND o.exchange_id = $ExchangeId
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 50000 -TimeoutSec 60
+    if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    $by = @{}
+    foreach ($row in (ConvertTo-DuneRowMaps -Result $r)) {
+        $tmpl = [string]$row['template_id']
+        if (-not $by.ContainsKey($tmpl)) { $by[$tmpl] = @() }
+        $by[$tmpl] += @{
+            order_id   = ConvertTo-DuneInt $row['id']
+            item_id    = ConvertTo-DuneInt $row['item_id']
+            item_price = ConvertTo-DuneInt $row['item_price']
+            stack_size = ConvertTo-DuneInt $row['stack_size']
+        }
+    }
+    return @{ ok = $true; byTemplate = $by }
+}
+
+# INSERT one (items, dune_exchange_orders, dune_exchange_sell_orders) trio.
+function New-DuneBotListing {
+    param([string]$Ip, $Ident, [hashtable]$Cand, [int]$ItemPrice, [int64]$OrderExpiry)
+    $tmplLit = ConvertTo-DuneSqlLiteral $Cand.template_id
+    $stack   = [int]$Cand.stack_max
+    $mask    = [int]$Cand.category_mask
+    $depth   = [int]$Cand.category_depth
+    $sql = @"
+BEGIN;
+SELECT dune.get_exchange_inventory_id($($Ident.exchangeId)) AS bot_inv_id \gset
+INSERT INTO dune.items (inventory_id, position_index, template_id, stack_size, stats, quality_level)
+SELECT :bot_inv_id,
+       COALESCE((SELECT MAX(position_index) + 1 FROM dune.items WHERE inventory_id = :bot_inv_id), 0),
+       '$tmplLit', $stack, '{}', 0
+RETURNING id AS new_item_id \gset
+INSERT INTO dune.dune_exchange_orders
+  (exchange_id, access_point_id, owner_id, template_id, expiration_time,
+   durability_cur, durability_max, item_price, category_mask, category_depth,
+   is_npc_order, item_id, quality_level)
+VALUES ($($Ident.exchangeId), $($Ident.accessPointId), $($Ident.ownerId), '$tmplLit', $OrderExpiry,
+        1.0, 1.0, $ItemPrice, $mask, $depth, TRUE, :new_item_id, 0)
+RETURNING id AS new_order_id \gset
+INSERT INTO dune.dune_exchange_sell_orders (order_id, initial_stack_size, wear_normalized_price)
+VALUES (:new_order_id, $stack, $ItemPrice);
+COMMIT;
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 5 -TimeoutSec 45
+    if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    return @{ ok = $true }
+}
+
+# Top-up list tick. -DryRun reports the plan without writing.
+function Invoke-DuneBotListTick {
+    param([switch]$DryRun)
+    $cfg = Read-DuneBotConfig
+    $summary = [ordered]@{
+        ok            = $true
+        dryRun        = [bool]$DryRun
+        enabled       = [bool]$cfg.enabled
+        considered    = 0
+        eligible      = 0
+        listed_before = 0
+        listed_after  = 0
+        inserted      = 0
+        deleted       = 0
+        errors        = 0
+        planned       = @()
+        message       = ''
+    }
+    $ctx = Get-DuneDbContext
+    if (-not $ctx.ok) { $summary.ok = $false; $summary.message = $ctx.message; return $summary }
+
+    $ident = Get-DuneBotIdentity -Ip $ctx.ip -CreateIfMissing:(!$DryRun)
+    if (-not $ident.ok) { $summary.ok = $false; $summary.message = $ident.error; return $summary }
+    if ($ident.ownerId -le 0) {
+        $summary.message = 'Bot not provisioned (run any live tick once to create the Duke actor).'
+        return $summary
+    }
+
+    $vs = Get-DuneBotVendorSnapshot -Ip $ctx.ip -ExchangeId $ident.exchangeId
+    if (-not $vs.ok) { $summary.ok = $false; $summary.message = "vendor snapshot: $($vs.error)"; return $summary }
+    $summary.considered = $vs.snapshot.Count
+
+    $cl = Get-DuneBotCurrentListings -Ip $ctx.ip -OwnerId $ident.ownerId -ExchangeId $ident.exchangeId
+    if (-not $cl.ok) { $summary.ok = $false; $summary.message = "current listings: $($cl.error)"; return $summary }
+    $current = $cl.byTemplate
+    foreach ($k in $current.Keys) { $summary.listed_before += @($current[$k]).Count }
+
+    $candidates = Resolve-DuneBotListingCandidates -Snapshot $vs.snapshot -Cfg $cfg
+    $summary.eligible = @($candidates).Count
+
+    $perGrade = [int]$cfg.listings_per_grade
+    $orderExpiry = if ($DryRun) { 999999999L } else { Get-DuneBotOrderExpiry -Ip $ctx.ip }
+
+    foreach ($cand in $candidates) {
+        $target = Get-DuneBotItemPrice -Cfg $cfg -Cand $cand
+        $existing = if ($current.ContainsKey($cand.template_id)) { @($current[$cand.template_id]) } else { @() }
+        $aligned = @($existing | Where-Object { $_.item_price -eq $target })
+        $stale   = @($existing | Where-Object { $_.item_price -ne $target })
+        $need    = $perGrade - $aligned.Count
+        if ($need -lt 0) { $need = 0 }
+
+        $summary.planned += ,([ordered]@{
+            template_id  = $cand.template_id
+            target_price = ($target * 10)
+            stack_max    = $cand.stack_max
+            existing     = $existing.Count
+            aligned      = $aligned.Count
+            stale        = $stale.Count
+            to_insert    = $need
+            tier         = $cand.tier
+            rarity       = $cand.rarity
+            stackable    = [bool]$cand.is_stackable
+        })
+
+        if ($DryRun) { continue }
+
+        if ($stale.Count -gt 0) {
+            $orderIds = ($stale | ForEach-Object { $_.order_id }) -join ','
+            $itemIds  = ($stale | Where-Object { $_.item_id -gt 0 } | ForEach-Object { $_.item_id }) -join ','
+            $delItems = if ($itemIds) { "DELETE FROM dune.items WHERE id IN ($itemIds);" } else { '' }
+            $delSql = @"
+BEGIN;
+DELETE FROM dune.dune_exchange_sell_orders WHERE order_id IN ($orderIds);
+DELETE FROM dune.dune_exchange_orders WHERE id IN ($orderIds) AND owner_id = $($ident.ownerId) AND is_npc_order = TRUE;
+$delItems
+COMMIT;
+"@
+            $dr = Invoke-DuneSqlQuery -Ip $ctx.ip -Sql $delSql -ReadOnly $false -MaxRows 5 -TimeoutSec 60
+            if ($dr.ok) {
+                $summary.deleted += $stale.Count
+            } else {
+                $summary.errors++
+                $summary.message = "stale delete $($cand.template_id): $($dr.error)"
+            }
+        }
+
+        for ($i = 0; $i -lt $need; $i++) {
+            $r = New-DuneBotListing -Ip $ctx.ip -Ident $ident -Cand $cand -ItemPrice $target -OrderExpiry $orderExpiry
+            if ($r.ok) {
+                $summary.inserted++
+            } else {
+                $summary.errors++
+                $summary.message = "list $($cand.template_id): $($r.error)"
+                break
+            }
+        }
+    }
+
+    $cl2 = Get-DuneBotCurrentListings -Ip $ctx.ip -OwnerId $ident.ownerId -ExchangeId $ident.exchangeId
+    if ($cl2.ok) { foreach ($k in $cl2.byTemplate.Keys) { $summary.listed_after += @($cl2.byTemplate[$k]).Count } }
+
+    if (-not $DryRun) {
+        $state = Read-DuneBotState
+        $state.last_list_tick   = (Get-Date).ToUniversalTime().ToString('o')
+        $state.last_list_result = @{
+            considered = $summary.considered; eligible = $summary.eligible
+            inserted   = $summary.inserted;   deleted  = $summary.deleted
+            errors     = $summary.errors;     dryRun   = $false
+        }
+        if ($summary.errors -gt 0) { $state.error_count = ([int]$state.error_count + [int]$summary.errors) }
+        if ($summary.message)      { $state.last_error  = [string]$summary.message }
+        Save-DuneBotState -State $state
+    }
+    return $summary
+}
+
+# Wipe NPC orders owned by any actor whose class is not 'Duke'. Used to evict
+# leftover Revy orphans from the old external dune-admin integration.
+function Clear-DuneBotLegacyListings {
+    $ctx = Get-DuneDbContext
+    if (-not $ctx.ok) { return @{ ok = $false; error = $ctx.message } }
+    $cntSql = @"
+SELECT COUNT(*) FROM dune.dune_exchange_orders o
+JOIN dune.actors a ON a.id = o.owner_id
+WHERE o.is_npc_order = TRUE AND a.class <> 'Duke'
+"@
+    $cnt = Get-DuneBotScalar -Ip $ctx.ip -Sql $cntSql
+    $before = if ($cnt.ok) { ConvertTo-DuneInt $cnt.value } else { 0L }
+    if ($before -le 0) { return @{ ok = $true; cleared = 0; message = 'No legacy NPC listings to clear.' } }
+    $sql = @"
+BEGIN;
+DELETE FROM dune.items WHERE id IN (
+  SELECT o.item_id FROM dune.dune_exchange_orders o
+  JOIN dune.actors a ON a.id = o.owner_id
+  WHERE o.is_npc_order = TRUE AND a.class <> 'Duke' AND o.item_id IS NOT NULL
+);
+DELETE FROM dune.dune_exchange_sell_orders WHERE order_id IN (
+  SELECT o.id FROM dune.dune_exchange_orders o
+  JOIN dune.actors a ON a.id = o.owner_id
+  WHERE o.is_npc_order = TRUE AND a.class <> 'Duke'
+);
+DELETE FROM dune.dune_exchange_orders WHERE id IN (
+  SELECT o.id FROM dune.dune_exchange_orders o
+  JOIN dune.actors a ON a.id = o.owner_id
+  WHERE o.is_npc_order = TRUE AND a.class <> 'Duke'
+);
+COMMIT;
+"@
+    $r = Invoke-DuneSqlQuery -Ip $ctx.ip -Sql $sql -ReadOnly $false -MaxRows 5 -TimeoutSec 120
+    if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    return @{ ok = $true; cleared = $before }
+}
+
 # ----------------------------------------------------------------------------
 # Native bot status for the UI (replaces the external proxy status).
 # ----------------------------------------------------------------------------
@@ -455,18 +926,22 @@ function Get-DuneNativeBotStatus {
     $cfg = Read-DuneBotConfig
     $state = Read-DuneBotState
     $out = [ordered]@{
-        configured     = $true
-        running        = [bool]$cfg.enabled
-        enabled        = [bool]$cfg.enabled
-        die_size       = [int]$cfg.die_size
-        die_target     = [int]$cfg.die_target
-        last_buy_tick  = $state.last_buy_tick
-        error_count    = [int]$state.error_count
-        error          = [string]$state.last_error
-        balance        = $null
-        listing_count  = $null
-        provisioned    = $false
-        source         = 'live'
+        configured            = $true
+        running               = [bool]$cfg.enabled
+        enabled               = [bool]$cfg.enabled
+        die_size              = [int]$cfg.die_size
+        die_target            = [int]$cfg.die_target
+        last_buy_tick         = $state.last_buy_tick
+        last_list_tick        = $state.last_list_tick
+        error_count           = [int]$state.error_count
+        error                 = [string]$state.last_error
+        balance               = $null
+        listing_count         = $null    # Duke's own NPC listings
+        listings_npc_total    = $null    # ALL NPC listings (any actor class)
+        listings_by_class     = @()      # [{class; count}]
+        legacy_listings_count = $null    # NPC listings owned by non-Duke actors
+        provisioned           = $false
+        source                = 'live'
     }
     $ctx = Get-DuneDbContext
     if (-not $ctx.ok) {
@@ -475,12 +950,38 @@ function Get-DuneNativeBotStatus {
         return $out
     }
     $ident = Get-DuneBotIdentity -Ip $ctx.ip
-    if ($ident.ok) {
+    if ($ident.ok -and $ident.ownerId -gt 0) {
         $out.provisioned = $true
         $bal = Get-DuneBotBalance -Ip $ctx.ip -OwnerId $ident.ownerId
         if ($bal.ok) { $out.balance = $bal.balance }
         $lc = Get-DuneBotScalar -Ip $ctx.ip -Sql "SELECT COUNT(*) FROM dune.dune_exchange_orders WHERE owner_id = $($ident.ownerId) AND is_npc_order = TRUE"
         if ($lc.ok) { $out.listing_count = ConvertTo-DuneInt $lc.value }
+    }
+    # All-NPC-orders breakdown — runs regardless of whether Duke is provisioned
+    # so the UI surfaces leftover Revy/etc. listings honestly.
+    $tot = Get-DuneBotScalar -Ip $ctx.ip -Sql 'SELECT COUNT(*) FROM dune.dune_exchange_orders WHERE is_npc_order = TRUE'
+    if ($tot.ok) { $out.listings_npc_total = ConvertTo-DuneInt $tot.value }
+    $brkSql = @"
+SELECT COALESCE(a.class, '?') AS owner_class, COUNT(*) AS n
+FROM dune.dune_exchange_orders o
+LEFT JOIN dune.actors a ON a.id = o.owner_id
+WHERE o.is_npc_order = TRUE
+GROUP BY a.class
+ORDER BY n DESC
+"@
+    $brk = Invoke-DuneSqlQuery -Ip $ctx.ip -Sql $brkSql -ReadOnly $true -MaxRows 100 -TimeoutSec 30
+    if ($brk.ok) {
+        $rows = ConvertTo-DuneRowMaps -Result $brk
+        $legacy = 0L
+        $list = @()
+        foreach ($r in $rows) {
+            $cls = [string]$r['owner_class']
+            $n   = ConvertTo-DuneInt $r['n']
+            $list += [ordered]@{ class = $cls; count = $n }
+            if ($cls -ne 'Duke') { $legacy += $n }
+        }
+        $out.listings_by_class = $list
+        $out.legacy_listings_count = $legacy
     }
     return $out
 }
@@ -518,15 +1019,25 @@ function Start-DuneGameplayBotScheduler {
                     $cfg = Read-DuneBotConfig
                     if ($cfg.enabled) {
                         $state = Read-DuneBotState
-                        $due = $true
+                        # Buy tick.
+                        $dueBuy = $true
                         if ($state.last_buy_tick) {
                             try {
                                 $last = [datetime]::Parse($state.last_buy_tick).ToUniversalTime()
-                                $elapsed = ([datetime]::UtcNow - $last).TotalSeconds
-                                $due = ($elapsed -ge [int]$cfg.buy_tick_interval)
-                            } catch { $due = $true }
+                                $dueBuy = (([datetime]::UtcNow - $last).TotalSeconds -ge [int]$cfg.buy_tick_interval)
+                            } catch { $dueBuy = $true }
                         }
-                        if ($due) { [void](Invoke-DuneBotBuyTick) }
+                        if ($dueBuy) { [void](Invoke-DuneBotBuyTick) }
+                        # List tick (independent cadence).
+                        $state2 = Read-DuneBotState
+                        $dueList = $true
+                        if ($state2.last_list_tick) {
+                            try {
+                                $lastL = [datetime]::Parse($state2.last_list_tick).ToUniversalTime()
+                                $dueList = (([datetime]::UtcNow - $lastL).TotalSeconds -ge [int]$cfg.list_tick_interval)
+                            } catch { $dueList = $true }
+                        }
+                        if ($dueList) { [void](Invoke-DuneBotListTick) }
                     }
                 } catch {}
                 Start-Sleep -Seconds 15

--- a/app/server/routes/Gameplay.ps1
+++ b/app/server/routes/Gameplay.ps1
@@ -343,3 +343,76 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/market-bot/clear-listings' 
         Write-DuneError -Response $res -Status 500 -Message "Clear listings failed: $($_.Exception.Message)"
     }
 }
+
+# ---------------------------------------------------------------------------
+# POST /api/gameplay/market-bot/clear-legacy-listings — wipe NPC orders owned
+# by any actor class that ISN'T Duke (Revy orphans from the old external
+# dune-admin integration, etc.). One-shot cleanup; player listings untouched.
+# ---------------------------------------------------------------------------
+Register-DuneRoute -Method POST -Path '/api/gameplay/market-bot/clear-legacy-listings' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $r = Clear-DuneBotLegacyListings
+        if (-not $r.ok) { Write-DuneError -Response $res -Status 503 -Message $r.error; return }
+        Write-DuneJson -Response $res -Body @{ ok = $true; cleared = $r.cleared; message = $r.message }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Clear legacy listings failed: $($_.Exception.Message)"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# POST /api/gameplay/market-bot/tick/list — run one LIST tick now. ?dry=1 (or
+# body { dryRun: true }) reports the planned listing actions WITHOUT writing.
+# ---------------------------------------------------------------------------
+Register-DuneRoute -Method POST -Path '/api/gameplay/market-bot/tick/list' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $dry = $false
+        $q = (Get-DuneQ -Request $req -Name 'dry').ToLower()
+        if ($q -eq '1' -or $q -eq 'true' -or $q -eq 'yes') { $dry = $true }
+        if (Test-DuneBodyTruthy -Body $body -Name 'dryRun') { $dry = $true }
+        $summary = Invoke-DuneBotListTick -DryRun:$dry
+        $status = if ($summary.ok) { 200 } else { 503 }
+        Write-DuneJson -Response $res -Status $status -Body $summary
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Bot list tick failed: $($_.Exception.Message)"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# GET /api/gameplay/market-bot/vendor-snapshot — preview what the bot WOULD
+# list (catalog derived from live NPC vendor inventory). Useful for tuning
+# pricing rules before flipping the bot on.
+# ---------------------------------------------------------------------------
+Register-DuneRoute -Method GET -Path '/api/gameplay/market-bot/vendor-snapshot' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $ctx = Get-DuneDbContext
+        if (-not $ctx.ok) { Write-DuneError -Response $res -Status 503 -Message $ctx.message; return }
+        $ident = Get-DuneBotIdentity -Ip $ctx.ip
+        if (-not $ident.ok) {
+            Write-DuneJson -Response $res -Body @{ ok = $true; provisioned = $false; candidates = @(); message = $ident.error }
+            return
+        }
+        $cfg = Read-DuneBotConfig
+        $vs = Get-DuneBotVendorSnapshot -Ip $ctx.ip -ExchangeId $ident.exchangeId
+        if (-not $vs.ok) { Write-DuneError -Response $res -Status 503 -Message $vs.error; return }
+        $cands = Resolve-DuneBotListingCandidates -Snapshot $vs.snapshot -Cfg $cfg
+        $rows = @()
+        foreach ($c in $cands) {
+            $price = Get-DuneBotItemPrice -Cfg $cfg -Cand $c
+            $rows += [ordered]@{
+                template_id   = $c.template_id
+                tier          = $c.tier
+                rarity        = $c.rarity
+                stackable     = [bool]$c.is_stackable
+                stack_max     = $c.stack_max
+                vendor_price  = ($c.vendor_price * 10)
+                target_price  = ($price * 10)
+            }
+        }
+        Write-DuneJson -Response $res -Body @{ ok = $true; provisioned = $true; total = $rows.Count; candidates = $rows }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Vendor snapshot failed: $($_.Exception.Message)"
+    }
+}

--- a/docs/internal/marketbot-port-spec.md
+++ b/docs/internal/marketbot-port-spec.md
@@ -1,0 +1,1093 @@
+Agent is idle (waiting for messages). agent_id: marketbot-upstream, agent_type: research, status: idle, description: Study upstream marketbot, elapsed: 540s, total_turns: 1
+
+[Turn 0]
+I now have all the information needed. Let me compile the comprehensive implementation spec.
+
+---
+
+# Dune Admin Market Bot — Full Port Spec for PowerShell/Postgres-via-SSH
+
+**Reference sources:**
+- `Icehunter/dune-admin` HEAD commit `f6dfc68fc6ef324c51038293c34c20fb995a1c31` (latest public HEAD, v0.33.x era — v0.34.0 introduced the `@heroui-pro/react` licence break)
+- `coastal-ms/DST-DuneServerTool` branch `coastal-ms/version-11.5.2` tip commit `5d7e92b60d13ae0a27485831fd57dccfbc123e45`
+- Sane-pricing patch at DST commit `cf903665c49a2b645d2f9987c22e4fca9159599d` (parent of `665364e1cf...` "Remove dune-admin integration")
+- DST fix commit `421693ae8fb0e5751928625200b4e7e1efc232f2` ("v10.1.15: fix pricing patch on dune-admin v0.23.2")
+
+---
+
+## Canonical Version Note
+
+The **canonical reference version for the sane-pricing patch** is dune-admin **v0.23.2**. DST commit `421693ae` explicitly states "fix pricing patch on dune-admin v0.23.2" — this is the version the patch was calibrated against. The upstream HEAD (`f6dfc68f`) has substantially refactored the exchange module (e.g. `buyPlayerListings` now takes `gameNow int64` as a parameter, the pricing engine is different), but the patch's Go symbols map cleanly onto it. Use the upstream HEAD for all SQL column shapes (they have not changed materially from v0.23.2). When the commit body says "v0.23.2 added `gameNow int64` to `buyPlayerListings`", it means the upstream HEAD at `f6dfc68f` already matches that v0.23.2 signature — no further adjustment needed.
+
+---
+
+## Section 1 — Bot Identity Model
+
+### Upstream Actor Class
+
+The bot uses **`class = 'Revy'`** in `dune.actors`.
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go` (SHA `d927cb87`):
+
+```go
+err := e.db.QueryRow(ctx,
+    `SELECT id FROM dune.actors WHERE class = 'Revy' LIMIT 1`).Scan(&e.ownerID)
+```
+
+### Owner ID Resolution — Full Cascade (initBotUser)
+
+```go
+// Step 1: Try to find existing Revy actor
+err := e.db.QueryRow(ctx,
+    `SELECT id FROM dune.actors WHERE class = 'Revy' LIMIT 1`).Scan(&e.ownerID)
+
+// Step 2: If not found, create it
+if err == pgx.ErrNoRows {
+    // Step 2a: Resolve a valid world_partition
+    var partitionID int64
+    _ = e.db.QueryRow(ctx,
+        `SELECT partition_id FROM dune.world_partition ORDER BY partition_id LIMIT 1`).Scan(&partitionID)
+
+    // Step 2b: INSERT new actor row
+    err = e.db.QueryRow(ctx,
+        `INSERT INTO dune.actors (class, serial, gas_attributes, properties, dimension_index, partition_id)
+         VALUES ('Revy', 0, '{}', '{}', 0, $1) RETURNING id`, partitionArg).Scan(&e.ownerID)
+}
+
+// Step 3: Ensure exchange-user record exists
+var userID int64
+e.db.QueryRow(ctx,
+    `SELECT dune.dune_exchange_get_user_id($1)`, e.ownerID).Scan(&userID)
+
+// Step 4: Seed Solari balance if below floor
+const seedFloor int64 = 1_000_000_000_000  // 1T
+const seedAmount int64 = 9_000_000_000_000 // 9T
+var currentBalance int64
+e.db.QueryRow(ctx,
+    `SELECT dune.dune_exchange_retrieve_solari_balance($1)`, e.ownerID).Scan(&currentBalance)
+if currentBalance < seedFloor {
+    e.db.Exec(ctx,
+        `SELECT dune.dune_exchange_modify_user_solari_balance($1, $2)`,
+        e.ownerID, seedAmount-currentBalance) // tops up to 9T
+}
+```
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:initBotUser`
+
+### `actors` Row Column Values
+
+| Column | Value |
+|--------|-------|
+| `class` | `'Revy'` |
+| `serial` | `0` |
+| `gas_attributes` | `'{}'` |
+| `properties` | `'{}'` |
+| `dimension_index` | `0` |
+| `partition_id` | first row from `dune.world_partition ORDER BY partition_id LIMIT 1` (NULL if table empty) |
+
+### Exchange and Access-Point ID Resolution
+
+The bot resolves three IDs at startup via cascading fallbacks:
+
+**Exchange ID** — 4-tier cascade:
+```sql
+-- Tier 1 (authoritative — avoids the phantom "Global" exchange):
+SELECT ap.exchange_id
+FROM dune.dune_exchange_accesspoints ap
+JOIN dune.dune_exchanges e ON e.id = ap.exchange_id
+ORDER BY ap.id LIMIT 1
+
+-- Tier 2 (player orders):
+SELECT exchange_id FROM dune.dune_exchange_orders WHERE is_npc_order = FALSE LIMIT 1
+
+-- Tier 3 (any exchange row):
+SELECT id FROM dune.dune_exchanges ORDER BY id LIMIT 1
+
+-- Tier 4 (upsert/create):
+SELECT dune.get_dune_exchange_id('Global')
+```
+
+**Access Point ID** — 2-tier cascade:
+```sql
+-- Tier 1 (from access points table):
+SELECT id FROM dune.dune_exchange_accesspoints WHERE exchange_id = $exchangeId ORDER BY id LIMIT 1
+
+-- Tier 2 (from existing player orders):
+SELECT DISTINCT access_point_id FROM dune.dune_exchange_orders WHERE exchange_id = $exchangeId LIMIT 1
+-- Falls back to 1 if both fail
+```
+
+**Exchange Inventory ID** (for `items.inventory_id`):
+```sql
+SELECT dune.get_exchange_inventory_id($exchangeId)
+```
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:Init` and `detectExchangeID`, `detectAccessPointID`.
+
+### DST Port Divergence on Identity
+
+DST's `Get-DuneBotIdentity` uses class **`'Duke'`** instead of `'Revy'`, and skips Tier 1 of the exchange-ID detection (the access-point-table query). This is intentional — the upstream Tier-1 fix was added post-v0.23.2 specifically to avoid the phantom "Global" exchange. **The port should implement the same Tier-1 access-point lookup** to ensure listings appear in-game.
+
+---
+
+## Section 2 — List-Tick Cadence
+
+### Default Intervals
+
+| Parameter | Default | Config Key |
+|-----------|---------|------------|
+| `ListInterval` | **30 minutes** | `list_interval` |
+| `BuyInterval` | **5 minutes** | `buy_interval` |
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/bot.go`:
+```go
+if cfg.ListInterval == 0 {
+    cfg.ListInterval = 30 * time.Minute
+}
+if cfg.BuyInterval == 0 {
+    cfg.BuyInterval = 5 * time.Minute
+}
+```
+
+### Scheduler Loop
+
+The scheduler is a single goroutine with a 1-minute resolution ticker:
+
+```go
+func runLoop(ctx, logger, cfg, ex, catalog) {
+    ex.Tick(ctx, catalog)  // Runs both buy + list immediately on startup
+
+    tick := time.NewTicker(time.Minute)
+    snap0 := cfg.Snapshot()
+    nextBuy := time.Now().Add(snap0.BuyInterval)
+    nextList := time.Now().Add(snap0.ListInterval)
+    for {
+        select {
+        case <-ctx.Done(): return
+        case now := <-tick.C:
+            snap := cfg.Snapshot()
+            if !snap.Enabled { continue }
+            if now.After(nextBuy) {
+                ex.BuyTick(ctx)
+                nextBuy = now.Add(snap.BuyInterval)
+            }
+            if now.After(nextList) {
+                ex.ListTick(ctx, catalog)
+                nextList = now.Add(snap.ListInterval)
+            }
+        }
+    }
+}
+```
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/bot.go:runLoop`
+
+**Key design:** The loop checks at minute granularity. On startup, one combined tick fires immediately. Each subsequent tick fires when `now > nextDue`, not on a strict wall-clock schedule.
+
+**Minimum configurable interval:** 1 minute (enforced in `config.go:Apply`).
+
+### DST Port Design
+
+DST's `Start-DuneGameplayBotScheduler` wakes every 15 seconds and checks `$elapsed -ge [int]$cfg.buy_tick_interval`. The **list side** is not yet implemented (there is no `Invoke-DuneBotListTick`). DST should add a parallel `nextList` tracking variable and call a `Invoke-DuneBotListTick` function when due.
+
+---
+
+## Section 3 — Per-Item Listing Algorithm (ListTick)
+
+### High-Level Flow
+
+```
+ListTick:
+  1. learnGameEpoch        — infer game clock offset from existing orders
+  2. refreshCategoryCache  — load category_mask from existing player orders
+  3. fetchMarketPrices     — call dune_exchange_get_item_price_stats() for real prices
+  4. updatePrices          — apply adaptive price drift per item
+  5. expireAndPurgeOrders  — delete own expired NPC listings
+  6. Load current bot listings grouped by (template_id, quality_level)
+  7. For each catalog item × each applicable grade:
+       a. If item disabled → mark existing listings stale, skip
+       b. Compute target listing price
+       c. Listings with wrong price → mark stale (queue for delete)
+       d. Listings with correct price but depleted stack → queue top-up
+       e. If valid count < ListingsPerGrade → queue new listing(s)
+  8. Bulk-delete stale orders + items
+  9. Bulk-update depleted stacks
+  10. Batch-insert new listings (in batches of 100)
+  11. Refresh balance and listing_count for status reporting
+```
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:ListTick`
+
+### Quota Check: Top-Up vs. Spawn Fresh
+
+The bot **does NOT always spawn fresh**. It counts existing non-expired valid listings (correct price, not stale) and only creates enough new ones to reach `ListingsPerGrade`. It never deletes correct-price listings. Concretely:
+
+```go
+key := gradeKey{item.TemplateID, grade}
+listings := current[key]  // current valid listings for (tmpl, grade)
+
+// Determine listing price
+price := gradeFloor(item, grade, snap)
+if item.MaterialCost <= 0 {
+    price = gradedPrice(basePrice, grade, snap.GradeMultipliers)
+}
+
+// Mark listings with wrong price as stale
+var valid []listingInfo
+for _, l := range listings {
+    if l.price != price {
+        staleOrderIDs = append(staleOrderIDs, l.orderID)
+        staleItemIDs  = append(staleItemIDs, l.itemID)
+    } else {
+        valid = append(valid, l)
+    }
+}
+
+// Queue depleted stacks for refill
+for _, l := range valid {
+    if l.stackSize < stackMax { topUps = append(topUps, ...) }
+}
+
+// Fill up to quota
+for i := len(valid); i < snap.ListingsPerGrade; i++ {
+    pending = append(pending, pendingListing{...})
+}
+```
+
+**Default `ListingsPerGrade` = 5.** Minimum = 1. This means up to 5 concurrent listings of the same (item, grade) combination exist simultaneously.
+
+### Applicable Grades
+
+```go
+func applicableGrades(item CatalogItem) []int64 {
+    if item.StackMax > 1 || !item.IsGradeable {
+        return []int64{0}  // non-gradeable: only grade 0
+    }
+    min := item.MinQualityLevel
+    // 0..5 for gradeable gear (e.g. ecolab schematic drops)
+    return grades from min to 5
+}
+```
+
+- Stackable items (materials, ammo): grade 0 only
+- Non-gradeable single items: grade 0 only
+- Gradeable single items (armor, weapons, augments from ecotesting stations): grades `MinQualityLevel` through 5
+
+### Stack Size Policy
+
+**One stack of `StackMax`** units per listing. The item row is inserted with `stack_size = StackMax` and the sell order with `initial_stack_size = StackMax`. No "N stacks of 1" pattern — it's always a single listing with the maximum stack.
+
+---
+
+## Section 3a — Exact SQL Statements for Listing Insert
+
+### Step 1: INSERT backing item
+
+```sql
+INSERT INTO dune.items
+  (inventory_id, stack_size, position_index, template_id, quality_level, stats)
+VALUES
+  ($botInvID, $stackMax, $nextPos, $templateID, $qualityLevel, '{}')
+RETURNING id
+```
+
+| Column | Value |
+|--------|-------|
+| `inventory_id` | Exchange inventory ID from `dune.get_exchange_inventory_id($exchangeId)` |
+| `stack_size` | `item.StackMax` (or 1 if StackMax ≤ 0) |
+| `position_index` | Auto-incrementing counter starting from `MAX(position_index)+1` in that inventory |
+| `template_id` | Item's template ID string (e.g. `T6_Lasgun`) |
+| `quality_level` | Grade (0–5) |
+| `stats` | `'{}'` (empty JSON) |
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:createListingsBatch`
+
+### Step 2: INSERT order row
+
+```sql
+INSERT INTO dune.dune_exchange_orders
+  (exchange_id, access_point_id, owner_id, is_npc_order, expiration_time,
+   template_id, durability_cur, durability_max, category_mask, category_depth,
+   item_price, quality_level, item_id)
+VALUES
+  ($exchangeId, $accessPointId, $ownerID, TRUE, $expiry,
+   $templateID, 1.0, 1.0,
+   $catMask, $catDepth, $listPrice, $qualityLevel, $itemID)
+RETURNING id
+```
+
+| Column | Value |
+|--------|-------|
+| `exchange_id` | Resolved exchange ID |
+| `access_point_id` | Resolved access point ID |
+| `owner_id` | Bot's actor ID (Revy) |
+| `is_npc_order` | `TRUE` |
+| `expiration_time` | `gameNow + 86400` (24 h in game seconds). If game epoch unknown: `999_999_999` sentinel |
+| `template_id` | Item template ID |
+| `durability_cur` | `1.0` (float) |
+| `durability_max` | `1.0` (float) |
+| `category_mask` | 32-bit signed int encoding category hierarchy (see Section 5 below) |
+| `category_depth` | Depth (1–3) matching mask, or 0 for uncategorized |
+| `item_price` | Computed listing price (see Section 3b) |
+| `quality_level` | Grade (0–5) |
+| `item_id` | ID returned from items INSERT |
+
+### Step 3: INSERT sell-order row
+
+```sql
+INSERT INTO dune.dune_exchange_sell_orders
+  (order_id, initial_stack_size, wear_normalized_price)
+VALUES
+  ($orderID, $stackMax, $listPrice)
+```
+
+| Column | Value |
+|--------|-------|
+| `order_id` | ID returned from orders INSERT |
+| `initial_stack_size` | `StackMax` |
+| `wear_normalized_price` | Same as `item_price` (listing price) |
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:createListingsBatch`
+
+### Expiration Time Calculation
+
+```go
+const orderExpirySecs = int64(24 * 3600)  // 86,400 game-time seconds
+
+gameNow = time.Now().Unix() - e.gameEpochUnix  // derived from existing order timestamps
+orderExpiry = gameNow + orderExpirySecs         // if epoch known
+
+// Fallback when epoch is unknown:
+orderExpiry = 999_999_999  // sentinel — server proc will not expire these
+```
+
+The `gameEpochUnix` is derived by reverse-engineering existing orders:
+```sql
+-- Tier 1 (own non-sentinel bot listings):
+SELECT expiration_time FROM dune.dune_exchange_orders
+WHERE owner_id = $botOwnerID
+  AND is_npc_order = TRUE
+  AND expiration_time IS NOT NULL
+  AND expiration_time < 999_999_999
+ORDER BY expiration_time DESC LIMIT 1
+-- Then: gameEpochUnix = time.Now().Unix() - (ref - orderExpirySecs)
+```
+
+**For the PowerShell port:** instead of implementing the full epoch-learning machine, DST already uses a simpler approach: `SELECT COALESCE(MAX(expiration_time), 999999999) FROM dune.dune_exchange_orders WHERE expiration_time < 999999999`. This is fine for listing — just use the most recent real expiry time as a reference point (it will be approximately `gameNow + 24h`). For the initial install before any listings exist, use the `999_999_999` sentinel.
+
+---
+
+## Section 3b — Listing Price Calculation
+
+### Upstream Pricing (dune-admin HEAD, unpatched)
+
+The upstream `pricing.go` uses a complex multi-branch formula:
+
+1. **Unique/Memento equipment with MaterialCost**: `schematicEquipmentPrice(tier) × rarityMult + materialCostForGrade(grade) × 0.75`
+2. **Items with vendor_price ≥ 10**: `vendor_price × vendorMult(rarity, VendorMultipliers)`
+3. **Fallback (no vendor price), non-stackable**: `equipmentPrice(tier) × rarityMult` (or `schematicEquipmentPrice(tier) × rarityMult` if schematic)
+4. **Fallback, stackable**: `materialUnitPrice(tier) × rarityMult`
+
+**Upstream default upstream multipliers (unpatched HEAD):**
+```
+GradeMultipliers:   [1.0, 1.0, 1.25, 1.5, 1.75, 2.0]
+RarityMultipliers:  common=1.0, rare=5.0, unique=5.0, memento=2.0
+VendorMultipliers:  common=1.0, rare=5.0, unique=5.0, memento=2.0
+```
+
+**Upstream equipment tier prices (no vendor price):**
+```
+T0: 500     T1: 2,000   T2: 8,000    T3: 30,000
+T4: 100,000 T5: 300,000 T6: 750,000
+```
+
+**Upstream schematic tier prices:**
+```
+T0: 500   T1: 500   T2: 1,500   T3: 4,000
+T4: 12,000 T5: 30,000 T6: 75,000
+```
+
+**Upstream material unit prices (per unit, stackables):**
+```
+T0: 5  T1: 20  T2: 80  T3: 200  T4: 600  T5: 1,500  T6: 4,000
+```
+
+**Adaptive price adjustment (`adjustPrice`):** On each list tick, sold fraction is computed (`sold / initial_stack_size`). If >50% sold → price × 1.10; if 0% sold → price × 0.95; otherwise unchanged. Floor = `basePrice`. Ceiling = `floor × 5`. Per-item `MinPrice`/`MaxPrice` overrides from `item-data.json` take precedence.
+
+**Market price influence (`fetchMarketPrices`):** Uses `dune_exchange_get_item_price_stats(template_ids[])` to get real market minimum. If market min < `adjusted × 0.9`, price trends toward `(adjusted + market_min) / 2`.
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/pricing.go` (SHA `de6592d4`)
+
+### Sane-Pricing Patch (DST / Coastal) — THE AUTHORITATIVE RULES
+
+**Patch file:** `coastal-ms/DST-DuneServerTool:app/resources/dune-admin-patches/0001-sane-pricing-100k-cap.patch` (SHA `6dbd524ef7a5c80dba9acd2ce04afab7686050c9`, at commit `cf903665`)
+
+**What it changes:** Replaces upstream's rarity-weighted pricing (which produced multi-million-solari T6 listings) with a tier-driven model capped at 100,000 Solari, calibrated for a small private server (~2 active players, ~5–20k Solari/hr).
+
+#### Global Hard Ceiling
+
+```go
+const maxAnyPrice = 100_000
+func capPrice(p int64) int64 {
+    if p > maxAnyPrice { return maxAnyPrice }
+    return p
+}
+```
+
+Every price — formula output, adaptive drift, `adjustPrice`, `gradedPrice`, `gradeFloor` — is passed through `capPrice()`. **Nothing may ever exceed 100,000 Solari.**
+
+#### New Tier Base Prices (replaces `equipmentPrice`, `schematicEquipmentPrice`, `materialUnitPrice`)
+
+**Non-stackable items — `tierBasePrice(tier)`:**
+
+| Tier | Base Price |
+|------|-----------|
+| 0 (cosmetic/unknown) | 10 |
+| 1 | 50 |
+| 2 | 200 |
+| 3 | 800 |
+| 4 | 3,000 |
+| 5 | 10,000 |
+| 6 | 30,000 |
+
+**Stackable crafting materials — `stackUnitPrice(tier)`** (per unit):
+
+| Tier | Unit Price |
+|------|-----------|
+| 0 (raw unknown) | 1 |
+| 1 | 1 |
+| 2 | 5 |
+| 3 | 20 |
+| 4 | 75 |
+| 5 | 250 |
+| 6 | 800 |
+
+*Calibration: a 100-unit T6 material stack at standard grade = 800 × 1.0 × 1.0 = 80,000 Solari (under the cap).*
+
+#### Category Factors (non-stackable items only)
+
+| Item Category | Factor |
+|---------------|--------|
+| Augment (category starts with `items/augment`) | `0.6` |
+| Schematic (IsSchematic = true) | `1.0` |
+| All other gear | `0.8` |
+
+#### New `basePrice` Formula
+
+```
+if StackMax > 1:
+    p = stackUnitPrice(tier) × rarity_mult
+
+else (non-stackable):
+    factor = augmentTierFactor(0.6) | schemFactor(1.0) | gearFactor(0.8)
+    p = tierBasePrice(tier) × factor × rarity_mult
+    
+    // Vendor-price soft floor:
+    if vendor_price ≥ 10:
+        vendorFloor = vendor_price × vendor_floor_fraction(rarity)
+        if vendorFloor > p: p = vendorFloor
+
+return capPrice(p)
+```
+
+#### New Default Multipliers (patched `defaultConfig()`)
+
+```
+GradeMultipliers:   [1.0, 1.25, 1.55, 2.0, 2.6, 3.3]
+RarityMultipliers:  common=1.0, rare=1.03, unique=1.05, memento=1.08
+VendorMultipliers:  common=0.95, rare=0.95, unique=0.95, memento=0.95
+```
+
+*The COASTAL-PRICING.md states "rarity is only a minor relevancy" — rarity gives ≤8% premium, not the upstream 5× multiplier.*
+
+#### Worked Examples
+
+| Item | Tier | StackMax | Category | Rarity | Vendor | Grade | Patched Price |
+|------|------|----------|----------|--------|--------|-------|---------------|
+| T6 Schematic | 6 | 1 | weapons (schematic) | common | 0 | 0 | 30,000 × 1.0 × 1.0 = **30,000** |
+| T6 Schematic | 6 | 1 | weapons (schematic) | common | 0 | 5 (Flawless) | 30,000 × 3.3 = **99,000** |
+| T6 Heavy Armor | 6 | 1 | garment/heavyarmor | common | 215,000 | 0 | max(30,000×0.8, 215,000×0.95) = max(24,000, 204,250) → cap(204,250) = **100,000** |
+| T3 Material | 3 | 500 | misc/rawresources | common | 5 | 0 | 20 × 1.0 = **20** per unit |
+| T6 Augment | 6 | 1 | augment/ranged | unique | 0 | 0 | 30,000 × 0.6 × 1.05 = **18,900** |
+| T1 Common Gear | 1 | 1 | garment/lightarmor | common | 100 | 0 | max(50×0.8, 100×0.95) = max(40, 95) = **95** → rounded to **100** |
+
+#### Adaptive Drift (patched)
+
+```go
+// In adjustPrice:
+ceiling = floor * 2  // was 5× in upstream
+
+// Hard vendor cap:
+if vendor_price >= 10 {
+    vendorCap = vendor_price * 2
+    if ceiling > vendorCap: ceiling = vendorCap
+}
+
+// Hard global cap everywhere:
+if floor   > maxAnyPrice: floor   = maxAnyPrice
+if ceiling > maxAnyPrice: ceiling = maxAnyPrice
+
+// Drift rules (unchanged from upstream):
+soldFraction > 0.5 → next = current × 1.10
+soldFraction == 0  → next = current × 0.95
+else               → next = current (unchanged)
+
+// Final:
+return capPrice(next)
+```
+
+#### One-Time Migration (saneDefaultsRevision = 1)
+
+When a persisted state file has `defaults_revision < 1` (or lacks the field), on next load the Grade/Rarity/Vendor multipliers are **overwritten** with the current sane defaults (a one-time migration). Non-pricing fields (intervals, max_buys, disabled_items) are preserved. After migration, `defaults_revision = 1` is persisted so the reset happens only once.
+
+#### d12 Gamble-Buy (also in the patch)
+
+The pricing patch **also patches `exchange.go`** to replace the `BuyThreshold` price gate with a randomised buy:
+
+```go
+// Removed from buyPlayerListings:
+// if snap.BuyThreshold <= 0 { return }
+// if price > int64(float64(refPrice)*snap.BuyThreshold) { skip }
+
+// Replaced with:
+import "math/rand"
+
+if roll := rand.Intn(12) + 1; roll != 5 {
+    log.Printf("buy: d12 skip %s price=%d roll=%d (need 5)", tmpl, price, roll)
+    skippedPrice++
+    continue
+}
+// Buying happens regardless of price
+```
+
+**DST has already ported this** (GameplayBot.ps1 uses `Get-Random -Minimum 1 -Maximum ($dieSize + 1)` and checks `$roll -ne $dieTarget`), with the die size and target configurable. The upstream patch hardcodes `rand.Intn(12) + 1` (d12) and winning number `5`.
+
+---
+
+## Section 4 — Sane-Pricing Patch Summary
+
+> This section repeats the patch in spec form rather than code form for the implementer.
+
+**Patch source:** `coastal-ms/DST-DuneServerTool:app/resources/dune-admin-patches/0001-sane-pricing-100k-cap.patch` (commit `cf903665`). Files touched: `pricing.go`, `config.go`, `config_test.go`, `exchange.go`.
+
+**What the patch does:**
+1. Hard-caps all listings at **100,000 Solari** (`maxAnyPrice`). No exception.
+2. Replaces the upstream vendor-multiplier (which scaled vendor_price × 5 for rare/unique) with a **tier-driven base formula** using `tierBasePrice()` / `stackUnitPrice()` and flat category factors (0.6 / 0.8 / 1.0).
+3. Adds a vendor-price **soft floor** at 95% of NPC vendor price — bot undercuts vendors slightly, never gutting the NPC economy.
+4. Resets rarity multipliers to near-1.0 nudges (1.0 / 1.03 / 1.05 / 1.08) and vendor-floor fractions to 0.95 flat across all rarities.
+5. Replaces grade multipliers `[1.0, 1.0, 1.25, 1.5, 1.75, 2.0]` with `[1.0, 1.25, 1.55, 2.0, 2.6, 3.3]` so Flawless (grade 5) caps a T6 schematic at ≈ 99,000.
+6. Lowers adaptive-drift ceiling from `floor × 5` to `floor × 2`, and caps vendor-ceiling at `vendor_price × 2`.
+7. Adds a `DefaultsRevision` field with one-time migration to re-seed old configs.
+8. Replaces the buy-side price-threshold gate with the d12 gamble (see Section 3b).
+
+**Verifying the patch is in effect** (from COASTAL-PRICING.md):
+The Bot Control panel should show exactly:
+- Grade multipliers: `1, 1.25, 1.55, 2, 2.6, 3.3`
+- Rarity multipliers: `common=1, rare=1.03, unique=1.05, memento=1.08`
+- Vendor multipliers: `common=0.95, rare=0.95, unique=0.95, memento=0.95`
+
+If you see upstream values (rarity=1/5/2, vendor=1/5/2, grade=1/1/1.25/1.5/1.75/2.0), the patch is not applied.
+
+---
+
+## Section 5 — Configuration Surface (Upstream dune-admin UI)
+
+### Runtime Config Schema (`configValues`)
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/config.go` (SHA `1d32425b`)
+
+```json
+{
+  "buy_interval":        "5m0s",
+  "list_interval":       "30m0s",
+  "buy_threshold":       1.05,
+  "max_buys":            50,
+  "listings_per_grade":  5,
+  "enabled":             true,
+  "grade_multipliers":   [1.0, 1.0, 1.25, 1.5, 1.75, 2.0],
+  "rarity_multipliers":  {"common": 1.0, "rare": 5.0, "unique": 5.0, "memento": 2.0},
+  "vendor_multipliers":  {"common": 1.0, "rare": 5.0, "unique": 5.0, "memento": 2.0},
+  "disabled_items":      []
+}
+```
+
+*(With sane-pricing patch applied, defaults are replaced as described above.)*
+
+### Validation Constraints
+
+| Field | Minimum | Maximum | Notes |
+|-------|---------|---------|-------|
+| `buy_interval` | 1 minute | — | String duration, e.g. "5m0s" |
+| `list_interval` | 1 minute | — | String duration |
+| `buy_threshold` | 0 | — | 0 disables price-gate in unpatched; irrelevant with patch |
+| `max_buys` | 0 | — | 0 disables buying |
+| `listings_per_grade` | 1 | — | |
+| `grade_multipliers` | all > 0 | — | 6-element array |
+| `rarity_multipliers` | all > 0 | — | Map; unknown keys ignored |
+| `vendor_multipliers` | all > 0 | — | Map |
+
+### Persistence
+
+Config is persisted via `SaveState(path, configValues)` to a JSON file at the path specified by `BotConfig.StatePath`. The format matches the JSON wire format above. State is loaded on startup; UI applies through `PUT /config` (partial JSON patch). The state file is written atomically (tmp file + rename).
+
+### HTTP API Endpoints (upstream dune-admin embedded bot)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/health` | Liveness probe (no auth) |
+| `GET` | `/status` | Bot status snapshot (auth required) |
+| `GET` | `/config` | Read current config (auth required) |
+| `PUT` | `/config` | Apply partial config patch (auth required) |
+| `POST` | `/config/reload` | No-op (compatibility stub) |
+| `GET` | `/report` | Per-item sales data (auth required) |
+| `POST` | `/exec` | `start`/`stop`/`restart` commands (auth required) |
+| `POST` | `/cleanup` | Wipe bot listings (auth required) |
+| `GET` | `/logs` | WebSocket log stream (auth required) |
+
+**Auth:** `Authorization: Bearer <token>` header. Token set via `BotConfig.APIToken` (corresponding `market_bot_token` in `config.yaml`). Empty token = all auth endpoints disabled (401).
+
+### UI Fields (dune-admin web panel, inferred from config schema and API)
+
+The dune-admin web UI's Bot Control panel surfaces all `configValues` fields plus:
+- Enable/disable toggle
+- Buy interval slider/input
+- List interval slider/input
+- BuyThreshold input (ignored in patched build)
+- MaxBuys input
+- ListingsPerGrade input
+- Grade multiplier array (6 fields)
+- Rarity multiplier map (editable per-rarity)
+- Vendor multiplier map (editable per-rarity)
+- Disabled items (multi-line textarea)
+- "Start/Stop/Restart" actions
+- "Cleanup Listings" button
+- Per-item sales report
+
+### DST Config (as-is for buy side, `gameplay-bot.json`)
+
+```json
+{
+  "enabled":           false,
+  "buy_tick_interval": 120,
+  "max_buys_per_tick": 25,
+  "die_size":          12,
+  "die_target":        5,
+  "target_balance":    9000000000000,
+  "maintain_balance":  true,
+  "disabled_items":    []
+}
+```
+
+**Source:** `coastal-ms/DST-DuneServerTool:app/server/lib/GameplayBot.ps1:Get-DuneBotConfigDefaults` (SHA `c4865b53`)
+
+The **listing config** (ListingsPerGrade, GradeMultipliers, RarityMultipliers, VendorMultipliers, list_tick_interval) has not yet been ported. These need to be added.
+
+---
+
+## Section 6 — DB Tables Touched
+
+### Tables Read / Written by Listing Path
+
+| Table | Operations | Key Columns |
+|-------|-----------|-------------|
+| `dune.actors` | SELECT, INSERT (bot identity) | `id`, `class`, `serial`, `gas_attributes`, `properties`, `dimension_index`, `partition_id` |
+| `dune.world_partition` | SELECT (for partition_id on INSERT) | `partition_id` |
+| `dune.dune_exchanges` | SELECT (exchange ID detection) | `id` |
+| `dune.dune_exchange_accesspoints` | SELECT (access point / exchange ID detection) | `id`, `exchange_id` |
+| `dune.dune_exchange_users` | SELECT/UPDATE (balance operations) | `owner_id`, `solari_balance` |
+| `dune.items` | SELECT, INSERT, UPDATE, DELETE | `id`, `inventory_id`, `stack_size`, `position_index`, `template_id`, `quality_level`, `stats` |
+| `dune.dune_exchange_orders` | SELECT, INSERT, DELETE | See below |
+| `dune.dune_exchange_sell_orders` | INSERT, DELETE | `order_id`, `initial_stack_size`, `wear_normalized_price` |
+| `dune.dune_exchange_fulfilled_orders` | INSERT (buy side only), SELECT (price stats) | `order_id`, `source_order_id`, `completion_type`, `stack_size`, `original_order_id` |
+
+### `dune.dune_exchange_orders` Full Column Reference
+
+| Column | Type | Bot-Listing Value | Notes |
+|--------|------|------------------|-------|
+| `id` | bigint PK | RETURNING | Auto-generated |
+| `exchange_id` | bigint FK | Resolved exchange ID | FK → `dune_exchanges.id` |
+| `access_point_id` | bigint | Resolved access point ID | FK → `dune_exchange_accesspoints.id` |
+| `owner_id` | bigint FK | Bot actor ID (Revy) | FK → `actors.id` |
+| `is_npc_order` | boolean | `TRUE` | Critical — separates bot from player orders |
+| `expiration_time` | int8 | `gameNow + 86400` or `999_999_999` | Game-time seconds, not Unix |
+| `template_id` | text | Item template ID | e.g. `T6_Lasgun` |
+| `durability_cur` | float4 | `1.0` | |
+| `durability_max` | float4 | `1.0` | |
+| `category_mask` | int4 | Bit-packed category code | See Section 5 encoding |
+| `category_depth` | int2 | Depth of the category path (1–3) | |
+| `item_price` | int8 | Computed listing price per unit | |
+| `quality_level` | int8 | Grade (0–5) | |
+| `item_id` | bigint FK | Backing `items.id` | FK → `dune.items.id` |
+
+### Stored Procedures Used
+
+| Procedure | Purpose |
+|-----------|---------|
+| `dune.dune_exchange_get_user_id($actorId)` | Creates/retrieves exchange user row |
+| `dune.get_exchange_inventory_id($exchangeId)` | Returns the exchange's item inventory ID |
+| `dune.dune_exchange_retrieve_solari_balance($actorId)` | Read Solari balance |
+| `dune.dune_exchange_modify_user_solari_balance($actorId, $delta)` | Add/subtract Solari |
+| `dune.get_dune_exchange_id($name)` | Upsert/retrieve exchange by name |
+| `dune.dune_exchange_get_item_price_stats($templateIds[])` | Real market minimum + average prices |
+
+### Unique Constraints / FK Constraints Relevant to Listing
+
+- `dune_exchange_sell_orders.order_id` → `dune_exchange_orders.id` (FK; cascade delete may be present — the upstream explicitly deletes sell_orders before orders in CleanupListings as a safety measure)
+- `items.id` must be in the bot's exchange inventory (`inventory_id = botInvID`) for the listing to be valid
+- The `(template_id, category_mask)` combination must match what player orders use — conflicting masks cause the category snapshot to fail (which is why the bot reads and caches player-order masks)
+
+---
+
+## Section 7 — Cleanup / Wipe SQL
+
+### Upstream CleanupListings (wipes only bot NPC listings)
+
+```sql
+-- Step 1: Delete backing items
+DELETE FROM dune.items
+WHERE id IN (
+    SELECT item_id FROM dune.dune_exchange_orders
+    WHERE owner_id = $ownerID AND is_npc_order = TRUE AND item_id IS NOT NULL
+);
+
+-- Step 2: Delete sell-order side-rows (FK safety — upstream always explicit)
+DELETE FROM dune.dune_exchange_sell_orders
+WHERE order_id IN (
+    SELECT id FROM dune.dune_exchange_orders
+    WHERE owner_id = $ownerID AND is_npc_order = TRUE
+);
+
+-- Step 3: Delete the order rows
+DELETE FROM dune.dune_exchange_orders
+WHERE owner_id = $ownerID AND is_npc_order = TRUE;
+```
+
+All three steps run in a single transaction. Player listings, fulfilled-order history, and the bot's Solari balance are untouched.
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:CleanupListings`
+
+### DST's `Clear-DuneBotListings` (functionally equivalent)
+
+```sql
+BEGIN;
+DELETE FROM dune.items WHERE id IN (
+  SELECT item_id FROM dune.dune_exchange_orders
+  WHERE owner_id = $o AND is_npc_order = TRUE AND item_id IS NOT NULL
+);
+DELETE FROM dune.dune_exchange_sell_orders WHERE order_id IN (
+  SELECT id FROM dune.dune_exchange_orders
+  WHERE owner_id = $o AND is_npc_order = TRUE
+);
+DELETE FROM dune.dune_exchange_orders WHERE owner_id = $o AND is_npc_order = TRUE;
+COMMIT;
+```
+
+**Source:** `coastal-ms/DST-DuneServerTool:app/server/lib/GameplayBot.ps1:Clear-DuneBotListings`
+
+This is already correctly ported. The **only difference** from upstream is that DST uses `$o` (Duke's `owner_id`) and upstream uses `$ownerID` (Revy's). The guard shape `AND is_npc_order = TRUE` is correct and prevents touching player listings.
+
+### Stale-Listing Prune (during normal ListTick)
+
+Stale listings (wrong price) are collected during the catalog scan and bulk-deleted:
+
+```sql
+-- Belt-and-suspenders guard even though IDs are already bot-only:
+DELETE FROM dune.dune_exchange_orders
+WHERE id = ANY($staleOrderIDs) AND owner_id = $ownerID AND is_npc_order = TRUE;
+
+DELETE FROM dune.items WHERE id = ANY($staleItemIDs);
+```
+
+### Expired-Listing Purge (during ListTick, bot's own expirations only)
+
+```sql
+DELETE FROM dune.dune_exchange_orders
+WHERE owner_id = $ownerID
+  AND is_npc_order = TRUE
+  AND expiration_time IS NOT NULL
+  AND expiration_time < $gameNow;
+```
+
+The game server's own `dune_exchange_expire_orders` proc is **NOT called** — it would affect all orders including player listings.
+
+---
+
+## Section 8 — Buy-Side Comparison (Upstream vs. DST Port)
+
+### Upstream `buyPlayerListings` (unpatched HEAD)
+
+1. Guards on `BuyThreshold > 0`
+2. Fetches candidates: `SELECT ... WHERE is_npc_order = FALSE AND exchange_id = $exchangeID LIMIT $maxBuys*10`
+3. Skips items not in catalog, non-buyable items, disabled items
+4. Computes `refPrice = gradedPrice(botPrice, grade, GradeMultipliers)`
+5. Skips if `price > refPrice * BuyThreshold`
+6. Executes purchase transaction
+
+### DST Patched `Invoke-DuneBotBuyTick` (current)
+
+**Source:** `coastal-ms/DST-DuneServerTool:app/server/lib/GameplayBot.ps1` (SHA `c4865b53`)
+
+```sql
+-- Candidate query (lines ~360-375 of GameplayBot.ps1):
+SELECT o.id, o.template_id, o.item_price, COALESCE(o.item_id, 0) AS item_id, o.owner_id,
+       COALESCE(i.stack_size, s.initial_stack_size) AS actual_stack
+FROM dune.dune_exchange_orders o
+JOIN dune.dune_exchange_sell_orders s ON s.order_id = o.id
+LEFT JOIN dune.items i ON i.id = o.item_id
+WHERE o.is_npc_order = FALSE AND o.exchange_id = $exchangeId
+LIMIT $limit
+```
+
+Upstream also includes `COALESCE(o.quality_level, 0) AS quality_level` — **DST is missing the `quality_level` column**. This means DST's buy tick cannot grade-adjust prices, but since the patched build ignores price entirely (d12 gamble), it's not a functional issue for buying. However, the `quality_level` column should be added for completeness and future use.
+
+### Buy Transaction SQL (DST — `Invoke-DuneBotBuyTick`)
+
+```sql
+BEGIN;
+-- 1. Payment log entry for seller
+INSERT INTO dune.dune_exchange_orders
+  (exchange_id, access_point_id, owner_id, template_id, expiration_time,
+   durability_cur, durability_max, item_price, category_mask, category_depth, is_npc_order)
+VALUES ($exchangeId, $accessPointId, $sellerId, '$tmpl', $orderExpiry,
+        1.0, 1.0, $price, 0, 0, FALSE)
+RETURNING id AS logid \gset
+
+-- 2. Fulfilled-order record
+INSERT INTO dune.dune_exchange_fulfilled_orders
+  (order_id, source_order_id, completion_type, stack_size, original_order_id)
+VALUES (:logid, NULL, 4, $stack, $orderId);
+
+-- 3. Debit bot balance
+UPDATE dune.dune_exchange_users
+SET solari_balance = solari_balance - $totalCost
+WHERE owner_id = $ownerId;
+
+-- 4. Remove player's sell order
+DELETE FROM dune.dune_exchange_sell_orders WHERE order_id = $orderId;
+DELETE FROM dune.dune_exchange_orders WHERE id = $orderId;
+-- 5. Delete backing item (if item_id > 0)
+DELETE FROM dune.items WHERE id = $itemId;
+COMMIT;
+```
+
+**Source:** `coastal-ms/DST-DuneServerTool:app/server/lib/GameplayBot.ps1` (lines ~395-428)
+
+### Drift Analysis: DST vs. Upstream
+
+| Feature | Upstream | DST Port | Gap |
+|---------|----------|----------|-----|
+| Actor class | `'Revy'` | `'Duke'` | Intentional divergence |
+| Exchange detection Tier 1 | access-point table | ❌ skipped | **Port should add this** |
+| Price gate | BuyThreshold (patched: d12) | d12 gamble | ✅ equivalent |
+| Die size | hardcoded 12 (patched) | configurable | ✅ DST is better |
+| Winning number | hardcoded 5 (patched) | configurable | ✅ DST is better |
+| quality_level in candidate query | ✅ present | ❌ missing | Minor gap |
+| Seller payment expiry | `epochSentinelCutoff` (999,999,999) | `COALESCE(MAX(expiration_time), 999999999)` | Different but both safe |
+| Balance debit | stored proc `modify_user_solari_balance` | direct UPDATE | Functionally equivalent |
+| Sell-side (listing) | ✅ implemented | ❌ NOT PORTED | **Main gap to fill** |
+
+---
+
+## Section 9 — Other Operator-Facing Knobs
+
+### From Upstream dune-admin Config
+
+All the following are exposed via `PUT /config` (partial JSON patch) and saved to the state file:
+
+| Knob | Default | Purpose |
+|------|---------|---------|
+| `enabled` | `true` | Master on/off for both buy and list tick |
+| `buy_interval` | `5m` | How often to run the buy tick |
+| `list_interval` | `30m` | How often to run the list tick |
+| `buy_threshold` | `1.05` | (Unused in patched build) Price gate multiplier |
+| `max_buys` | `50` | Max purchases per buy tick |
+| `listings_per_grade` | `5` | Max concurrent listings per (item, grade) combination |
+| `grade_multipliers` | `[1.0,1.0,1.25,1.5,1.75,2.0]` (upstream) | Per-grade price scaling (patched values differ) |
+| `rarity_multipliers` | See above | Per-rarity price nudge |
+| `vendor_multipliers` | See above | Fraction of NPC vendor price to list at |
+| `disabled_items` | `[]` | Template IDs the bot skips entirely (no buy, no list) |
+
+### Balance Seeding
+
+On startup and when balance < 1T Solari:
+```
+target = 9T (9,000,000,000,000)
+delta = target - current
+SELECT dune.dune_exchange_modify_user_solari_balance($ownerID, $delta)
+```
+
+DST implements this as `Set-DuneBotBalance` called at the start of each buy tick when `balance < target_balance / 2`.
+
+### Errors Log / Status
+
+The `GET /status` response exposes:
+```json
+{
+  "uptime":          "1h23m",
+  "last_buy_tick":   "2026-06-11T22:00:00Z",
+  "last_list_tick":  "2026-06-11T21:30:00Z",
+  "listing_count":   142,
+  "balance":         8942710000000,
+  "error_count":     0
+}
+```
+
+DST uses `Get-DuneNativeBotStatus` which returns similar fields from state file + live DB queries.
+
+### Dry-Run Mode
+
+DST's `Invoke-DuneBotBuyTick -DryRun` rolls dice and reports winners without writing to DB. Upstream does not have an explicit dry-run flag in the external API — the UI's "Dry run" button is DST-only.
+
+### `POST /cleanup` (upstream cleanup endpoint)
+
+Calls `CleanupListings` which pauses the tick loop, wipes all bot NPC orders + items, then resumes. Next list tick rebuilds from scratch. This is equivalent to DST's **"Clear listings"** button.
+
+---
+
+## Section 10 — Category Mask Encoding
+
+Category masks are 32-bit signed integers where each byte encodes a depth level:
+```
+bits 24-31: depth-1 tab index (0=Garments, 1=Weapons, 2=Vehicles, 3=Utility, 4=Augmentations, 5=Misc)
+bits 16-23: depth-2 subcategory index (position in UI list, 0-indexed)
+bits  8-15: depth-3 sub-subcategory index (0-indexed)
+bits  0-7:  always 0 (root "items")
+```
+
+The bot resolves masks via a three-tier precedence:
+1. **Live player-order cache** (most authoritative — reuses exact mask from real player orders for the same template)
+2. **UniqueSchematicsMask** for schematics in a UNIQUE SCHEMATICS subcategory
+3. **CategoryMask** from the item's category path
+
+**Source:** `Icehunter/dune-admin:internal/marketbot/pricing.go:CategoryMask` and `UniqueSchematicsMask` (SHA `de6592d4`)
+
+For the PowerShell port: implement the player-order cache read first (Tier 1 covers the vast majority of items); implement the static code tables only for items not yet seen in any player order. The full code tables from `pricing.go` (knownCodes, depth3Parent, weaponPathRemap, uniqueSchematicsD2, uniqueSchematicsD3) run to ~150 lines and should be reproduced verbatim as a lookup hashtable.
+
+---
+
+## Port Checklist
+
+The following checklist is for the PowerShell implementer. Each item corresponds to a discrete unit of work.
+
+### Phase 1 — Identity & Session (prerequisite)
+- [ ] **1.1** Add `'Duke'` → `'Revy'` decision point to `Get-DuneBotIdentity`. The upstream uses `'Revy'`; DST chose `'Duke'`. If the intent is to match upstream exactly, change the actor class to `'Revy'`. If keeping `'Duke'`, document the divergence clearly.
+- [ ] **1.2** Add Tier-1 exchange detection (access-point table query) to `Get-DuneBotIdentity` before the player-order fallback. This prevents listings going to the phantom "Global" exchange on servers with no player trades yet.
+- [ ] **1.3** Add `quality_level` column to the candidate SELECT in `Invoke-DuneBotBuyTick`.
+
+### Phase 2 — List-Tick Scaffolding
+- [ ] **2.1** Add `list_tick_interval` (default 1800 seconds = 30 min), `listings_per_grade` (default 5) to `Get-DuneBotConfigDefaults`.
+- [ ] **2.2** Add `last_list_tick` to the state file (`gameplay-bot-state.json`).
+- [ ] **2.3** Add `nextList` tracking to `Start-DuneGameplayBotScheduler` — wake and call `Invoke-DuneBotListTick` when due, same pattern as the buy tick.
+- [ ] **2.4** Create top-level function `Invoke-DuneBotListTick` (parallel of `Invoke-DuneBotBuyTick`).
+
+### Phase 3 — Catalog & Category Masks
+- [ ] **3.1** Port the item-data.json catalog structure to PowerShell. The `CatalogItem` struct fields that matter for listing: `TemplateID`, `StackMax`, `Tier`, `Rarity`, `BasePrice` (vendor_price), `Category`, `IsSchematic`, `IsGradeable`, `MinQualityLevel`, `MinPrice`, `MaxPrice`.
+- [ ] **3.2** Implement `Get-DuneBotCatalog` which reads item-data.json (or a subset for the items to be listed) and computes `ListPrice` via the patched pricing formula.
+- [ ] **3.3** Implement `Get-CategoryMask` using the static code tables from `pricing.go`. At minimum implement Tier-1 (query player-order masks) and Tier-3 (static code table for the most common categories). Return `ok=$false` for unknown categories and skip those items rather than inserting a zero mask.
+- [ ] **3.4** Implement `Get-ApplicableGrades` returning `@(0)` for stackables / non-gradeable, and `$MinQualityLevel..5` for gradeable items.
+
+### Phase 4 — Pricing (Sane-Price Patch)
+- [ ] **4.1** Implement `Get-DuneSaneBasePrice` using the patched `basePrice` formula:
+  - Stackable: `stackUnitPrice(tier) × rarityMult`
+  - Non-stackable augment: `tierBasePrice(tier) × 0.6 × rarityMult`
+  - Non-stackable schematic: `tierBasePrice(tier) × 1.0 × rarityMult`
+  - Non-stackable gear: `tierBasePrice(tier) × 0.8 × rarityMult`
+  - Vendor-floor: `if vendor_price ≥ 10: take max(tierPrice, vendor_price × 0.95)`
+  - Apply global cap: `[Math]::Min($price, 100000)`
+- [ ] **4.2** Implement `Get-DuneSaneGradePrice` = `roundPrice(basePrice × gradeMultipliers[$grade])` capped at 100,000.
+- [ ] **4.3** Add `grade_multipliers`, `rarity_multipliers`, `vendor_multipliers` to `Get-DuneBotConfigDefaults` using the patched defaults: `[1.0, 1.25, 1.55, 2.0, 2.6, 3.3]` / `{common:1.0, rare:1.03, unique:1.05, memento:1.08}` / `{all: 0.95}`.
+- [ ] **4.4** Implement `roundPrice` (rounds to magnitude-appropriate step: ≥1M→100k, ≥100k→10k, ≥10k→1k, ≥1k→100, else→10).
+
+### Phase 5 — Current Listing Load
+- [ ] **5.1** Implement `Get-DuneBotCurrentListings` query:
+  ```sql
+  SELECT o.id, o.template_id, o.item_id, o.item_price, i.stack_size, o.quality_level
+  FROM dune.dune_exchange_orders o
+  JOIN dune.items i ON i.id = o.item_id
+  WHERE o.owner_id = $ownerID AND o.is_npc_order = TRUE
+    AND (o.expiration_time IS NULL OR o.expiration_time > $gameNow)
+  ```
+- [ ] **5.2** Group results into a hashtable keyed by `"$templateId|$grade"`.
+
+### Phase 6 — List-Tick Main Loop
+- [ ] **6.1** Implement expiry/purge of own stale listings:
+  ```sql
+  DELETE FROM dune.dune_exchange_orders
+  WHERE owner_id = $ownerID AND is_npc_order = TRUE
+    AND expiration_time IS NOT NULL AND expiration_time < $gameNow
+  ```
+- [ ] **6.2** For each catalog item × applicable grade:
+  - If disabled → collect existing order IDs for bulk delete
+  - Compute target price
+  - Existing listings with wrong price → stale (collect IDs)
+  - Existing listings with correct price but `stack_size < StackMax` → queue for UPDATE
+  - Count of correct-price valid listings < `listings_per_grade` → queue N new listings
+- [ ] **6.3** Execute bulk delete (stale orders + items):
+  ```sql
+  DELETE FROM dune.dune_exchange_orders WHERE id = ANY($staleIds) AND owner_id=$o AND is_npc_order=TRUE
+  DELETE FROM dune.items WHERE id = ANY($staleItemIds)
+  ```
+- [ ] **6.4** Execute bulk stack top-up:
+  ```sql
+  UPDATE dune.items SET stack_size = $stackMax WHERE id = $itemId
+  -- (one UPDATE per item, or use unnest batch if available)
+  ```
+- [ ] **6.5** Implement `New-DuneBotListing` which INSERTs one (item + order + sell_order) in a transaction:
+  - Items INSERT (inventory_id, stack_size, position_index, template_id, quality_level, stats='{}')
+  - Orders INSERT (all columns from Section 3a, is_npc_order=TRUE)
+  - Sell-orders INSERT (order_id, initial_stack_size, wear_normalized_price)
+  - On failure: rollback; log error; continue to next item
+- [ ] **6.6** Add `position_index` tracking: initialize from `SELECT COALESCE(MAX(position_index), -1)+1 FROM dune.items WHERE inventory_id=$botInvId`, then increment per insert.
+- [ ] **6.7** Implement game-epoch derivation for `expiration_time` using `Get-DuneBotOrderExpiry` (already in `GameplayBot.ps1` — reuse).
+
+### Phase 7 — Adaptive Price Drift (Optional but recommended)
+- [ ] **7.1** After `Get-DuneBotCurrentListings`, also query `dune_exchange_fulfilled_orders` join:
+  ```sql
+  SELECT o.template_id, COALESCE(SUM(f.stack_size),0) AS sold,
+         COALESCE(MAX(s.initial_stack_size),0) AS listed
+  FROM dune.dune_exchange_orders o
+  JOIN dune.dune_exchange_sell_orders s ON s.order_id = o.id
+  LEFT JOIN dune.dune_exchange_fulfilled_orders f ON f.order_id = o.id
+  WHERE o.owner_id=$ownerID AND o.is_npc_order=TRUE
+  GROUP BY o.template_id
+  ```
+- [ ] **7.2** Compute `soldFraction = sold / listed`. Apply drift: >50% sold → price × 1.10; 0% → price × 0.95; else no change.
+- [ ] **7.3** Floor = basePrice; ceiling = min(basePrice × 2, vendor_price × 2, 100,000).
+
+### Phase 8 — UI Extensions
+- [ ] **8.1** Add `listings_per_grade`, `list_tick_interval`, `grade_multipliers`, `rarity_multipliers`, `vendor_multipliers` to `MarketBotTab.tsx`.
+- [ ] **8.2** Add a "Run list tick" button (dry-run + live) alongside the existing "Run buy tick" button.
+- [ ] **8.3** Add "last_list_tick" to the status panel.
+- [ ] **8.4** Add backend API routes: `POST /api/gameplay/bot/tick/list`, route handlers in `Gameplay.ps1` or `GameplayBot.ps1`.
+
+### Phase 9 — Cleanup Update
+- [ ] **9.1** `Clear-DuneBotListings` is already correctly ported — no changes needed. ✅
+- [ ] **9.2** Confirm the UI "Clear listings" button confirms modal text is still accurate after listing is implemented. ✅
+
+### Phase 10 — Verification
+- [ ] **10.1** After first list tick, verify `category_mask != 0` for inserted orders (zero mask means category lookup failed and the item is invisible in-game).
+- [ ] **10.2** Verify bot listings appear in the in-game market UI under the correct category tabs.
+- [ ] **10.3** Verify `is_npc_order = TRUE` on all inserted rows (spot-check via `SELECT COUNT(*) FROM dune.dune_exchange_orders WHERE is_npc_order = TRUE AND owner_id = $botId`).
+- [ ] **10.4** Verify no listing price exceeds 100,000 Solari.
+- [ ] **10.5** Verify grade-5 listings are ~3.3× the grade-0 price (confirming patched grade multipliers).
+- [ ] **10.6** Verify vendor-multiplier items (those with vendor_price ≥ 10) list at ≤95% of vendor price.
+- [ ] **10.7** Run `Clear-DuneBotListings`, confirm only bot's rows gone, player listings intact.
+- [ ] **10.8** Verify the COASTAL-PRICING.md "verification checklist" values appear in the UI after a fresh config.
+
+---
+
+## Gaps and Uncertainties
+
+1. **Sane-pricing patch is the only representation of Coastal's customizations.** The patch was removed from the DST repo at commit `665364e1` (2026-06-11) when dune-admin v0.34.0 adopted the non-free `@heroui-pro/react` package and the external bot integration was dropped entirely. The patch content recovered at `cf903665` is the definitive final version of the patch as shipped in DST v10.2.6+.
+
+2. **`dune.dune_exchange_get_item_price_stats`** — The market-price fetching proc is used upstream for adaptive drift. Its exact signature and return columns could not be verified from source alone; the upstream calls it as `SELECT * FROM dune.dune_exchange_get_item_price_stats($1::text[])` returning columns `(template_id, min_price, avg_price)`. This is optional for Phase 1 of the port; the simpler `adjustPrice` drift (sold fraction only) can be implemented without it.
+
+3. **`dune.get_exchange_inventory_id`** and **`dune.dune_exchange_get_user_id`** — These stored procedures are called by the upstream bot but their body is in the game server's Postgres schema (not open source). They appear to be simple upsert-or-create procedures. If they don't exist on the target DB, the port will need to implement the equivalent logic manually.
+
+4. **Item-data.json** — The catalog file (`item-data.json`) is not present in the dune-admin GitHub repo (it's generated from game data). The PowerShell port needs this file to know tier, rarity, StackMax, IsSchematic, IsGradeable, MinQualityLevel, MinPrice, MaxPrice, and Category for each template ID. Verify the file location from dune-admin's runtime config (`item_data_path` in `config.yaml`, defaulting to `item-data.json` in the working directory).
+
+5. **`position_index` auto-increment** — The upstream tracks `nextPos` in memory and increments it per insert. The PowerShell port will need to re-read the max from DB on each list-tick startup (since the scheduler runs in a fresh runspace). Re-reading `SELECT COALESCE(MAX(position_index), -1)+1 FROM dune.items WHERE inventory_id=$botInvId` at the start of each `Invoke-DuneBotListTick` is the correct approach.
+
+6. **`quality_level` column presence** — The `dune.dune_exchange_orders` table schema shows `quality_level` as an `int8` column. On very early versions of the game server, this column may not exist. The port should test for its presence or use `COALESCE(o.quality_level, 0)` in reads.
+
+7. **`dune.dune_exchange_sell_orders` FK** — Whether there is a `CASCADE DELETE` from orders → sell_orders varies by server version. The upstream always explicitly deletes sell_orders before orders (belt-and-suspenders); the port should do the same.

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -83,6 +83,11 @@ export interface MarketStatsResponse {
   liveError?: string
 }
 
+export interface BotStatusByClass {
+  class: string
+  count: number
+}
+
 export interface BotStatus {
   configured?: boolean
   running: boolean
@@ -90,7 +95,11 @@ export interface BotStatus {
   die_size?: number
   die_target?: number
   last_buy_tick?: string
-  listing_count?: number
+  last_list_tick?: string
+  listing_count?: number               // Duke's own NPC listings
+  listings_npc_total?: number          // ALL NPC listings across actor classes
+  listings_by_class?: BotStatusByClass[]
+  legacy_listings_count?: number       // NPC listings owned by non-Duke actors
   balance?: number
   provisioned?: boolean
   error_count?: number
@@ -99,7 +108,19 @@ export interface BotStatus {
   db_message?: string
 }
 
-export interface BotConfig {
+export interface BotPricingConfig {
+  price_cap: number
+  default_unit_price: number
+  tier_base_prices: Record<string, number>
+  stack_unit_prices: Record<string, number>
+  category_factors: Record<string, number>
+  grade_multipliers: number[]
+  rarity_multipliers: Record<string, number>
+  vendor_multipliers: Record<string, number>
+  price_overrides: Record<string, number>
+}
+
+export interface BotConfig extends Partial<BotPricingConfig> {
   enabled: boolean
   buy_tick_interval: number
   max_buys_per_tick: number
@@ -108,6 +129,11 @@ export interface BotConfig {
   target_balance: number
   maintain_balance: boolean
   disabled_items: string[]
+  // Listing side (sane-pricing port, v11.5.2+).
+  list_tick_interval: number
+  listings_per_grade: number
+  stackables_only: boolean
+  sane_defaults_revision?: number
   configured?: boolean
   source?: DataSource
 }
@@ -133,6 +159,52 @@ export interface BotTickResult {
   die: string
   winners: BotTickWinner[]
   message: string
+}
+
+export interface BotListTickPlan {
+  template_id: string
+  target_price: number
+  stack_max: number
+  existing: number
+  aligned: number
+  stale: number
+  to_insert: number
+  tier: number
+  rarity: string
+  stackable: boolean
+}
+
+export interface BotListTickResult {
+  ok: boolean
+  dryRun: boolean
+  enabled: boolean
+  considered: number
+  eligible: number
+  listed_before: number
+  listed_after: number
+  inserted: number
+  deleted: number
+  errors: number
+  planned: BotListTickPlan[]
+  message: string
+}
+
+export interface BotVendorCandidate {
+  template_id: string
+  tier: number
+  rarity: string
+  stackable: boolean
+  stack_max: number
+  vendor_price: number
+  target_price: number
+}
+
+export interface BotVendorSnapshotResponse {
+  ok: boolean
+  provisioned: boolean
+  total?: number
+  candidates: BotVendorCandidate[]
+  message?: string
 }
 
 export interface BotBalance {
@@ -254,6 +326,24 @@ export function clearBotListings() {
     '/api/gameplay/market-bot/clear-listings',
     { method: 'POST' },
   )
+}
+
+export function clearBotLegacyListings() {
+  return api<{ ok: boolean; cleared: number; message?: string }>(
+    '/api/gameplay/market-bot/clear-legacy-listings',
+    { method: 'POST' },
+  )
+}
+
+export function runBotListTick(dryRun: boolean) {
+  return api<BotListTickResult>(`/api/gameplay/market-bot/tick/list${dryRun ? '?dry=1' : ''}`, {
+    method: 'POST',
+    body: JSON.stringify({ dryRun }),
+  })
+}
+
+export function getBotVendorSnapshot() {
+  return api<BotVendorSnapshotResponse>('/api/gameplay/market-bot/vendor-snapshot')
 }
 
 // ---------------------------------------------------------------------------

--- a/webui/src/pages/gameplay/MarketBotTab.tsx
+++ b/webui/src/pages/gameplay/MarketBotTab.tsx
@@ -1,10 +1,14 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import {
-  getBotStatus, getBotConfig, saveBotConfig, runBotTick, botExec, setBotBalance, clearBotListings,
-  type BotStatus, type BotConfig, type BotTickResult,
+  getBotStatus, getBotConfig, saveBotConfig, runBotTick, runBotListTick, botExec,
+  setBotBalance, clearBotListings, clearBotLegacyListings, getBotVendorSnapshot,
+  type BotStatus, type BotConfig, type BotTickResult, type BotListTickResult,
+  type BotVendorCandidate,
 } from '../../api/gameplay'
 import { fmtSolari, fmtNum, SourceBadge } from './shared'
+
+type SubTab = 'buy' | 'list' | 'pricing'
 
 export function MarketBotTab() {
   const [status, setStatus] = useState<BotStatus | null>(null)
@@ -16,8 +20,14 @@ export function MarketBotTab() {
   const [saveMsg, setSaveMsg] = useState<string | null>(null)
   const [tick, setTick] = useState<BotTickResult | null>(null)
   const [ticking, setTicking] = useState(false)
+  const [listTick, setListTick] = useState<BotListTickResult | null>(null)
+  const [listTicking, setListTicking] = useState(false)
   const [balanceBusy, setBalanceBusy] = useState(false)
   const [clearing, setClearing] = useState(false)
+  const [clearingLegacy, setClearingLegacy] = useState(false)
+  const [snapshot, setSnapshot] = useState<BotVendorCandidate[] | null>(null)
+  const [snapshotLoading, setSnapshotLoading] = useState(false)
+  const [sub, setSub] = useState<SubTab>('buy')
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -36,7 +46,6 @@ export function MarketBotTab() {
 
   useEffect(() => { void load() }, [load])
 
-  // Poll status while the tab is open (config draft is left untouched).
   useEffect(() => {
     const id = window.setInterval(() => {
       getBotStatus().then(setStatus).catch(() => {})
@@ -48,20 +57,15 @@ export function MarketBotTab() {
 
   const save = async () => {
     if (!draft) return
-    setSaving(true)
-    setSaveMsg(null)
-    setError(null)
+    setSaving(true); setSaveMsg(null); setError(null)
     try {
       const saved = await saveBotConfig(draft)
-      setConfig(saved)
-      setDraft(structuredClone(saved))
+      setConfig(saved); setDraft(structuredClone(saved))
       setSaveMsg('Configuration saved.')
       getBotStatus().then(setStatus).catch(() => {})
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setSaving(false)
-    }
+    } finally { setSaving(false) }
   }
 
   const toggleEnabled = async (v: boolean) => {
@@ -71,61 +75,78 @@ export function MarketBotTab() {
       if (draft) setDraft({ ...draft, enabled: v })
       if (config) setConfig({ ...config, enabled: v })
       getBotStatus().then(setStatus).catch(() => {})
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    }
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
   }
 
   const doTick = async (dry: boolean) => {
-    setTicking(true)
-    setTick(null)
-    setError(null)
+    setTicking(true); setTick(null); setError(null)
     try {
       const r = await runBotTick(dry)
       setTick(r)
       if (!dry) getBotStatus().then(setStatus).catch(() => {})
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setTicking(false)
-    }
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
+    finally { setTicking(false) }
+  }
+
+  const doListTick = async (dry: boolean) => {
+    setListTicking(true); setListTick(null); setError(null)
+    try {
+      const r = await runBotListTick(dry)
+      setListTick(r)
+      if (!dry) getBotStatus().then(setStatus).catch(() => {})
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
+    finally { setListTicking(false) }
   }
 
   const maintainBalance = async () => {
     if (!draft) return
-    setBalanceBusy(true)
-    setError(null)
-    setSaveMsg(null)
+    setBalanceBusy(true); setError(null); setSaveMsg(null)
     try {
       const r = await setBotBalance(draft.target_balance)
       setSaveMsg(`Balance set to ${fmtSolari(r.after)} (Δ ${fmtSolari(r.delta)}).`)
       getBotStatus().then(setStatus).catch(() => {})
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setBalanceBusy(false)
-    }
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
+    finally { setBalanceBusy(false) }
   }
 
   const clearListings = async () => {
     if (!window.confirm("Delete ALL of Duke's market listings? Player listings are not affected. This cannot be undone.")) return
-    setClearing(true)
-    setError(null)
-    setSaveMsg(null)
+    setClearing(true); setError(null); setSaveMsg(null)
     try {
       const r = await clearBotListings()
       setSaveMsg(r.message ?? `Cleared ${fmtNum(r.cleared)} of Duke's listings.`)
       getBotStatus().then(setStatus).catch(() => {})
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setClearing(false)
-    }
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
+    finally { setClearing(false) }
+  }
+
+  const clearLegacy = async () => {
+    const n = status?.legacy_listings_count ?? 0
+    if (n <= 0) { setSaveMsg('No legacy (non-Duke) NPC listings to clear.'); return }
+    if (!window.confirm(`Permanently delete ${fmtNum(n)} legacy NPC market listings (any actor whose class is NOT Duke — e.g. leftover Revy orders from the old external bot)?\n\nPlayer listings and Duke's own listings are NOT affected. This cannot be undone.`)) return
+    setClearingLegacy(true); setError(null); setSaveMsg(null)
+    try {
+      const r = await clearBotLegacyListings()
+      setSaveMsg(r.message ?? `Cleared ${fmtNum(r.cleared)} legacy NPC listings.`)
+      getBotStatus().then(setStatus).catch(() => {})
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
+    finally { setClearingLegacy(false) }
+  }
+
+  const loadSnapshot = async () => {
+    setSnapshotLoading(true); setError(null)
+    try {
+      const r = await getBotVendorSnapshot()
+      setSnapshot(r.candidates ?? [])
+    } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
+    finally { setSnapshotLoading(false) }
   }
 
   if (loading && !status) {
     return <div className="text-text-dim py-8 text-center"><Icon name="Loader2" size={20} className="animate-spin inline" /> Loading bot…</div>
   }
+
+  const legacyCount = status?.legacy_listings_count ?? 0
 
   return (
     <div>
@@ -133,9 +154,12 @@ export function MarketBotTab() {
         <Icon name="Info" size={14} className="text-accent shrink-0 mt-0.5" />
         <span>
           <span className="font-semibold text-text">Duke</span> runs natively inside this server — no external bot process.
-          On each buy tick every player listing rolls a <span className="font-mono text-accent">d{draft?.die_size ?? 12}</span>;
-          only a roll of <span className="font-mono text-accent">{draft?.die_target ?? 5}</span> buys the item, regardless of price.
-          Writes go straight to the live game database, so keep the bot disabled until you've dry-run a tick.
+          On each <span className="text-text">buy tick</span> every player listing rolls a
+          {' '}<span className="font-mono text-accent">d{draft?.die_size ?? 12}</span>; only a roll of
+          {' '}<span className="font-mono text-accent">{draft?.die_target ?? 5}</span> buys the item.
+          On each <span className="text-text">list tick</span> Duke tops up its own NPC sell orders for items already on
+          the live vendor inventory, priced via the sane-pricing rules (100 k Solari hard cap).
+          Writes go straight to the live game DB — dry-run first.
         </span>
       </div>
 
@@ -151,11 +175,44 @@ export function MarketBotTab() {
           </div>
           <div className="text-[11px] text-text-dim">{status?.provisioned ? 'provisioned' : 'not provisioned'}</div>
         </div>
-        <StatCard label="NPC listings" value={fmtNum(status?.listing_count)} icon="Tags" />
+        <StatCard label="Duke listings" value={fmtNum(status?.listing_count)} icon="Tags"
+          sub={status?.listings_npc_total != null ? `${fmtNum(status.listings_npc_total)} NPC total` : undefined} />
         <StatCard label="Balance" value={status?.balance != null ? fmtSolari(status.balance) : '—'} icon="Coins" />
-        <StatCard label="Errors" value={fmtNum(status?.error_count ?? 0)} icon="TriangleAlert"
-          tone={status?.error_count ? 'text-danger' : 'text-text'} />
+        <StatCard label="Legacy listings" value={fmtNum(legacyCount)} icon="TriangleAlert"
+          tone={legacyCount > 0 ? 'text-warning' : 'text-text-dim'}
+          sub={legacyCount > 0 ? 'non-Duke NPC orders' : 'all NPC orders are Duke'} />
       </section>
+
+      {/* Last tick timestamps */}
+      {(status?.last_buy_tick || status?.last_list_tick) && (
+        <div className="card p-3 mb-4 text-xs text-text-muted grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <div><span className="text-text-dim">Last buy tick:</span> {status?.last_buy_tick ? new Date(status.last_buy_tick).toLocaleString() : '—'}</div>
+          <div><span className="text-text-dim">Last list tick:</span> {status?.last_list_tick ? new Date(status.last_list_tick).toLocaleString() : '—'}</div>
+        </div>
+      )}
+
+      {/* NPC class breakdown */}
+      {status?.listings_by_class && status.listings_by_class.length > 0 && (
+        <div className="card p-3 mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs uppercase tracking-wider text-text-dim">NPC listings by actor class</span>
+            {legacyCount > 0 && (
+              <button className="btn-secondary text-xs" disabled={clearingLegacy} onClick={() => { void clearLegacy() }}
+                title="Permanently delete NPC orders whose actor class is not Duke (e.g. legacy Revy orphans).">
+                <Icon name={clearingLegacy ? 'Loader2' : 'Trash2'} size={13} className={clearingLegacy ? 'animate-spin' : ''} />
+                {' '}Wipe legacy ({fmtNum(legacyCount)})
+              </button>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {status.listings_by_class.map(b => (
+              <span key={b.class} className={`text-xs px-2 py-1 rounded border ${b.class === 'Duke' ? 'border-accent/40 bg-accent/10 text-accent-bright' : 'border-warning/40 bg-warning/10 text-warning'}`}>
+                <span className="font-mono">{b.class}</span>: {fmtNum(b.count)}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
 
       {status?.error && (
         <div className="card p-3 mb-4 text-sm text-danger break-words">
@@ -163,70 +220,15 @@ export function MarketBotTab() {
         </div>
       )}
 
-      {/* Run a buy tick */}
-      <div className="card p-4 mb-4">
-        <div className="flex items-center justify-between mb-2">
-          <h4 className="text-xs uppercase tracking-wider text-text-dim flex items-center gap-2">
-            <Icon name="Dices" size={14} className="text-accent" /> Run a buy tick
-          </h4>
-          <div className="flex items-center gap-2">
-            <button className="btn-secondary" disabled={clearing} onClick={() => { void clearListings() }}
-              title="Delete all of Duke's own market listings (player listings are untouched)">
-              <Icon name={clearing ? 'Loader2' : 'Trash2'} size={15} className={clearing ? 'animate-spin' : ''} /> Clear listings
-            </button>
-            <button className="btn-secondary" disabled={ticking} onClick={() => { void doTick(true) }}>
-              <Icon name={ticking ? 'Loader2' : 'FlaskConical'} size={15} className={ticking ? 'animate-spin' : ''} /> Dry run
-            </button>
-            <button className="btn-primary" disabled={ticking} onClick={() => { void doTick(false) }}>
-              <Icon name={ticking ? 'Loader2' : 'Play'} size={15} className={ticking ? 'animate-spin' : ''} /> Run now
-            </button>
-          </div>
-        </div>
-        <p className="text-[11px] text-text-dim mb-2">
-          Dry run rolls the dice and reports what it <em>would</em> buy without touching the database. Run now executes the purchases.
-        </p>
-        {tick && (
-          <div className="text-sm">
-            <div className="flex flex-wrap gap-x-4 gap-y-1 text-text-muted">
-              <span><span className="text-text-dim">die:</span> <span className="font-mono">{tick.die}</span></span>
-              <span><span className="text-text-dim">candidates:</span> {fmtNum(tick.candidates)}</span>
-              <span><span className="text-text-dim">rolled:</span> {fmtNum(tick.rolled)}</span>
-              <span><span className="text-text-dim">won:</span> {fmtNum(tick.won)}</span>
-              <span className={tick.dryRun ? 'text-accent' : 'text-success'}>
-                <span className="text-text-dim">{tick.dryRun ? 'would buy:' : 'purchased:'}</span> {fmtNum(tick.purchased)}
-              </span>
-              {tick.errors > 0 && <span className="text-danger"><span className="text-text-dim">errors:</span> {fmtNum(tick.errors)}</span>}
-            </div>
-            {tick.dryRun && <div className="mt-1 text-[11px] text-accent">Dry run — nothing was written.</div>}
-            {tick.message && <div className="mt-1 text-[11px] text-danger break-words">{tick.message}</div>}
-            {tick.winners?.length > 0 && (
-              <div className="mt-2 max-h-40 overflow-auto rounded-lg border border-border">
-                <table className="w-full text-xs">
-                  <thead className="text-text-dim bg-surface-2 sticky top-0">
-                    <tr><th className="text-left px-2 py-1">Item</th><th className="text-right px-2 py-1">Price</th><th className="text-right px-2 py-1">Qty</th><th className="text-right px-2 py-1">Roll</th></tr>
-                  </thead>
-                  <tbody>
-                    {tick.winners.map((w, i) => (
-                      <tr key={`${w.order_id}-${i}`} className="border-t border-border">
-                        <td className="px-2 py-1 font-mono text-text">{w.template_id}</td>
-                        <td className="px-2 py-1 text-right">{fmtSolari(w.price)}</td>
-                        <td className="px-2 py-1 text-right">{fmtNum(w.stack)}</td>
-                        <td className="px-2 py-1 text-right font-mono text-accent">{w.roll}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-semibold uppercase tracking-wider text-text-muted flex items-center gap-2">
-          <Icon name="Sliders" size={14} className="text-accent" /> Buy tuning
-        </h3>
-        <div className="flex items-center gap-2">
+      {/* Subtab nav for the tick + config sections */}
+      <div className="flex gap-1 mb-3 border-b border-border">
+        {([['buy', 'Buy side', 'Dices'], ['list', 'List side', 'Tags'], ['pricing', 'Pricing rules', 'Sliders']] as [SubTab, string, string][]).map(([id, label, icon]) => (
+          <button key={id} onClick={() => setSub(id)}
+            className={`px-3 py-2 text-sm flex items-center gap-1.5 border-b-2 -mb-px ${sub === id ? 'border-accent text-text' : 'border-transparent text-text-muted hover:text-text'}`}>
+            <Icon name={icon} size={14} /> {label}
+          </button>
+        ))}
+        <div className="ml-auto flex items-center gap-2">
           <SourceBadge source={config?.source} />
           <button className="btn-secondary" onClick={() => { void load() }} disabled={loading}>
             <Icon name="RefreshCw" size={15} className={loading ? 'animate-spin' : ''} /> Refresh
@@ -234,82 +236,459 @@ export function MarketBotTab() {
         </div>
       </div>
 
+      {draft && sub === 'buy' && (
+        <BuySection draft={draft} setDraft={setDraft} status={status} tick={tick} ticking={ticking}
+          clearing={clearing} balanceBusy={balanceBusy}
+          onTick={doTick} onClear={clearListings} onMaintainBalance={maintainBalance}
+          onToggleEnabled={toggleEnabled} />
+      )}
+
+      {draft && sub === 'list' && (
+        <ListSection draft={draft} setDraft={setDraft} listTick={listTick} listTicking={listTicking}
+          snapshot={snapshot} snapshotLoading={snapshotLoading}
+          onListTick={doListTick} onLoadSnapshot={loadSnapshot} />
+      )}
+
+      {draft && sub === 'pricing' && (
+        <PricingSection draft={draft} setDraft={setDraft} />
+      )}
+
+      {/* Save bar (shared across all subtabs) */}
       {draft && (
-        <div className="space-y-4">
-          {/* Core toggles + intervals */}
-          <div className="card p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <Toggle label="Bot enabled" checked={draft.enabled} onChange={v => { void toggleEnabled(v) }} />
-            <NumField label="Buy tick (s)" value={draft.buy_tick_interval}
-              onChange={v => setDraft({ ...draft, buy_tick_interval: v })} />
-            <NumField label="Max buys / tick" value={draft.max_buys_per_tick}
-              onChange={v => setDraft({ ...draft, max_buys_per_tick: v })} />
-          </div>
-
-          {/* Dice roll buy */}
-          <div className="card p-4">
-            <h4 className="text-xs uppercase tracking-wider text-text-dim mb-1 flex items-center gap-2">
-              <Icon name="Dices" size={14} className="text-accent" /> Dice roll buy
-            </h4>
-            <p className="text-[11px] text-text-dim mb-3">
-              Each candidate listing rolls 1–<span className="font-mono">{draft.die_size}</span>; a roll equal to the winning number buys it.
-              A larger die buys less often; the winning number is clamped to the die size.
-            </p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              <NumField label="Die size" value={draft.die_size}
-                onChange={v => setDraft({ ...draft, die_size: v })} />
-              <NumField label="Winning number" value={draft.die_target}
-                onChange={v => setDraft({ ...draft, die_target: v })} />
-            </div>
-          </div>
-
-          {/* Solari balance maintenance */}
-          <div className="card p-4">
-            <h4 className="text-xs uppercase tracking-wider text-text-dim mb-1 flex items-center gap-2">
-              <Icon name="Coins" size={14} className="text-accent" /> Solari balance
-            </h4>
-            <p className="text-[11px] text-text-dim mb-3">
-              Current balance: <span className="font-mono text-text">{status?.balance != null ? fmtSolari(status.balance) : '—'}</span>.
-              When auto-maintain is on, Duke tops back up to the target at the start of a tick if it drops below half.
-            </p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 items-end">
-              <Toggle label="Auto-maintain balance" checked={draft.maintain_balance}
-                onChange={v => setDraft({ ...draft, maintain_balance: v })} />
-              <NumField label="Target balance" value={draft.target_balance}
-                onChange={v => setDraft({ ...draft, target_balance: v })} />
-              <button className="btn-secondary" disabled={balanceBusy} onClick={() => { void maintainBalance() }}>
-                <Icon name={balanceBusy ? 'Loader2' : 'Wallet'} size={15} className={balanceBusy ? 'animate-spin' : ''} /> Set balance to target
-              </button>
-            </div>
-          </div>
-
-          {/* Disabled items */}
-          <div className="card p-4">
-            <h4 className="text-xs uppercase tracking-wider text-text-dim mb-1">Disabled items</h4>
-            <p className="text-[11px] text-text-dim mb-2">Template IDs Duke will never buy. One per line.</p>
-            <textarea rows={4}
-              value={(draft.disabled_items ?? []).join('\n')}
-              onChange={e => setDraft({ ...draft, disabled_items: e.target.value.split('\n').map(s => s.trim()).filter(Boolean) })}
-              className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ibad" />
-          </div>
-
-          {/* Actions */}
-          <div className="flex items-center gap-3">
-            <button className="btn-primary" disabled={!dirty || saving} onClick={() => { void save() }}>
-              <Icon name={saving ? 'Loader2' : 'Save'} size={15} className={saving ? 'animate-spin' : ''} /> Save config
-            </button>
-            <button className="btn-secondary" disabled={!dirty || saving} onClick={() => setDraft(structuredClone(config))}>
-              Reset
-            </button>
-            {saveMsg && <span className="text-xs text-success">{saveMsg}</span>}
-            {error && <span className="text-xs text-danger break-words">{error}</span>}
-          </div>
+        <div className="flex items-center gap-3 mt-4 sticky bottom-0 bg-bg/80 backdrop-blur py-2">
+          <button className="btn-primary" disabled={!dirty || saving} onClick={() => { void save() }}>
+            <Icon name={saving ? 'Loader2' : 'Save'} size={15} className={saving ? 'animate-spin' : ''} /> Save config
+          </button>
+          <button className="btn-secondary" disabled={!dirty || saving} onClick={() => setDraft(structuredClone(config))}>
+            Reset
+          </button>
+          {saveMsg && <span className="text-xs text-success">{saveMsg}</span>}
+          {error && <span className="text-xs text-danger break-words">{error}</span>}
+          {dirty && <span className="text-xs text-warning ml-auto">Unsaved changes</span>}
         </div>
       )}
     </div>
   )
 }
 
-function StatCard({ label, value, icon, tone }: { label: string; value: string; icon: string; tone?: string }) {
+// ---------------------------------------------------------------------------
+// Buy section — existing dice-roll buy tuning + clear-listings.
+// ---------------------------------------------------------------------------
+function BuySection({ draft, setDraft, status, tick, ticking, clearing, balanceBusy,
+  onTick, onClear, onMaintainBalance, onToggleEnabled }: {
+    draft: BotConfig; setDraft: (c: BotConfig) => void; status: BotStatus | null;
+    tick: BotTickResult | null; ticking: boolean; clearing: boolean; balanceBusy: boolean;
+    onTick: (dry: boolean) => void; onClear: () => void; onMaintainBalance: () => void;
+    onToggleEnabled: (v: boolean) => void;
+  }) {
+  return (
+    <div className="space-y-4">
+      <div className="card p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h4 className="text-xs uppercase tracking-wider text-text-dim flex items-center gap-2">
+            <Icon name="Dices" size={14} className="text-accent" /> Run a buy tick
+          </h4>
+          <div className="flex items-center gap-2">
+            <button className="btn-secondary" disabled={clearing} onClick={onClear}
+              title="Delete all of Duke's own market listings.">
+              <Icon name={clearing ? 'Loader2' : 'Trash2'} size={15} className={clearing ? 'animate-spin' : ''} /> Clear Duke listings
+            </button>
+            <button className="btn-secondary" disabled={ticking} onClick={() => onTick(true)}>
+              <Icon name={ticking ? 'Loader2' : 'FlaskConical'} size={15} className={ticking ? 'animate-spin' : ''} /> Dry run
+            </button>
+            <button className="btn-primary" disabled={ticking} onClick={() => onTick(false)}>
+              <Icon name={ticking ? 'Loader2' : 'Play'} size={15} className={ticking ? 'animate-spin' : ''} /> Run now
+            </button>
+          </div>
+        </div>
+        <p className="text-[11px] text-text-dim mb-2">
+          Dry run rolls the dice and reports what it <em>would</em> buy without touching the database.
+        </p>
+        {tick && <BuyTickResultView tick={tick} />}
+      </div>
+
+      <div className="card p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <Toggle label="Bot enabled" checked={draft.enabled} onChange={v => onToggleEnabled(v)} />
+        <NumField label="Buy tick (s)" value={draft.buy_tick_interval}
+          onChange={v => setDraft({ ...draft, buy_tick_interval: v })} />
+        <NumField label="Max buys / tick" value={draft.max_buys_per_tick}
+          onChange={v => setDraft({ ...draft, max_buys_per_tick: v })} />
+      </div>
+
+      <div className="card p-4">
+        <h4 className="text-xs uppercase tracking-wider text-text-dim mb-1 flex items-center gap-2">
+          <Icon name="Dices" size={14} className="text-accent" /> Dice roll buy
+        </h4>
+        <p className="text-[11px] text-text-dim mb-3">
+          Each candidate rolls 1–<span className="font-mono">{draft.die_size}</span>; only the winning number buys.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <NumField label="Die size" value={draft.die_size}
+            onChange={v => setDraft({ ...draft, die_size: v })} />
+          <NumField label="Winning number" value={draft.die_target}
+            onChange={v => setDraft({ ...draft, die_target: v })} />
+        </div>
+      </div>
+
+      <div className="card p-4">
+        <h4 className="text-xs uppercase tracking-wider text-text-dim mb-1 flex items-center gap-2">
+          <Icon name="Coins" size={14} className="text-accent" /> Solari balance
+        </h4>
+        <p className="text-[11px] text-text-dim mb-3">
+          Current: <span className="font-mono text-text">{status?.balance != null ? fmtSolari(status.balance) : '—'}</span>.
+          With auto-maintain on, Duke tops back up to target at tick start when below half.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 items-end">
+          <Toggle label="Auto-maintain" checked={draft.maintain_balance}
+            onChange={v => setDraft({ ...draft, maintain_balance: v })} />
+          <NumField label="Target balance" value={draft.target_balance}
+            onChange={v => setDraft({ ...draft, target_balance: v })} />
+          <button className="btn-secondary" disabled={balanceBusy} onClick={onMaintainBalance}>
+            <Icon name={balanceBusy ? 'Loader2' : 'Wallet'} size={15} className={balanceBusy ? 'animate-spin' : ''} /> Set to target
+          </button>
+        </div>
+      </div>
+
+      <div className="card p-4">
+        <h4 className="text-xs uppercase tracking-wider text-text-dim mb-1">Disabled items</h4>
+        <p className="text-[11px] text-text-dim mb-2">Template IDs Duke will never buy <em>or</em> list. One per line.</p>
+        <textarea rows={4}
+          value={(draft.disabled_items ?? []).join('\n')}
+          onChange={e => setDraft({ ...draft, disabled_items: e.target.value.split('\n').map(s => s.trim()).filter(Boolean) })}
+          className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ibad" />
+      </div>
+    </div>
+  )
+}
+
+function BuyTickResultView({ tick }: { tick: BotTickResult }) {
+  return (
+    <div className="text-sm">
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-text-muted">
+        <span><span className="text-text-dim">die:</span> <span className="font-mono">{tick.die}</span></span>
+        <span><span className="text-text-dim">candidates:</span> {fmtNum(tick.candidates)}</span>
+        <span><span className="text-text-dim">rolled:</span> {fmtNum(tick.rolled)}</span>
+        <span><span className="text-text-dim">won:</span> {fmtNum(tick.won)}</span>
+        <span className={tick.dryRun ? 'text-accent' : 'text-success'}>
+          <span className="text-text-dim">{tick.dryRun ? 'would buy:' : 'purchased:'}</span> {fmtNum(tick.purchased)}
+        </span>
+        {tick.errors > 0 && <span className="text-danger"><span className="text-text-dim">errors:</span> {fmtNum(tick.errors)}</span>}
+      </div>
+      {tick.dryRun && <div className="mt-1 text-[11px] text-accent">Dry run — nothing was written.</div>}
+      {tick.message && <div className="mt-1 text-[11px] text-danger break-words">{tick.message}</div>}
+      {tick.winners?.length > 0 && (
+        <div className="mt-2 max-h-40 overflow-auto rounded-lg border border-border">
+          <table className="w-full text-xs">
+            <thead className="text-text-dim bg-surface-2 sticky top-0">
+              <tr><th className="text-left px-2 py-1">Item</th><th className="text-right px-2 py-1">Price</th><th className="text-right px-2 py-1">Qty</th><th className="text-right px-2 py-1">Roll</th></tr>
+            </thead>
+            <tbody>
+              {tick.winners.map((w, i) => (
+                <tr key={`${w.order_id}-${i}`} className="border-t border-border">
+                  <td className="px-2 py-1 font-mono text-text">{w.template_id}</td>
+                  <td className="px-2 py-1 text-right">{fmtSolari(w.price)}</td>
+                  <td className="px-2 py-1 text-right">{fmtNum(w.stack)}</td>
+                  <td className="px-2 py-1 text-right font-mono text-accent">{w.roll}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// List section — sell-side scheduler + listing tuning + vendor snapshot preview.
+// ---------------------------------------------------------------------------
+function ListSection({ draft, setDraft, listTick, listTicking, snapshot, snapshotLoading,
+  onListTick, onLoadSnapshot }: {
+    draft: BotConfig; setDraft: (c: BotConfig) => void;
+    listTick: BotListTickResult | null; listTicking: boolean;
+    snapshot: BotVendorCandidate[] | null; snapshotLoading: boolean;
+    onListTick: (dry: boolean) => void; onLoadSnapshot: () => void;
+  }) {
+  return (
+    <div className="space-y-4">
+      <div className="card p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h4 className="text-xs uppercase tracking-wider text-text-dim flex items-center gap-2">
+            <Icon name="Tags" size={14} className="text-accent" /> Run a list tick
+          </h4>
+          <div className="flex items-center gap-2">
+            <button className="btn-secondary" disabled={listTicking} onClick={() => onListTick(true)}>
+              <Icon name={listTicking ? 'Loader2' : 'FlaskConical'} size={15} className={listTicking ? 'animate-spin' : ''} /> Dry run
+            </button>
+            <button className="btn-primary" disabled={listTicking} onClick={() => onListTick(false)}>
+              <Icon name={listTicking ? 'Loader2' : 'Play'} size={15} className={listTicking ? 'animate-spin' : ''} /> Run now
+            </button>
+          </div>
+        </div>
+        <p className="text-[11px] text-text-dim mb-2">
+          Snapshots live NPC vendor inventory, applies sane-pricing rules, and tops up Duke's own listings to
+          <span className="font-mono"> {draft.listings_per_grade}</span> per (item, grade).
+          Dry run shows the planned actions without writing.
+        </p>
+        {listTick && <ListTickResultView tick={listTick} />}
+      </div>
+
+      <div className="card p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <NumField label="List tick (s)" value={draft.list_tick_interval}
+          onChange={v => setDraft({ ...draft, list_tick_interval: v })} />
+        <NumField label="Listings / grade" value={draft.listings_per_grade}
+          onChange={v => setDraft({ ...draft, listings_per_grade: v })} />
+        <Toggle label="Stackables only (v11.5.2)" checked={draft.stackables_only}
+          onChange={v => setDraft({ ...draft, stackables_only: v })} />
+      </div>
+
+      <div className="card p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h4 className="text-xs uppercase tracking-wider text-text-dim flex items-center gap-2">
+            <Icon name="Eye" size={14} className="text-accent" /> Vendor snapshot preview
+          </h4>
+          <button className="btn-secondary" disabled={snapshotLoading} onClick={onLoadSnapshot}>
+            <Icon name={snapshotLoading ? 'Loader2' : 'RefreshCw'} size={15} className={snapshotLoading ? 'animate-spin' : ''} /> Refresh snapshot
+          </button>
+        </div>
+        <p className="text-[11px] text-text-dim mb-2">
+          Items the bot would list (derived from the live NPC vendor inventory + current pricing rules).
+        </p>
+        {snapshot == null ? (
+          <div className="text-text-dim text-sm">No snapshot loaded. Click <em>Refresh snapshot</em>.</div>
+        ) : snapshot.length === 0 ? (
+          <div className="text-text-dim text-sm">No eligible items in the snapshot (try toggling <em>Stackables only</em> off, or seed NPC vendors first).</div>
+        ) : (
+          <div className="max-h-72 overflow-auto rounded-lg border border-border">
+            <table className="w-full text-xs">
+              <thead className="text-text-dim bg-surface-2 sticky top-0">
+                <tr>
+                  <th className="text-left px-2 py-1">Template</th>
+                  <th className="text-center px-2 py-1">Tier</th>
+                  <th className="text-left px-2 py-1">Rarity</th>
+                  <th className="text-right px-2 py-1">Stack</th>
+                  <th className="text-right px-2 py-1">Vendor price</th>
+                  <th className="text-right px-2 py-1">Target list</th>
+                </tr>
+              </thead>
+              <tbody>
+                {snapshot.slice(0, 500).map(c => (
+                  <tr key={c.template_id} className="border-t border-border">
+                    <td className="px-2 py-1 font-mono text-text truncate max-w-[280px]">{c.template_id}</td>
+                    <td className="px-2 py-1 text-center text-text-muted">{c.tier || '—'}</td>
+                    <td className="px-2 py-1 text-text-muted">{c.rarity}</td>
+                    <td className="px-2 py-1 text-right">{fmtNum(c.stack_max)}</td>
+                    <td className="px-2 py-1 text-right text-text-muted">{fmtSolari(c.vendor_price)}</td>
+                    <td className="px-2 py-1 text-right font-mono text-accent-bright">{fmtSolari(c.target_price)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {snapshot.length > 500 && (
+              <div className="px-2 py-1 text-[11px] text-text-dim border-t border-border">
+                Showing first 500 of {fmtNum(snapshot.length)} candidates.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ListTickResultView({ tick }: { tick: BotListTickResult }) {
+  return (
+    <div className="text-sm">
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-text-muted">
+        <span><span className="text-text-dim">considered:</span> {fmtNum(tick.considered)}</span>
+        <span><span className="text-text-dim">eligible:</span> {fmtNum(tick.eligible)}</span>
+        <span><span className="text-text-dim">listed before:</span> {fmtNum(tick.listed_before)}</span>
+        <span className={tick.dryRun ? 'text-accent' : 'text-success'}>
+          <span className="text-text-dim">listed after:</span> {fmtNum(tick.listed_after)}
+        </span>
+        <span><span className="text-text-dim">inserted:</span> {fmtNum(tick.inserted)}</span>
+        <span><span className="text-text-dim">deleted:</span> {fmtNum(tick.deleted)}</span>
+        {tick.errors > 0 && <span className="text-danger"><span className="text-text-dim">errors:</span> {fmtNum(tick.errors)}</span>}
+      </div>
+      {tick.dryRun && <div className="mt-1 text-[11px] text-accent">Dry run — nothing was written.</div>}
+      {tick.message && <div className="mt-1 text-[11px] text-danger break-words">{tick.message}</div>}
+      {tick.planned?.length > 0 && (
+        <div className="mt-2 max-h-48 overflow-auto rounded-lg border border-border">
+          <table className="w-full text-xs">
+            <thead className="text-text-dim bg-surface-2 sticky top-0">
+              <tr>
+                <th className="text-left px-2 py-1">Template</th>
+                <th className="text-right px-2 py-1">Target</th>
+                <th className="text-right px-2 py-1">Stack</th>
+                <th className="text-right px-2 py-1">Existing</th>
+                <th className="text-right px-2 py-1">Stale</th>
+                <th className="text-right px-2 py-1">To insert</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tick.planned.slice(0, 200).map((p, i) => (
+                <tr key={`${p.template_id}-${i}`} className="border-t border-border">
+                  <td className="px-2 py-1 font-mono text-text truncate max-w-[260px]">{p.template_id}</td>
+                  <td className="px-2 py-1 text-right font-mono text-accent-bright">{fmtSolari(p.target_price)}</td>
+                  <td className="px-2 py-1 text-right">{fmtNum(p.stack_max)}</td>
+                  <td className="px-2 py-1 text-right text-text-muted">{p.existing}{p.aligned !== p.existing && <span className="text-text-dim"> ({p.aligned} ok)</span>}</td>
+                  <td className="px-2 py-1 text-right text-warning">{p.stale}</td>
+                  <td className="px-2 py-1 text-right text-success">{p.to_insert}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {tick.planned.length > 200 && (
+            <div className="px-2 py-1 text-[11px] text-text-dim border-t border-border">
+              Showing first 200 of {fmtNum(tick.planned.length)} planned actions.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Pricing section — the sane-pricing knobs (100 k cap, tier base prices,
+// rarity / vendor / grade multipliers, per-template overrides).
+// ---------------------------------------------------------------------------
+function PricingSection({ draft, setDraft }: { draft: BotConfig; setDraft: (c: BotConfig) => void }) {
+  const tbp = draft.tier_base_prices ?? {}
+  const sup = draft.stack_unit_prices ?? {}
+  const cf  = draft.category_factors ?? {}
+  const rm  = draft.rarity_multipliers ?? {}
+  const vm  = draft.vendor_multipliers ?? {}
+  const gm  = draft.grade_multipliers ?? []
+  const overrides = draft.price_overrides ?? {}
+  const overrideRows = Object.entries(overrides)
+
+  const setMap = (key: 'tier_base_prices' | 'stack_unit_prices' | 'category_factors' | 'rarity_multipliers' | 'vendor_multipliers',
+                  next: Record<string, number>) => {
+    setDraft({ ...draft, [key]: next })
+  }
+
+  const tierKeys = ['0', '1', '2', '3', '4', '5', '6']
+
+  return (
+    <div className="space-y-4">
+      <div className="card p-3 text-xs text-text-muted border-l-2 border-warning flex items-start gap-2">
+        <Icon name="TriangleAlert" size={14} className="text-warning shrink-0 mt-0.5" />
+        <span>
+          Sane-pricing defaults (100 k Solari hard cap, tier base prices, category factors, rarity multipliers,
+          and 95 % vendor floor) are ported from the dune-admin patch. Touch with care — these directly drive
+          every listing the bot writes.
+        </span>
+      </div>
+
+      <div className="card p-4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <NumField label="Price cap (Solari)" value={draft.price_cap ?? 100000}
+          onChange={v => setDraft({ ...draft, price_cap: v })} />
+        <NumField label="Default unit price (fallback)" value={draft.default_unit_price ?? 50}
+          onChange={v => setDraft({ ...draft, default_unit_price: v })} />
+      </div>
+
+      <div className="card p-4">
+        <h4 className="text-xs uppercase tracking-wider text-text-dim mb-2">Tier base prices (non-stackable)</h4>
+        <div className="grid grid-cols-7 gap-2">
+          {tierKeys.map(t => (
+            <NumField key={`tbp-${t}`} label={`T${t}`} value={tbp[t] ?? 0}
+              onChange={v => setMap('tier_base_prices', { ...tbp, [t]: v })} />
+          ))}
+        </div>
+        <h4 className="text-xs uppercase tracking-wider text-text-dim mt-4 mb-2">Stack unit prices (stackable, per unit)</h4>
+        <div className="grid grid-cols-7 gap-2">
+          {tierKeys.map(t => (
+            <NumField key={`sup-${t}`} label={`T${t}`} value={sup[t] ?? 0}
+              onChange={v => setMap('stack_unit_prices', { ...sup, [t]: v })} />
+          ))}
+        </div>
+      </div>
+
+      <div className="card p-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <FloatField label="Augment factor" value={cf['augment'] ?? 0}
+          onChange={v => setMap('category_factors', { ...cf, augment: v })} />
+        <FloatField label="Schematic factor" value={cf['schematic'] ?? 0}
+          onChange={v => setMap('category_factors', { ...cf, schematic: v })} />
+        <FloatField label="Gear factor" value={cf['gear'] ?? 0}
+          onChange={v => setMap('category_factors', { ...cf, gear: v })} />
+      </div>
+
+      <div className="card p-4">
+        <h4 className="text-xs uppercase tracking-wider text-text-dim mb-2">Rarity multipliers</h4>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+          {['common', 'rare', 'unique', 'memento'].map(r => (
+            <FloatField key={r} label={r} value={rm[r] ?? 1.0}
+              onChange={v => setMap('rarity_multipliers', { ...rm, [r]: v })} />
+          ))}
+        </div>
+        <h4 className="text-xs uppercase tracking-wider text-text-dim mt-4 mb-2">Vendor multiplier</h4>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+          <FloatField label="all" value={vm['all'] ?? 0.95}
+            onChange={v => setMap('vendor_multipliers', { ...vm, all: v })} />
+        </div>
+        <h4 className="text-xs uppercase tracking-wider text-text-dim mt-4 mb-2">Grade multipliers (T0–T5 grade)</h4>
+        <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
+          {gm.map((g, i) => (
+            <FloatField key={`gm-${i}`} label={`G${i}`} value={g}
+              onChange={v => {
+                const next = [...gm]; next[i] = v
+                setDraft({ ...draft, grade_multipliers: next })
+              }} />
+          ))}
+        </div>
+      </div>
+
+      <div className="card p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h4 className="text-xs uppercase tracking-wider text-text-dim">Per-template price overrides</h4>
+          <button className="btn-secondary text-xs" onClick={() => {
+            const tmpl = window.prompt('Template ID to override:')?.trim()
+            if (!tmpl) return
+            const v = window.prompt(`Override price for ${tmpl} (Solari, integer):`)?.trim()
+            const n = v != null ? parseInt(v, 10) : NaN
+            if (!Number.isFinite(n) || n < 0) return
+            setDraft({ ...draft, price_overrides: { ...overrides, [tmpl]: n } })
+          }}>
+            <Icon name="Plus" size={13} /> Add override
+          </button>
+        </div>
+        <p className="text-[11px] text-text-dim mb-2">
+          Manual price (Solari, integer) for specific template IDs. Overrides win over the formula, then the 100 k cap applies.
+        </p>
+        {overrideRows.length === 0 ? (
+          <div className="text-text-dim text-sm">No overrides.</div>
+        ) : (
+          <div className="space-y-1">
+            {overrideRows.map(([tmpl, price]) => (
+              <div key={tmpl} className="flex items-center gap-2 text-sm">
+                <span className="font-mono text-text flex-1 truncate">{tmpl}</span>
+                <input type="number" value={price} min={0}
+                  onChange={e => {
+                    const next = { ...overrides, [tmpl]: parseInt(e.target.value, 10) || 0 }
+                    setDraft({ ...draft, price_overrides: next })
+                  }}
+                  className="w-32 px-2 py-1 rounded bg-surface-2 border border-border text-text font-mono text-sm" />
+                <button className="text-text-dim hover:text-danger" title="Remove override"
+                  onClick={() => {
+                    const next = { ...overrides }; delete next[tmpl]
+                    setDraft({ ...draft, price_overrides: next })
+                  }}>
+                  <Icon name="X" size={14} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Shared small UI helpers.
+// ---------------------------------------------------------------------------
+function StatCard({ label, value, icon, tone, sub }: { label: string; value: string; icon: string; tone?: string; sub?: string }) {
   return (
     <div className="card p-3">
       <div className="flex items-center justify-between">
@@ -317,6 +696,7 @@ function StatCard({ label, value, icon, tone }: { label: string; value: string; 
         <Icon name={icon} size={15} className="text-accent" />
       </div>
       <div className={`mt-1 text-xl font-semibold truncate ${tone ?? 'text-text'}`}>{value}</div>
+      {sub && <div className="text-[11px] text-text-dim truncate">{sub}</div>}
     </div>
   )
 }
@@ -329,6 +709,19 @@ function NumField({ label, value, onChange, step, disabled }: {
       <span className="block text-[11px] uppercase tracking-wider text-text-dim mb-1 capitalize">{label}</span>
       <input type="number" value={value} step={step ?? 1} disabled={disabled}
         onChange={e => onChange(parseFloat(e.target.value))}
+        className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ibad disabled:opacity-50" />
+    </label>
+  )
+}
+
+function FloatField({ label, value, onChange, disabled }: {
+  label: string; value: number; onChange: (v: number) => void; disabled?: boolean
+}) {
+  return (
+    <label className="block">
+      <span className="block text-[11px] uppercase tracking-wider text-text-dim mb-1 capitalize">{label}</span>
+      <input type="number" value={value} step={0.05} min={0} disabled={disabled}
+        onChange={e => onChange(parseFloat(e.target.value) || 0)}
         className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ibad disabled:opacity-50" />
     </label>
   )

--- a/webui/src/pages/gameplay/MarketTab.tsx
+++ b/webui/src/pages/gameplay/MarketTab.tsx
@@ -119,7 +119,7 @@ export function MarketTab() {
           sub={`${fmtNum(stats?.bot_listings)} bot · ${fmtNum(stats?.player_listings)} player`} />
         <StatCard label="Unique items" value={fmtNum(stats?.unique_items)} icon="Boxes" />
         <StatCard label="Total stock" value={fmtNum(stats?.total_stock)} icon="Package"
-          sub={`${fmtNum(stats?.bot_stock)} on Duke`} />
+          sub={`${fmtNum(stats?.bot_stock)} on bots`} />
         <StatCard label="Bot stock share" icon="Bot"
           value={stats && stats.total_stock > 0 ? `${Math.round((stats.bot_stock / stats.total_stock) * 100)}%` : '—'} />
       </section>


### PR DESCRIPTION
v11.5.2 — native Market Bot sell side + sane-pricing port + honest NPC labels.

### Bot (Duke)
- **Tier-1 access-point exchange detection** prepended to the identity cascade — Duke self-provisions on a virgin server with no player orders.
- **List tick:** snapshots live NPC vendor inventory, applies the sane-pricing formula (tier base × category × rarity × vendor × grade), and tops Duke's own listings up to a per-grade quota per (template, grade). Stale listings ±20 % from the new target are purged before re-listing.
- **Sane-pricing patch ported** from upstream dune-admin: hard 100 k Solari cap, tier base prices, stack unit prices, category factors, rarity multipliers, grade multipliers, 95 % vendor floor + 2× vendor ceiling, per-template overrides. One-shot \sane_defaults_revision\ migration writes the patched multipliers once, then preserves your edits.
- Buy + list ticks run on independent cadences from the same in-process scheduler.

### UI
- **Market Bot tab** rebuilt with three sub-tabs:
  - **Buy side** — existing dice-roll buy tuning + clear-listings (Duke's own)
  - **List side** — dry-run / live list-tick + listing tuning + **Vendor snapshot preview** table (shows target prices before flipping the bot on)
  - **Pricing rules** — editable Price cap, tier base prices, stack unit prices, category factors, rarity / vendor / grade multipliers, and a per-template override table
- **Honest NPC counters** — status strip shows Duke's listings *and* total NPC listings *and* a per-actor-class chip row. **Wipe legacy (N)** button visible only when there are non-Duke NPC orders (e.g. leftover Revy orphans).
- **Market tab** owner labels are now honest — uses the COALESCE(character_name, actor.class) the SQL already projects instead of a hardcoded \Duke\.

### New routes
\\\
POST /api/gameplay/market-bot/tick/list                  (?dry=1)
POST /api/gameplay/market-bot/clear-legacy-listings
GET  /api/gameplay/market-bot/vendor-snapshot
\\\

### Smoke
- All 3 changed PS files parse-clean
- All 18 bot functions resolve in a fresh runspace
- Webui builds, no new lint regressions
- Pricing formula validated on synthetic candidates (gear ×0.8 × unique ×1.05 on T5 vendor 8000 = 8400; vendor floor pulls Crysknife T6 vendor 80 k up to 76 k; override 100 M caps at 100 k)
- Magnitude-aware rounding (5732 → 5700, 573215 → 570000) ✓
- No-DB path returns structured failure, not exception
- Installer builds (47.9 MB \DuneServerSetup.exe\)
- All 5 version stamps now agree at 11.5.2