### PR TITLE
release: v12.0.1 - GameConfig blank-screen hotfix + diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.0"
+      placeholder: "v12.0.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,40 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.1] - 2026-06-12
+
+Hotfix for the Game Config "page goes blank" bug reported on v12.0.0, plus
+the diagnostics gap that made it untriageable in the wild.
+
+### Fixed
+
+- **Game Config blank-screen recovery.** Wrapped every route in a React error
+  boundary so a single render exception can no longer white-out the entire
+  WebView. Crashes now show an in-place error with Retry / Reload buttons
+  instead of an empty window. (#KEN-1)
+- **Game Config defensive guards.** Hardened the helper functions and JSX
+  iteration in `GameConfig.tsx` so a malformed/partial config response from
+  the API (missing `game` or `engine` bundle, missing `fields` on a category,
+  missing `options` on a select field) no longer throws during render.
+- **Schema fetch retry.** The page now retries `getGameConfigSchema()` up to
+  3 times with backoff before declaring the page errored, and adds an
+  explicit Retry button to the error banner so a transient API hiccup at
+  load time no longer requires navigating away.
+
+### Diagnostics
+
+- **WebView2 DevTools enabled.** Pressing **F12** in the desktop shell now
+  opens Chromium DevTools. Previously DevTools were hard-disabled, which made
+  it impossible for users to inspect render crashes themselves.
+- **`webview2-debug.log` now actually gets written.** The bug-report template
+  and `Save Logs` workflow have referenced this file since v11, but nothing
+  ever wrote it. The desktop shell now subscribes to the WebView2 DevTools
+  Protocol (`Runtime.consoleAPICalled`, `Runtime.exceptionThrown`,
+  `ProcessFailed`) and appends error/warn/assert/trace messages to
+  `%APPDATA%\DuneServer\webview2-debug.log` with a 2 MB ring buffer. Future
+  diagnostic ZIPs will include the actual JS exception that caused any
+  blank-screen issue.
+
 ## [12.0.0] - 2026-06-12
 
 Major milestone — full Gameplay Admin build-out lands directly inside DST.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.0'
+$script:DuneToolVersion = '12.0.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.0',
+    [string]$Version = '12.0.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.0</Version>
+    <Version>12.0.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -96,7 +96,11 @@ internal sealed class MainForm : Form
         var core = _web.CoreWebView2;
         core.Settings.AreDefaultContextMenusEnabled = true;
         core.Settings.IsStatusBarEnabled = false;
-        core.Settings.AreDevToolsEnabled = false;
+        // v12.0.1: DevTools enabled so users can press F12 and read JS console
+        // errors when a page misbehaves. The console output is also captured to
+        // %APPDATA%\DuneServer\webview2-debug.log by InitDiagnosticLogging below
+        // and bundled into Help -> Create GitHub Issue + Save Logs.
+        core.Settings.AreDevToolsEnabled = true;
 
         core.NewWindowRequested += OnNewWindowRequested;
         core.NavigationCompleted += OnNavigationCompleted;
@@ -107,8 +111,196 @@ internal sealed class MainForm : Form
             Text = string.IsNullOrWhiteSpace(t) ? "Dune Server Tool" : $"{t} — Dune Server Tool";
         };
 
+        await InitDiagnosticLoggingAsync(core);
+
         _web.Source = new Uri(url);
         _targetUrl = url;
