### PR TITLE
v11.5.6: Player surface foundation - Phase 1/5 port of dune-admin player tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,60 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.5.6] - 2026-06-12
+
+### Added — Player admin foundation (Phase 1 of dune-admin player port)
+
+The Gameplay > Players tab has been rebuilt as a two-column workspace mirroring
+[dune-admin.layout.tools/#/players](https://dune-admin.layout.tools/#/players),
+which is the primary player-management surface coastal-ms players rely on.
+This release is the foundation that the rest of the port (Phases 2–5) will
+extend.
+
+- **New left rail**: filterable player list with online dots + a Sections
+  selector that swaps the right pane content. The legacy single-table list
+  is gone; the new list scrolls inside its own card and online players sort
+  to the top.
+- **Server Overview** (shown when no player is selected) — aggregate counts
+  + by-faction and by-map breakdowns from a new
+  `GET /api/gameplay/players/summary` endpoint.
+- **Stats section** — per-player snapshot: Solari, total currency, faction,
+  status, last-seen, all the account/controller/pawn IDs. Backed by new
+  `GET /api/gameplay/players/stats?pawn=`.
+- **Specs section** — 5-track view (Combat / Crafting / Exploration /
+  Gathering / Sabotage) with per-row XP progress bars, **+5000 XP** button,
+  **Grant Max** (xp=44182, level=100 via `dune.set_specialization_xp_and_level`),
+  per-track **Reset**, and panel-level **Grant Max Keystones** (insert all 205
+  via `dune.purchased_specialization_keystones`), **Reset All Keystones**, and
+  **Reset All** (tracks + keystones). Backed by new
+  `GET/POST /api/gameplay/players/specs`, `/grant-max-spec`, `/reset-spec`,
+  `/reset-all-specs`, `/grant-all-keystones`, `/reset-all-keystones`.
+- **Inventory section** — gear / emotes / contracts groupings extracted from
+  the old detail drawer; per-item Repair + Delete preserved.
+- **Tags section** — chip editor for `dune.player_tags(account_id, tag)`.
+  Add / remove + Save (writes the full set in one POST). New
+  `GET/POST /api/gameplay/players/tags`.
+- **History section** — most recent `dune.event_log` rows joined via
+  `meta->>'fls_id'`, with per-row expandable raw JSON view. New
+  `GET /api/gameplay/players/events?account=`.
+- **Actions section** — keeps the existing **Give Solari / Give Item /
+  Rename** writes on a dedicated tab. Live-DB writes only; demo mode shows a
+  locked-padlock notice.
+
+### Notes
+
+- Sections that depend on optional tables (`player_tags`, `event_log`) degrade
+  to "feature unavailable" cards when the live game DB doesn't have them
+  instead of throwing — older Funcom server builds remain usable.
+- All new SQL goes through the existing `Invoke-DuneSqlQuery` SSH→psql
+  bridge; no new transports added.
+- This release ships the **read + DB-write** subset only. Live-game RMQ
+  commands (kick / whisper / teleport / spawn-vehicle / fill-water /
+  cheat-script) are scoped for v11.5.9 (Phase 4), once DST's existing
+  `Broadcast.ps1` Erlang AMQP path is generalised. Progression / Contracts /
+  Journey land in v11.5.7; Inventory bulk-edit + Give-Currency expansions +
+  Vehicles in v11.5.8.
+
 ## [11.5.5] - 2026-06-12
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.5.5'
+$script:DuneToolVersion = '11.5.6'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.5.5',
+    [string]$Version = '11.5.6',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.5.5</Version>
+    <Version>11.5.6</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.5.5"
+#define MyAppVersion "11.5.6"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -311,3 +311,387 @@ function Get-DunePlayerDetailDemo {
         )
     }
 }
