### PR TITLE
v11.5.7: User-reported hotfixes (Give Item search, Fill Water, Coriolis seeds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,52 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.5.7] - 2026-06-12
+
+### Added — User-reported hotfixes (Phase 1.5 of dune-admin player port)
+
+This release responds to direct user feedback on the v11.5.6 Players tab and pulls
+forward two features from the planned v11.5.9 work so users aren't blocked:
+
+- **Give Item search autocomplete** (reported by Chopper) — both the
+  *Players → Actions → Give Item* form and the *Storage → Add Items* form now
+  show a typeahead dropdown that searches the live game catalog (`/api/catalog/items`)
+  by friendly name *or* template id as you type. Selecting a result fills the
+  template id automatically. The catalog is fetched lazily on first focus and
+  cached for the session.
+- **Fill Water** (reported by Chopper) — restores the Icehunter add-on feature.
+  Adds a *Fill Water* button to *Players → Actions* that refills every
+  fillable water container in the selected player's storage, gear, mounts,
+  vehicles, dropship and chests to max. SQL is ported verbatim from
+  dune-admin's `cmdRefillWaterOffline` so it covers the same 49 fillable
+  templates and 6 inventory types. Online players see the effect on their
+  next relog (game server caches inventory in memory); offline players see
+  it immediately on next login.
+- **Coriolis Storm seed control** (requested by [user]) — new
+  *Coriolis Storm Seeds* panel under *Players → Server Overview* (visible
+  when no player is selected). Three scopes:
+  - **Farm seed** — reroll, stay on current, or set a specific seed for the
+    whole farm (cascades to every map and partition, triggers cleanup of
+    corpses + loose loot).
+  - **Map seed** — same controls per individual map (Hagga Basin, Vermillius
+    Gap, etc.). Cascades to that map's partitions.
+  - **Partition seed** — collapsible list with the same controls per
+    partition for fine-grained tweaks.
+  Uses the existing `dune.debug_get_coriolis_seeds()` / `debug_set_*_seed()`
+  Postgres routines, so private servers that have these routines available
+  get the live experience and others fall back to a demo view automatically.
+
+### Notes
+
+- The heavy *Progression / Contracts / Journey* port originally planned for
+  v11.5.7 has been deferred to v11.5.8 so these blocker-tier user fixes
+  could ship same-day.
+- Backend wiring is in `app/server/lib/CoriolisAdmin.ps1` +
+  `app/server/routes/CoriolisAdmin.ps1` and the new
+  `Invoke-DunePlayerFillWater` in `app/server/lib/GameplayPlayers.ps1`.
+  Frontend wiring uses the new reusable `ItemPicker` component in
+  `webui/src/components/ItemPicker.tsx`.
+
 ## [11.5.6] - 2026-06-12
 
 ### Added — Player admin foundation (Phase 1 of dune-admin player port)

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -1,4 +1,4 @@
-﻿# Dune Server — entry point (v6.1 web portal)
+# Dune Server — entry point (v6.1 web portal)
 #
 # Bootstrap: pick a free port, start HttpListener, open default browser at the
 # tokened localhost URL. The full UI is the React SPA in webui/dist/.
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.5.6'
+$script:DuneToolVersion = '11.5.7'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.5.6',
+    [string]$Version = '11.5.7',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.5.6</Version>
+    <Version>11.5.7</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.5.6"
+#define MyAppVersion "11.5.7"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/CoriolisAdmin.ps1
+++ b/app/server/lib/CoriolisAdmin.ps1
@@ -1,0 +1,117 @@
+# Coriolis Admin — v11.5.7
+#
+# Wraps dune.debug_get_coriolis_seeds() + dune.debug_set_farm_seed() /
+# debug_set_map_seed() / debug_set_partition_seed() so admins can inspect and
+# override the world-reset (Coriolis storm) seeds without resetting state.
+#
+# Background: every map + partition has a "world_reset_seed" that determines
+# the next Coriolis storm layout. The game updates it automatically on storm
+# events. Setting it manually lets admins (a) pin a specific layout / spawn
+# pattern across resets, or (b) force-trigger a reset by changing the value
+# (which cleans up old corpses / loose loot via coriolis_cleanup_*).
+#
+# All paths use Invoke-DuneSqlSoft so missing tables / functions on legacy or
+# self-hosted DBs degrade to a clear "unsupported" response instead of 500s.
+
+# ----------------------------------------------------------------------------
+# Read — current farm / map / partition seeds.
+# ----------------------------------------------------------------------------
+$script:DuneCoriolisSeedsSql = @'
+SELECT
+    COALESCE(farm_seed, 0)                              AS farm_seed,
+    COALESCE(array_to_json(map_names)::text, '[]')      AS map_names_json,
+    COALESCE(array_to_json(map_seeds)::text, '[]')      AS map_seeds_json,
+    COALESCE(array_to_json(partitions_ids)::text, '[]') AS partition_ids_json,
+    COALESCE(array_to_json(partitions_map)::text, '[]') AS partition_maps_json,
+    COALESCE(array_to_json(partitions_seeds)::text, '[]') AS partition_seeds_json
+FROM dune.debug_get_coriolis_seeds();
+'@
+
+function Get-DuneCoriolisSeedsLive {
+    param([string]$Ip)
+    $soft = Invoke-DuneSqlSoft -Ip $Ip -Sql $script:DuneCoriolisSeedsSql -MaxRows 1 -TimeoutSec 15
+    if (-not $soft.ok) { return @{ ok = $false; error = $soft.error } }
+    if ($soft.unsupported) {
+        return @{ ok = $true; unsupported = $true; farm_seed = 0; maps = @(); partitions = @() }
+    }
+    $maps = ConvertTo-DuneRowMaps -Result $soft.raw
+    if ($maps.Count -lt 1) {
+        return @{ ok = $true; farm_seed = 0; maps = @(); partitions = @() }
+    }
+    $r = $maps[0]
+    $farm = [int](ConvertTo-DuneInt $r['farm_seed'])
+    $mapNames  = @(); $mapSeeds = @()
+    $partIds   = @(); $partMaps = @(); $partSeeds = @()
+    try { $mapNames  = @(ConvertFrom-Json ([string]$r['map_names_json'])) } catch {}
+    try { $mapSeeds  = @(ConvertFrom-Json ([string]$r['map_seeds_json'])) } catch {}
+    try { $partIds   = @(ConvertFrom-Json ([string]$r['partition_ids_json'])) } catch {}
+    try { $partMaps  = @(ConvertFrom-Json ([string]$r['partition_maps_json'])) } catch {}
+    try { $partSeeds = @(ConvertFrom-Json ([string]$r['partition_seeds_json'])) } catch {}
+
+    $maps = @()
+    for ($i = 0; $i -lt $mapNames.Count; $i++) {
+        $maps += [ordered]@{
+            map  = [string]$mapNames[$i]
+            seed = if ($i -lt $mapSeeds.Count) { [int]$mapSeeds[$i] } else { 0 }
+        }
+    }
+    $partitions = @()
+    for ($i = 0; $i -lt $partIds.Count; $i++) {
+        $partitions += [ordered]@{
+            partition_id = [long]$partIds[$i]
+            map          = if ($i -lt $partMaps.Count)  { [string]$partMaps[$i] } else { '' }
+            seed         = if ($i -lt $partSeeds.Count) { [int]$partSeeds[$i] }    else { 0 }
+        }
+    }
+    return @{ ok = $true; farm_seed = $farm; maps = $maps; partitions = $partitions }
+}
+
+function Get-DuneCoriolisSeedsDemo {
+    return @{
+        ok         = $true
+        farm_seed  = 12345
+        maps       = @(
+            [ordered]@{ map = 'HaggaBasin';   seed = 12345 },
+            [ordered]@{ map = 'DeepDesert';   seed = 67890 }
+        )
+        partitions = @(
+            [ordered]@{ partition_id = 101; map = 'HaggaBasin'; seed = 12345 },
+            [ordered]@{ partition_id = 201; map = 'DeepDesert'; seed = 67890 }
+        )
+    }
+}
+
+# ----------------------------------------------------------------------------
+# Writes — set seed at farm / map / partition scope.
+# These call dune.debug_set_* functions, which also cascade cleanup (corpses,
+# coriolis-affected partition state) when the seed actually changes.
+# ----------------------------------------------------------------------------
+function Invoke-DuneCoriolisSetFarmSeed {
+    param([string]$Ip, [int]$Seed)
+    if ($Seed -lt 0) { return @{ ok = $false; error = 'Seed must be a non-negative 32-bit integer.' } }
+    $sql = "SELECT dune.debug_set_farm_seed($Seed::int);"
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    return @{ ok = $true; scope = 'farm'; seed = $Seed; message = "Set farm + all maps + all partitions to seed $Seed (cleanup will cascade if changed)." }
+}
+
+function Invoke-DuneCoriolisSetMapSeed {
+    param([string]$Ip, [string]$Map, [int]$Seed)
+    if (-not $Map) { return @{ ok = $false; error = 'map name is required.' } }
+    if ($Seed -lt 0) { return @{ ok = $false; error = 'Seed must be a non-negative 32-bit integer.' } }
+    $safeMap = ConvertTo-DuneSqlString $Map
+    $sql = "SELECT dune.debug_set_map_seed('$safeMap'::text, $Seed::int);"
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    return @{ ok = $true; scope = 'map'; map = $Map; seed = $Seed; message = "Set map '$Map' (+ its partitions) to seed $Seed." }
+}
+
+function Invoke-DuneCoriolisSetPartitionSeed {
+    param([string]$Ip, [long]$PartitionId, [int]$Seed)
+    if ($PartitionId -le 0) { return @{ ok = $false; error = 'partition_id is required.' } }
+    if ($Seed -lt 0) { return @{ ok = $false; error = 'Seed must be a non-negative 32-bit integer.' } }
+    $sql = "SELECT dune.debug_set_partition_seed($PartitionId::bigint, $Seed::int);"
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    return @{ ok = $true; scope = 'partition'; partition_id = $PartitionId; seed = $Seed; message = "Set partition $PartitionId to seed $Seed." }
+}

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -695,3 +695,71 @@ function Get-DunePlayerEventsDemo {
         [ordered]@{ id=3; ts='2026-06-11T22:10:00Z'; event_type='logout';        meta='{}' }
     )
 }
