### PR TITLE
release: v12.0.2 - GameConfig managedSections array coercion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.1"
+      placeholder: "v12.0.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.2] - 2026-06-12
+
+Same-day hotfix on top of v12.0.1 — confirms the v12.0.1 diagnostics work
+and fixes the actual render exception they captured.
+
+### Fixed
+
+- **Game Config render crash.** The page would render then immediately hit
+  `TypeError: managedSections.includes is not a function`, which the v12.0.1
+  error boundary caught (no more blank page) but still left users on a red
+  error card instead of the form. Root cause was a PowerShell + ConvertTo-Json
+  quirk: `Get-DuneIniManagedSectionNames` returned `@($names.Keys)`, which
+  serialized as `{}` (empty hashtable) or as a scalar string (single-element
+  array unwrap) instead of a JSON array. The webui's `sectionIsManaged()`
+  then called `.includes` on a non-array and threw on every field row.
+  - Server: `Get-DuneIniManagedSectionNames` now returns `,[string[]]@($names.Keys)`
+    (comma operator + explicit cast) to force a JSON array every time.
+  - Client: `sectionIsManaged()` is now type-tolerant — checks `Array.isArray`
+    before `.includes`, and accepts a single string as a one-element list.
+
+### Diagnostics confirmation
+
+- v12.0.1's `webview2-debug.log` writer worked exactly as designed — it caught
+  the exception with a full JS stack trace on first reproduction, which is
+  what enabled this same-day fix.
+
 ## [12.0.1] - 2026-06-12
 
 Hotfix for the Game Config "page goes blank" bug reported on v12.0.0, plus

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.1'
+$script:DuneToolVersion = '12.0.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.1',
+    [string]$Version = '12.0.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.1</Version>
+    <Version>12.0.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.1"
+#define MyAppVersion "12.0.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -652,7 +652,11 @@ function Get-DuneIniManagedSectionNames {
     $doc = ConvertFrom-DuneIniDoc -Raw $Raw
     $names = @{}
     foreach ($s in $doc.sections) { if ($s.managed) { $names[$s.name] = $true } }
-    return @($names.Keys)
+    # Comma operator forces array preservation through the function return so
+    # ConvertTo-Json always serializes [] / ["one"] / [...] rather than
+    # collapsing to {} (empty hashtable) or unwrapping a single-element array
+    # to a scalar string. The webui's sectionIsManaged() expects an array.
+    return ,[string[]]@($names.Keys)
 }
 
 # =============================================================================

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.1"
+$script:ToolVersion = "12.0.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -79,7 +79,13 @@ function currentValue(data: GameConfigResponse | null, field: GameConfigField): 
 function sectionIsManaged(data: GameConfigResponse, field: GameConfigField): boolean {
   if (!data || !field) return false
   const b = bundleFor(data, field.file)
-  return b?.managedSections?.includes(field.section) ?? false
+  // PS+ConvertTo-Json can collapse an empty hashtable to {} or unwrap a
+  // single-element array to a scalar, so managedSections may not always be
+  // an array on the wire. Defensively coerce before calling .includes.
+  const ms = b?.managedSections
+  if (Array.isArray(ms)) return ms.includes(field.section)
+  if (typeof ms === 'string') return ms === field.section
+  return false
 }
 
 export function GameConfig() {


### PR DESCRIPTION
Root cause fix for Ken's Game Config blank-screen, captured by v12.0.1's new `webview2-debug.log` diagnostics (17 minutes after release).

## Fixed

`TypeError: managedSections.includes is not a function` thrown in `sectionIsManaged` for every FieldRow.

**Server** (`app/server/lib/GameConfig.ps1`): `Get-DuneIniManagedSectionNames` returned `@(\.Keys)`, which `ConvertTo-Json` collapses to `{}` when the hashtable is empty (and unwraps a single-element array to a scalar) instead of emitting a JSON array. Now uses `,[string[]]@(\.Keys)` — comma operator + explicit cast forces array preservation through the function boundary AND through ConvertTo-Json.

**Client** (`webui/src/pages/GameConfig.tsx`): `sectionIsManaged()` now checks `Array.isArray` before `.includes` and tolerates a single string as a one-element list. Belt-and-braces.

## Validation

v12.0.1's error boundary + `webview2-debug.log` writer worked exactly as designed — caught the exception with full stack trace on first reproduction, enabling this same-day fix. Diagnostics strategy validated end-to-end.

All 5+1 version stamps bumped to 12.0.2. Installer build: 45.84 MB.