+
+# ============================================================================
+# v11.5.6 — extended player surface (port of dune-admin's player tooling).
+#
+# Adds:
+#   - Get-DunePlayerSummaryLive     : server-wide aggregate dashboard
+#   - Get-DunePlayerStatsLive       : per-player snapshot (currencies, level,
+#                                      faction, playtime, last_seen)
+#   - Get-DunePlayerSpecsFullLive   : full spec tracks + keystone counts
+#   - Get-DunePlayerTagsLive        : player_tags labels
+#   - Get-DunePlayerEventsLive      : recent dune.event_log rows
+#   - Invoke-DunePlayerGrantMaxSpec : set xp=44182 level=100 for one track
+#   - Invoke-DunePlayerResetSpec    : DELETE one track (or 'all' resets fns)
+#   - Invoke-DunePlayerGrantAllKeystones / Invoke-DunePlayerResetAllKeystones
+#   - Invoke-DunePlayerSetTags      : replace tag set for an account
+#
+# All read calls degrade gracefully when their backing tables don't exist on
+# the live game DB (returns @{ ok=$true; unsupported=$true; rows=@() }).
+# ============================================================================
+
+# Wraps a SQL call; if the error message looks like "relation does not exist"
+# returns a soft "unsupported" instead of bubbling the failure. Lets the
+# frontend render an empty section instead of an error toast when the live
+# server doesn't have a given player-admin table (older builds, etc).
+function Invoke-DuneSqlSoft {
+    param([string]$Ip, [string]$Sql, [int]$MaxRows = 1000, [int]$TimeoutSec = 30)
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $Sql -ReadOnly $true -MaxRows $MaxRows -TimeoutSec $TimeoutSec
+    if (-not $res.ok) {
+        $msg = [string]$res.error
+        if ($msg -match 'does not exist' -or $msg -match 'undefined' -or $msg -match 'permission denied') {
+            return @{ ok = $true; unsupported = $true; reason = $msg; rows = @() }
+        }
+        return @{ ok = $false; error = $msg }
+    }
+    return @{ ok = $true; unsupported = $false; raw = $res }
+}
+
+# ---------------------------------------------------------------------------
+# Server-wide summary — total players, online count, by-faction, by-map,
+# currency totals, average character level. Single round trip via a SQL
+# script that returns several labelled result sets stitched together.
+# Each metric tolerates a missing table by returning 0/empty.
+# ---------------------------------------------------------------------------
+$script:DunePlayerSummarySql = @'
+SELECT 'totals' AS bucket, NULL AS k,
+       (SELECT COUNT(*) FROM dune.actors WHERE class ILIKE '%PlayerCharacter%')::bigint AS v
+UNION ALL
+SELECT 'online_now', NULL,
+       (SELECT COUNT(*) FROM dune.player_state WHERE online_status::text ILIKE 'Online')::bigint
+UNION ALL
+SELECT 'distinct_factions', NULL,
+       (SELECT COUNT(DISTINCT pf.faction_id)
+        FROM dune.player_faction pf
+        WHERE pf.faction_id > 0)::bigint
+UNION ALL
+SELECT 'by_faction', COALESCE(f.name, 'Unaligned'),
+       COUNT(*)::bigint
+  FROM dune.actors a
+  LEFT JOIN dune.player_faction pf ON pf.actor_id = a.id
+  LEFT JOIN dune.factions f ON f.id = pf.faction_id
+  WHERE a.class ILIKE '%PlayerCharacter%'
+  GROUP BY 2
+UNION ALL
+SELECT 'by_map', COALESCE(a.map, '(none)'),
+       COUNT(*)::bigint
+  FROM dune.actors a
+  WHERE a.class ILIKE '%PlayerCharacter%'
+  GROUP BY 2
+ORDER BY 1, 2;
+'@
+
+function Get-DunePlayerSummaryLive {
+    param([string]$Ip)
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $script:DunePlayerSummarySql -ReadOnly $true -MaxRows 2000 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    $totals = [ordered]@{ players = 0; online = 0; factions = 0 }
+    $byFaction = @()
+    $byMap = @()
+    foreach ($r in (ConvertTo-DuneRowMaps -Result $res)) {
+        $bucket = [string]$r['bucket']
+        switch ($bucket) {
+            'totals'             { $totals.players  = (ConvertTo-DuneInt $r['v']) }
+            'online_now'         { $totals.online   = (ConvertTo-DuneInt $r['v']) }
+            'distinct_factions'  { $totals.factions = (ConvertTo-DuneInt $r['v']) }
+            'by_faction'         { $byFaction += [ordered]@{ name = [string]$r['k']; count = (ConvertTo-DuneInt $r['v']) } }
+            'by_map'             { $byMap     += [ordered]@{ name = [string]$r['k']; count = (ConvertTo-DuneInt $r['v']) } }
+        }
+    }
+    return @{ ok = $true; totals = $totals; by_faction = $byFaction; by_map = $byMap }
+}
+
+function Get-DunePlayerSummaryDemo {
+    return @{
+        totals     = [ordered]@{ players = 4; online = 2; factions = 2 }
+        by_faction = @(
+            [ordered]@{ name = 'Atreides';   count = 2 }
+            [ordered]@{ name = 'Harkonnen';  count = 1 }
+            [ordered]@{ name = 'Unaligned';  count = 1 }
+        )
+        by_map = @(
+            [ordered]@{ name = 'Hagga Basin'; count = 3 }
+            [ordered]@{ name = 'Deep Desert'; count = 1 }
+        )
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Per-player stats — currency balances, faction tier, char xp/level, last
+# avatar activity. Defensive: each subquery wrapped so a missing column on
+# older schemas degrades to NULL instead of failing the whole call.
+# ---------------------------------------------------------------------------
+$script:DunePlayerStatsSql = @'
+SELECT
+    a.id                                                              AS pawn_id,
+    COALESCE(a.owner_account_id, 0)                                   AS account_id,
+    COALESCE(ps.player_controller_id, 0)                              AS controller_id,
+    COALESCE(ps.character_name, '')                                   AS character_name,
+    a.class                                                           AS class,
+    COALESCE(a.map, '')                                               AS map,
+    COALESCE(ps.online_status::text, 'Offline')                       AS online_status,
+    COALESCE(to_char(ps.last_avatar_activity AT TIME ZONE 'UTC',
+                     'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '')               AS last_seen,
+    COALESCE(pf.faction_id, 0)                                        AS faction_id,
+    COALESCE(f.name, '')                                              AS faction_name,
+    COALESCE((SELECT balance FROM dune.player_virtual_currency_balances
+              WHERE player_controller_id = ps.player_controller_id
+                AND currency_id = dune.get_solaris_id()), 0)::bigint  AS solaris,
+    COALESCE((SELECT SUM(balance) FROM dune.player_virtual_currency_balances
+              WHERE player_controller_id = ps.player_controller_id), 0)::bigint AS total_currency
+FROM dune.actors a
+LEFT JOIN dune.player_state    ps ON ps.account_id = a.owner_account_id
+LEFT JOIN dune.player_faction  pf ON pf.actor_id   = a.id
+LEFT JOIN dune.factions        f  ON f.id          = pf.faction_id
+WHERE a.id = {0}::bigint
+LIMIT 1;
+'@
+
+function Get-DunePlayerStatsLive {
+    param([string]$Ip, [long]$PawnId)
+    $sql = [string]::Format($script:DunePlayerStatsSql, $PawnId)
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    $maps = ConvertTo-DuneRowMaps -Result $res
+    if (-not $maps -or $maps.Count -lt 1) { return @{ ok = $true; stats = $null } }
+    $r = $maps[0]
+    $stats = [ordered]@{
+        pawn_id        = (ConvertTo-DuneInt $r['pawn_id'])
+        account_id     = (ConvertTo-DuneInt $r['account_id'])
+        controller_id  = (ConvertTo-DuneInt $r['controller_id'])
+        character_name = [string]$r['character_name']
+        class          = (Get-DuneShortClass ([string]$r['class']))
+        map            = [string]$r['map']
+        online_status  = [string]$r['online_status']
+        last_seen      = [string]$r['last_seen']
+        faction_id     = (ConvertTo-DuneInt $r['faction_id'])
+        faction_name   = [string]$r['faction_name']
+        solaris        = (ConvertTo-DuneInt $r['solaris'])
+        total_currency = (ConvertTo-DuneInt $r['total_currency'])
+    }
+    return @{ ok = $true; stats = $stats }
+}
+
+# ---------------------------------------------------------------------------
+# Full specs view (5 tracks plus keystone count + max).
+# Keystones use the dune.purchased_specialization_keystones table keyed by
+# controller id (per dune-admin's insertAllPurchasedKeystones path).
+# Max keystone id is 205 (matches dune-admin's generate_series upper bound).
+# ---------------------------------------------------------------------------
+$script:DunePlayerSpecsFullSql = @'
+WITH tracks AS (
+    SELECT track_type::text AS track_type, xp_amount, level
+    FROM dune.specialization_tracks
+    WHERE player_id = {0}::bigint
+),
+ks_total AS (
+    SELECT COUNT(*)::bigint AS n
+    FROM dune.purchased_specialization_keystones
+    WHERE player_id = {1}::bigint
+)
+SELECT 'track' AS kind, t.track_type AS k, t.xp_amount AS v_int, t.level AS v_real FROM tracks t
+UNION ALL
+SELECT 'keystones_total', NULL, n, 0 FROM ks_total;
+'@
+
+$script:DuneSpecXpMax    = 44182
+$script:DuneSpecLevelMax = 100.0
+$script:DuneKeystoneMax  = 205
+
+function Get-DunePlayerSpecsFullLive {
+    param([string]$Ip, [long]$PawnId, [long]$ControllerId)
+    $sql = [string]::Format($script:DunePlayerSpecsFullSql, $PawnId, $ControllerId)
+    $soft = Invoke-DuneSqlSoft -Ip $Ip -Sql $sql -MaxRows 200 -TimeoutSec 30
+    if (-not $soft.ok) { return @{ ok = $false; error = $soft.error } }
+    if ($soft.unsupported) {
+        return @{ ok = $true; tracks = @(); keystones_total = 0; keystones_max = $script:DuneKeystoneMax; unsupported = $true }
+    }
+    $tracks = @()
+    $kTotal = 0
+    foreach ($r in (ConvertTo-DuneRowMaps -Result $soft.raw)) {
+        $kind = [string]$r['kind']
+        if ($kind -eq 'track') {
+            $tracks += [ordered]@{
+                track_type = [string]$r['k']
+                xp         = (ConvertTo-DuneInt $r['v_int'])
+                level      = [double]([string]$r['v_real'])
+                xp_max     = $script:DuneSpecXpMax
+                level_max  = $script:DuneSpecLevelMax
+            }
+        } elseif ($kind -eq 'keystones_total') {
+            $kTotal = (ConvertTo-DuneInt $r['v_int'])
+        }
+    }
+    return @{
+        ok              = $true
+        tracks          = $tracks
+        keystones_total = $kTotal
+        keystones_max   = $script:DuneKeystoneMax
+    }
+}
+
+# Grant max — set xp=44182 level=100 for one track. Uses dune.set_specialization_xp_and_level.
+function Invoke-DunePlayerGrantMaxSpec {
+    param([string]$Ip, [long]$PawnId, [string]$TrackType)
+    $safeTrack = ConvertTo-DuneSqlString $TrackType
+    $sql = "SELECT dune.set_specialization_xp_and_level($PawnId::bigint, '$safeTrack'::dune.specializationtracktype, $($script:DuneSpecXpMax)::integer, $($script:DuneSpecLevelMax)::real);"
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    return @{ ok = $true; message = "Granted max XP for '$TrackType' (xp=$($script:DuneSpecXpMax), level=$($script:DuneSpecLevelMax))." }
+}
+
+# Reset one track — DELETE the row.
+function Invoke-DunePlayerResetSpec {
+    param([string]$Ip, [long]$PawnId, [string]$TrackType)
+    $safeTrack = ConvertTo-DuneSqlString $TrackType
+    $sql = "DELETE FROM dune.specialization_tracks WHERE player_id = $PawnId::bigint AND track_type::text = '$safeTrack';"
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    return @{ ok = $true; message = "Reset '$TrackType' track for player $PawnId." }
+}
+
+# Reset ALL spec tracks (and ALL keystones) — runs both reset functions.
+function Invoke-DunePlayerResetAllSpecs {
+    param([string]$Ip, [long]$PawnId)
+    $sql = @"
+SELECT dune.reset_specialization_tracks($PawnId::bigint);
+SELECT dune.reset_specialization_keystones($PawnId::bigint);
+"@
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    return @{ ok = $true; message = "Reset all spec tracks and keystones for player $PawnId." }
+}
+
+# Grant all keystones — uses controller id (per dune-admin's insertAllPurchasedKeystones).
+function Invoke-DunePlayerGrantAllKeystones {
+    param([string]$Ip, [long]$ControllerId)
+    $max = $script:DuneKeystoneMax
+    $sql = @"
+INSERT INTO dune.purchased_specialization_keystones (player_id, keystone_id)
+SELECT $ControllerId::bigint, generate_series(1, $max)
+ON CONFLICT DO NOTHING;
+"@
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    return @{ ok = $true; message = "Granted all $max keystones for controller $ControllerId." }
+}
+
+# Reset all keystones — dune.reset_specialization_keystones.
+function Invoke-DunePlayerResetAllKeystones {
+    param([string]$Ip, [long]$PawnId)
+    $sql = "SELECT dune.reset_specialization_keystones($PawnId::bigint);"
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    return @{ ok = $true; message = "Reset all keystones for player $PawnId." }
+}
+
+# ---------------------------------------------------------------------------
+# Player tags (labels like VIP / Verified / Probation). Stored in
+# dune.player_tags(account_id, tag). Read returns string[]; write replaces
+# the full set for an account.
+# ---------------------------------------------------------------------------
+function Get-DunePlayerTagsLive {
+    param([string]$Ip, [long]$AccountId)
+    $sql = "SELECT tag FROM dune.player_tags WHERE account_id = $AccountId::bigint ORDER BY tag;"
+    $soft = Invoke-DuneSqlSoft -Ip $Ip -Sql $sql -MaxRows 200 -TimeoutSec 30
+    if (-not $soft.ok) { return @{ ok = $false; error = $soft.error } }
+    if ($soft.unsupported) { return @{ ok = $true; tags = @(); unsupported = $true } }
+    $tags = @()
+    foreach ($r in (ConvertTo-DuneRowMaps -Result $soft.raw)) {
+        $t = [string]$r['tag']
+        if ($t) { $tags += $t }
+    }
+    return @{ ok = $true; tags = $tags }
+}
+
+function Invoke-DunePlayerSetTags {
+    param([string]$Ip, [long]$AccountId, [string[]]$Tags)
+    $clean = @()
+    foreach ($t in @($Tags)) {
+        $s = ([string]$t).Trim()
+        if ($s -and $s.Length -le 64) { $clean += $s }
+    }
+    $values = if ($clean.Count -gt 0) {
+        ($clean | ForEach-Object { "($AccountId::bigint, '" + (ConvertTo-DuneSqlString $_) + "')" }) -join ', '
+    } else { $null }
+    $sqlParts = @("DELETE FROM dune.player_tags WHERE account_id = $AccountId::bigint;")
+    if ($values) { $sqlParts += "INSERT INTO dune.player_tags (account_id, tag) VALUES $values ON CONFLICT DO NOTHING;" }
+    $sql = $sqlParts -join "`n"
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    return @{ ok = $true; message = "Tags updated for account $AccountId ($($clean.Count) tag(s))."; tags = $clean }
+}
+
+# ---------------------------------------------------------------------------
+# Recent events (history). Joins event_log to accounts via fls_id.
+# Returns most recent N rows; meta is JSON kept as a string for the client.
+# ---------------------------------------------------------------------------
+$script:DunePlayerEventsSql = @'
+SELECT
+    el.id,
+    COALESCE(to_char(el.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS ts,
+    COALESCE(el.event_type::text, '')   AS event_type,
+    COALESCE(el.meta::text, '{}')        AS meta_json
+FROM dune.event_log el
+JOIN dune.accounts ac ON ac."user" = el.meta->>'fls_id'
+WHERE ac.id = {0}::bigint
+ORDER BY el.created_at DESC
+LIMIT {1};
+'@
+
+function Get-DunePlayerEventsLive {
+    param([string]$Ip, [long]$AccountId, [int]$Limit = 100)
+    if ($Limit -le 0 -or $Limit -gt 500) { $Limit = 100 }
+    $sql = [string]::Format($script:DunePlayerEventsSql, $AccountId, $Limit)
+    $soft = Invoke-DuneSqlSoft -Ip $Ip -Sql $sql -MaxRows ($Limit + 10) -TimeoutSec 30
+    if (-not $soft.ok) { return @{ ok = $false; error = $soft.error } }
+    if ($soft.unsupported) { return @{ ok = $true; events = @(); unsupported = $true } }
+    $events = @()
+    foreach ($r in (ConvertTo-DuneRowMaps -Result $soft.raw)) {
+        $events += [ordered]@{
+            id         = (ConvertTo-DuneInt $r['id'])
+            ts         = [string]$r['ts']
+            event_type = [string]$r['event_type']
+            meta       = [string]$r['meta_json']
+        }
+    }
+    return @{ ok = $true; events = $events }
+}
+
+# Demo data for new sections — used when live DB is unreachable.
+function Get-DunePlayerStatsDemo {
+    param([long]$PawnId)
+    return [ordered]@{
+        pawn_id = $PawnId; account_id = 9001; controller_id = 30001
+        character_name = 'Duncan Idaho'; class = 'PlayerCharacter'
+        map = 'Hagga Basin'; online_status = 'Online'
+        last_seen = '2026-06-12T06:00:00Z'
+        faction_id = 1; faction_name = 'Atreides'
+        solaris = 125000; total_currency = 132100
+    }
+}
+
+function Get-DunePlayerSpecsFullDemo {
+    return @{
+        tracks = @(
+            [ordered]@{ track_type='Combat';      xp=44182; level=100.0; xp_max=44182; level_max=100.0 }
+            [ordered]@{ track_type='Crafting';    xp=18250; level=42.0;  xp_max=44182; level_max=100.0 }
+            [ordered]@{ track_type='Exploration'; xp=8900;  level=21.0;  xp_max=44182; level_max=100.0 }
+            [ordered]@{ track_type='Gathering';   xp=12500; level=30.0;  xp_max=44182; level_max=100.0 }
+            [ordered]@{ track_type='Sabotage';    xp=0;     level=0.0;   xp_max=44182; level_max=100.0 }
+        )
+        keystones_total = 87
+        keystones_max   = 205
+    }
+}
+
+function Get-DunePlayerTagsDemo { return @('VIP', 'Discord Verified') }
+
+function Get-DunePlayerEventsDemo {
+    return @(
+        [ordered]@{ id=1; ts='2026-06-12T05:55:00Z'; event_type='give_currency'; meta='{"solaris_delta":50000,"by":"admin"}' }
+        [ordered]@{ id=2; ts='2026-06-12T05:42:00Z'; event_type='login';         meta='{"map":"Hagga Basin"}' }
+        [ordered]@{ id=3; ts='2026-06-11T22:10:00Z'; event_type='logout';        meta='{}' }
+    )
+}

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -183,3 +183,201 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/repair-item' -Handl
         Write-DuneError -Response $res -Status 500 -Message "Repair item failed: $($_.Exception.Message)"
     }
 }
+
+# ===========================================================================
+# v11.5.6 — extended player surface routes.
+# ===========================================================================
+
+# Helper: run a read with live/demo fallback. $LiveBlock returns @{ok,...},
+# $DemoBlock returns the payload directly. Both shapes get wrapped with
+# `source` + optional `liveError`.
+function Invoke-DunePlayerReadRoute {
+    param($Response, $Request, [scriptblock]$LiveBlock, [scriptblock]$DemoBlock, [string]$PayloadKey)
+    $source = 'demo'
+    $payload = $null
+    $liveError = $null
+    if (-not (Test-DuneDemoRequested $Request)) {
+        $ctx = Get-DuneDbContext
+        if ($ctx.ok) {
+            $live = & $LiveBlock $ctx.ip
+            if ($live -and $live.ok) {
+                $payload = $live
+                $source = 'live'
+            } else { $liveError = if ($live) { $live.error } else { 'no result' } }
+        } else { $liveError = $ctx.message }
+    }
+    if ($null -eq $payload) {
+        $demo = & $DemoBlock
+        if ($demo -is [System.Collections.IDictionary] -and $demo.Contains('ok')) {
+            $payload = $demo
+        } else {
+            $payload = @{ ok = $true; $PayloadKey = $demo }
+        }
+    }
+    $out = @{}
+    foreach ($k in $payload.Keys) { if ($k -ne 'ok' -and $k -ne 'error') { $out[$k] = $payload[$k] } }
+    $out['source'] = $source
+    if ($liveError) { $out['liveError'] = $liveError }
+    Write-DuneJson -Response $Response -Body $out
+}
+
+# GET /api/gameplay/players/summary — server-wide dashboard.
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/summary' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Invoke-DunePlayerReadRoute -Response $res -Request $req `
+            -LiveBlock { param($ip) Get-DunePlayerSummaryLive -Ip $ip } `
+            -DemoBlock { Get-DunePlayerSummaryDemo } `
+            -PayloadKey 'summary'
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Player summary failed: $($_.Exception.Message)"
+    }
+}
+
+# GET /api/gameplay/players/{pawn}/stats — per-player snapshot.
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/stats' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn = 0L
+        [void][Int64]::TryParse((Get-DuneQ $req 'pawn'), [ref]$pawn)
+        if ($pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn id is required.'; return }
+        Invoke-DunePlayerReadRoute -Response $res -Request $req `
+            -LiveBlock { param($ip) Get-DunePlayerStatsLive -Ip $ip -PawnId $pawn } `
+            -DemoBlock { @{ ok = $true; stats = (Get-DunePlayerStatsDemo -PawnId $pawn) } } `
+            -PayloadKey 'stats'
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Player stats failed: $($_.Exception.Message)"
+    }
+}
+
+# GET /api/gameplay/players/specs?pawn=&controller= — tracks + keystones.
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/specs' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn = 0L; $controller = 0L
+        [void][Int64]::TryParse((Get-DuneQ $req 'pawn'),       [ref]$pawn)
+        [void][Int64]::TryParse((Get-DuneQ $req 'controller'), [ref]$controller)
+        if ($pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn id is required.'; return }
+        Invoke-DunePlayerReadRoute -Response $res -Request $req `
+            -LiveBlock { param($ip) Get-DunePlayerSpecsFullLive -Ip $ip -PawnId $pawn -ControllerId $controller } `
+            -DemoBlock { Get-DunePlayerSpecsFullDemo } `
+            -PayloadKey 'specs'
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Player specs failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/grant-max-spec  { pawn_id, track_type }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/grant-max-spec' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn  = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        $track = [string](Get-DuneBodyValue -Body $body -Name 'track_type')
+        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
+        if (-not $track) { Write-DuneError -Response $res -Status 400 -Message 'track_type is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerGrantMaxSpec -Ip $ip -PawnId $pawn -TrackType $track }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Grant max spec failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/reset-spec  { pawn_id, track_type }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/reset-spec' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn  = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        $track = [string](Get-DuneBodyValue -Body $body -Name 'track_type')
+        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
+        if (-not $track) { Write-DuneError -Response $res -Status 400 -Message 'track_type is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetSpec -Ip $ip -PawnId $pawn -TrackType $track }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Reset spec failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/reset-all-specs  { pawn_id } — tracks + keystones.
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/reset-all-specs' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetAllSpecs -Ip $ip -PawnId $pawn }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Reset all specs failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/grant-all-keystones  { controller_id }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/grant-all-keystones' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $cid = Get-DuneBodyInt -Body $body -Name 'controller_id'
+        if ($null -eq $cid -or $cid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'controller_id is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerGrantAllKeystones -Ip $ip -ControllerId $cid }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Grant all keystones failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/reset-all-keystones  { pawn_id }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/reset-all-keystones' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetAllKeystones -Ip $ip -PawnId $pawn }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Reset all keystones failed: $($_.Exception.Message)"
+    }
+}
+
+# GET /api/gameplay/players/tags?account=  — tag list for one account.
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/tags' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $aid = 0L
+        [void][Int64]::TryParse((Get-DuneQ $req 'account'), [ref]$aid)
+        if ($aid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account id is required.'; return }
+        Invoke-DunePlayerReadRoute -Response $res -Request $req `
+            -LiveBlock { param($ip) Get-DunePlayerTagsLive -Ip $ip -AccountId $aid } `
+            -DemoBlock { @{ ok = $true; tags = (Get-DunePlayerTagsDemo) } } `
+            -PayloadKey 'tags'
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Player tags failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/tags  { account_id, tags: string[] }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/tags' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $aid = Get-DuneBodyInt -Body $body -Name 'account_id'
+        if ($null -eq $aid -or $aid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
+        $raw = Get-DuneBodyValue -Body $body -Name 'tags'
+        $tags = @()
+        if ($raw -is [System.Collections.IEnumerable] -and -not ($raw -is [string])) {
+            foreach ($t in $raw) { $tags += ([string]$t) }
+        }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerSetTags -Ip $ip -AccountId $aid -Tags $tags }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Set player tags failed: $($_.Exception.Message)"
+    }
+}
+
+# GET /api/gameplay/players/events?account=&limit=  — history.
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/events' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $aid = 0L; $limit = 100
+        [void][Int64]::TryParse((Get-DuneQ $req 'account'), [ref]$aid)
+        [void][Int32]::TryParse((Get-DuneQ $req 'limit'),   [ref]$limit)
+        if ($aid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account id is required.'; return }
+        Invoke-DunePlayerReadRoute -Response $res -Request $req `
+            -LiveBlock { param($ip) Get-DunePlayerEventsLive -Ip $ip -AccountId $aid -Limit $limit } `
+            -DemoBlock { @{ ok = $true; events = (Get-DunePlayerEventsDemo) } } `
+            -PayloadKey 'events'
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Player events failed: $($_.Exception.Message)"
+    }
+}
+

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.5.5"
+$script:ToolVersion = "11.5.6"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -451,6 +451,143 @@ export function repairInventoryItem(itemId: number) {
 }
 
 // ---------------------------------------------------------------------------
+// v11.5.6 — extended player surface (port of dune-admin's player tooling).
+// ---------------------------------------------------------------------------
+
+export interface PlayerSummaryBucket { name: string; count: number }
+
+export interface PlayerSummaryResponse {
+  totals: { players: number; online: number; factions: number }
+  by_faction: PlayerSummaryBucket[]
+  by_map: PlayerSummaryBucket[]
+  source: DataSource
+  liveError?: string
+}
+
+export function getPlayerSummary(demo?: boolean) {
+  return api<PlayerSummaryResponse>(`/api/gameplay/players/summary${qs({ demo: demo ? 1 : undefined })}`)
+}
+
+export interface PlayerStats {
+  pawn_id: number
+  account_id: number
+  controller_id: number
+  character_name: string
+  class: string
+  map: string
+  online_status: string
+  last_seen: string
+  faction_id: number
+  faction_name: string
+  solaris: number
+  total_currency: number
+}
+
+export interface PlayerStatsResponse {
+  stats: PlayerStats | null
+  source: DataSource
+  liveError?: string
+}
+
+export function getPlayerStats(pawnId: number, demo?: boolean) {
+  return api<PlayerStatsResponse>(`/api/gameplay/players/stats${qs({
+    pawn: pawnId, demo: demo ? 1 : undefined,
+  })}`)
+}
+
+export interface SpecTrackFull {
+  track_type: string
+  xp: number
+  level: number
+  xp_max: number
+  level_max: number
+}
+
+export interface PlayerSpecsResponse {
+  tracks: SpecTrackFull[]
+  keystones_total: number
+  keystones_max: number
+  unsupported?: boolean
+  source: DataSource
+  liveError?: string
+}
+
+export function getPlayerSpecs(pawnId: number, controllerId: number, demo?: boolean) {
+  return api<PlayerSpecsResponse>(`/api/gameplay/players/specs${qs({
+    pawn: pawnId, controller: controllerId, demo: demo ? 1 : undefined,
+  })}`)
+}
+
+export function grantMaxSpec(pawnId: number, trackType: string) {
+  return api<WriteResult>('/api/gameplay/players/grant-max-spec', {
+    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, track_type: trackType }),
+  })
+}
+
+export function resetSpec(pawnId: number, trackType: string) {
+  return api<WriteResult>('/api/gameplay/players/reset-spec', {
+    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, track_type: trackType }),
+  })
+}
+
+export function resetAllSpecs(pawnId: number) {
+  return api<WriteResult>('/api/gameplay/players/reset-all-specs', {
+    method: 'POST', body: JSON.stringify({ pawn_id: pawnId }),
+  })
+}
+
+export function grantAllKeystones(controllerId: number) {
+  return api<WriteResult>('/api/gameplay/players/grant-all-keystones', {
+    method: 'POST', body: JSON.stringify({ controller_id: controllerId }),
+  })
+}
+
+export function resetAllKeystones(pawnId: number) {
+  return api<WriteResult>('/api/gameplay/players/reset-all-keystones', {
+    method: 'POST', body: JSON.stringify({ pawn_id: pawnId }),
+  })
+}
+
+export interface PlayerTagsResponse {
+  tags: string[]
+  unsupported?: boolean
+  source: DataSource
+  liveError?: string
+}
+
+export function getPlayerTags(accountId: number, demo?: boolean) {
+  return api<PlayerTagsResponse>(`/api/gameplay/players/tags${qs({
+    account: accountId, demo: demo ? 1 : undefined,
+  })}`)
+}
+
+export function setPlayerTags(accountId: number, tags: string[]) {
+  return api<WriteResult>('/api/gameplay/players/tags', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId, tags }),
+  })
+}
+
+export interface PlayerEvent {
+  id: number
+  ts: string
+  event_type: string
+  meta: string
+}
+
+export interface PlayerEventsResponse {
+  events: PlayerEvent[]
+  unsupported?: boolean
+  source: DataSource
+  liveError?: string
+}
+
+export function getPlayerEvents(accountId: number, limit?: number, demo?: boolean) {
+  return api<PlayerEventsResponse>(`/api/gameplay/players/events${qs({
+    account: accountId, limit: limit ?? undefined, demo: demo ? 1 : undefined,
+  })}`)
+}
+
+// ---------------------------------------------------------------------------
 // Bases / Storage / Blueprints (read-only)
 // ---------------------------------------------------------------------------
 export interface BaseRow {

--- a/webui/src/pages/gameplay/PlayersTab.tsx
+++ b/webui/src/pages/gameplay/PlayersTab.tsx
@@ -1,83 +1,121 @@
+// v11.5.6 — Players tab. Two-column layout: left rail with player list +
+// section selector, right pane with active section content.
+//
+// Reads /api/gameplay/players for the list + /api/gameplay/players/summary
+// for the server overview. Each section component owns its own data fetch.
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import {
-  getPlayers, getPlayerDetail,
-  giveSolari, giveItem, renamePlayer, awardSpecXp, deleteInventoryItem, repairInventoryItem,
-  type Player, type PlayerDetailResponse, type InventoryItem, type DataSource,
+  getPlayers, getPlayerSummary,
+  type Player, type PlayerSummaryResponse, type DataSource,
 } from '../../api/gameplay'
-import { fmtNum, fmtSolari, SourceBadge, StatCard, DemoNotice, qualityClass } from './shared'
+import { fmtNum, SourceBadge, StatCard, DemoNotice } from './shared'
+import {
+  SECTIONS, SECTION_COMPONENTS, type SectionId,
+} from './players/sections'
 
-type SortKey = 'name' | 'class' | 'map' | 'faction_name' | 'online_status'
+type OnlineFilter = '' | 'online' | 'offline'
+
+const isOnline = (s: string) => s.toLowerCase().includes('online')
 
 export function PlayersTab() {
-  const [players, setPlayers] = useState<Player[]>([])
-  const [source, setSource] = useState<DataSource>('demo')
-  const [liveError, setLiveError] = useState<string | undefined>()
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [search, setSearch] = useState('')
-  const [online, setOnline] = useState<'' | 'online' | 'offline'>('')
-  const [sort, setSort] = useState<SortKey>('name')
-  const [dir, setDir] = useState<'asc' | 'desc'>('asc')
-  const [selected, setSelected] = useState<Player | null>(null)
+  const [players, setPlayers]   = useState<Player[]>([])
+  const [source, setSource]     = useState<DataSource>('demo')
+  const [liveError, setLive]    = useState<string | undefined>()
+  const [loading, setLoading]   = useState(true)
+  const [error, setError]       = useState<string | null>(null)
+  const [search, setSearch]     = useState('')
+  const [online, setOnline]     = useState<OnlineFilter>('')
+  const [selectedId, setSel]    = useState<number | null>(null)
+  const [section, setSection]   = useState<SectionId>('stats')
+  const [flash, setFlash]       = useState<{ msg: string; kind: 'ok' | 'err' } | null>(null)
+  const [refreshKey, setRefresh] = useState(0)
+  const [summary, setSummary]   = useState<PlayerSummaryResponse | null>(null)
 
-  const load = useCallback(async () => {
+  const loadList = useCallback(async () => {
     setLoading(true); setError(null)
     try {
       const r = await getPlayers()
-      setPlayers(r.players); setSource(r.source); setLiveError(r.liveError)
+      setPlayers(r.players); setSource(r.source); setLive(r.liveError)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     } finally {
       setLoading(false)
     }
   }, [])
-  useEffect(() => { void load() }, [load])
 
-  const toggleSort = (col: SortKey) => {
-    if (sort === col) setDir(d => (d === 'asc' ? 'desc' : 'asc'))
-    else { setSort(col); setDir('asc') }
-  }
+  const loadSummary = useCallback(async () => {
+    try {
+      const r = await getPlayerSummary()
+      setSummary(r)
+    } catch {
+      // summary is best-effort
+    }
+  }, [])
 
-  const isOnline = (s: string) => s.toLowerCase().includes('online')
+  useEffect(() => { void loadList(); void loadSummary() }, [loadList, loadSummary])
 
-  const rows = useMemo(() => {
+  // Auto-dismiss flash after 4s.
+  useEffect(() => {
+    if (!flash) return
+    const t = window.setTimeout(() => setFlash(null), 4000)
+    return () => window.clearTimeout(t)
+  }, [flash])
+
+  const filtered = useMemo(() => {
     const q = search.trim().toLowerCase()
     let out = players
     if (q) out = out.filter(p =>
-      p.name.toLowerCase().includes(q) || p.faction_name.toLowerCase().includes(q) || String(p.id).includes(q))
-    if (online === 'online') out = out.filter(p => isOnline(p.online_status))
-    else if (online === 'offline') out = out.filter(p => !isOnline(p.online_status))
-    const mul = dir === 'asc' ? 1 : -1
-    return [...out].sort((a, b) => String(a[sort]).localeCompare(String(b[sort])) * mul)
-  }, [players, search, online, sort, dir])
+      p.name.toLowerCase().includes(q) ||
+      p.faction_name.toLowerCase().includes(q) ||
+      String(p.id).includes(q) ||
+      String(p.account_id).includes(q))
+    if (online === 'online')  out = out.filter(p => isOnline(p.online_status))
+    if (online === 'offline') out = out.filter(p => !isOnline(p.online_status))
+    return [...out].sort((a, b) => {
+      const ao = isOnline(a.online_status) ? 0 : 1
+      const bo = isOnline(b.online_status) ? 0 : 1
+      if (ao !== bo) return ao - bo
+      return (a.name || '').localeCompare(b.name || '')
+    })
+  }, [players, search, online])
 
   const onlineCount = useMemo(() => players.filter(p => isOnline(p.online_status)).length, [players])
+  const selected = useMemo(() => players.find(p => p.id === selectedId) ?? null, [players, selectedId])
+
+  const refresh = useCallback(() => {
+    setRefresh(k => k + 1)
+    void loadList()
+    void loadSummary()
+  }, [loadList, loadSummary])
+
+  const SectionComponent = SECTION_COMPONENTS[section]
 
   return (
     <div>
+      {/* Top-of-tab stat cards */}
       <section className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-4">
-        <StatCard label="Players" value={fmtNum(players.length)} icon="Users" />
-        <StatCard label="Online now" value={fmtNum(onlineCount)} icon="Wifi" />
-        <StatCard label="Factions" value={fmtNum(new Set(players.map(p => p.faction_name).filter(Boolean)).size)} icon="Flag" />
+        <StatCard label="Players"    value={fmtNum(players.length)}                                                icon="Users" />
+        <StatCard label="Online now" value={fmtNum(onlineCount)}                                                   icon="Wifi" />
+        <StatCard label="Factions"   value={fmtNum(summary?.totals.factions ?? new Set(players.map(p => p.faction_name).filter(Boolean)).size)} icon="Flag" />
       </section>
 
       <div className="card p-3 mb-4 flex flex-wrap items-center gap-2">
         <div className="relative flex-1 min-w-[200px]">
-          <Icon name="Search" size={15} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-dim" />
-          <input type="text" value={search} onChange={e => setSearch(e.target.value)} placeholder="Search players or factions…"
+          <Icon name="Search" size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-dim" />
+          <input type="text" value={search} onChange={e => setSearch(e.target.value)} placeholder="Search players, factions, ids…"
             className="w-full pl-8 pr-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
         </div>
         <div className="flex rounded-lg border border-border overflow-hidden">
           {([['', 'All'], ['online', 'Online'], ['offline', 'Offline']] as const).map(([val, label]) => (
             <button key={val} onClick={() => setOnline(val)}
-              className={`px-3 py-2 text-sm ${online === val ? 'bg-accent/20 text-accent-bright' : 'bg-surface-2 text-text-muted hover:text-text'}`}>
+              className={`px-3 py-1.5 text-xs ${online === val ? 'bg-accent/20 text-accent-bright' : 'bg-surface-2 text-text-muted hover:text-text'}`}>
               {label}
             </button>
           ))}
         </div>
-        <button className="btn-secondary" onClick={() => { void load() }} disabled={loading}>
-          <Icon name="RefreshCw" size={15} className={loading ? 'animate-spin' : ''} /> Refresh
+        <button className="btn-secondary" onClick={refresh} disabled={loading}>
+          <Icon name="RefreshCw" size={14} className={loading ? 'animate-spin' : ''} /> Refresh
         </button>
         <SourceBadge source={source} />
       </div>
@@ -85,320 +123,165 @@ export function PlayersTab() {
       {source === 'demo' && <DemoNotice liveError={liveError} what="player data" />}
       {error && <div className="card p-3 mb-4 text-sm text-danger break-words">{error}</div>}
 
-      <div className="card overflow-hidden">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-left text-xs uppercase tracking-wider text-text-dim border-b border-border">
-              <Th label="Player" col="name" sort={sort} dir={dir} onSort={toggleSort} />
-              <Th label="Faction" col="faction_name" sort={sort} dir={dir} onSort={toggleSort} className="hidden md:table-cell" />
-              <Th label="Map" col="map" sort={sort} dir={dir} onSort={toggleSort} className="hidden lg:table-cell" />
-              <Th label="Status" col="online_status" sort={sort} dir={dir} onSort={toggleSort} align="right" />
-            </tr>
-          </thead>
-          <tbody>
-            {loading && players.length === 0 && (
-              <tr><td colSpan={4} className="px-3 py-8 text-center text-text-dim">
-                <Icon name="Loader2" size={18} className="animate-spin inline" /> Loading players…
-              </td></tr>
-            )}
-            {!loading && rows.length === 0 && (
-              <tr><td colSpan={4} className="px-3 py-8 text-center text-text-dim">No players match.</td></tr>
-            )}
-            {rows.map(p => (
-              <tr key={p.id} onClick={() => setSelected(p)}
-                className="border-b border-border/50 hover:bg-surface-2 cursor-pointer">
-                <td className="px-3 py-2">
-                  <div className="font-medium text-text truncate max-w-[240px]">{p.name || <span className="text-text-dim italic">Unnamed</span>}</div>
-                  <div className="text-[11px] text-text-dim font-mono">#{p.id}</div>
-                </td>
-                <td className="px-3 py-2 hidden md:table-cell text-text-muted">{p.faction_name || '—'}</td>
-                <td className="px-3 py-2 hidden lg:table-cell text-text-dim">{p.map || '—'}</td>
-                <td className="px-3 py-2 text-right">
-                  <span className={`inline-flex items-center gap-1 text-xs ${isOnline(p.online_status) ? 'text-success' : 'text-text-dim'}`}>
-                    <Icon name={isOnline(p.online_status) ? 'Wifi' : 'WifiOff'} size={12} /> {p.online_status}
-                  </span>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      {selected && (
-        <PlayerDetail player={selected} canWrite={source === 'live'} demo={source === 'demo'}
-          onClose={() => setSelected(null)} onChanged={() => { void load() }} />
-      )}
-    </div>
-  )
-}
-
-function PlayerDetail({ player, canWrite, demo, onClose, onChanged }: {
-  player: Player; canWrite: boolean; demo: boolean; onClose: () => void; onChanged: () => void
-}) {
-  const [detail, setDetail] = useState<PlayerDetailResponse | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [err, setErr] = useState<string | null>(null)
-  const [busy, setBusy] = useState(false)
-  const [flash, setFlash] = useState<string | null>(null)
-  const [form, setForm] = useState<'solari' | 'rename' | 'item' | null>(null)
-
-  const loadDetail = useCallback(() => {
-    let alive = true
-    setLoading(true); setErr(null)
-    getPlayerDetail(player.id, player.controller_id, demo)
-      .then(r => { if (alive) setDetail(r) })
-      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
-      .finally(() => { if (alive) setLoading(false) })
-    return () => { alive = false }
-  }, [player.id, player.controller_id, demo])
-  useEffect(() => loadDetail(), [loadDetail])
-
-  // Run a write action, then refresh detail + the parent list.
-  const run = async (fn: () => Promise<{ ok: boolean; message: string }>, label: string) => {
-    setBusy(true); setErr(null); setFlash(null)
-    try {
-      const r = await fn()
-      setFlash(r.message || `${label} done.`)
-      setForm(null)
-      loadDetail()
-      onChanged()
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e))
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const solari = detail?.currency.find(c => c.currency_id === 1)?.balance
-
-  // Separate emotes and contract (quest) items from real gear/loot so the
-  // inventory list stays focused; they're shown in their own sub-sections.
-  const groups = useMemo(() => {
-    const inv = detail?.inventory ?? []
-    return {
-      gear: inv.filter(i => (i.kind ?? 'item') === 'item'),
-      emotes: inv.filter(i => i.kind === 'emote'),
-      contracts: inv.filter(i => i.kind === 'contract'),
-    }
-  }, [detail])
-
-  return (
-    <div className="fixed inset-0 z-40 flex justify-end" onClick={onClose}>
-      <div className="absolute inset-0 bg-black/50" />
-      <div className="relative w-full max-w-lg h-full bg-surface border-l border-border overflow-y-auto p-5" onClick={e => e.stopPropagation()}>
-        <div className="flex items-start justify-between mb-4">
-          <div>
-            <h3 className="text-lg font-semibold text-text">{player.name || 'Unnamed player'}</h3>
-            <div className="text-xs text-text-dim">{player.class || 'Player'} · #{player.id}</div>
-            <div className="mt-1 flex items-center gap-2 text-xs text-text-muted">
-              {player.faction_name && <span><Icon name="Flag" size={11} className="inline" /> {player.faction_name}</span>}
-              {player.map && <span>· {player.map}</span>}
-              <span className={isOnlineStr(player.online_status) ? 'text-success' : 'text-text-dim'}>· {player.online_status}</span>
+      {/* Two-column body */}
+      <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-4">
+        {/* Left rail */}
+        <aside className="space-y-3 min-w-0">
+          {/* Player list */}
+          <div className="card p-0 overflow-hidden">
+            <div className="px-3 py-2 border-b border-border text-[11px] uppercase tracking-wider text-text-dim flex items-center justify-between">
+              <span>Players</span>
+              <span className="font-mono text-text-muted">{fmtNum(filtered.length)}</span>
+            </div>
+            <div className="max-h-[60vh] overflow-y-auto">
+              {loading && filtered.length === 0 ? (
+                <div className="px-3 py-6 text-center text-text-dim text-sm">
+                  <Icon name="Loader2" size={15} className="animate-spin inline" /> Loading…
+                </div>
+              ) : filtered.length === 0 ? (
+                <div className="px-3 py-6 text-center text-text-dim text-sm">No players match.</div>
+              ) : (
+                filtered.map(p => (
+                  <button key={p.id} type="button" onClick={() => setSel(p.id)}
+                    className={`w-full flex items-center justify-between gap-2 px-3 py-2 text-left border-b border-border/30 hover:bg-surface-2 ${selectedId === p.id ? 'bg-surface-2 border-l-2 border-l-accent' : ''}`}>
+                    <span className="min-w-0 flex-1">
+                      <div className="text-sm text-text truncate">{p.name || <span className="italic text-text-dim">Unnamed</span>}</div>
+                      <div className="text-[11px] text-text-dim truncate">
+                        {p.faction_name || 'Unaligned'} {p.map ? `· ${p.map}` : ''}
+                      </div>
+                    </span>
+                    <span className={`shrink-0 w-2 h-2 rounded-full ${isOnline(p.online_status) ? 'bg-success' : 'bg-text-dim/40'}`}
+                      title={p.online_status} />
+                  </button>
+                ))
+              )}
             </div>
           </div>
-          <button onClick={onClose} className="text-text-dim hover:text-text"><Icon name="X" size={20} /></button>
-        </div>
 
-        {/* Currency */}
-        <div className="grid grid-cols-3 gap-2 mb-4">
-          <MiniStat label="Solari" value={fmtSolari(solari)} />
-          <MiniStat label="Inventory" value={fmtNum(groups.gear.length)} />
-          <MiniStat label="Spec tracks" value={fmtNum(detail?.specs.length)} />
-        </div>
-
-        {/* Admin actions */}
-        {canWrite ? (
-          <div className="flex flex-wrap gap-2 mb-3">
-            <button className="btn-secondary" disabled={busy} onClick={() => setForm(form === 'solari' ? null : 'solari')}>
-              <Icon name="Coins" size={14} /> Give Solari
-            </button>
-            <button className="btn-secondary" disabled={busy} onClick={() => setForm(form === 'item' ? null : 'item')}>
-              <Icon name="PackagePlus" size={14} /> Give Item
-            </button>
-            <button className="btn-secondary" disabled={busy} onClick={() => setForm(form === 'rename' ? null : 'rename')}>
-              <Icon name="PenLine" size={14} /> Rename
-            </button>
-          </div>
-        ) : (
-          <div className="text-xs text-text-dim mb-3 flex items-center gap-1.5">
-            <Icon name="Lock" size={12} /> Editing is available when the live game database is connected.
-          </div>
-        )}
-
-        {form === 'solari' && (
-          <InlineForm busy={busy} fields={[{ key: 'amount', label: 'Amount (Solari)', type: 'number', placeholder: 'e.g. 10000' }]}
-            submitLabel="Give Solari"
-            onSubmit={v => run(() => giveSolari(player.controller_id, Number(v.amount) || 0), 'Give Solari')} />
-        )}
-        {form === 'item' && (
-          <InlineForm busy={busy} fields={[
-            { key: 'template', label: 'Item template id', type: 'text', placeholder: 'e.g. Spice_Melange' },
-            { key: 'qty', label: 'Quantity', type: 'number', placeholder: '1' },
-            { key: 'quality', label: 'Quality (0–5)', type: 'number', placeholder: '0' },
-          ]} submitLabel="Give Item"
-            onSubmit={v => run(() => giveItem(player.id, String(v.template || '').trim(), Number(v.qty) || 0, Number(v.quality) || 0), 'Give Item')} />
-        )}
-        {form === 'rename' && (
-          <InlineForm busy={busy} fields={[{ key: 'name', label: 'New character name', type: 'text', placeholder: player.name }]}
-            submitLabel="Rename"
-            onSubmit={v => run(() => renamePlayer(player.account_id, String(v.name || '').trim()), 'Rename')} />
-        )}
-
-        {flash && <div className="card p-2.5 mb-3 text-xs text-success border-l-2 border-success break-words">{flash}</div>}
-        {err && <div className="card p-2.5 mb-3 text-xs text-danger break-words">{err}</div>}
-
-        {loading ? (
-          <div className="text-text-dim text-sm py-4"><Icon name="Loader2" size={16} className="animate-spin inline" /> Loading…</div>
-        ) : (
-          <>
-            {/* Specs */}
-            {detail && detail.specs.length > 0 && (
-              <>
-                <h4 className="text-xs uppercase tracking-wider text-text-dim mb-2">Specialization tracks</h4>
-                <div className="space-y-1 mb-4">
-                  {detail.specs.map(s => (
-                    <div key={s.track_type} className="flex items-center justify-between text-sm bg-surface-2 rounded-lg px-3 py-2 border border-border/50">
-                      <span className="text-text">{s.track_type}</span>
-                      <span className="flex items-center gap-2">
-                        <span className="font-mono text-text-muted text-xs">Lv {Math.round(s.level)} · {fmtNum(s.xp)} xp</span>
-                        {canWrite && (
-                          <button className="text-accent hover:text-accent-bright" title="Award +5000 XP" disabled={busy}
-                            onClick={() => run(() => awardSpecXp(player.id, s.track_type, 5000), 'Award XP')}>
-                            <Icon name="Plus" size={14} />
-                          </button>
-                        )}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </>
-            )}
-
-            {/* Inventory (gear/loot only — emotes & contracts shown separately) */}
-            <h4 className="text-xs uppercase tracking-wider text-text-dim mb-2">Inventory ({fmtNum(groups.gear.length)})</h4>
-            {groups.gear.length === 0 ? (
-              <div className="text-text-dim text-sm py-2">No items.</div>
-            ) : (
-              <div className="space-y-1">
-                {groups.gear.map(it => (
-                  <ItemRow key={it.id} item={it} canWrite={canWrite} busy={busy} run={run} />
-                ))}
+          {/* Section nav (only when a player is selected) */}
+          {selected && (
+            <div className="card p-0 overflow-hidden">
+              <div className="px-3 py-2 border-b border-border text-[11px] uppercase tracking-wider text-text-dim">
+                Sections
               </div>
-            )}
+              {SECTIONS.map(s => (
+                <button key={s.id} type="button" onClick={() => setSection(s.id)}
+                  className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left border-b border-border/30 last:border-b-0 hover:bg-surface-2 ${section === s.id ? 'bg-surface-2 text-accent-bright border-l-2 border-l-accent' : 'text-text'}`}>
+                  <Icon name={s.icon} size={14} className="text-text-dim" />
+                  <span>{s.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </aside>
 
-            {/* Emotes & contract items — separated to keep the list above clean */}
-            <ItemSection title="Emotes" icon="Smile" items={groups.emotes} canWrite={canWrite} busy={busy} run={run} />
-            <ItemSection title="Contract items" icon="FileText" items={groups.contracts} canWrite={canWrite} busy={busy} run={run} />
-          </>
-        )}
+        {/* Right pane */}
+        <section className="min-w-0">
+          {flash && (
+            <div className={`card p-2.5 mb-3 text-xs border-l-2 break-words ${flash.kind === 'ok' ? 'text-success border-success' : 'text-danger border-danger'}`}>
+              {flash.msg}
+            </div>
+          )}
+          {selected ? (
+            <div className="space-y-3">
+              <PlayerHeader player={selected} />
+              <SectionComponent
+                player={selected}
+                canWrite={source === 'live'}
+                demo={source === 'demo'}
+                refreshKey={refreshKey}
+                flash={(msg, kind = 'ok') => setFlash({ msg, kind })}
+                onChanged={refresh}
+              />
+            </div>
+          ) : (
+            <ServerOverview summary={summary} />
+          )}
+        </section>
       </div>
     </div>
   )
 }
 
-function isOnlineStr(s: string) { return s.toLowerCase().includes('online') }
-
-type RunFn = (fn: () => Promise<{ ok: boolean; message: string }>, label: string) => void | Promise<void>
-
-function ItemRow({ item: it, canWrite, busy, run }: {
-  item: InventoryItem; canWrite: boolean; busy: boolean; run: RunFn
-}) {
+function PlayerHeader({ player }: { player: Player }) {
   return (
-    <div className="flex items-center justify-between text-sm bg-surface-2 rounded-lg px-3 py-2 border border-border/50">
-      <span className="truncate max-w-[240px]">
-        <span className="text-text">{it.name}</span>
-        {it.quality > 0 && <span className={`ml-1.5 text-[11px] ${qualityClass(it.quality)}`}>Q{it.quality}</span>}
-        <span className="ml-1.5 font-mono text-text-dim text-xs">×{fmtNum(it.stack_size)}</span>
-      </span>
-      {canWrite && (
-        <span className="flex items-center gap-2 shrink-0">
-          {it.durability !== 'N/A' && (
-            <button className="text-info hover:text-accent-bright" title="Repair to full" disabled={busy}
-              onClick={() => run(() => repairInventoryItem(it.id), 'Repair')}>
-              <Icon name="Wrench" size={14} />
-            </button>
-          )}
-          <button className="text-danger/80 hover:text-danger" title="Delete item" disabled={busy}
-            onClick={() => { if (window.confirm(`Delete ${it.name} (×${it.stack_size})? This cannot be undone.`)) void run(() => deleteInventoryItem(it.id), 'Delete') }}>
-            <Icon name="Trash2" size={14} />
-          </button>
-        </span>
+    <div className="card p-3 flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        <h3 className="text-lg font-semibold text-text truncate">{player.name || 'Unnamed player'}</h3>
+        <div className="text-xs text-text-dim flex flex-wrap gap-x-3 gap-y-0.5 mt-1">
+          <span><Icon name="Hash" size={11} className="inline" /> pawn {player.id}</span>
+          <span>account {player.account_id}</span>
+          <span>controller {player.controller_id}</span>
+          {player.class && <span>{player.class}</span>}
+        </div>
+        <div className="mt-2 flex items-center gap-3 text-xs text-text-muted">
+          {player.faction_name && <span><Icon name="Flag" size={11} className="inline mr-1" />{player.faction_name}</span>}
+          {player.map && <span><Icon name="MapPin" size={11} className="inline mr-1" />{player.map}</span>}
+          <span className={isOnline(player.online_status) ? 'text-success' : 'text-text-dim'}>
+            <Icon name={isOnline(player.online_status) ? 'Wifi' : 'WifiOff'} size={11} className="inline mr-1" />
+            {player.online_status}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ServerOverview({ summary }: { summary: PlayerSummaryResponse | null }) {
+  return (
+    <div className="space-y-3">
+      <div className="card p-4">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-text-dim mb-2">
+          <Icon name="LayoutDashboard" size={13} /> Server overview
+        </div>
+        <p className="text-sm text-text-dim">Pick a player from the list to inspect or edit their data.</p>
+      </div>
+
+      {summary && (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <Bucket title="By faction" data={summary.by_faction} icon="Flag" />
+            <Bucket title="By map"     data={summary.by_map}     icon="MapPin" />
+          </div>
+        </>
       )}
     </div>
   )
 }
 
-// Collapsible sub-section for emotes / contract items, collapsed by default so
-// they don't clutter the main inventory list. Hidden entirely when empty.
-function ItemSection({ title, icon, items, canWrite, busy, run }: {
-  title: string; icon: string; items: InventoryItem[]; canWrite: boolean; busy: boolean; run: RunFn
+function Bucket({ title, data, icon }: {
+  title: string; data: { name: string; count: number }[]; icon: string
 }) {
-  const [open, setOpen] = useState(false)
-  if (items.length === 0) return null
+  const total = data.reduce((acc, r) => acc + (r.count || 0), 0)
+  const sorted = [...data].sort((a, b) => b.count - a.count)
   return (
-    <div className="mt-4">
-      <button type="button" onClick={() => setOpen(o => !o)}
-        className="flex w-full items-center gap-2 text-xs uppercase tracking-wider text-text-dim hover:text-text mb-2">
-        <Icon name={open ? 'ChevronDown' : 'ChevronRight'} size={14} />
-        <Icon name={icon} size={13} />
-        <span>{title} ({fmtNum(items.length)})</span>
-      </button>
-      {open && (
-        <div className="space-y-1">
-          {items.map(it => (
-            <ItemRow key={it.id} item={it} canWrite={canWrite} busy={busy} run={run} />
-          ))}
+    <div className="card p-3">
+      <div className="flex items-center justify-between mb-2">
+        <h4 className="text-xs uppercase tracking-wider text-text-dim flex items-center gap-1.5">
+          <Icon name={icon} size={13} /> {title}
+        </h4>
+        <span className="font-mono text-xs text-text-muted">{fmtNum(total)}</span>
+      </div>
+      {sorted.length === 0 ? (
+        <div className="text-sm text-text-dim italic">No data.</div>
+      ) : (
+        <div className="space-y-1.5">
+          {sorted.map(row => {
+            const pct = total > 0 ? (row.count / total) * 100 : 0
+            return (
+              <div key={row.name}>
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-text truncate">{row.name || '—'}</span>
+                  <span className="font-mono text-text-muted">{fmtNum(row.count)}</span>
+                </div>
+                <div className="h-1 bg-surface-2 rounded-full overflow-hidden">
+                  <div className="h-full bg-accent" style={{ width: `${pct}%` }} />
+                </div>
+              </div>
+            )
+          })}
         </div>
       )}
     </div>
-  )
-}
-
-interface FieldDef { key: string; label: string; type: 'text' | 'number'; placeholder?: string }
-
-function InlineForm({ fields, submitLabel, busy, onSubmit }: {
-  fields: FieldDef[]; submitLabel: string; busy: boolean; onSubmit: (values: Record<string, string>) => void
-}) {
-  const [values, setValues] = useState<Record<string, string>>({})
-  return (
-    <div className="card p-3 mb-3 space-y-2">
-      {fields.map(f => (
-        <div key={f.key}>
-          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">{f.label}</label>
-          <input type={f.type} value={values[f.key] ?? ''} placeholder={f.placeholder}
-            onChange={e => setValues(v => ({ ...v, [f.key]: e.target.value }))}
-            className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
-        </div>
-      ))}
-      <button className="btn-primary" disabled={busy} onClick={() => onSubmit(values)}>
-        {busy ? <Icon name="Loader2" size={14} className="animate-spin" /> : <Icon name="Check" size={14} />} {submitLabel}
-      </button>
-    </div>
-  )
-}
-
-function MiniStat({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="bg-surface-2 rounded-lg p-2 border border-border/50 text-center">
-      <div className="text-[11px] uppercase tracking-wider text-text-dim">{label}</div>
-      <div className="text-sm font-semibold font-mono text-text mt-0.5">{value}</div>
-    </div>
-  )
-}
-
-function Th({ label, col, sort, dir, onSort, align = 'left', className = '' }: {
-  label: string; col: SortKey; sort: SortKey; dir: 'asc' | 'desc'
-  onSort: (c: SortKey) => void; align?: 'left' | 'right' | 'center'; className?: string
-}) {
-  const active = sort === col
-  const justify = align === 'right' ? 'justify-end' : align === 'center' ? 'justify-center' : 'justify-start'
-  return (
-    <th className={`px-3 py-2 font-medium ${className}`}>
-      <button type="button" onClick={() => onSort(col)}
-        className={`flex w-full items-center gap-1 ${justify} uppercase tracking-wider transition-colors ${active ? 'text-accent-bright' : 'hover:text-text'}`}>
-        <span>{label}</span>
-        <Icon name={active ? (dir === 'asc' ? 'ChevronUp' : 'ChevronDown') : 'ChevronsUpDown'} size={12} className={active ? '' : 'opacity-40'} />
-      </button>
-    </th>
   )
 }

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -1,0 +1,679 @@
+// v11.5.6 — Player section panels. One component per section nav entry
+// (Stats / Specs / Tags / History / Inventory / Actions). All sections take
+// a common props shape: the selected player + a `canWrite` flag (live DB)
+// + a callback to flash status messages to the parent.
+//
+// Most sections are self-contained: they fetch their own data, render, and
+// expose action buttons. The parent owns selection + refresh ticks; sections
+// re-fetch when `refreshKey` changes.
+
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react'
+import { Icon } from '../../../components/Icon'
+import {
+  awardSpecXp, deleteInventoryItem, getPlayerEvents, getPlayerSpecs, getPlayerStats,
+  getPlayerTags, giveItem, giveSolari, grantAllKeystones, grantMaxSpec,
+  renamePlayer, repairInventoryItem, resetAllKeystones, resetAllSpecs, resetSpec,
+  setPlayerTags,
+  type Player, type PlayerEvent, type PlayerStats, type SpecTrackFull,
+} from '../../../api/gameplay'
+import { fmtNum, fmtSolari } from '../shared'
+
+type Flash = (msg: string, kind?: 'ok' | 'err') => void
+
+interface SectionProps {
+  player: Player
+  canWrite: boolean
+  demo: boolean
+  refreshKey: number
+  flash: Flash
+  onChanged: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Stats — per-player snapshot. Shows currency, faction, last seen, account
+// numbers. Read-only here; mutations live in Actions.
+// ---------------------------------------------------------------------------
+export function StatsSection({ player, demo, refreshKey }: SectionProps) {
+  const [stats, setStats] = useState<PlayerStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true); setErr(null)
+    getPlayerStats(player.id, demo)
+      .then(r => { if (alive) setStats(r.stats) })
+      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [player.id, demo, refreshKey])
+
+  if (loading) return <Loading label="Loading stats…" />
+  if (err)     return <ErrorBox msg={err} />
+  if (!stats)  return <EmptyBox msg="No stats for this player." />
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Stat label="Solari" value={fmtSolari(stats.solaris)} icon="Coins" />
+        <Stat label="Total currency" value={fmtNum(stats.total_currency)} icon="Banknote" />
+        <Stat label="Faction" value={stats.faction_name || 'Unaligned'} icon="Flag" />
+        <Stat label="Status" value={stats.online_status} icon={stats.online_status.toLowerCase().includes('online') ? 'Wifi' : 'WifiOff'} />
+      </div>
+
+      <Card title="Identity">
+        <KV k="Character" v={stats.character_name || '(unnamed)'} />
+        <KV k="Class" v={stats.class || '—'} />
+        <KV k="Map" v={stats.map || '—'} />
+        <KV k="Last seen" v={fmtTs(stats.last_seen)} />
+      </Card>
+
+      <Card title="Account">
+        <KV k="Pawn id"       v={`#${stats.pawn_id}`}       mono />
+        <KV k="Account id"    v={`#${stats.account_id}`}    mono />
+        <KV k="Controller id" v={`#${stats.controller_id}`} mono />
+        <KV k="Faction id"    v={`#${stats.faction_id}`}    mono />
+      </Card>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Specs — 5 tracks + keystone counter. Header buttons grant/reset all
+// keystones; per-row buttons grant max XP / reset one track / +5000 XP.
+// ---------------------------------------------------------------------------
+export function SpecsSection({ player, canWrite, demo, refreshKey, flash, onChanged }: SectionProps) {
+  const [tracks, setTracks] = useState<SpecTrackFull[]>([])
+  const [keystones, setKeystones] = useState({ total: 0, max: 205 })
+  const [unsupported, setUnsupported] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true); setErr(null)
+    getPlayerSpecs(player.id, player.controller_id, demo)
+      .then(r => {
+        if (!alive) return
+        setTracks(r.tracks)
+        setKeystones({ total: r.keystones_total, max: r.keystones_max })
+        setUnsupported(Boolean(r.unsupported))
+      })
+      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [player.id, player.controller_id, demo, refreshKey, tick])
+
+  const run = useCallback(async (fn: () => Promise<{ message: string }>, label: string) => {
+    setBusy(true)
+    try {
+      const r = await fn()
+      flash(r.message || `${label} done.`, 'ok')
+      setTick(t => t + 1)
+      onChanged()
+    } catch (e) {
+      flash(e instanceof Error ? e.message : String(e), 'err')
+    } finally {
+      setBusy(false)
+    }
+  }, [flash, onChanged])
+
+  return (
+    <div className="space-y-3">
+      {/* Header bar — refresh + bulk keystone actions */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-xs text-text-dim">
+          Keystones: <span className="font-mono text-text">{fmtNum(keystones.total)}</span> / {fmtNum(keystones.max)}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button className="btn-secondary" disabled={loading || busy} onClick={() => setTick(t => t + 1)}>
+            <Icon name="RefreshCw" size={13} className={loading ? 'animate-spin' : ''} /> Refresh
+          </button>
+          {canWrite && (
+            <>
+              <button className="btn-secondary" disabled={busy}
+                onClick={() => { if (window.confirm(`Grant all ${keystones.max} keystones to ${player.name}?`)) void run(() => grantAllKeystones(player.controller_id), 'Grant all keystones') }}>
+                <Icon name="Star" size={13} /> Grant Max Keystones
+              </button>
+              <button className="btn-secondary text-warning" disabled={busy}
+                onClick={() => { if (window.confirm(`Reset ALL keystones for ${player.name}? Cannot be undone.`)) void run(() => resetAllKeystones(player.id), 'Reset all keystones') }}>
+                <Icon name="RotateCcw" size={13} /> Reset All Keystones
+              </button>
+              <button className="btn-secondary text-danger" disabled={busy}
+                onClick={() => { if (window.confirm(`Reset ALL spec tracks + keystones for ${player.name}? Cannot be undone.`)) void run(() => resetAllSpecs(player.id), 'Reset all specs') }}>
+                <Icon name="AlertTriangle" size={13} /> Reset All
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {err && <ErrorBox msg={err} />}
+      {unsupported && (
+        <div className="card p-3 text-xs text-text-muted border-l-2 border-warning">
+          The live game database doesn't expose specialization tables on this server — feature unavailable.
+        </div>
+      )}
+
+      {loading && tracks.length === 0 ? (
+        <Loading label="Loading specs…" />
+      ) : (
+        <div className="space-y-2">
+          {SPEC_TRACK_ORDER.map(name => {
+            const t = tracks.find(x => x.track_type.toLowerCase() === name.toLowerCase())
+            return (
+              <SpecRow key={name} name={name} track={t} canWrite={canWrite} busy={busy}
+                onGrantMax={() => { if (window.confirm(`Grant max XP for ${name}?`)) void run(() => grantMaxSpec(player.id, name), 'Grant max') }}
+                onReset={() => { if (window.confirm(`Reset ${name} track?`)) void run(() => resetSpec(player.id, name), 'Reset') }}
+                onAdd5k={() => run(() => awardSpecXp(player.id, name, 5000), '+5000 XP')}
+              />
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const SPEC_TRACK_ORDER = ['Combat', 'Crafting', 'Exploration', 'Gathering', 'Sabotage']
+
+function SpecRow({ name, track, canWrite, busy, onGrantMax, onReset, onAdd5k }: {
+  name: string; track: SpecTrackFull | undefined; canWrite: boolean; busy: boolean
+  onGrantMax: () => void; onReset: () => void; onAdd5k: () => void
+}) {
+  const xp = track?.xp ?? 0
+  const level = Math.round(track?.level ?? 0)
+  const xpMax = track?.xp_max ?? 44182
+  const levelMax = Math.round(track?.level_max ?? 100)
+  const pct = Math.min(100, Math.max(0, (xp / xpMax) * 100))
+  return (
+    <div className="card p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-[140px]">
+          <div className="text-sm font-medium text-text">{name}</div>
+          <div className="text-[11px] text-text-dim font-mono">Lv {level}/{levelMax} · {fmtNum(xp)}/{fmtNum(xpMax)} xp</div>
+        </div>
+        <div className="flex-1 mx-2">
+          <div className="h-1.5 bg-surface-2 rounded-full overflow-hidden">
+            <div className="h-full bg-accent" style={{ width: `${pct}%` }} />
+          </div>
+        </div>
+        {canWrite && (
+          <div className="flex gap-1.5 shrink-0">
+            <button className="btn-secondary" disabled={busy} title="+5000 XP" onClick={onAdd5k}>
+              <Icon name="Plus" size={13} /> 5k
+            </button>
+            <button className="btn-secondary" disabled={busy} title="Grant max XP for this track" onClick={onGrantMax}>
+              <Icon name="ChevronsUp" size={13} /> Max
+            </button>
+            <button className="btn-secondary text-warning" disabled={busy} title="Reset this track" onClick={onReset}>
+              <Icon name="RotateCcw" size={13} />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tags — chip list with add/remove + Save button. Writes the full set in
+// one POST (matches backend's replace semantics).
+// ---------------------------------------------------------------------------
+export function TagsSection({ player, canWrite, demo, refreshKey, flash, onChanged }: SectionProps) {
+  const [tags, setTags] = useState<string[]>([])
+  const [draft, setDraft] = useState('')
+  const [dirty, setDirty] = useState(false)
+  const [unsupported, setUnsupported] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true); setErr(null); setDirty(false)
+    getPlayerTags(player.account_id, demo)
+      .then(r => { if (alive) { setTags(r.tags); setUnsupported(Boolean(r.unsupported)) } })
+      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [player.account_id, demo, refreshKey])
+
+  const add = () => {
+    const t = draft.trim()
+    if (!t) return
+    if (tags.includes(t)) { setDraft(''); return }
+    setTags([...tags, t].sort())
+    setDraft('')
+    setDirty(true)
+  }
+  const remove = (t: string) => { setTags(tags.filter(x => x !== t)); setDirty(true) }
+
+  const save = async () => {
+    setBusy(true); setErr(null)
+    try {
+      const r = await setPlayerTags(player.account_id, tags)
+      flash(r.message, 'ok')
+      setDirty(false)
+      onChanged()
+    } catch (e) {
+      flash(e instanceof Error ? e.message : String(e), 'err')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (loading) return <Loading label="Loading tags…" />
+
+  return (
+    <div className="space-y-3">
+      {err && <ErrorBox msg={err} />}
+      {unsupported && (
+        <div className="card p-3 text-xs text-text-muted border-l-2 border-warning">
+          The live game database has no <code className="text-text">dune.player_tags</code> table — feature unavailable.
+        </div>
+      )}
+
+      <div className="card p-3">
+        {tags.length === 0 ? (
+          <div className="text-sm text-text-dim">No tags. Add one below.</div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {tags.map(t => (
+              <span key={t} className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full bg-surface-2 border border-border text-xs text-text">
+                {t}
+                {canWrite && !unsupported && (
+                  <button className="text-text-dim hover:text-danger" onClick={() => remove(t)} title="Remove">
+                    <Icon name="X" size={11} />
+                  </button>
+                )}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {canWrite && !unsupported && (
+        <div className="flex gap-2">
+          <input type="text" value={draft} onChange={e => setDraft(e.target.value)}
+            placeholder="Add tag (e.g. VIP, Banned, Verified)…" maxLength={64}
+            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add() } }}
+            className="flex-1 px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+          <button className="btn-secondary" onClick={add} disabled={busy || !draft.trim()}>
+            <Icon name="Plus" size={13} /> Add
+          </button>
+          <button className="btn-primary" onClick={save} disabled={busy || !dirty}>
+            <Icon name="Save" size={13} /> Save
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// History — recent event_log rows. Read-only. Pretty-prints event type +
+// timestamps; raw meta JSON shown in an expandable details block.
+// ---------------------------------------------------------------------------
+export function HistorySection({ player, demo, refreshKey }: SectionProps) {
+  const [events, setEvents] = useState<PlayerEvent[]>([])
+  const [unsupported, setUnsupported] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState<string | null>(null)
+  const [limit, setLimit] = useState(50)
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true); setErr(null)
+    getPlayerEvents(player.account_id, limit, demo)
+      .then(r => { if (alive) { setEvents(r.events); setUnsupported(Boolean(r.unsupported)) } })
+      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [player.account_id, demo, refreshKey, limit])
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="text-xs text-text-dim">{fmtNum(events.length)} event(s)</div>
+        <select value={limit} onChange={e => setLimit(Number(e.target.value))}
+          className="px-2 py-1 rounded-md bg-surface-2 border border-border text-text text-xs">
+          <option value={25}>Last 25</option>
+          <option value={50}>Last 50</option>
+          <option value={100}>Last 100</option>
+          <option value={250}>Last 250</option>
+        </select>
+      </div>
+
+      {err && <ErrorBox msg={err} />}
+      {unsupported && (
+        <div className="card p-3 text-xs text-text-muted border-l-2 border-warning">
+          <code className="text-text">dune.event_log</code> is unavailable on this server — history feature offline.
+        </div>
+      )}
+
+      {loading && events.length === 0 ? (
+        <Loading label="Loading events…" />
+      ) : events.length === 0 ? (
+        <EmptyBox msg="No events recorded for this player." />
+      ) : (
+        <div className="space-y-1">
+          {events.map(ev => <EventRow key={ev.id} ev={ev} />)}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function EventRow({ ev }: { ev: PlayerEvent }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="card p-2.5 text-sm">
+      <button type="button" onClick={() => setOpen(o => !o)} className="w-full flex items-center justify-between gap-2 text-left">
+        <span className="flex items-center gap-2 min-w-0">
+          <Icon name={open ? 'ChevronDown' : 'ChevronRight'} size={12} className="text-text-dim shrink-0" />
+          <span className="text-text font-medium truncate">{ev.event_type || 'event'}</span>
+        </span>
+        <span className="text-[11px] text-text-dim font-mono shrink-0">{fmtTs(ev.ts)}</span>
+      </button>
+      {open && (
+        <pre className="mt-2 p-2 bg-surface-2 rounded-md text-[11px] text-text-muted overflow-x-auto font-mono">
+{prettyMeta(ev.meta)}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Actions — write surface. Give Solari / Give Item / Rename. Inventory mgmt
+// and per-track XP already covered by Inventory + Specs sections.
+// ---------------------------------------------------------------------------
+export function ActionsSection({ player, canWrite, flash, onChanged }: SectionProps) {
+  const [form, setForm] = useState<'solari' | 'item' | 'rename' | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const run = async (fn: () => Promise<{ message: string }>, label: string) => {
+    setBusy(true)
+    try {
+      const r = await fn()
+      flash(r.message || `${label} done.`, 'ok')
+      setForm(null)
+      onChanged()
+    } catch (e) {
+      flash(e instanceof Error ? e.message : String(e), 'err')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!canWrite) {
+    return (
+      <div className="card p-4 text-sm text-text-dim flex items-center gap-2">
+        <Icon name="Lock" size={14} /> Editing is available when the live game database is connected.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        <button className="btn-secondary" disabled={busy} onClick={() => setForm(form === 'solari' ? null : 'solari')}>
+          <Icon name="Coins" size={13} /> Give Solari
+        </button>
+        <button className="btn-secondary" disabled={busy} onClick={() => setForm(form === 'item' ? null : 'item')}>
+          <Icon name="PackagePlus" size={13} /> Give Item
+        </button>
+        <button className="btn-secondary" disabled={busy} onClick={() => setForm(form === 'rename' ? null : 'rename')}>
+          <Icon name="PenLine" size={13} /> Rename
+        </button>
+      </div>
+
+      {form === 'solari' && (
+        <InlineForm busy={busy} submitLabel="Give Solari" fields={[
+          { key: 'amount', label: 'Amount (Solari)', type: 'number', placeholder: 'e.g. 10000' },
+        ]} onSubmit={v => run(() => giveSolari(player.controller_id, Number(v.amount) || 0), 'Give Solari')} />
+      )}
+      {form === 'item' && (
+        <InlineForm busy={busy} submitLabel="Give Item" fields={[
+          { key: 'template', label: 'Item template id', type: 'text', placeholder: 'e.g. Spice_Melange' },
+          { key: 'qty',      label: 'Quantity',         type: 'number', placeholder: '1' },
+          { key: 'quality',  label: 'Quality (0–5)',    type: 'number', placeholder: '0' },
+        ]} onSubmit={v => run(() => giveItem(player.id, String(v.template || '').trim(), Number(v.qty) || 0, Number(v.quality) || 0), 'Give Item')} />
+      )}
+      {form === 'rename' && (
+        <InlineForm busy={busy} submitLabel="Rename" fields={[
+          { key: 'name', label: 'New character name', type: 'text', placeholder: player.name },
+        ]} onSubmit={v => run(() => renamePlayer(player.account_id, String(v.name || '').trim()), 'Rename')} />
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Inventory — re-uses the existing detail endpoint via the section pattern.
+// Repair + delete per item; sub-sections for emotes & contract items.
+// ---------------------------------------------------------------------------
+import { getPlayerDetail, type InventoryItem, type PlayerDetailResponse } from '../../../api/gameplay'
+import { qualityClass } from '../shared'
+
+export function InventorySection({ player, canWrite, demo, refreshKey, flash, onChanged }: SectionProps) {
+  const [detail, setDetail] = useState<PlayerDetailResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true); setErr(null)
+    getPlayerDetail(player.id, player.controller_id, demo)
+      .then(r => { if (alive) setDetail(r) })
+      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [player.id, player.controller_id, demo, refreshKey, tick])
+
+  const groups = useMemo(() => {
+    const inv = detail?.inventory ?? []
+    return {
+      gear:      inv.filter(i => (i.kind ?? 'item') === 'item'),
+      emotes:    inv.filter(i => i.kind === 'emote'),
+      contracts: inv.filter(i => i.kind === 'contract'),
+    }
+  }, [detail])
+
+  const run = async (fn: () => Promise<{ message: string }>, label: string) => {
+    setBusy(true)
+    try {
+      const r = await fn()
+      flash(r.message || `${label} done.`, 'ok')
+      setTick(t => t + 1)
+      onChanged()
+    } catch (e) {
+      flash(e instanceof Error ? e.message : String(e), 'err')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (loading && !detail) return <Loading label="Loading inventory…" />
+  if (err) return <ErrorBox msg={err} />
+
+  return (
+    <div className="space-y-4">
+      <ItemList title={`Inventory (${fmtNum(groups.gear.length)})`} icon="Backpack" items={groups.gear}
+        canWrite={canWrite} busy={busy} run={run} />
+      <ItemList title={`Emotes (${fmtNum(groups.emotes.length)})`} icon="Smile" items={groups.emotes} collapsed
+        canWrite={canWrite} busy={busy} run={run} />
+      <ItemList title={`Contract items (${fmtNum(groups.contracts.length)})`} icon="FileText" items={groups.contracts} collapsed
+        canWrite={canWrite} busy={busy} run={run} />
+    </div>
+  )
+}
+
+function ItemList({ title, icon, items, canWrite, busy, run, collapsed }: {
+  title: string; icon: string; items: InventoryItem[]; canWrite: boolean; busy: boolean
+  run: (fn: () => Promise<{ message: string }>, label: string) => void | Promise<void>
+  collapsed?: boolean
+}) {
+  const [open, setOpen] = useState(!collapsed)
+  if (collapsed && items.length === 0) return null
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(o => !o)}
+        className="flex w-full items-center gap-2 text-xs uppercase tracking-wider text-text-dim hover:text-text mb-2">
+        <Icon name={open ? 'ChevronDown' : 'ChevronRight'} size={13} />
+        <Icon name={icon} size={13} />
+        <span>{title}</span>
+      </button>
+      {open && (
+        items.length === 0 ? (
+          <div className="text-sm text-text-dim italic py-1">No items.</div>
+        ) : (
+          <div className="space-y-1">
+            {items.map(it => (
+              <div key={it.id} className="flex items-center justify-between text-sm bg-surface-2 rounded-lg px-3 py-2 border border-border/50">
+                <span className="truncate max-w-[320px]">
+                  <span className="text-text">{it.name || it.template_id}</span>
+                  {it.quality > 0 && <span className={`ml-1.5 text-[11px] ${qualityClass(it.quality)}`}>Q{it.quality}</span>}
+                  <span className="ml-1.5 font-mono text-text-dim text-xs">×{fmtNum(it.stack_size)}</span>
+                </span>
+                {canWrite && (
+                  <span className="flex items-center gap-2 shrink-0">
+                    {it.durability !== 'N/A' && (
+                      <button className="text-info hover:text-accent-bright" title="Repair to full" disabled={busy}
+                        onClick={() => run(() => repairInventoryItem(it.id), 'Repair')}>
+                        <Icon name="Wrench" size={13} />
+                      </button>
+                    )}
+                    <button className="text-danger/80 hover:text-danger" title="Delete item" disabled={busy}
+                      onClick={() => { if (window.confirm(`Delete ${it.name || it.template_id} (×${it.stack_size})?`)) void run(() => deleteInventoryItem(it.id), 'Delete') }}>
+                      <Icon name="Trash2" size={13} />
+                    </button>
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        )
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Small shared widgets
+// ---------------------------------------------------------------------------
+function Stat({ label, value, icon }: { label: string; value: string; icon: string }) {
+  return (
+    <div className="card p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] uppercase tracking-wider text-text-dim">{label}</span>
+        <Icon name={icon} size={14} className="text-accent" />
+      </div>
+      <div className="mt-1 text-lg font-semibold text-text truncate">{value}</div>
+    </div>
+  )
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="card p-3">
+      <h4 className="text-xs uppercase tracking-wider text-text-dim mb-2">{title}</h4>
+      <div className="space-y-1.5 text-sm">{children}</div>
+    </div>
+  )
+}
+
+function KV({ k, v, mono }: { k: string; v: string; mono?: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-text-dim">{k}</span>
+      <span className={mono ? 'font-mono text-text-muted text-xs' : 'text-text truncate max-w-[200px]'}>{v}</span>
+    </div>
+  )
+}
+
+function Loading({ label }: { label: string }) {
+  return (
+    <div className="text-text-dim text-sm py-4 flex items-center gap-2">
+      <Icon name="Loader2" size={15} className="animate-spin" /> {label}
+    </div>
+  )
+}
+
+function EmptyBox({ msg }: { msg: string }) {
+  return <div className="card p-4 text-sm text-text-dim text-center">{msg}</div>
+}
+
+function ErrorBox({ msg }: { msg: string }) {
+  return <div className="card p-3 text-sm text-danger break-words">{msg}</div>
+}
+
+interface FieldDef { key: string; label: string; type: 'text' | 'number'; placeholder?: string }
+
+function InlineForm({ fields, submitLabel, busy, onSubmit }: {
+  fields: FieldDef[]; submitLabel: string; busy: boolean; onSubmit: (values: Record<string, string>) => void
+}) {
+  const [values, setValues] = useState<Record<string, string>>({})
+  return (
+    <div className="card p-3 space-y-2">
+      {fields.map(f => (
+        <div key={f.key}>
+          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">{f.label}</label>
+          <input type={f.type} value={values[f.key] ?? ''} placeholder={f.placeholder}
+            onChange={e => setValues(v => ({ ...v, [f.key]: e.target.value }))}
+            className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+        </div>
+      ))}
+      <button className="btn-primary w-full" disabled={busy} onClick={() => onSubmit(values)}>
+        {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} {submitLabel}
+      </button>
+    </div>
+  )
+}
+
+// Format an ISO 8601 timestamp into a compact local-time string, or '—' on
+// empty / unparseable. Used in Stats + History.
+function fmtTs(ts: string | undefined): string {
+  if (!ts) return '—'
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return ts
+  return d.toLocaleString()
+}
+
+// Pretty-print event meta JSON, falling back to the raw string when it
+// can't be parsed (older event_log rows have free-form meta).
+function prettyMeta(meta: string): string {
+  if (!meta) return '{}'
+  try {
+    const o = JSON.parse(meta)
+    return JSON.stringify(o, null, 2)
+  } catch {
+    return meta
+  }
+}
+
+// Re-export the section component type for the tab shell.
+export type SectionId = 'stats' | 'specs' | 'tags' | 'history' | 'inventory' | 'actions'
+
+export const SECTIONS: Array<{ id: SectionId; label: string; icon: string }> = [
+  { id: 'stats',     label: 'Stats',     icon: 'User' },
+  { id: 'specs',     label: 'Specs',     icon: 'Sparkles' },
+  { id: 'inventory', label: 'Inventory', icon: 'Backpack' },
+  { id: 'tags',      label: 'Tags',      icon: 'Tag' },
+  { id: 'history',   label: 'History',   icon: 'History' },
+  { id: 'actions',   label: 'Actions',   icon: 'Wand2' },
+]
+
+export const SECTION_COMPONENTS: Record<SectionId, (p: SectionProps) => ReactElement> = {
+  stats:     StatsSection,
+  specs:     SpecsSection,
+  tags:      TagsSection,
+  history:   HistorySection,
+  inventory: InventorySection,
+  actions:   ActionsSection,
+}


### PR DESCRIPTION
Rebuilds the **Gameplay → Players** tab as a 2-column workspace mirroring [dune-admin.layout.tools/#/players](https://dune-admin.layout.tools/#/players), which is the primary player-management surface coastal-ms players rely on. Phase 1 ships the layout shell plus six sections backed by 11 new endpoints. Subsequent phases add Progression/Contracts/Journey (v11.5.7), Vehicles/bulk Give (v11.5.8), live RMQ commands (v11.5.9), and specialised ops (v11.5.10).

## What ships

**New left rail** - filterable player list + Sections selector. Online players sort to the top; selection drives the right pane.

**Server Overview** (shown when no player selected) - totals, by-faction, by-map breakdowns from new `GET /api/gameplay/players/summary`.

**Six sections** (right pane, switched by the Sections nav):

| Section | What it does | New API |
|---|---|---|
| **Stats** | Per-player snapshot: Solari, total currency, faction, status, last-seen, all account/controller/pawn IDs | `GET /stats?pawn=` |
| **Specs** | 5 tracks (Combat/Crafting/Exploration/Gathering/Sabotage) with XP progress bars, +5000 XP, **Grant Max** (xp=44182 level=100), per-track **Reset**; panel-level **Grant Max Keystones** (all 205), **Reset All Keystones**, **Reset All** | `GET /specs` + 5 POSTs |
| **Inventory** | Gear / Emotes / Contracts groupings with per-item Repair + Delete (preserved from v11.5.5) | (existing) |
| **Tags** | Chip editor for `dune.player_tags`; Add / Remove / Save (replaces full set in one POST) | `GET/POST /tags` |
| **History** | Recent `dune.event_log` rows joined via `meta->>''fls_id''`; expandable raw-JSON view per row | `GET /events` |
| **Actions** | Give Solari / Give Item / Rename (preserved) | (existing) |

## Defensive design

Sections backed by optional tables (`player_tags`, `event_log`) degrade to "feature unavailable" cards when the live game DB returns `relation does not exist` - older Funcom server builds remain usable instead of throwing. Implemented via new `Invoke-DuneSqlSoft` helper.

## SQL provenance

All write SQL is lifted verbatim from dune-admin/cmd/dune-admin/db.go:
- Grant max: `dune.set_specialization_xp_and_level(pawnId, track::dune.specializationtracktype, 44182, 100.0)`
- Reset all specs: `dune.reset_specialization_tracks($1)` + `dune.reset_specialization_keystones($1)`
- Grant all keystones: `INSERT INTO dune.purchased_specialization_keystones SELECT $1, generate_series(1, 205) ON CONFLICT DO NOTHING`
- Reset one track: `DELETE FROM dune.specialization_tracks WHERE player_id=$1 AND track_type::text=$2`

All run through existing `Invoke-DuneSqlQuery` SSH/psql bridge - no new transports.

## Files

| Layer | Files |
|---|---|
| Backend | `app/server/lib/GameplayPlayers.ps1` (+384), `app/server/routes/GameplayPlayers.ps1` (+198) |
| Frontend API | `webui/src/api/gameplay.ts` (+137: 11 new functions + types) |
| Frontend UI | `webui/src/pages/gameplay/PlayersTab.tsx` (rewritten as 2-col shell), `webui/src/pages/gameplay/players/sections.tsx` (NEW, 679 LOC: all 6 sections) |
| Versioning | 5 stamps bumped to 11.5.6 |
| Docs | `CHANGELOG.md` |

## Verified

- `tsc -b && vite build` clean
- Both modified PS files parse OK
- Backend SQL patterns cross-checked against dune-admin db.go callsites

## Multi-release plan

| Phase | Scope | Endpoints (approx) |
|---|---|---|
| **v11.5.6** (this) | Stats / Specs / Inventory / Tags / History / Actions | 25 |
| v11.5.7 | Progression / Contracts / Journey | 16 |
| v11.5.8 | Vehicles / bulk Give / Give-Currency expansion | 16 |
| v11.5.9 | RMQ live commands (kick / whisper / teleport / spawn-vehicle / fill-water / cheat-script) via Broadcast.ps1 Erlang pipeline | 12 |
| v11.5.10 | Specialised (account delete / rename / character export) | 9 |