+
+# ---------------------------------------------------------------------------
+# v11.5.7 — Fill Water (offline path). Ported from dune-admin db.go:6325
+# cmdRefillWaterOffline. Sets all water-fillable items in the actor's relevant
+# inventories to their MaxAmount via jsonb_set. Takes effect on next relog for
+# online players; instant for offline players.
+#
+# Source list: dune-admin fillables_gen.go waterFillableTemplates (49 entries,
+# generated from DT_ItemTableFillables.json — FillableTypeRestriction=Water).
+# repairGearInventoryTypes mirrors dune-admin's set (0,1,14,15,27,30).
+# ---------------------------------------------------------------------------
+$script:DuneWaterFillableTemplates = @(
+    'advancedstillsuit','combat_nati_fremenexile04_top','decajon','dewpack',
+    'highcapacityliterjon','highcapacityliterjon_02','highcapacityliterjon_03',
+    'highcapacityliterjon_04','highcapacityliterjon_05','highcapacityliterjon_06',
+    'literjon','literjon_03','literjon_04','literjon_05','literjon_06',
+    'literjon_07','literjon_08','literjon_09','literjon_t6','simplestillsuit',
+    'stillsuit_choam_01_top','stillsuit_choam_02_top','stillsuit_choam_04_top',
+    'stillsuit_choam_05_top','stillsuit_choam_06_top',
+    'stillsuit_choam_unique_dashed02_top','stillsuit_choam_unique_dashed03_top',
+    'stillsuit_choam_unique_dashed04_top','stillsuit_choam_unique_dashed05_top',
+    'stillsuit_choam_unique_dashed06_top','stillsuit_nati_05_body',
+    'stillsuit_nati_06_body','stillsuit_nati_07_body','stillsuit_nati_08_body',
+    'stillsuit_nati_arrakeen05_body','stillsuit_neut_leaking01_top',
+    'stillsuit_neut_patchy02_top','stillsuit_unique_armored_01_top',
+    'stillsuit_unique_armored_02_top','stillsuit_unique_armored_03_top',
+    'stillsuit_unique_armored_04_top','stillsuit_unique_armored_05_top',
+    'stillsuit_unique_armored_06_top','stillsuit_unique_efficient_04_top',
+    'stillsuit_unique_efficient_05_top','stillsuit_unique_efficient_06_top',
+    'stillsuit_unique_highcapacity_06_top','stillsuit_unique_thermalsuit_06_top',
+    'waterpack_consumable'
+)
+$script:DuneWaterFillableInventoryTypes = @(0, 1, 14, 15, 27, 30)
+
+function Invoke-DunePlayerFillWater {
+    param([string]$Ip, [long]$PawnId)
+    if ($PawnId -le 0) { return @{ ok = $false; error = 'pawn_id (actor id) is required.' } }
+    $tmplCsv = ($script:DuneWaterFillableTemplates | ForEach-Object { "'" + $_ + "'" }) -join ','
+    $invCsv  = ($script:DuneWaterFillableInventoryTypes -join ',')
+    $sql = @"
+WITH upd AS (
+    UPDATE dune.items i
+    SET stats = jsonb_set(
+        i.stats,
+        '{FFillableItemStats,1,CurrentAmount}',
+        (i.stats->'FFillableItemStats'->1->'MaxAmount')
+    )
+    FROM dune.inventories inv
+    WHERE inv.actor_id = $PawnId::bigint
+      AND inv.inventory_type = ANY(ARRAY[$invCsv]::int[])
+      AND i.inventory_id = inv.id
+      AND lower(i.template_id) = ANY(ARRAY[$tmplCsv]::text[])
+      AND i.stats ? 'FFillableItemStats'
+      AND (i.stats->'FFillableItemStats'->1->'MaxAmount') IS NOT NULL
+    RETURNING i.id
+)
+SELECT COUNT(*)::bigint AS refilled FROM upd;
+"@
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    $maps = ConvertTo-DuneRowMaps -Result $res
+    $count = 0
+    if ($maps.Count -ge 1) { $count = [int](ConvertTo-DuneInt $maps[0]['refilled']) }
+    if ($count -le 0) {
+        return @{ ok = $true; refilled = 0; message = 'No water-fillable items found for that player (already empty inventory or no stillsuits/jons).' }
+    }
+    return @{ ok = $true; refilled = $count; message = "Refilled $count water-fillable item(s). Online players: takes effect on next relog." }
+}

