### PR TITLE
fix(v11.5.5): throttle mask refresh; harden scheduler against SSH hangs

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,0 +1,3 @@
+automation:
+  auto_issue_session: true
+  remote_control: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.5.5] - 2026-06-12
+
+### Fixed
+- **Market Bot mask harvest no longer hangs the UI.** v11.5.4 added a
+  per-list-tick `SELECT DISTINCT template_id, category_mask FROM
+  dune.dune_exchange_orders` call that ran on every 30-min list tick. When
+  the SSH control socket got wedged (a known intermittent failure mode of
+  long-lived ssh sessions), that 60s timeout cascaded into every UI refresh
+  that hit `/api/bot/listings/preview`, freezing every panel because the
+  HTTP listener fell back to single-threaded inline dispatch.
+- Mask refresh is now throttled by a new `mask_refresh_interval` config
+  (default **6 hours**). Funcom category masks are server-binary constants
+  per `template_id` so daily-scale harvest is plenty — the bundled 1378-
+  entry seed already covers ~83% of the catalog on every install.
+- The mask-refresh timestamp is stamped to disk **before** the SSH call, so
+  a wedged ssh that gets killed at the 15s timeout cannot cause back-to-
+  back retries on every subsequent tick.
+- `Invoke-DuneBotListTick` now writes `state.last_list_tick` at the start
+  of the non-dry-run path, so a SSH hang downstream cannot cause the
+  scheduler to re-fire the same tick 15 s later.
+- Tightened mask-harvest SSH timeout from 60s to **15s** and vendor
+  snapshot SSH timeout from 60s to **25s** so a wedged connection fails
+  fast instead of blocking the entire backend.
+- Hardened all scheduler/throttle timestamp comparisons against PowerShell
+  5.1's `ConvertFrom-Json` ISO 8601 → DateTime auto-conversion, which
+  double-shifted parsed times (string round-trip + `.ToUniversalTime()`)
+  and could push the "last run" instant hours into the future, defeating
+  every elapsed-time check. A new `ConvertTo-DuneBotUtcInstant` helper
+  normalises both string and DateTime inputs to a true UTC instant.
+
 ## [11.5.4] - 2026-06-12
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.5.4'
+$script:DuneToolVersion = '11.5.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.5.4',
+    [string]$Version = '11.5.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.5.4</Version>
+    <Version>11.5.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.5.4"
+#define MyAppVersion "11.5.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -129,15 +129,45 @@ function Save-DuneBotMaskCache {
 # prior Duke listings — all are valid). Mirrors refreshCategoryCache() from
 # dune-admin/internal/marketbot/exchange.go. Returns the merged cache so the
 # caller can pass it straight to Resolve-DuneBotListingCandidates.
