### PR TITLE
v11.5.2: Duke bot — warn + offer to wipe foreign-bot (Revy) listings on enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,30 @@ here cover everything those tags shipped.
   later restarts).
 
 ### Fixed
+- **Bot enable now offers to wipe foreign-bot listings before starting.**
+  When the operator flips Duke to *Enabled*, the toggle now first checks
+  for non-Duke NPC orders sitting in `dune.dune_exchange_orders` (Revy
+  from a still-deployed upstream Go `market-bot` pod, anything else).
+  If any exist, a confirm dialog lists the affected actor classes + row
+  counts and offers a one-click wipe before Duke starts ticking — so
+  players don't see two bots' listings side-by-side in-game.
+- **Persistent warning banner while a foreign bot's listings linger.**
+  A high-visibility warning bar sits at the top of the *Market Bot* tab
+  whenever Duke is enabled **and** the exchange still has legacy NPC
+  listings. It names the offending actor class(es) + count and embeds
+  the same *Wipe legacy* one-click action so the operator can clear at
+  any time without leaving the tab. Disappears the moment the legacy
+  count hits zero.
+- **`Get-DuneBotIdentity` only accepts a "clean" Duke actor and now
+  re-validates its cached identity on every call.** Previously a cached
+  Duke `actor_id` was trusted blindly; if the row's `owner_account_id`
+  got bound to a player account between server starts, the in-game
+  market would render Duke's listings under that player's character
+  name (the `COALESCE(ps.character_name, a.class, …)` falls through to
+  the player). The resolver now filters
+  `class = 'Duke' AND owner_account_id IS NULL`, re-checks the cache
+  with a cheap `SELECT id WHERE …` on every call, and the
+  create-if-missing path explicitly sets `owner_account_id = NULL`.
 - **Gameplay → Blueprints: offline players' blueprints now show their
   owner.** The list query previously joined `player_state` through the
   *live pawn* (`player_state.player_pawn_id = actors.id`), which only

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -249,13 +249,28 @@ function Get-DuneBotScalar {
 function Get-DuneBotIdentity {
     param([string]$Ip, [switch]$CreateIfMissing)
 
+    # Validate any cached identity against the current "clean Duke" filter
+    # (owner_account_id IS NULL). Stale caches from a previous run where the
+    # bot was bound to a player account would otherwise label every new
+    # listing with that player's character_name.
     if ($script:DuneBotIdentityCache -and $script:DuneBotIdentityCache.ownerId -gt 0) {
-        return $script:DuneBotIdentityCache
+        $cachedId = [int64]$script:DuneBotIdentityCache.ownerId
+        $vc = Get-DuneBotScalar -Ip $Ip -Sql "SELECT id FROM dune.actors WHERE id = $cachedId AND class = 'Duke' AND owner_account_id IS NULL"
+        if ($vc.ok -and $vc.value) {
+            return $script:DuneBotIdentityCache
+        }
+        # Cache is stale (actor deleted, reassigned to a player account, or
+        # class changed). Drop it and re-resolve from scratch.
+        $script:DuneBotIdentityCache = $null
     }
 
-    # Owner actor (class = 'Duke').
+    # Owner actor: only a "clean" Duke is acceptable — one whose actor row
+    # has owner_account_id IS NULL. A Duke bound to a player account causes
+    # both the in-game UI and the Market view to render the bot listings
+    # under that player's character_name (e.g. "Revy") because the market
+    # owner-label query falls through ps.character_name first.
     $ownerId = 0L
-    $r = Get-DuneBotScalar -Ip $Ip -Sql "SELECT id FROM dune.actors WHERE class = 'Duke' LIMIT 1"
+    $r = Get-DuneBotScalar -Ip $Ip -Sql "SELECT id FROM dune.actors WHERE class = 'Duke' AND owner_account_id IS NULL ORDER BY id LIMIT 1"
     if (-not $r.ok) { return @{ ok = $false; error = "actor lookup: $($r.error)" } }
     if ($r.value) { $ownerId = ConvertTo-DuneInt $r.value }
 
@@ -283,12 +298,13 @@ function Get-DuneBotIdentity {
             if ($ap0.ok -and $ap0.value) { $apId = ConvertTo-DuneInt $ap0.value }
             return @{ ok = $true; provisioned = $false; ownerId = 0L; exchangeId = $exId; accessPointId = $apId }
         }
-        # Idempotent create-or-fetch in one statement.
+        # Idempotent create-or-fetch in one statement. Only matches Dukes that
+        # are NOT bound to a player account, so we never reuse a borked one.
         $createSql = @"
-WITH existing AS (SELECT id FROM dune.actors WHERE class = 'Duke' LIMIT 1),
+WITH existing AS (SELECT id FROM dune.actors WHERE class = 'Duke' AND owner_account_id IS NULL ORDER BY id LIMIT 1),
 ins AS (
-  INSERT INTO dune.actors (class, serial, gas_attributes, properties, dimension_index, partition_id)
-  SELECT 'Duke', 0, '{}', '{}', 0, (SELECT partition_id FROM dune.world_partition ORDER BY partition_id LIMIT 1)
+  INSERT INTO dune.actors (class, serial, gas_attributes, properties, dimension_index, partition_id, owner_account_id)
+  SELECT 'Duke', 0, '{}', '{}', 0, (SELECT partition_id FROM dune.world_partition ORDER BY partition_id LIMIT 1), NULL
   WHERE NOT EXISTS (SELECT 1 FROM existing)
   RETURNING id
 )

--- a/webui/src/pages/gameplay/MarketBotTab.tsx
+++ b/webui/src/pages/gameplay/MarketBotTab.tsx
@@ -70,6 +70,35 @@ export function MarketBotTab() {
 
   const toggleEnabled = async (v: boolean) => {
     setError(null)
+    // When the operator enables Duke and the live DB still has NPC orders
+    // from a previous bot (Revy from the upstream Go bot, or anything else
+    // that isn't a clean Duke actor), offer to wipe them right now. Two
+    // bots fighting over the same exchange is the #1 source of mislabeled
+    // listings in-game, so we make this front-and-center on enable.
+    if (v) {
+      const refreshed = await getBotStatus().catch(() => null)
+      if (refreshed) setStatus(refreshed)
+      const legacy = refreshed?.legacy_listings_count ?? status?.legacy_listings_count ?? 0
+      if (legacy > 0) {
+        const breakdown = (refreshed?.listings_by_class ?? status?.listings_by_class ?? [])
+          .filter(b => b.class !== 'Duke')
+          .map(b => `  • ${b.class}: ${fmtNum(b.count)}`)
+          .join('\n')
+        const msg = `Heads up — the live exchange already has ${fmtNum(legacy)} NPC listings from a previous bot:\n\n${breakdown}\n\nThese will keep showing up in-game alongside Duke's listings unless they're removed. Wipe them now before starting Duke?\n\n(Player listings and Duke's own listings are NOT affected. This cannot be undone.)`
+        if (window.confirm(msg)) {
+          setClearingLegacy(true)
+          try {
+            const r = await clearBotLegacyListings()
+            setSaveMsg(r.message ?? `Cleared ${fmtNum(r.cleared)} legacy NPC listings.`)
+          } catch (e) {
+            setError(e instanceof Error ? e.message : String(e))
+            setClearingLegacy(false)
+            return
+          }
+          setClearingLegacy(false)
+        }
+      }
+    }
     try {
       await botExec(v ? 'start' : 'stop')
       if (draft) setDraft({ ...draft, enabled: v })
@@ -150,6 +179,35 @@ export function MarketBotTab() {
 
   return (
     <div>
+      {/* Persistent warning: bot is running but the exchange still has
+          listings from another bot. Stays visible until legacy_count is 0. */}
+      {status?.enabled && legacyCount > 0 && (
+        <div className="card p-3 mb-4 border-l-4 border-warning bg-warning/10 flex items-start gap-3">
+          <Icon name="TriangleAlert" size={18} className="text-warning shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-semibold text-warning">
+              Duke is running alongside {fmtNum(legacyCount)} legacy NPC listings from a previous bot.
+            </div>
+            <div className="text-xs text-text-muted mt-1">
+              Players will see both sets in-game until these are cleared. Wipe them so Duke owns the exchange cleanly.
+              {(() => {
+                const others = (status.listings_by_class ?? []).filter(b => b.class !== 'Duke')
+                if (others.length === 0) return null
+                return (
+                  <span className="ml-1">
+                    Affected actor{others.length > 1 ? 's' : ''}: {others.map(b => `${b.class} (${fmtNum(b.count)})`).join(', ')}.
+                  </span>
+                )
+              })()}
+            </div>
+          </div>
+          <button className="btn-primary text-xs shrink-0" disabled={clearingLegacy} onClick={() => { void clearLegacy() }}>
+            <Icon name={clearingLegacy ? 'Loader2' : 'Trash2'} size={13} className={clearingLegacy ? 'animate-spin' : ''} />
+            {' '}Wipe legacy ({fmtNum(legacyCount)})
+          </button>
+        </div>
+      )}
+
       <div className="card p-3 mb-4 text-xs text-text-muted border-l-2 border-accent flex items-start gap-2">
         <Icon name="Info" size={14} className="text-accent shrink-0 mt-0.5" />
         <span>


### PR DESCRIPTION
Found in smoke-testing v11.5.2 against an operator's live VM: the upstream Go `dune-market-bot` deployment was still running in k3s alongside the just-shipped native Duke, ticking 15 100 orders every 30 min as actor 1285 (`Revy`). Both bots writing to the same exchange = players see two NPC stocks side-by-side in-game.

Operational fix (operator's VM, already done): the `market-bot` deployment + service in namespace `dune-market-bot` have been `kubectl delete`-d. Revy stops ticking immediately; ~14 k orphan orders remain in `dune_exchange_orders` until cleared.

Code fix (this PR): make it impossible for the same situation to slip past silently on any other deployment.

### Changes

* `webui/src/pages/gameplay/MarketBotTab.tsx`
  * `toggleEnabled`: when flipping Duke to *Enabled*, re-fetches status and if `legacy_listings_count > 0` pops a confirm dialog listing the offending actor classes + counts. `OK` wipes via the existing `clearBotLegacyListings` route before the `start` call goes out.
  * New persistent warning bar at the top of the *Market Bot* tab whenever Duke is enabled AND legacy listings exist. Names affected actor class(es) + count, embeds a one-click *Wipe legacy* action, disappears when the count hits zero.

* `app/server/lib/GameplayBot.ps1` -- `Get-DuneBotIdentity` only accepts a Duke actor with `owner_account_id IS NULL`, re-validates its cached identity on every call, and the create path explicitly sets `owner_account_id = NULL`. Defence-in-depth in case any future deployment ends up with a player-bound Duke.

* `CHANGELOG.md` -- three new bullets in `[11.5.2] / Fixed`.

### Validation

* TypeScript build clean (`npm run build` -> 1.59 MB bundle, 0 errors).
* `GameplayBot.ps1` parse-check OK.
* Manual reasoning trace: with the old bot dead, `listings_by_class` returns `[Revy: 14305, Duke: 907]`; the warning bar will surface immediately on next status refresh and the one-click wipe drops to `[Duke: 907]`.