--- a/app/server/routes/CoriolisAdmin.ps1
+++ b/app/server/routes/CoriolisAdmin.ps1
@@ -1,0 +1,80 @@
+# Coriolis Admin routes — v11.5.7
+#
+# Endpoints for inspecting and setting Coriolis storm seeds. Mounted under
+# /api/gameplay/coriolis/* so it lives next to the existing Gameplay admin
+# surface (no separate admin tab needed).
+
+# GET /api/gameplay/coriolis/seeds  → current seeds
+Register-DuneRoute -Method GET -Path '/api/gameplay/coriolis/seeds' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $source = 'demo'; $payload = $null; $liveError = $null
+        if (-not (Test-DuneDemoRequested $req)) {
+            $ctx = Get-DuneDbContext
+            if ($ctx.ok) {
+                $live = Get-DuneCoriolisSeedsLive -Ip $ctx.ip
+                if ($live.ok) { $payload = $live; $source = if ($live.unsupported) { 'demo' } else { 'live' } }
+                else { $liveError = $live.error }
+            } else { $liveError = $ctx.message }
+        }
+        if (-not $payload) { $payload = Get-DuneCoriolisSeedsDemo }
+        $out = @{
+            ok         = $true
+            source     = $source
+            farm_seed  = $payload.farm_seed
+            maps       = $payload.maps
+            partitions = $payload.partitions
+        }
+        if ($liveError) { $out['liveError'] = $liveError }
+        Write-DuneJson -Response $res -Body $out
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Coriolis seeds failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/coriolis/set-farm-seed  { seed }
+Register-DuneRoute -Method POST -Path '/api/gameplay/coriolis/set-farm-seed' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $seed = Get-DuneBodyInt -Body $body -Name 'seed'
+        if ($null -eq $seed -or $seed -lt 0) { Write-DuneError -Response $res -Status 400 -Message 'seed (non-negative integer) is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip) Invoke-DuneCoriolisSetFarmSeed -Ip $ip -Seed ([int]$seed)
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Set farm seed failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/coriolis/set-map-seed  { map, seed }
+Register-DuneRoute -Method POST -Path '/api/gameplay/coriolis/set-map-seed' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $map = ''
+        if ($body -and $body.PSObject.Properties['map']) { $map = [string]$body.map }
+        $seed = Get-DuneBodyInt -Body $body -Name 'seed'
+        if (-not $map) { Write-DuneError -Response $res -Status 400 -Message 'map (string) is required.'; return }
+        if ($null -eq $seed -or $seed -lt 0) { Write-DuneError -Response $res -Status 400 -Message 'seed (non-negative integer) is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip) Invoke-DuneCoriolisSetMapSeed -Ip $ip -Map $map -Seed ([int]$seed)
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Set map seed failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/coriolis/set-partition-seed  { partition_id, seed }
+Register-DuneRoute -Method POST -Path '/api/gameplay/coriolis/set-partition-seed' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pid = Get-DuneBodyInt -Body $body -Name 'partition_id'
+        $seed = Get-DuneBodyInt -Body $body -Name 'seed'
+        if ($null -eq $pid -or $pid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'partition_id (positive integer) is required.'; return }
+        if ($null -eq $seed -or $seed -lt 0) { Write-DuneError -Response $res -Status 400 -Message 'seed (non-negative integer) is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip) Invoke-DuneCoriolisSetPartitionSeed -Ip $ip -PartitionId ([long]$pid) -Seed ([int]$seed)
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Set partition seed failed: $($_.Exception.Message)"
+    }
+}

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -381,3 +381,21 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/players/events' -Handler {
     }
 }
 
