### PR TITLE
v11.5.8: Item search autocomplete everywhere (Market Bot price overrides)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [11.5.8] - 2026-06-12
+
+### Changed — Item search autocomplete everywhere (user requirement)
+
+Follow-up to v11.5.7. User requirement: *every* item search box across the
+app must use the typeahead dropdown introduced in v11.5.7, not just the two
+add-item forms (Players → Give Item, Storage → Add Items).
+
+- **Market Bot → Pricing → Per-template price overrides → Add override** —
+  previously two ``window.prompt()`` dialogs (one for template id, one for
+  price). Now opens an inline form with the ``ItemPicker`` typeahead for the
+  item search and a number field for the override price, with Add / Cancel
+  buttons. No more typing raw template ids from memory.
+
 ## [11.5.7] - 2026-06-12
 
 ### Added — User-reported hotfixes (Phase 1.5 of dune-admin player port)

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '11.5.7'
+$script:DuneToolVersion = '11.5.8'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '11.5.7',
+    [string]$Version = '11.5.8',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>11.5.7</Version>
+    <Version>11.5.8</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "11.5.7"
+#define MyAppVersion "11.5.8"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "11.5.7"
+$script:ToolVersion = "11.5.8"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/gameplay/MarketBotTab.tsx
+++ b/webui/src/pages/gameplay/MarketBotTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Icon } from '../../components/Icon'
+import { ItemPicker } from '../../components/ItemPicker'
 import {
   getBotStatus, getBotConfig, saveBotConfig, runBotTick, runBotListTick, botExec,
   setBotBalance, clearBotListings, clearBotLegacyListings, getBotVendorSnapshot,
@@ -621,6 +622,10 @@ function PricingSection({ draft, setDraft }: { draft: BotConfig; setDraft: (c: B
   const overrides = draft.price_overrides ?? {}
   const overrideRows = Object.entries(overrides)
 
+  const [showAddOverride, setShowAddOverride] = useState(false)
+  const [newTmpl, setNewTmpl] = useState('')
+  const [newPrice, setNewPrice] = useState('0')
+
   const setMap = (key: 'tier_base_prices' | 'stack_unit_prices' | 'category_factors' | 'rarity_multipliers' | 'vendor_multipliers',
                   next: Record<string, number>) => {
     setDraft({ ...draft, [key]: next })
@@ -700,20 +705,43 @@ function PricingSection({ draft, setDraft }: { draft: BotConfig; setDraft: (c: B
       <div className="card p-4">
         <div className="flex items-center justify-between mb-2">
           <h4 className="text-xs uppercase tracking-wider text-text-dim">Per-template price overrides</h4>
-          <button className="btn-secondary text-xs" onClick={() => {
-            const tmpl = window.prompt('Template ID to override:')?.trim()
-            if (!tmpl) return
-            const v = window.prompt(`Override price for ${tmpl} (Solari, integer):`)?.trim()
-            const n = v != null ? parseInt(v, 10) : NaN
-            if (!Number.isFinite(n) || n < 0) return
-            setDraft({ ...draft, price_overrides: { ...overrides, [tmpl]: n } })
-          }}>
-            <Icon name="Plus" size={13} /> Add override
+          <button className="btn-secondary text-xs" onClick={() => setShowAddOverride(s => !s)}>
+            <Icon name={showAddOverride ? 'X' : 'Plus'} size={13} /> {showAddOverride ? 'Cancel' : 'Add override'}
           </button>
         </div>
         <p className="text-[11px] text-text-dim mb-2">
           Manual price (Solari, integer) for specific template IDs. Overrides win over the formula, then the 100 k cap applies.
         </p>
+        {showAddOverride && (
+          <div className="mb-3 p-3 rounded-lg bg-surface-2 border border-border space-y-2">
+            <ItemPicker
+              value={newTmpl}
+              onChange={setNewTmpl}
+              label="Item"
+              placeholder="Type to search items by name or template id…"
+              autoFocus
+            />
+            <div className="flex items-end gap-2">
+              <label className="block flex-1 max-w-[200px]">
+                <span className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Override price (Solari)</span>
+                <input type="number" value={newPrice} min={0}
+                  onChange={e => setNewPrice(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ibad" />
+              </label>
+              <button className="btn-primary"
+                disabled={!newTmpl.trim() || !Number.isFinite(parseInt(newPrice, 10)) || parseInt(newPrice, 10) < 0}
+                onClick={() => {
+                  const tmpl = newTmpl.trim()
+                  const n = parseInt(newPrice, 10)
+                  if (!tmpl || !Number.isFinite(n) || n < 0) return
+                  setDraft({ ...draft, price_overrides: { ...overrides, [tmpl]: n } })
+                  setNewTmpl(''); setNewPrice('0'); setShowAddOverride(false)
+                }}>
+                <Icon name="Plus" size={14} /> Add
+              </button>
+            </div>
+          </div>
+        )}
         {overrideRows.length === 0 ? (
           <div className="text-text-dim text-sm">No overrides.</div>
         ) : (


### PR DESCRIPTION
**v11.5.8 — Item search autocomplete everywhere**

Follow-up to v11.5.7 per direct user requirement: *every* item search box across the app must use the `ItemPicker` typeahead, not just the two add-item forms (Players > Give Item and Storage > Add Items).

### What's in
- **Market Bot > Pricing > Per-template price overrides > Add override** — previously two `window.prompt()` dialogs (one for the template id, one for the override price). Now opens an inline form with the `ItemPicker` typeahead for the item search + a number input for the price, with Add / Cancel buttons. No more typing raw template ids from memory.

### Files
- `webui/src/pages/gameplay/MarketBotTab.tsx` — replaces the `window.prompt` flow with an `<ItemPicker>`-backed inline form.
- 5 version stamps bumped to 11.5.8
- CHANGELOG entry above v11.5.7