+#
+# v11.5.5: throttled by $RefreshIntervalSec (default 6h). The bundled seed
+# already covers ~83% of the catalog and Funcom masks are server-binary
+# constants per template_id (they do not change between sessions), so daily-
+# scale harvesting is plenty. The on-disk timestamp is written BEFORE the SSH
+# call so a wedged SSH connection cannot cause back-to-back retries every
+# tick. SSH timeout is 15s — if the harvest fails the existing cache is
+# returned untouched and the list tick continues normally.
 function Update-DuneBotMaskCache {
-    param([string]$Ip, [int64]$ExchangeId)
+    param(
+        [string]$Ip,
+        [int64]$ExchangeId,
+        [int]$RefreshIntervalSec = 21600,
+        [int]$MinSeededCount      = 1000
+    )
     $cache = Read-DuneBotMaskCache
+    $state = Read-DuneBotState
+    $skip  = $false
+    if ($cache.Count -ge $MinSeededCount -and $state.last_mask_refresh) {
+        $last = ConvertTo-DuneBotUtcInstant $state.last_mask_refresh
+        if ($null -ne $last) {
+            $age = ([datetime]::UtcNow - $last).TotalSeconds
+            if ($age -ge 0 -and $age -lt $RefreshIntervalSec) { $skip = $true }
+        }
+    }
+    if ($skip) { return $cache }
+
+    # Stamp BEFORE the SSH call so a hang/timeout still satisfies the
+    # interval check on the next tick — prevents a wedged ssh socket from
+    # turning every list tick into a fresh 15s hang.
+    $state.last_mask_refresh = (Get-Date).ToUniversalTime().ToString('o')
+    Save-DuneBotState -State $state
+
     $sql = @"
 SELECT DISTINCT template_id, category_mask, category_depth
 FROM dune.dune_exchange_orders
 WHERE category_mask != 0 AND exchange_id = $ExchangeId
 "@
-    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 50000 -TimeoutSec 60
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 50000 -TimeoutSec 15
     if (-not $r.ok) { return $cache }
     $added = 0
     foreach ($row in (ConvertTo-DuneRowMaps -Result $r)) {
@@ -191,6 +221,10 @@ function Get-DuneBotConfigDefaults {
         # orders yet, as long as ANY market activity has happened (the cache
         # is harvested from every dune_exchange_orders row with mask != 0).
         seed_from_catalog    = $true
+        # How often the mask cache is refreshed from the DB. Funcom masks are
+        # server-binary constants per template_id, so once-per-day is plenty
+        # for new templates introduced by patches. Default 6h.
+        mask_refresh_interval = 21600
     }
 }
 
@@ -285,6 +319,7 @@ function Save-DuneBotConfig {
     $v = _Get $Incoming 'seed_from_catalog'; if ($null -ne $v) { $cfg['seed_from_catalog'] = [bool]$v }
     $v = _Get $Incoming 'buy_tick_interval'; if ($null -ne $v) { $cfg['buy_tick_interval'] = [Math]::Max(10,  [int]$v) }
     $v = _Get $Incoming 'list_tick_interval';if ($null -ne $v) { $cfg['list_tick_interval'] = [Math]::Max(60, [int]$v) }
+    $v = _Get $Incoming 'mask_refresh_interval'; if ($null -ne $v) { $cfg['mask_refresh_interval'] = [Math]::Min(604800, [Math]::Max(300, [int]$v)) }
     $v = _Get $Incoming 'listings_per_grade';if ($null -ne $v) { $cfg['listings_per_grade'] = [Math]::Min(50, [Math]::Max(1, [int]$v)) }
     $v = _Get $Incoming 'price_cap';         if ($null -ne $v) { $cfg['price_cap'] = [Math]::Max(1, [int]$v) }
     $v = _Get $Incoming 'default_unit_price';if ($null -ne $v) { $cfg['default_unit_price'] = [Math]::Max(1, [int]$v) }
@@ -316,12 +351,13 @@ function Save-DuneBotConfig {
 
 function Read-DuneBotState {
     $state = [ordered]@{
-        last_buy_tick   = $null
-        last_list_tick  = $null
-        last_result     = $null
-        last_list_result = $null
-        error_count     = 0
-        last_error      = ''
+        last_buy_tick     = $null
+        last_list_tick    = $null
+        last_mask_refresh = $null
+        last_result       = $null
+        last_list_result  = $null
+        error_count       = 0
+        last_error        = ''
     }
     $path = Get-DuneBotStatePath
     if (Test-Path -LiteralPath $path) {
@@ -333,6 +369,29 @@ function Read-DuneBotState {
         } catch {}
     }
     return $state
+}
+
+# PowerShell 5.1's ConvertFrom-Json eagerly parses ISO 8601 strings into
+# [datetime] instances with Kind=Local (with the wall-clock value already
+# shifted from UTC to local). Calling [datetime]::Parse() on such an instance
+# stringifies it via the local culture (losing TZ info), reparses as local,
+# then .ToUniversalTime() shifts AGAIN — turning a recent timestamp into one
+# many hours in the future and breaking every elapsed-time check. This
+# helper normalises both string and DateTime inputs to a real UTC instant.
+function ConvertTo-DuneBotUtcInstant {
+    param($Value)
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [datetime]) {
+        if ($Value.Kind -eq [DateTimeKind]::Utc) { return $Value }
+        if ($Value.Kind -eq [DateTimeKind]::Local) { return $Value.ToUniversalTime() }
+        return [datetime]::SpecifyKind($Value, [DateTimeKind]::Utc)
+    }
+    try {
+        return [datetime]::Parse(
+            [string]$Value,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal)
+    } catch { return $null }
 }
 
 function Save-DuneBotState {
@@ -729,7 +788,7 @@ LEFT JOIN dune.items i ON i.id = o.item_id
 WHERE o.is_npc_order = TRUE AND o.exchange_id = $ExchangeId
 GROUP BY o.template_id
 "@
-    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 50000 -TimeoutSec 60
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 50000 -TimeoutSec 25
     if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
     $snap = @{}
     foreach ($row in (ConvertTo-DuneRowMaps -Result $r)) {
@@ -1007,15 +1066,26 @@ function Invoke-DuneBotListTick {
         return $summary
     }
 
+    # v11.5.5: stamp last_list_tick BEFORE the SSH-heavy work so a wedged
+    # SSH connection inside the tick can't cause the scheduler to re-fire
+    # the tick on the very next 15s poll. The final timestamp/result is
+    # rewritten on successful completion below.
+    if (-not $DryRun) {
+        $earlyState = Read-DuneBotState
+        $earlyState.last_list_tick = (Get-Date).ToUniversalTime().ToString('o')
+        Save-DuneBotState -State $earlyState
+    }
+
     $vs = Get-DuneBotVendorSnapshot -Ip $ctx.ip -ExchangeId $ident.exchangeId
     if (-not $vs.ok) { $summary.ok = $false; $summary.message = "vendor snapshot: $($vs.error)"; return $summary }
     $summary.considered = $vs.snapshot.Count
 
     # Refresh persistent mask cache from any non-zero-mask order on this
     # exchange (player, NPC, prior Duke). Seeded with the bundled snapshot
-    # on first run so a brand-new BG already has coverage. Without this,
-    # Resolve-DuneBotListingCandidates can't fall back to catalog templates.
-    $maskCache = Update-DuneBotMaskCache -Ip $ctx.ip -ExchangeId $ident.exchangeId
+    # on first run so a brand-new BG already has coverage. Throttled to
+    # mask_refresh_interval (default 6h) so a wedged SSH doesn't repeatedly
+    # hang every list tick.
+    $maskCache = Update-DuneBotMaskCache -Ip $ctx.ip -ExchangeId $ident.exchangeId -RefreshIntervalSec ([int]$cfg.mask_refresh_interval)
     $summary.masks_known = $maskCache.Count
 
     $cl = Get-DuneBotCurrentListings -Ip $ctx.ip -OwnerId $ident.ownerId -ExchangeId $ident.exchangeId
@@ -1245,20 +1315,20 @@ function Start-DuneGameplayBotScheduler {
                         # Buy tick.
                         $dueBuy = $true
                         if ($state.last_buy_tick) {
-                            try {
-                                $last = [datetime]::Parse($state.last_buy_tick).ToUniversalTime()
+                            $last = ConvertTo-DuneBotUtcInstant $state.last_buy_tick
+                            if ($null -ne $last) {
                                 $dueBuy = (([datetime]::UtcNow - $last).TotalSeconds -ge [int]$cfg.buy_tick_interval)
-                            } catch { $dueBuy = $true }
+                            }
                         }
                         if ($dueBuy) { [void](Invoke-DuneBotBuyTick) }
                         # List tick (independent cadence).
                         $state2 = Read-DuneBotState
                         $dueList = $true
                         if ($state2.last_list_tick) {
-                            try {
-                                $lastL = [datetime]::Parse($state2.last_list_tick).ToUniversalTime()
+                            $lastL = ConvertTo-DuneBotUtcInstant $state2.last_list_tick
+                            if ($null -ne $lastL) {
                                 $dueList = (([datetime]::UtcNow - $lastL).TotalSeconds -ge [int]$cfg.list_tick_interval)
-                            } catch { $dueList = $true }
+                            }
                         }
                         if ($dueList) { [void](Invoke-DuneBotListTick) }
                     }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.5.4"
+$script:ToolVersion = "11.5.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Hotfix for the UI hang observed right after deploying v11.5.4 — refresh buttons spinning, blank Game Config dialog, stale `ssh.exe` PIDs accumulating, requiring DuneServer to be killed.

## Root cause

v11.5.4 introduced `Update-DuneBotMaskCache`, a `SELECT DISTINCT template_id, category_mask FROM dune.dune_exchange_orders` harvest that runs on every list tick (every 30 min by default). When the SSH control socket gets wedged (intermittent OpenSSH failure mode on long-lived sessions), the 60s timeout cascades into every UI refresh hitting `/api/bot/listings/preview`, because the HTTP listener falls back to single-threaded inline dispatch under load (`API handler pool init failed; falling back to inline dispatch`). One hung handler freezes every panel.

Compounded by a latent PS 5.1 `ConvertFrom-Json` bug: ISO-8601 strings deserialise into `[datetime]` with `Kind=Local` and the wall-clock value already shifted from UTC to local. Subsequent `[datetime]::Parse($it).ToUniversalTime()` double-shifts: string conversion via local culture loses TZ info, reparse-as-local picks up the wall-clock value, and `.ToUniversalTime()` shifts it AGAIN. Result: the "last run" instant gets pushed hours into the future and every elapsed-time check silently fails.

## Fix

- **`mask_refresh_interval`** config field, default **6h** (clamped 5min-7d). Funcom masks are server-binary constants per `template_id` — the bundled 1378-entry seed already covers ~83% of the catalog, so daily-scale harvesting is plenty.
- `Update-DuneBotMaskCache` stamps `state.last_mask_refresh` **before** the SSH call so a wedged ssh killed at the 15s timeout cannot trigger back-to-back retries on every tick.
- `Invoke-DuneBotListTick` stamps `state.last_list_tick` at the **start** of the non-dry-run path so a downstream SSH hang cannot cause the scheduler to re-fire 15s later.
- SSH timeouts: mask harvest **60s -> 15s**, vendor snapshot **60s -> 25s**.
- New `ConvertTo-DuneBotUtcInstant` helper handles both `string` and `[datetime]` inputs without the double-shift. Applied to mask refresh, buy tick, and list tick throttles.

5 version stamps bumped to 11.5.5. CHANGELOG entry.

## Validation

Local smoke test in isolated `%APPDATA%` (`C:\Users\<USER>\AppData\Local\Temp\dst-smoke-v1155`):

- `app/server/lib/GameplayBot.ps1` parses clean
- Defaults: `mask_refresh_interval=21600`, `list_tick_interval=1800`
- Seed cache: **1378 entries**
- Call 1 (empty state): SSH attempted -> True (no prior timestamp)
- Call 2 (within 6h):   SSH attempted -> **False** (skipped, as expected)
- Call 3 (interval=1s, after 2s sleep): SSH attempted -> **True** (re-fired correctly)
- `last_mask_refresh` round-trip age: **0.01s** (was hours-in-future before the helper fix)

Installer is rebuilt and ready to install over v11.5.4 to confirm UI no longer hangs after a wedged ssh.