+
+# v11.5.7 — POST /api/gameplay/players/fill-water  { pawn_id }
+# Online players: takes effect on next relog (game server caches inventory in
+# memory). Offline players: instant.
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/fill-water' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        if (-not $pawn) { $pawn = Get-DuneBodyInt -Body $body -Name 'actor_id' }
+        if (-not $pawn) { $pawn = Get-DuneBodyInt -Body $body -Name 'id' }
+        if (-not $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id (actor id) is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip) Invoke-DunePlayerFillWater -Ip $ip -PawnId $pawn
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Fill water failed: $($_.Exception.Message)"
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -RunAsAdministrator
+#Requires -RunAsAdministrator
 
 [CmdletBinding()]
 param(
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.5.6"
+$script:ToolVersion = "11.5.7"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -756,3 +756,117 @@ export function downloadBlueprintFile(blueprint: BlueprintFile, filename: string
   document.body.removeChild(a)
   URL.revokeObjectURL(url)
 }
+
+// ---------------------------------------------------------------------------
+// v11.5.7 — Item catalog (for autocomplete), Fill Water, Coriolis admin.
+// ---------------------------------------------------------------------------
+
+export interface CatalogItem {
+  template_id: string
+  name: string
+  category: string
+}
+
+interface CatalogResponse {
+  _meta?: { count?: number; source?: string }
+  items: Record<string, { name: string; category: string }>
+}
+
+let _catalogCache: CatalogItem[] | null = null
+let _catalogPromise: Promise<CatalogItem[]> | null = null
+
+/**
+ * Load + cache the full item catalog. The /api/catalog/items response is a
+ * dict of { template_id: { name, category } }; we flatten to an array so the
+ * autocomplete can sort + slice efficiently. ~5k entries, ~110KB JSON; only
+ * fetched once per session.
+ */
+export function getItemCatalog(): Promise<CatalogItem[]> {
+  if (_catalogCache) return Promise.resolve(_catalogCache)
+  if (_catalogPromise) return _catalogPromise
+  _catalogPromise = api<CatalogResponse>('/api/catalog/items').then(r => {
+    const items = r.items || {}
+    const flat: CatalogItem[] = []
+    for (const tid of Object.keys(items)) {
+      const v = items[tid]
+      flat.push({ template_id: tid, name: v?.name || tid, category: v?.category || '' })
+    }
+    flat.sort((a, b) => a.name.localeCompare(b.name))
+    _catalogCache = flat
+    _catalogPromise = null
+    return flat
+  }).catch(e => {
+    _catalogPromise = null
+    throw e
+  })
+  return _catalogPromise
+}
+
+/**
+ * Case-insensitive substring filter over name OR template_id. Returns up to
+ * `limit` matches sorted by best-match (template_id prefix > name prefix >
+ * substring), then alphabetically.
+ */
+export function filterCatalog(catalog: CatalogItem[], query: string, limit = 20): CatalogItem[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return []
+  const out: { item: CatalogItem; rank: number }[] = []
+  for (const it of catalog) {
+    const tid = it.template_id.toLowerCase()
+    const nm  = it.name.toLowerCase()
+    let rank = -1
+    if (tid === q || nm === q)                 rank = 0
+    else if (tid.startsWith(q))                rank = 1
+    else if (nm.startsWith(q))                 rank = 2
+    else if (tid.includes(q) || nm.includes(q)) rank = 3
+    if (rank >= 0) out.push({ item: it, rank })
+  }
+  out.sort((a, b) => a.rank - b.rank || a.item.name.localeCompare(b.item.name))
+  return out.slice(0, limit).map(o => o.item)
+}
+
+export interface FillWaterResponse {
+  ok: boolean
+  message: string
+  result?: { refilled?: number }
+}
+
+export function fillWater(pawnId: number): Promise<FillWaterResponse> {
+  return api<FillWaterResponse>('/api/gameplay/players/fill-water', {
+    method: 'POST', body: JSON.stringify({ pawn_id: pawnId }),
+  })
+}
+
+export interface CoriolisMap       { map: string; seed: number }
+export interface CoriolisPartition { partition_id: number; map: string; seed: number }
+
+export interface CoriolisSeedsResponse {
+  ok: boolean
+  source: DataSource
+  farm_seed: number
+  maps: CoriolisMap[]
+  partitions: CoriolisPartition[]
+  liveError?: string
+}
+
+export function getCoriolisSeeds() {
+  return api<CoriolisSeedsResponse>('/api/gameplay/coriolis/seeds')
+}
+
+export function setCoriolisFarmSeed(seed: number) {
+  return api<WriteResult>('/api/gameplay/coriolis/set-farm-seed', {
+    method: 'POST', body: JSON.stringify({ seed }),
+  })
+}
+
+export function setCoriolisMapSeed(map: string, seed: number) {
+  return api<WriteResult>('/api/gameplay/coriolis/set-map-seed', {
+    method: 'POST', body: JSON.stringify({ map, seed }),
+  })
+}
+
+export function setCoriolisPartitionSeed(partitionId: number, seed: number) {
+  return api<WriteResult>('/api/gameplay/coriolis/set-partition-seed', {
+    method: 'POST', body: JSON.stringify({ partition_id: partitionId, seed }),
+  })
+}

--- a/webui/src/components/ItemPicker.tsx
+++ b/webui/src/components/ItemPicker.tsx
@@ -1,0 +1,140 @@
+// ItemPicker — typeahead autocomplete for the item catalog.
+// v11.5.7. Used in player Give Item, storage Give Item, etc.
+//
+// Behaviour mirrors dune-admin's item search: lazy-load the catalog on first
+// keystroke, filter on every change with substring match against display
+// name OR template_id (case-insensitive), show up to 20 matches in a popup
+// listing "Name — template_id (category)". Arrow keys + Enter to select,
+// Escape to clear.
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { Icon } from './Icon'
+import { filterCatalog, getItemCatalog, type CatalogItem } from '../api/gameplay'
+
+interface Props {
+  value: string
+  onChange: (templateId: string) => void
+  label?: string
+  placeholder?: string
+  autoFocus?: boolean
+  disabled?: boolean
+}
+
+export function ItemPicker({ value, onChange, label, placeholder, autoFocus, disabled }: Props) {
+  const inputId = useId()
+  const [catalog, setCatalog] = useState<CatalogItem[] | null>(null)
+  const [catalogError, setCatalogError] = useState<string | null>(null)
+  const [catalogLoading, setCatalogLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [active, setActive] = useState(0)
+  const wrapRef = useRef<HTMLDivElement>(null)
+
+  // Lazy-load on first focus.
+  const ensureCatalog = useCallback(() => {
+    if (catalog || catalogLoading) return
+    setCatalogLoading(true)
+    getItemCatalog()
+      .then(setCatalog)
+      .catch(e => setCatalogError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setCatalogLoading(false))
+  }, [catalog, catalogLoading])
+
+  // Compute matches against current value.
+  const matches: CatalogItem[] = catalog ? filterCatalog(catalog, value, 20) : []
+
+  // Close popup on outside click.
+  useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (!wrapRef.current) return
+      if (!wrapRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [])
+
+  const pick = (it: CatalogItem) => {
+    onChange(it.template_id)
+    setOpen(false)
+    setActive(0)
+  }
+
+  const onKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open || matches.length === 0) {
+      if (e.key === 'ArrowDown' && catalog) { setOpen(true); setActive(0); e.preventDefault() }
+      return
+    }
+    if (e.key === 'ArrowDown')      { setActive(a => Math.min(a + 1, matches.length - 1)); e.preventDefault() }
+    else if (e.key === 'ArrowUp')   { setActive(a => Math.max(a - 1, 0));                    e.preventDefault() }
+    else if (e.key === 'Enter')     { pick(matches[active]); e.preventDefault() }
+    else if (e.key === 'Escape')    { setOpen(false); e.preventDefault() }
+    else if (e.key === 'Tab' && matches.length > 0) { pick(matches[active]) }
+  }
+
+  return (
+    <div ref={wrapRef} className="relative">
+      {label && (
+        <label htmlFor={inputId} className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        <input
+          id={inputId}
+          type="text"
+          autoComplete="off"
+          spellCheck={false}
+          disabled={disabled}
+          autoFocus={autoFocus}
+          value={value}
+          placeholder={placeholder || 'e.g. spice, stillsuit, literjon…'}
+          onFocus={() => { ensureCatalog(); setOpen(true) }}
+          onChange={e => { onChange(e.target.value); setOpen(true); setActive(0) }}
+          onKeyDown={onKey}
+          className="w-full pl-9 pr-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
+        />
+        <Icon name="Search" size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-dim pointer-events-none" />
+      </div>
+
+      {open && (catalogLoading || catalogError || matches.length > 0 || value.trim().length > 0) && (
+        <div className="absolute left-0 right-0 mt-1 z-30 max-h-72 overflow-y-auto rounded-lg border border-border bg-surface-1 shadow-2xl">
+          {catalogLoading && (
+            <div className="px-3 py-2 text-xs text-text-dim flex items-center gap-2">
+              <Icon name="Loader2" size={12} className="animate-spin" /> Loading item catalog…
+            </div>
+          )}
+          {catalogError && (
+            <div className="px-3 py-2 text-xs text-danger">
+              Catalog load failed: {catalogError}
+            </div>
+          )}
+          {!catalogLoading && !catalogError && matches.length === 0 && value.trim().length > 0 && (
+            <div className="px-3 py-2 text-xs text-text-dim">
+              No items match "{value}". Type fewer letters or paste the exact template id.
+            </div>
+          )}
+          {matches.map((it, i) => (
+            <button
+              key={it.template_id}
+              type="button"
+              onMouseEnter={() => setActive(i)}
+              onMouseDown={e => { e.preventDefault(); pick(it) }}
+              className={`w-full text-left px-3 py-2 flex items-center gap-2 text-sm ${
+                i === active ? 'bg-surface-2 text-text' : 'text-text-dim hover:bg-surface-2/60'
+              }`}
+            >
+              <span className="flex-1 min-w-0 truncate">
+                <span className={i === active ? 'text-text font-medium' : 'text-text'}>{it.name}</span>
+                <span className="ml-2 text-text-dim text-[11px] font-mono">{it.template_id}</span>
+              </span>
+              {it.category && (
+                <span className="text-[10px] uppercase tracking-wider text-text-dim/70 shrink-0">
+                  {it.category}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/webui/src/pages/gameplay/PlayersTab.tsx
+++ b/webui/src/pages/gameplay/PlayersTab.tsx
@@ -13,6 +13,7 @@ import { fmtNum, SourceBadge, StatCard, DemoNotice } from './shared'
 import {
   SECTIONS, SECTION_COMPONENTS, type SectionId,
 } from './players/sections'
+import { CoriolisAdmin } from './players/coriolis'
 
 type OnlineFilter = '' | 'online' | 'offline'
 
@@ -195,7 +196,12 @@ export function PlayersTab() {
               />
             </div>
           ) : (
-            <ServerOverview summary={summary} />
+            <>
+              <ServerOverview summary={summary} />
+              <div className="mt-3">
+                <CoriolisAdmin flash={(msg, kind = 'ok') => setFlash({ msg, kind })} />
+              </div>
+            </>
           )}
         </section>
       </div>

--- a/webui/src/pages/gameplay/StorageTab.tsx
+++ b/webui/src/pages/gameplay/StorageTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Icon } from '../../components/Icon'
+import { ItemPicker } from '../../components/ItemPicker'
 import {
   getStorage, getStorageItems, giveItemsToStorage, deleteStorageItem,
   type StorageContainer, type InventoryItem, type DataSource, type StorageGiveItemInput,
@@ -263,13 +264,12 @@ function AddItemsForm({ busy, onSubmit, onCancel }: {
 
   return (
     <div className="card p-3 mb-3 space-y-2">
-      <div>
-        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Item template id</label>
-        <input type="text" value={template} placeholder="e.g. Spice_Melange"
-          onChange={e => setTemplate(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter') add() }}
-          className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
-      </div>
+      <ItemPicker
+        label="Item — type to search by name or template id"
+        value={template}
+        onChange={setTemplate}
+        disabled={busy}
+      />
       <div className="grid grid-cols-2 gap-2">
         <div>
           <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Quantity</label>

--- a/webui/src/pages/gameplay/players/coriolis.tsx
+++ b/webui/src/pages/gameplay/players/coriolis.tsx
@@ -1,0 +1,212 @@
+// CoriolisAdmin — v11.5.7 storm seed inspector + editor.
+//
+// Lives in the Server Overview pane (Players tab, no player selected) so admins
+// can see + override the world-reset seed at three scopes:
+//   - farm   (cascades to every map + partition)
+//   - map    (cascades to that map's partitions)
+//   - partition (single partition only)
+//
+// Backed by /api/gameplay/coriolis/* which wraps Postgres dune.debug_set_*
+// functions. Read endpoint returns 'source: demo' when the live DB is offline
+// or the debug_get_coriolis_seeds() routine isn't available.
+
+import { useEffect, useState } from 'react'
+import { Icon } from '../../../components/Icon'
+import {
+  getCoriolisSeeds, setCoriolisFarmSeed, setCoriolisMapSeed, setCoriolisPartitionSeed,
+  type CoriolisMap, type CoriolisPartition, type DataSource,
+} from '../../../api/gameplay'
+
+type Flash = (msg: string, kind?: 'ok' | 'err') => void
+
+export function CoriolisAdmin({ flash }: { flash: Flash }) {
+  const [loading, setLoading]   = useState(true)
+  const [err, setErr]           = useState<string | null>(null)
+  const [source, setSource]     = useState<DataSource>('demo')
+  const [farmSeed, setFarmSeed] = useState(0)
+  const [maps, setMaps]         = useState<CoriolisMap[]>([])
+  const [parts, setParts]       = useState<CoriolisPartition[]>([])
+  const [busy, setBusy]         = useState(false)
+  const [tick, setTick]         = useState(0)
+
+  // Per-scope draft inputs.
+  const [farmDraft, setFarmDraft]               = useState('')
+  const [mapDrafts, setMapDrafts]               = useState<Record<string, string>>({})
+  const [partDrafts, setPartDrafts]             = useState<Record<number, string>>({})
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true); setErr(null)
+    getCoriolisSeeds()
+      .then(r => {
+        if (!alive) return
+        setSource(r.source)
+        setFarmSeed(r.farm_seed)
+        setMaps(r.maps || [])
+        setParts(r.partitions || [])
+        setFarmDraft(String(r.farm_seed))
+        const md: Record<string, string> = {}
+        for (const m of r.maps || []) md[m.map] = String(m.seed)
+        setMapDrafts(md)
+        const pd: Record<number, string> = {}
+        for (const p of r.partitions || []) pd[p.partition_id] = String(p.seed)
+        setPartDrafts(pd)
+      })
+      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [tick])
+
+  const run = async (fn: () => Promise<{ message: string }>, label: string) => {
+    setBusy(true)
+    try {
+      const r = await fn()
+      flash(r.message || `${label} done.`, 'ok')
+      setTick(t => t + 1)
+    } catch (e) {
+      flash(e instanceof Error ? e.message : String(e), 'err')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const applyFarm = () => {
+    const seed = Number(farmDraft)
+    if (!Number.isFinite(seed) || seed < 0) return flash('Farm seed must be a non-negative integer.', 'err')
+    if (!confirm(`Set FARM coriolis seed to ${seed}?\n\nThis cascades to every map + partition and (when changed) cleans up corpses / coriolis-affected loose state.`)) return
+    run(() => setCoriolisFarmSeed(seed), 'Set farm seed')
+  }
+  const applyMap = (map: string) => {
+    const seed = Number(mapDrafts[map])
+    if (!Number.isFinite(seed) || seed < 0) return flash(`Map seed for ${map} must be a non-negative integer.`, 'err')
+    if (!confirm(`Set MAP "${map}" coriolis seed to ${seed}?\n\nCascades to that map's partitions.`)) return
+    run(() => setCoriolisMapSeed(map, seed), `Set ${map} seed`)
+  }
+  const applyPart = (p: CoriolisPartition) => {
+    const seed = Number(partDrafts[p.partition_id])
+    if (!Number.isFinite(seed) || seed < 0) return flash(`Partition seed must be a non-negative integer.`, 'err')
+    if (!confirm(`Set PARTITION ${p.partition_id} (${p.map}) coriolis seed to ${seed}?`)) return
+    run(() => setCoriolisPartitionSeed(p.partition_id, seed), `Set partition ${p.partition_id} seed`)
+  }
+  const reroll = () => {
+    const seed = Math.floor(Math.random() * 2_000_000_000) + 1
+    setFarmDraft(String(seed))
+  }
+  const stay = () => setFarmDraft(String(farmSeed))
+
+  if (loading) {
+    return (
+      <div className="card p-4 text-sm text-text-dim flex items-center gap-2">
+        <Icon name="Loader2" size={13} className="animate-spin" /> Loading coriolis storm seeds…
+      </div>
+    )
+  }
+  if (err) {
+    return <div className="card p-3 text-sm text-danger">Coriolis: {err}</div>
+  }
+
+  return (
+    <div className="card p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-text-dim">
+          <Icon name="Wind" size={13} /> Coriolis Storm Seeds
+          {source === 'demo' && (
+            <span className="ml-2 px-1.5 py-0.5 rounded bg-warning/10 text-warning text-[10px] uppercase">demo</span>
+          )}
+        </div>
+        <button className="btn-secondary text-[11px]" disabled={busy} onClick={() => setTick(t => t + 1)}>
+          <Icon name="RefreshCw" size={11} /> Refresh
+        </button>
+      </div>
+
+      <p className="text-xs text-text-dim">
+        World-reset seeds drive Coriolis storm layout (spawns, dunes, loot scatter). Changing a seed
+        triggers cleanup (corpses, loose loot) on next storm tick. Use <em>Stay on current</em> to
+        lock the layout across resets, or <em>Reroll</em> to pick a fresh random one.
+      </p>
+
+      {/* Farm scope */}
+      <div className="rounded-lg border border-border bg-surface-2/40 p-3 space-y-2">
+        <div className="flex items-center justify-between">
+          <div className="text-sm font-medium text-text">Farm (all maps)</div>
+          <div className="font-mono text-xs text-text-dim">current: {farmSeed}</div>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            min={0}
+            value={farmDraft}
+            onChange={e => setFarmDraft(e.target.value)}
+            disabled={busy}
+            className="flex-1 px-3 py-2 rounded-lg bg-surface-1 border border-border text-text text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
+            placeholder="seed"
+          />
+          <button className="btn-secondary text-xs" disabled={busy} onClick={reroll} title="Pick a fresh random seed">
+            <Icon name="Shuffle" size={12} /> Reroll
+          </button>
+          <button className="btn-secondary text-xs" disabled={busy} onClick={stay} title="Reset draft to current seed (no change on apply)">
+            <Icon name="Lock" size={12} /> Stay
+          </button>
+          <button className="btn-primary text-xs" disabled={busy || farmDraft === ''} onClick={applyFarm}>
+            <Icon name="Check" size={12} /> Apply
+          </button>
+        </div>
+      </div>
+
+      {/* Per-map scope */}
+      {maps.length > 0 && (
+        <div className="rounded-lg border border-border bg-surface-2/40 p-3 space-y-2">
+          <div className="text-sm font-medium text-text">Per map</div>
+          <div className="space-y-2">
+            {maps.map(m => (
+              <div key={m.map} className="flex items-center gap-2">
+                <div className="w-32 text-xs text-text truncate" title={m.map}>{m.map}</div>
+                <span className="font-mono text-[11px] text-text-dim w-24">cur: {m.seed}</span>
+                <input
+                  type="number"
+                  min={0}
+                  value={mapDrafts[m.map] ?? ''}
+                  onChange={e => setMapDrafts(d => ({ ...d, [m.map]: e.target.value }))}
+                  disabled={busy}
+                  className="flex-1 px-3 py-1.5 rounded-lg bg-surface-1 border border-border text-text text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
+                />
+                <button className="btn-secondary text-xs" disabled={busy} onClick={() => applyMap(m.map)}>
+                  <Icon name="Check" size={11} /> Apply
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Per-partition scope */}
+      {parts.length > 0 && (
+        <details className="rounded-lg border border-border bg-surface-2/40 p-3">
+          <summary className="text-sm font-medium text-text cursor-pointer select-none">
+            Per partition ({parts.length})
+          </summary>
+          <div className="mt-2 space-y-2 max-h-72 overflow-y-auto pr-1">
+            {parts.map(p => (
+              <div key={p.partition_id} className="flex items-center gap-2">
+                <div className="w-12 text-xs text-text-dim font-mono">#{p.partition_id}</div>
+                <div className="w-28 text-xs text-text truncate" title={p.map}>{p.map}</div>
+                <span className="font-mono text-[11px] text-text-dim w-24">cur: {p.seed}</span>
+                <input
+                  type="number"
+                  min={0}
+                  value={partDrafts[p.partition_id] ?? ''}
+                  onChange={e => setPartDrafts(d => ({ ...d, [p.partition_id]: e.target.value }))}
+                  disabled={busy}
+                  className="flex-1 px-3 py-1.5 rounded-lg bg-surface-1 border border-border text-text text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
+                />
+                <button className="btn-secondary text-xs" disabled={busy} onClick={() => applyPart(p)}>
+                  <Icon name="Check" size={11} /> Apply
+                </button>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  )
+}

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -9,8 +9,9 @@
 
 import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react'
 import { Icon } from '../../../components/Icon'
+import { ItemPicker } from '../../../components/ItemPicker'
 import {
-  awardSpecXp, deleteInventoryItem, getPlayerEvents, getPlayerSpecs, getPlayerStats,
+  awardSpecXp, deleteInventoryItem, fillWater, getPlayerEvents, getPlayerSpecs, getPlayerStats,
   getPlayerTags, giveItem, giveSolari, grantAllKeystones, grantMaxSpec,
   renamePlayer, repairInventoryItem, resetAllKeystones, resetAllSpecs, resetSpec,
   setPlayerTags,
@@ -388,25 +389,38 @@ function EventRow({ ev }: { ev: PlayerEvent }) {
 }
 
 // ---------------------------------------------------------------------------
-// Actions — write surface. Give Solari / Give Item / Rename. Inventory mgmt
-// and per-track XP already covered by Inventory + Specs sections.
+// Actions — write surface. Give Solari / Give Item / Rename / Fill Water.
+// Inventory mgmt and per-track XP already covered by Inventory + Specs sections.
+// v11.5.7: Give Item now uses the ItemPicker typeahead; Fill Water added
+// (offline-safe SQL refill of stillsuits + literjons).
 // ---------------------------------------------------------------------------
 export function ActionsSection({ player, canWrite, flash, onChanged }: SectionProps) {
   const [form, setForm] = useState<'solari' | 'item' | 'rename' | null>(null)
   const [busy, setBusy] = useState(false)
 
-  const run = async (fn: () => Promise<{ message: string }>, label: string) => {
+  // Give-item form state lives at the section level so the ItemPicker keeps
+  // its selection when the user tabs to Quantity / Quality fields.
+  const [giveTpl, setGiveTpl] = useState('')
+  const [giveQty, setGiveQty] = useState('1')
+  const [giveQual, setGiveQual] = useState('0')
+
+  const run = async (fn: () => Promise<{ message: string }>, label: string, closeAfter = true) => {
     setBusy(true)
     try {
       const r = await fn()
       flash(r.message || `${label} done.`, 'ok')
-      setForm(null)
+      if (closeAfter) setForm(null)
       onChanged()
     } catch (e) {
       flash(e instanceof Error ? e.message : String(e), 'err')
     } finally {
       setBusy(false)
     }
+  }
+
+  const handleFillWater = () => {
+    if (!confirm(`Refill all water-fillable items (stillsuits, literjons, dewpacks) for ${player.name}?\n\nOnline players: takes effect on next relog.`)) return
+    run(() => fillWater(player.id), 'Fill Water', false)
   }
 
   if (!canWrite) {
@@ -429,6 +443,9 @@ export function ActionsSection({ player, canWrite, flash, onChanged }: SectionPr
         <button className="btn-secondary" disabled={busy} onClick={() => setForm(form === 'rename' ? null : 'rename')}>
           <Icon name="PenLine" size={13} /> Rename
         </button>
+        <button className="btn-secondary" disabled={busy} onClick={handleFillWater} title="Refill stillsuits + literjons to max">
+          <Icon name="Droplets" size={13} /> Fill Water
+        </button>
       </div>
 
       {form === 'solari' && (
@@ -437,11 +454,39 @@ export function ActionsSection({ player, canWrite, flash, onChanged }: SectionPr
         ]} onSubmit={v => run(() => giveSolari(player.controller_id, Number(v.amount) || 0), 'Give Solari')} />
       )}
       {form === 'item' && (
-        <InlineForm busy={busy} submitLabel="Give Item" fields={[
-          { key: 'template', label: 'Item template id', type: 'text', placeholder: 'e.g. Spice_Melange' },
-          { key: 'qty',      label: 'Quantity',         type: 'number', placeholder: '1' },
-          { key: 'quality',  label: 'Quality (0–5)',    type: 'number', placeholder: '0' },
-        ]} onSubmit={v => run(() => giveItem(player.id, String(v.template || '').trim(), Number(v.qty) || 0, Number(v.quality) || 0), 'Give Item')} />
+        <div className="card p-3 space-y-3">
+          <ItemPicker
+            label="Item — type to search by name or template id"
+            value={giveTpl}
+            onChange={setGiveTpl}
+            autoFocus
+            disabled={busy}
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Quantity</label>
+              <input type="number" min={1} value={giveQty} disabled={busy}
+                onChange={e => setGiveQty(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+            </div>
+            <div>
+              <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Quality (0–5)</label>
+              <input type="number" min={0} max={5} value={giveQual} disabled={busy}
+                onChange={e => setGiveQual(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+            </div>
+          </div>
+          <button
+            className="btn-primary w-full"
+            disabled={busy || !giveTpl.trim()}
+            onClick={() => run(
+              () => giveItem(player.id, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0),
+              'Give Item',
+            )}
+          >
+            {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} Give Item
+          </button>
+        </div>
       )}
       {form === 'rename' && (
         <InlineForm busy={busy} submitLabel="Rename" fields={[


### PR DESCRIPTION
**v11.5.7 — User-reported hotfixes (Phase 1.5)**

Same-day pivot from the planned Progression/Contracts/Journey port to fix three direct user reports against v11.5.6. Heavy progression port moves to v11.5.8.

### What's in
- **Give Item autocomplete** (Chopper) — Players > Actions > Give Item *and* Storage > Add Items now use a new `ItemPicker` typeahead component. Searches `/api/catalog/items` by friendly name or template id, arrow-key navigation, lazy fetch + session cache.
- **Fill Water** (Chopper, restores Icehunter add-on feature) — refills every fillable water container in storage / gear / mounts / vehicles / dropship / chests. SQL ported verbatim from dune-admin `cmdRefillWaterOffline` (49 templates × 6 inventory types). Offline players: next login. Online players: next relog (game server inventory cache).
- **Coriolis Storm Seed control** — new panel under Players > Server Overview (no player selected). Three scopes: **farm** (cascades to all maps and partitions, triggers cleanup of corpses + loose loot), **per-map**, and **per-partition** (collapsible). Wraps existing `dune.debug_get_coriolis_seeds()` and `debug_set_*_seed()` Postgres routines; graceful fallback when unavailable.

### Files
- `app/server/lib/CoriolisAdmin.ps1` (NEW), `app/server/routes/CoriolisAdmin.ps1` (NEW)
- `app/server/lib/GameplayPlayers.ps1` (+ `Invoke-DunePlayerFillWater`)
- `app/server/routes/GameplayPlayers.ps1` (+ POST `/api/gameplay/players/fill-water`)
- `webui/src/components/ItemPicker.tsx` (NEW)
- `webui/src/pages/gameplay/players/coriolis.tsx` (NEW)
- Modifies `PlayersTab.tsx`, `sections.tsx`, `StorageTab.tsx`, `gameplay.ts`
- 5 version stamps bumped to 11.5.7
- CHANGELOG entry above v11.5.6

### Verification
- `tsc -b && vite build` clean (1,619 KB / 420 KB gzip)
- PS parse check clean on all 4 backend files
- Live VM smoke pending (VM was off during dev)
