### PR TITLE
docs(v11.5.2): expand Market Bot copy in README and features page

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,15 @@ console, one theme, no second program to install. A tabbed surface
 (**Overview, Market, Market Bot, Players, Bases, Storage, Blueprints**) sits
 on top of the same SSH + psql bridge the rest of DST uses. **Market /
 Exchange** aggregates every active listing by item (lowest price, stock, bot
-vs. player split, recent sales) and **Market Bot** monitors the automated
-vendor and tunes its pricing — both read your **live game Postgres** directly.
+vs. player split, recent sales) and **Market Bot** runs the native bot
+("Duke") — both *buys* player listings and *lists* its own NPC stock via
+sane-pricing rules (tier × category × rarity × vendor × grade, 100,000
+Solari hard cap, per-template overrides), with three sub-tabs (Buy /
+List / Pricing rules), a vendor-snapshot preview, per-actor-class
+listing breakdown, and a safety net that detects leftover listings from
+any prior bot deployment (e.g. Revy from the old external Go market-bot)
+and offers a one-click wipe before Duke starts ticking. Both read your
+**live game Postgres** directly.
 When the battlegroup is offline the page falls back to a realistic **demo
 dataset** (clearly badged) so the tools are explorable out of the box and flip
 to live data automatically once the battlegroup is running.

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -28,7 +28,7 @@ const sections = [
     id: "gameplay",
     title: "Gameplay Admin",
     img: "gameplay-admin.png",
-    body: "The open-source Dune admin portal, rebuilt natively inside DST — one console, one theme, no second program to install. Market / Exchange and Market Bot tabs read your live game Postgres directly (and fall back to a realistic demo dataset when the battlegroup is offline), with Players, Bases, Storage, and Blueprints rounding out the toolset.",
+    body: "The open-source Dune admin portal, rebuilt natively inside DST — one console, one theme, no second program to install. Market / Exchange and Market Bot tabs read your live game Postgres directly (and fall back to a realistic demo dataset when the battlegroup is offline). Duke — the native bot — both buys player listings and lists its own NPC stock with sane-pricing rules (tier × category × rarity × vendor × grade, 100,000 Solari hard cap, per-template overrides), and a safety net detects leftover listings from any prior bot (e.g. Revy from the old Go market-bot) and offers a one-click wipe before Duke starts ticking. Players, Bases, Storage, and Blueprints round out the toolset.",
   },
   {
     id: "database",


### PR DESCRIPTION
Reflect the v11.5.2 sell-side Market Bot + Revy safety net in the operator-facing copy on README.md and site/src/pages/features.astro. Docs only, no code.