### PR TITLE
fix(v11.5.3): bot exchange-id FK + Game Config disclaimer blank screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.5.3] - 2026-06-11
+
+### Fixed
+- **Market Bot list tick failing with `inventories_exchange_id_fkey`
+  violation on fresh battlegroups or after a Duke wipe.** `Get-DuneBotIdentity`'s
+  exchange-id cascade had two read paths that didn't validate the resolved
+  id against `dune.dune_exchanges`, so a stale row in
+  `dune_exchange_orders` (or any other dependent table) pointing at a
+  wiped exchange would feed a phantom id to `get_exchange_inventory_id()`,
+  which then tripped the inventories FK on insert. Every cascade tier
+  now JOINs against `dune_exchanges`, and a final guard re-validates
+  the resolved id and falls through to
+  `dune.get_dune_exchange_id('Global')` (create-on-miss) when the row
+  truly doesn't exist yet. `New-DuneBotListing` also wraps the raw FK
+  error with a diagnostic hint so future occurrences don't surface as
+  a cryptic constraint name.
+- **Game Config page going fully blank after acknowledging the risk
+  disclaimer modal**, leaving the WebView2 app unresponsive and hard to
+  close. The disclaimer modal (and its `dst.gameConfig.disclaimerAck`
+  localStorage gate) has been removed outright. The page-level "How
+  it works" notice and the existing per-section warnings are sufficient
+  caution for a tool that already backs up every INI file before every
+  write — the blocking modal was protecting the user against a problem
+  that was already mitigated, at the cost of an unrecoverable UI lock
+  when it misbehaved.
+
 ## [11.5.2] - 2026-06-11
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.5.2'
+$script:DuneToolVersion = '11.5.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.5.2',
+    [string]$Version = '11.5.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.5.2</Version>
+    <Version>11.5.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.5.2"
+#define MyAppVersion "11.5.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -283,14 +283,29 @@ function Get-DuneBotIdentity {
             foreach ($q in @(
                 # Tier 1 (upstream parity): the access-point table is the
                 # authoritative exchange index even on virgin servers with no
-                # player orders yet.
+                # player orders yet. JOIN ensures the referenced exchange row
+                # actually exists — otherwise we'd hand a phantom id to
+                # get_exchange_inventory_id() and trip the inventories FK.
                 'SELECT ap.exchange_id FROM dune.dune_exchange_accesspoints ap JOIN dune.dune_exchanges e ON e.id = ap.exchange_id ORDER BY ap.id LIMIT 1',
-                'SELECT exchange_id FROM dune.dune_exchange_orders WHERE is_npc_order = FALSE LIMIT 1',
+                # Tier 2: player orders can carry a stale exchange_id even when
+                # the matching dune_exchanges row was wiped (Duke wipe / BG
+                # reset). JOIN-guard so we never return a phantom id.
+                'SELECT o.exchange_id FROM dune.dune_exchange_orders o JOIN dune.dune_exchanges e ON e.id = o.exchange_id WHERE o.is_npc_order = FALSE LIMIT 1',
                 'SELECT id FROM dune.dune_exchanges ORDER BY id LIMIT 1',
                 "SELECT dune.get_dune_exchange_id('Global')"
             )) {
                 $er = Get-DuneBotScalar -Ip $Ip -Sql $q
                 if ($er.ok -and $er.value) { $exId = ConvertTo-DuneInt $er.value; if ($exId -gt 0) { break } }
+            }
+            # Final guard: if every fallback yielded a phantom id, force-create
+            # the canonical Global exchange row so get_exchange_inventory_id
+            # has a valid FK target on its first call.
+            if ($exId -gt 0) {
+                $vex = Get-DuneBotScalar -Ip $Ip -Sql "SELECT id FROM dune.dune_exchanges WHERE id = $exId"
+                if (-not ($vex.ok -and $vex.value)) {
+                    $fc = Get-DuneBotScalar -Ip $Ip -Sql "SELECT dune.get_dune_exchange_id('Global')"
+                    if ($fc.ok -and $fc.value) { $exId = ConvertTo-DuneInt $fc.value }
+                }
             }
             if ($exId -le 0) { return @{ ok = $false; provisioned = $false; error = 'could not resolve exchange id.' } }
             $apId = 1L
@@ -320,15 +335,28 @@ SELECT id FROM ins UNION ALL SELECT id FROM existing LIMIT 1;
 
     # Exchange id (try the same fallbacks dune-admin uses, with the upstream
     # access-point cascade prepended so we always pick the canonical exchange).