+    }
+
+    // ----- Diagnostic logging -------------------------------------------------
+    //
+    // v12.0.1: subscribe to WebView2 DevTools Protocol events so unhandled JS
+    // exceptions and console.error/warn calls land in
+    // %APPDATA%\DuneServer\webview2-debug.log. The diagnostics bundle
+    // (Help -> Create GitHub Issue + Save Logs) tails the last 200 KB of that
+    // file, which previously was always missing because nothing ever wrote it.
+    //
+    // We cap the file at WebView2LogMaxBytes and trim from the front on the
+    // next write when we exceed it, so a chatty page can't fill the user's
+    // disk. Writes are best-effort and silently swallow IO errors.
+
+    private const long WebView2LogMaxBytes = 2L * 1024 * 1024;  // 2 MB cap
+    private static readonly object _logLock = new();
+
+    private static string WebView2LogPath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "DuneServer", "webview2-debug.log");
+
+    private async Task InitDiagnosticLoggingAsync(CoreWebView2 core)
+    {
+        try
+        {
+            // Runtime.enable is a prerequisite for consoleAPICalled /
+            // exceptionThrown events to fire on the protocol channel.
+            await core.CallDevToolsProtocolMethodAsync("Runtime.enable", "{}");
+
+            var consoleRecv = core.GetDevToolsProtocolEventReceiver("Runtime.consoleAPICalled");
+            consoleRecv.DevToolsProtocolEventReceived += OnConsoleApiCalled;
+
+            var exceptionRecv = core.GetDevToolsProtocolEventReceiver("Runtime.exceptionThrown");
+            exceptionRecv.DevToolsProtocolEventReceived += OnRuntimeExceptionThrown;
+
+            core.ProcessFailed += OnProcessFailed;
+
+            AppendDiagnosticLine($"[shell] DST v{typeof(MainForm).Assembly.GetName().Version} logging started; WebView2 runtime {core.Environment.BrowserVersionString}");
+        }
+        catch (Exception ex)
+        {
+            // Logging is best-effort. If the DevTools protocol can't be wired
+            // (older WebView2 runtime, etc.) the app still works — we just
+            // won't capture console output.
+            AppendDiagnosticLine($"[shell] failed to wire diagnostic logging: {ex.Message}");
+        }
+    }
+
+    private void OnConsoleApiCalled(object? sender, CoreWebView2DevToolsProtocolEventReceivedEventArgs e)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(e.ParameterObjectAsJson);
+            var root = doc.RootElement;
+            string type = root.TryGetProperty("type", out var t) ? (t.GetString() ?? "log") : "log";
+
+            // We only persist console.error / console.warn / console.assert /
+            // console.trace — debug / info / log are extremely noisy on a
+            // live React page and rarely useful for postmortem analysis.
+            bool keep = type is "error" or "warning" or "warn" or "assert" or "trace";
+            if (!keep) return;
+
+            var sb = new StringBuilder();
+            sb.Append("[console.").Append(type).Append("] ");
+            if (root.TryGetProperty("args", out var args) && args.ValueKind == System.Text.Json.JsonValueKind.Array)
+            {
+                bool first = true;
+                foreach (var a in args.EnumerateArray())
+                {
+                    if (!first) sb.Append(' ');
+                    first = false;
+                    if (a.TryGetProperty("value", out var v))
+                        sb.Append(v.ToString());
+                    else if (a.TryGetProperty("description", out var d))
+                        sb.Append(d.GetString());
+                    else
+                        sb.Append(a.ToString());
+                }
+            }
+            if (root.TryGetProperty("stackTrace", out var st) &&
+                st.TryGetProperty("callFrames", out var cf) &&
+                cf.ValueKind == System.Text.Json.JsonValueKind.Array)
+            {
+                foreach (var frame in cf.EnumerateArray())
+                {
+                    string fn  = frame.TryGetProperty("functionName", out var f) ? (f.GetString() ?? "") : "";
+                    string url = frame.TryGetProperty("url",          out var u) ? (u.GetString() ?? "") : "";
+                    int line   = frame.TryGetProperty("lineNumber",   out var l) ? l.GetInt32() : 0;
+                    sb.Append("\r\n    at ").Append(string.IsNullOrEmpty(fn) ? "(anonymous)" : fn)
+                      .Append(" (").Append(url).Append(':').Append(line + 1).Append(')');
+                }
+            }
+            AppendDiagnosticLine(sb.ToString());
+        }
+        catch { /* best-effort */ }
+    }
+
+    private void OnRuntimeExceptionThrown(object? sender, CoreWebView2DevToolsProtocolEventReceivedEventArgs e)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(e.ParameterObjectAsJson);
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("exceptionDetails", out var ex)) return;
+
+            var sb = new StringBuilder("[exception] ");
+            if (ex.TryGetProperty("text", out var txt)) sb.Append(txt.GetString());
+            if (ex.TryGetProperty("exception", out var exo) &&
+                exo.TryGetProperty("description", out var exd))
+            {
+                sb.Append(" :: ").Append(exd.GetString());
+            }
+            else if (ex.TryGetProperty("exception", out var exo2) &&
+                     exo2.TryGetProperty("value", out var exv))
+            {
+                sb.Append(" :: ").Append(exv.ToString());
+            }
+            if (ex.TryGetProperty("url",        out var u))  sb.Append("\r\n    url:    ").Append(u.GetString());
+            if (ex.TryGetProperty("lineNumber", out var ln)) sb.Append("\r\n    line:   ").Append(ln.GetInt32() + 1);
+            if (ex.TryGetProperty("stackTrace", out var st) &&
+                st.TryGetProperty("callFrames", out var cf) &&
+                cf.ValueKind == System.Text.Json.JsonValueKind.Array)
+            {
+                foreach (var frame in cf.EnumerateArray())
+                {
+                    string fn  = frame.TryGetProperty("functionName", out var f) ? (f.GetString() ?? "") : "";
+                    string url = frame.TryGetProperty("url",          out var u2) ? (u2.GetString() ?? "") : "";
+                    int line   = frame.TryGetProperty("lineNumber",   out var l) ? l.GetInt32() : 0;
+                    sb.Append("\r\n    at ").Append(string.IsNullOrEmpty(fn) ? "(anonymous)" : fn)
+                      .Append(" (").Append(url).Append(':').Append(line + 1).Append(')');
+                }
+            }
+            AppendDiagnosticLine(sb.ToString());
+        }
+        catch { /* best-effort */ }
+    }
+
+    private void OnProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
+    {
+        try
+        {
+            AppendDiagnosticLine(
+                $"[process-failed] kind={e.ProcessFailedKind} reason={e.Reason} exitCode={e.ExitCode} status={e.ProcessDescription}");
+        }
+        catch { /* best-effort */ }
+    }
+
+    private static void AppendDiagnosticLine(string line)
+    {
+        if (string.IsNullOrEmpty(line)) return;
+        try
+        {
+            string path = WebView2LogPath;
+            string dir = Path.GetDirectoryName(path)!;
+            Directory.CreateDirectory(dir);
+            string stamped = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}  {line}\r\n";
+
+            lock (_logLock)
+            {
+                // Front-trim when over cap so the file behaves like a ring buffer.
+                // Keeps the most recent ~half so old context still survives a
+                // single noisy burst.
+                try
+                {
+                    var fi = new FileInfo(path);
+                    if (fi.Exists && fi.Length > WebView2LogMaxBytes)
+                    {
+                        long keep = WebView2LogMaxBytes / 2;
+                        var bytes = File.ReadAllBytes(path);
+                        if (bytes.Length > keep)
+                        {
+                            int start = (int)(bytes.Length - keep);
+                            // Skip to the next line boundary so we don't leave
+                            // a half line at the top of the file.
+                            for (; start < bytes.Length; start++)
+                                if (bytes[start] == (byte)'\n') { start++; break; }
+                            File.WriteAllBytes(path, new ArraySegment<byte>(bytes, start, bytes.Length - start).ToArray());
+                        }
+                    }
+                }
+                catch { /* best-effort trim */ }
+
+                File.AppendAllText(path, stamped, Encoding.UTF8);
+            }
+        }
+        catch { /* logging must never throw into the caller */ }
     }
 
     private async void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.0"
