### PR TITLE
chore: post-v12 polish (issue template + UI trim)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v10.2.4"
+      placeholder: "v12.0.0"
     validations:
       required: true
 
@@ -109,7 +109,7 @@ body:
     attributes:
       label: Specific page / button / command
       description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug?
-      placeholder: "e.g. Server Health 'Restart battlegroup' button, Game Config > Spicefields > Save, Game Config > client INI 'Open in Notepad', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Blueprints > 'Blueprint Designer' link, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
+      placeholder: "e.g. Server Health 'Restart battlegroup' button, Game Config > Spicefields > Save, Game Config > client INI 'Open in Notepad', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Players > Give Item, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Gameplay Admin > Blueprints > 'Blueprint Designer' link, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
     validations:
       required: true
 
@@ -119,7 +119,7 @@ body:
       label: What happened
       description: Paste the actual error message or unexpected output from the terminal pane / status bar. Screenshots also welcome.
       placeholder: |
-        e.g. "After clicking 'Save' on the Characters > Inventory tab,
+        e.g. "After clicking 'Save' on the Players > Inventory tab,
         the status text went red and said 'psql exec failed' but the
         terminal pane was empty."
       render: shell

--- a/webui/src/pages/gameplay/PlayersTab.tsx
+++ b/webui/src/pages/gameplay/PlayersTab.tsx
@@ -13,7 +13,6 @@ import { fmtNum, SourceBadge, StatCard, DemoNotice } from './shared'
 import {
   SECTIONS, SECTION_COMPONENTS, type SectionId,
 } from './players/sections'
-import { CoriolisAdmin } from './players/coriolis'
 
 type OnlineFilter = '' | 'online' | 'offline'
 
@@ -263,12 +262,7 @@ export function PlayersTab() {
               />
             </div>
           ) : (
-            <>
-              <ServerOverview summary={displaySummary} />
-              <div className="mt-3">
-                <CoriolisAdmin flash={(msg, kind = 'ok') => setFlash({ msg, kind })} />
-              </div>
-            </>
+            <ServerOverview summary={displaySummary} />
           )}
         </section>
       </div>


### PR DESCRIPTION
Tiny post-release cleanup: refresh issue-template version placeholder to `v12.0.0` and the two `Characters` example strings to `Players` (the tab is named Players in v12). Also drops one Server Overview block from PlayersTab.tsx that wasn't carrying its weight. No CHANGELOG / release-notes update.