+    # Every tier JOINs against dune_exchanges so a stale access-point or
+    # player-order row pointing at a wiped exchange id can never be returned —
+    # otherwise get_exchange_inventory_id() trips inventories_exchange_id_fkey.
     $exchangeId = 0L
     foreach ($q in @(
         'SELECT ap.exchange_id FROM dune.dune_exchange_accesspoints ap JOIN dune.dune_exchanges e ON e.id = ap.exchange_id ORDER BY ap.id LIMIT 1',
-        'SELECT exchange_id FROM dune.dune_exchange_orders WHERE is_npc_order = FALSE LIMIT 1',
+        'SELECT o.exchange_id FROM dune.dune_exchange_orders o JOIN dune.dune_exchanges e ON e.id = o.exchange_id WHERE o.is_npc_order = FALSE LIMIT 1',
         'SELECT id FROM dune.dune_exchanges ORDER BY id LIMIT 1',
         "SELECT dune.get_dune_exchange_id('Global')"
     )) {
         $er = Get-DuneBotScalar -Ip $Ip -Sql $q
         if ($er.ok -and $er.value) { $exchangeId = ConvertTo-DuneInt $er.value; if ($exchangeId -gt 0) { break } }
+    }
+    # Final guard: validate that the resolved exchange row exists. If not (e.g.
+    # cascade hit a phantom from a stale dependent table), force-create the
+    # canonical Global exchange so the FK target is present.
+    if ($exchangeId -gt 0) {
+        $vex = Get-DuneBotScalar -Ip $Ip -Sql "SELECT id FROM dune.dune_exchanges WHERE id = $exchangeId"
+        if (-not ($vex.ok -and $vex.value)) {
+            $fc = Get-DuneBotScalar -Ip $Ip -Sql "SELECT dune.get_dune_exchange_id('Global')"
+            if ($fc.ok -and $fc.value) { $exchangeId = ConvertTo-DuneInt $fc.value }
+        }
     }
     if ($exchangeId -le 0) { return @{ ok = $false; error = 'could not resolve exchange id.' } }
 
@@ -778,7 +806,13 @@ VALUES (:new_order_id, $stack, $ItemPrice);
 COMMIT;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 5 -TimeoutSec 45
-    if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    if (-not $r.ok) {
+        $err = $r.error
+        if ($err -match 'inventories_exchange_id_fkey') {
+            $err = "exchange id $($Ident.exchangeId) is missing from dune_exchanges (phantom from a stale access-point or wiped Duke). Disable then re-enable the bot to re-resolve identity, or list one item in-game first to seed the exchange row. raw: $err"
+        }
+        return @{ ok = $false; error = $err }
+    }
     return @{ ok = $true }
 }
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.5.2"
+$script:ToolVersion = "11.5.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useMemo, useCallback, type FormEvent, type ReactEl
 import { PageHeader } from '../components/PageHeader'
 import { Icon } from '../components/Icon'
 import { useStatus } from '../hooks/useStatus'