+#define MyAppVersion "12.0.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.0"
+$script:ToolVersion = "12.0.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -15,6 +15,16 @@ import { Tailscale } from './pages/Tailscale'
 import { PageStub } from './pages/PageStub'
 import { StatusProvider } from './hooks/useStatus'
 import { isLocalViewer } from './util/viewer'
+import { PageErrorBoundary } from './components/PageErrorBoundary'
+
+// Wrap every route subtree in an error boundary so an unhandled render
+// exception on one page can't white-out the entire app. The boundary
+// renders an inline error card with the JS stack trace and logs the
+// failure through console.error so it lands in webview2-debug.log for
+// the diagnostics ZIP (added in v12.0.1).
+function Boundary({ name, children }: { name: string; children: React.ReactNode }) {
+  return <PageErrorBoundary pageName={name}>{children}</PageErrorBoundary>
+}
 
 export default function App() {
   // The free-form PowerShell page can run arbitrary commands on the host
@@ -28,26 +38,30 @@ export default function App() {
     <StatusProvider>
       <AppShell>
         <Routes>
-          <Route path="/"           element={<Dashboard />} />
-          <Route path="/commands"   element={<Commands />} />
+          <Route path="/"           element={<Boundary name="Dashboard"><Dashboard /></Boundary>} />
+          <Route path="/commands"   element={<Boundary name="Commands"><Commands /></Boundary>} />
           <Route
             path="/terminal"
-            element={showTerminal ? <TerminalPage /> : <Navigate to="/" replace />}
+            element={showTerminal
+              ? <Boundary name="Terminal"><TerminalPage /></Boundary>
+              : <Navigate to="/" replace />}
           />
-          <Route path="/gameconfig" element={<GameConfig />} />
-          <Route path="/gameplay"   element={<GameplayEnvironment />} />
-          <Route path="/database"   element={<Database />} />
-          <Route path="/sietches"   element={<Sietches />} />
-          <Route path="/dd-map"     element={<DDMap />} />
-          <Route path="/map-spinup" element={<MapSpinUp />} />
-          <Route path="/settings"   element={<Settings />} />
-          <Route path="/setup"      element={<SetupWizard />} />
+          <Route path="/gameconfig" element={<Boundary name="Game Config"><GameConfig /></Boundary>} />
+          <Route path="/gameplay"   element={<Boundary name="Gameplay Admin"><GameplayEnvironment /></Boundary>} />
+          <Route path="/database"   element={<Boundary name="Database"><Database /></Boundary>} />
+          <Route path="/sietches"   element={<Boundary name="Sietches"><Sietches /></Boundary>} />
+          <Route path="/dd-map"     element={<Boundary name="Deep Desert Map"><DDMap /></Boundary>} />
+          <Route path="/map-spinup" element={<Boundary name="Map SpinUp"><MapSpinUp /></Boundary>} />
+          <Route path="/settings"   element={<Boundary name="Settings"><Settings /></Boundary>} />
+          <Route path="/setup"      element={<Boundary name="Setup Wizard"><SetupWizard /></Boundary>} />
           <Route
             path="/tailscale"
-            element={isLocalViewer() ? <Tailscale /> : <Navigate to="/" replace />}
+            element={isLocalViewer()
+              ? <Boundary name="Tailscale"><Tailscale /></Boundary>
+              : <Navigate to="/" replace />}
           />
           {/* /monitoring merged into Dashboard in v6.1 — redirect old path */}
-          <Route path="/monitoring" element={<Dashboard />} />
+          <Route path="/monitoring" element={<Boundary name="Dashboard"><Dashboard /></Boundary>} />
           <Route path="*"           element={<PageStub title="Not Found"   icon="HelpCircle"      description="No page at that path." phase="—" />} />
         </Routes>
       </AppShell>

--- a/webui/src/components/PageErrorBoundary.tsx
+++ b/webui/src/components/PageErrorBoundary.tsx
@@ -1,0 +1,103 @@
+// PageErrorBoundary — last-resort guard for a route subtree. When a child
+// render throws, instead of letting the exception propagate to the root and
+// white-out the entire app (no error boundary => empty document), we trap it
+// here and render an inline error card with the message, the React component
+// stack, and a Retry button.
+//
+// Why this exists: v11.5.x and v12.0.0 had a long-standing "Game Config goes
+// blank" report we couldn't diagnose because the whole WebView would clear
+// and there was no way to see the underlying exception. Wrapping the page
+// gives us a visible error UI on the user's screen AND lets us log the
+// failure via console.error so it lands in webview2-debug.log.
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+type Props = {
+  // Friendly label for the page wrapped by this boundary. Surfaced in the
+  // header of the fallback card so users know which page crashed.
+  pageName: string
+  children: ReactNode
+}
+
+type State = {
+  error: Error | null
+  componentStack: string | null
+}
+
+export class PageErrorBoundary extends Component<Props, State> {
+  state: State = { error: null, componentStack: null }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Emit to the console so the WebView2 console-event listener (added in
+    // v12.0.1) captures it into webview2-debug.log. This is what makes the
+    // diagnostics ZIP useful for postmortem analysis.
+    // eslint-disable-next-line no-console
+    console.error(`[PageErrorBoundary:${this.props.pageName}]`, error, info.componentStack)
+    this.setState({ componentStack: info.componentStack ?? null })
+  }
+
+  private handleRetry = (): void => {
+    this.setState({ error: null, componentStack: null })
+  }
+
+  render(): ReactNode {
+    const { error, componentStack } = this.state
+    if (!error) return this.props.children
+
+    return (
+      <div className="p-6">
+        <div className="card p-5 border-danger/40 bg-danger/5">
+          <div className="text-sm font-semibold uppercase tracking-wider text-danger mb-2">
+            {this.props.pageName} crashed
+          </div>
+          <p className="text-sm text-text mb-3">
+            The page hit an unhandled error and was prevented from rendering. The full stack has been
+            written to <span className="font-mono">%APPDATA%\DuneServer\webview2-debug.log</span>; please
+            attach the ZIP from <strong>Help → Create GitHub Issue + Save Logs</strong>.
+          </p>
+
+          <div className="mb-3">
+            <div className="text-xs font-medium text-text-muted mb-1">Error</div>
+            <pre className="text-xs font-mono whitespace-pre-wrap break-words text-text bg-surface-2 border border-border rounded-lg p-3 max-h-40 overflow-auto">
+              {error.message || String(error)}
+            </pre>
+          </div>
+
+          {error.stack && (
+            <details className="mb-3">
+              <summary className="text-xs text-text-muted cursor-pointer select-none">
+                JS stack trace
+              </summary>
+              <pre className="mt-1 text-[11px] font-mono whitespace-pre-wrap break-words text-text-muted bg-surface-2 border border-border rounded-lg p-3 max-h-60 overflow-auto">
+                {error.stack}
+              </pre>
+            </details>
+          )}
+
+          {componentStack && (
+            <details className="mb-3">
+              <summary className="text-xs text-text-muted cursor-pointer select-none">
+                React component stack
+              </summary>
+              <pre className="mt-1 text-[11px] font-mono whitespace-pre-wrap break-words text-text-muted bg-surface-2 border border-border rounded-lg p-3 max-h-60 overflow-auto">
+                {componentStack}
+              </pre>
+            </details>
+          )}
+
+          <div className="flex items-center gap-2">
+            <button type="button" className="btn-primary" onClick={this.handleRetry}>
+              Retry render
+            </button>
+            <button type="button" className="btn-secondary" onClick={() => window.location.reload()}>
+              Reload page
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -44,18 +44,24 @@ function boolPair(type: GameConfigField['type']): { on: string; off: string } | 
   return null
 }
 
-function bundleFor(data: GameConfigResponse, file: 'game' | 'engine'): GameConfigFileBundle {
-  return file === 'game' ? data.game : data.engine
+function bundleFor(data: GameConfigResponse, file: 'game' | 'engine'): GameConfigFileBundle | null {
+  // Defensive: a malformed / partial server response could omit one of the
+  // bundles. Returning null lets every caller short-circuit to an "unset"
+  // value instead of throwing on `.effective` and white-outing the form.
+  if (!data) return null
+  const b = file === 'game' ? data.game : data.engine
+  return b ?? null
 }
 
 function fieldDefault(field: GameConfigField): string {
-  return field.default ?? ''
+  return field?.default ?? ''
 }
 
 // Live value written in the battlegroup's INI for this field ('' when unset or VM down).
 function liveValue(data: GameConfigResponse | null, field: GameConfigField): string {
-  if (!data) return ''
-  return bundleFor(data, field.file).effective?.[`${field.section}||${field.key}`] ?? ''
+  if (!data || !field) return ''
+  const b = bundleFor(data, field.file)
+  return b?.effective?.[`${field.section}||${field.key}`] ?? ''
 }
 
 // A field is "customized" when the live file overrides it with a value other than the default.
@@ -71,7 +77,9 @@ function currentValue(data: GameConfigResponse | null, field: GameConfigField): 
 }
 
 function sectionIsManaged(data: GameConfigResponse, field: GameConfigField): boolean {
-  return bundleFor(data, field.file).managedSections?.includes(field.section) ?? false
+  if (!data || !field) return false
+  const b = bundleFor(data, field.file)
+  return b?.managedSections?.includes(field.section) ?? false
 }
 
 export function GameConfig() {
@@ -259,8 +267,10 @@ export function GameConfig() {
   // so every field is populated even before (or without) a live battlegroup.
   const seedValues = useCallback((cats: GameConfigCategory[], data: GameConfigResponse | null) => {
     const out: Record<string, string> = {}
-    for (const cat of cats) {
-      for (const f of cat.fields) out[f.key] = currentValue(data, f)
+    for (const cat of cats ?? []) {
+      for (const f of cat?.fields ?? []) {
+        if (f?.key) out[f.key] = currentValue(data, f)
+      }
     }
     return out
   }, [])
@@ -270,8 +280,13 @@ export function GameConfig() {
     setLoadError(null)
     setSavedMsg(null)
     try {
-      const sch = schema ?? (await getGameConfigSchema()).schema
-      if (!schema) setSchema(sch)
+      let sch = schema
+      if (!sch) {
+        const resp = await getGameConfigSchema()
+        sch = resp?.schema
+        if (!Array.isArray(sch)) throw new Error('Game config schema response was empty or malformed.')
+        setSchema(sch)
+      }
       const data = await getGameConfig()
       setCfg(data)
       const seeded = seedValues(sch, data)
@@ -289,12 +304,25 @@ export function GameConfig() {
     void (async () => {
       let s = schema
       if (!s) {
-        try {
-          const resp = await getGameConfigSchema()
-          s = resp.schema
-          setSchema(s)
-        } catch (e) {
-          setLoadError(e instanceof Error ? e.message : String(e))
+        // Retry the schema fetch up to 3 times — the WebView2 occasionally races
+        // the dev/prod server startup, and a single failure here previously
+        // left the page in a permanent error state until the user navigated away.
+        let lastErr: unknown = null
+        for (let attempt = 0; attempt < 3; attempt++) {
+          try {
+            const resp = await getGameConfigSchema()
+            if (!Array.isArray(resp?.schema)) throw new Error('Schema response was empty or malformed.')
+            s = resp.schema
+            setSchema(s)
+            lastErr = null
+            break
+          } catch (e) {
+            lastErr = e
+            if (attempt < 2) await new Promise(r => setTimeout(r, 400 * (attempt + 1)))
+          }
+        }
+        if (!s) {
+          setLoadError(lastErr instanceof Error ? lastErr.message : String(lastErr ?? 'Failed to load schema'))
           setLoadState('error')
           return
         }
@@ -304,9 +332,15 @@ export function GameConfig() {
       } else {
         // No live battlegroup: populate every field with its funcom default so the
         // form is readable. Editing/saving is gated until the VM is up.
-        const seeded = seedValues(s, null)
-        setValues(seeded)
-        setOriginals(seeded)
+        try {
+          const seeded = seedValues(s, null)
+          setValues(seeded)
+          setOriginals(seeded)
+        } catch (e) {
+          // Seeding should never throw with the guards in seedValues, but if it
+          // does we still want to leave the page in a recoverable state.
+          console.error('GameConfig seedValues failed', e)
+        }
         setCfg(null)
         setLoadState('unavailable')
         setLoadError('Showing Funcom defaults — start the battlegroup to load live values and edit.')
@@ -330,11 +364,11 @@ export function GameConfig() {
     return schema
       .map(cat => ({
         category: cat.category,
-        fields: cat.fields.filter(
+        fields: (cat.fields ?? []).filter(
           f =>
-            f.label.toLowerCase().includes(q) ||
-            f.key.toLowerCase().includes(q) ||
-            (f.help ?? '').toLowerCase().includes(q) ||
+            (f?.label ?? '').toLowerCase().includes(q) ||
+            (f?.key ?? '').toLowerCase().includes(q) ||
+            (f?.help ?? '').toLowerCase().includes(q) ||
             cat.category.toLowerCase().includes(q),
         ),
       }))
@@ -583,8 +617,15 @@ export function GameConfig() {
         </div>
       )}
       {loadState === 'error' && loadError && (
-        <div className="card p-4 mb-4 border-danger/40 bg-danger/10 text-danger text-sm flex items-center gap-2">
-          <Icon name="AlertCircle" size={14} /> {loadError}
+        <div className="card p-4 mb-4 border-danger/40 bg-danger/10 text-danger text-sm flex items-center justify-between gap-2">
+          <span className="flex items-center gap-2"><Icon name="AlertCircle" size={14} /> {loadError}</span>
+          <button
+            type="button"
+            onClick={() => void loadAll()}
+            className="px-3 py-1 rounded bg-danger/20 hover:bg-danger/30 text-danger text-xs font-medium"
+          >
+            Retry
+          </button>
         </div>
       )}
       {saveError && (
@@ -675,21 +716,23 @@ export function GameConfig() {
 
           <div className="space-y-5">
             {(filteredSchema ?? []).map(cat => (
-              <CategoryCard key={cat.category} category={cat.category} count={cat.fields.length}>
+              <CategoryCard key={cat.category} category={cat.category} count={(cat.fields ?? []).length}>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
-                  {cat.fields.map(f => (
-                    <FieldRow
-                      key={`${f.section}||${f.key}`}
-                      field={f}
-                      value={values[f.key] ?? ''}
-                      onChange={v => handleFieldChange(f.key, v)}
-                      disabled={loadState !== 'ready' || saving}
-                      isDirty={(values[f.key] ?? '') !== (originals[f.key] ?? '')}
-                      isSet={liveValue(cfg, f) !== ''}
-                      isCustom={isCustomized(cfg, f)}
-                      defaultValue={fieldDefault(f)}
-                      managed={cfg ? sectionIsManaged(cfg, f) : false}
-                    />
+                  {(cat.fields ?? []).map(f => (
+                    f && f.key ? (
+                      <FieldRow
+                        key={`${f.section}||${f.key}`}
+                        field={f}
+                        value={values[f.key] ?? ''}
+                        onChange={v => handleFieldChange(f.key, v)}
+                        disabled={loadState !== 'ready' || saving}
+                        isDirty={(values[f.key] ?? '') !== (originals[f.key] ?? '')}
+                        isSet={liveValue(cfg, f) !== ''}
+                        isCustom={isCustomized(cfg, f)}
+                        defaultValue={fieldDefault(f)}
+                        managed={cfg ? sectionIsManaged(cfg, f) : false}
+                      />
+                    ) : null
                   ))}
                 </div>
               </CategoryCard>
@@ -993,8 +1036,8 @@ function FieldRow({ field, value, onChange, disabled, isDirty, isSet, isCustom, 
       {field.type === 'select' && field.options ? (
         <select value={value} disabled={disabled} onChange={e => onChange(e.target.value)} className={inputBase}>
           <option value="">(unset)</option>
-          {field.options.map(o => (
-            <option key={o.value} value={o.value}>{o.label}</option>
+          {(field.options ?? []).filter(o => o && typeof o.value === 'string').map(o => (
+            <option key={o.value} value={o.value}>{o.label ?? o.value}</option>
           ))}
         </select>
       ) : pair ? (


### PR DESCRIPTION
Fixes the user-reported `Game Config keeps going blank` bug on v12.0.0 and closes the diagnostics gap that made it untriageable.

## Fixed
- **React error boundary** on every route so a render crash can no longer white-out the WebView. Crashes show an in-place error with Retry / Reload.
- **GameConfig defensive guards** — `bundleFor`/`liveValue`/`isCustomized`/`currentValue`/`sectionIsManaged` tolerate malformed/partial responses. Iteration over schema categories, fields, and select options is now null-safe.
- **Schema fetch retries 3x** with backoff before declaring the page errored. Error banner gets an explicit Retry button.

## Diagnostics
- **WebView2 DevTools enabled** (F12 opens Chromium DevTools).
- **`webview2-debug.log` now actually gets written.** DuneShell subscribes to `Runtime.consoleAPICalled`/`Runtime.exceptionThrown`/`ProcessFailed` via DevTools Protocol and appends error/warn/assert/trace lines with a 2 MB ring buffer. Future diagnostic ZIPs will include the actual JS exception that caused any blank-screen issue.

## Version stamps
All 5 + bug template bumped to 12.0.1. Installer build verified: `DuneServerSetup.exe` 45.84 MB.

Closes Ken's report (v12 Game Config blanking).