-import { useUpdateCheck } from '../hooks/useUpdateCheck'
 import { api } from '../api/client'
 import {
   getGameConfigSchema,
@@ -36,12 +35,6 @@ import { SpicefieldsCard } from './gameconfig/SpicefieldsCard'
 type LoadState = 'idle' | 'loading' | 'ready' | 'error' | 'unavailable'
 
 const SANDWORM_ENABLED_KEY = 'sandworm.dune.Enabled'
-
-// Stores the DST version the risk disclaimer was acknowledged for. When the
-// user ticks "remember", we save the current version here; the modal then only
-// re-appears after a DST update (version mismatch). Sentinel 'acknowledged' is
-// used when the version isn't known yet and never triggers a re-show.
-const DISCLAIMER_ACK_KEY = 'dst.gameConfig.disclaimerAck'
 
 // Bool literal pairs per type so toggles emit exactly what UE expects.
 function boolPair(type: GameConfigField['type']): { on: string; off: string } | null {
@@ -84,44 +77,6 @@ function sectionIsManaged(data: GameConfigResponse, field: GameConfigField): boo
 export function GameConfig() {
   const { status } = useStatus()
   const vmRunning = status?.vm?.running === true
-  const { data: upd } = useUpdateCheck()
-  const currentVersion = upd?.currentVersion ?? ''
-
-  // Risk disclaimer shown on first visit to this page (and again after updates).
-  const [disclaimerOpen, setDisclaimerOpen] = useState<boolean>(() => {
-    try {
-      return localStorage.getItem(DISCLAIMER_ACK_KEY) === null
-    } catch {
-      return true
-    }
-  })
-  const [disclaimerRemember, setDisclaimerRemember] = useState(true)
-
-  // Re-show the disclaimer when DST has been updated since it was acknowledged.
-  useEffect(() => {
-    if (!currentVersion) return
-    try {
-      const ack = localStorage.getItem(DISCLAIMER_ACK_KEY)
-      if (ack && ack !== 'acknowledged' && ack !== currentVersion) {
-        setDisclaimerOpen(true)
-      }
-    } catch {
-      /* ignore */
-    }
-  }, [currentVersion])
-
-  const acknowledgeDisclaimer = useCallback(() => {
-    try {
-      if (disclaimerRemember) {
-        localStorage.setItem(DISCLAIMER_ACK_KEY, currentVersion || 'acknowledged')
-      } else {
-        localStorage.removeItem(DISCLAIMER_ACK_KEY)
-      }
-    } catch {
-      /* ignore */
-    }
-    setDisclaimerOpen(false)
-  }, [disclaimerRemember, currentVersion])
 
   const [schema, setSchema] = useState<GameConfigCategory[] | null>(null)
   const [cfg, setCfg] = useState<GameConfigResponse | null>(null)
@@ -788,13 +743,6 @@ export function GameConfig() {
         open={sandwormModalOpen}
         onCancel={() => setSandwormModalOpen(false)}
         onConfirm={confirmSandwormEnable}
-      />
-
-      <ConfigDisclaimerModal
-        open={disclaimerOpen}
-        remember={disclaimerRemember}
-        onToggleRemember={setDisclaimerRemember}
-        onAcknowledge={acknowledgeDisclaimer}
       />
 
       {backupsOpen && (
@@ -1677,66 +1625,3 @@ function SandwormConfirmModal({
   )
 }
 
-// -----------------------------------------------------------------------------
-// Risk disclaimer modal — shown on first visit (and again after DST updates)
-// -----------------------------------------------------------------------------
-
-function ConfigDisclaimerModal({
-  open, remember, onToggleRemember, onAcknowledge,
-}: {
-  open: boolean
-  remember: boolean
-  onToggleRemember: (v: boolean) => void
-  onAcknowledge: () => void
-}) {
-  if (!open) return null
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
-      <div className="card p-0 max-w-md w-full border-danger/40">
-        <div className="px-5 py-4 border-b border-border flex items-center gap-2">
-          <Icon name="AlertTriangle" size={18} className="text-danger" />
-          <h3 className="font-semibold text-text">Proceed with caution</h3>
-        </div>
-
-        <div className="px-5 py-4 space-y-3 text-sm text-text leading-relaxed">
-          <p>
-            These settings directly edit your server's configuration. Incorrect
-            values can{' '}
-            <span className="font-semibold text-danger">
-              cause irreversible damage
-            </span>{' '}
-            to your world and save data.
-          </p>
-          <p className="text-text-muted">
-            Back up your settings before changing anything. You use this page at
-            your own risk.
-          </p>
-
-          <label className="flex items-center gap-2 pt-1 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={remember}
-              onChange={e => onToggleRemember(e.target.checked)}
-              className="h-4 w-4 rounded border-border bg-surface-2 accent-accent-bright"
-            />
-            <span className="text-xs text-text-muted">
-              Remember selection (show again only after a DST update)
-            </span>
-          </label>
-        </div>
-
-        <div className="px-5 py-3 border-t border-border flex items-center justify-end">
-          <button
-            type="button"
-            onClick={onAcknowledge}
-            className="btn-primary"
-          >
-            <Icon name="Check" size={14} />
-            I acknowledge
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}


### PR DESCRIPTION
Two post-v11.5.2 bugs surfaced during real-world testing on a fresh battlegroup.

### 1. Market Bot list tick: `inventories_exchange_id_fkey` violation
`Get-DuneBotIdentity`'s exchange-id cascade had two read paths that returned an exchange id without validating it actually exists in `dune.dune_exchanges`. On a wiped/fresh BG, a stale row in `dune_exchange_orders` pointing at a phantom exchange id fed `get_exchange_inventory_id`, which then tripped the inventories FK on insert.

**Fix**: every cascade tier now JOINs against `dune_exchanges`, and a final guard re-validates the resolved id and falls through to `dune.get_dune_exchange_id('Global')` (create-on-miss) if needed. `New-DuneBotListing` also wraps the raw FK error with diagnostic hint text so future occurrences don't surface as a cryptic constraint name.

### 2. Game Config page goes fully blank after acknowledging disclaimer
The risk disclaimer modal (added in v11.5.2) blanked the entire page on acknowledge for some users, leaving the WebView2 app unresponsive and hard to close.

**Fix**: removed the disclaimer modal and its `dst.gameConfig.disclaimerAck` localStorage gate outright. The page already backs up every INI before every write and surfaces per-section warnings — the blocking modal was protecting against a problem already mitigated, at the cost of an unrecoverable UI lock when it misbehaved.

### Changes
- `app/server/lib/GameplayBot.ps1`: hardened exchange-id cascade in both branches of `Get-DuneBotIdentity`; added FK-aware error wrapping in `New-DuneBotListing`
- `webui/src/pages/GameConfig.tsx`: removed `ConfigDisclaimerModal` component, state, localStorage gate, and `useUpdateCheck` dependency
- All 5 version stamps bumped to 11.5.3
- `CHANGELOG.md` updated