### PR TITLE
config(marketbot): default Duke starting balance to 454,720,162,028

### DIFF
--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -210,7 +210,7 @@ function Get-DuneBotConfigDefaults {
         max_buys_per_tick = 25
         die_size          = 12
         die_target        = 5
-        target_balance    = 9000000000000
+        target_balance    = 454720162028
         maintain_balance  = $true
         disabled_items    = @()
         # ----- Listing side (sane-pricing port of dune-admin/internal/marketbot) -----


### PR DESCRIPTION
**Staged for the next batched release — not for an immediate hotfix.**

Lowers the default `target_balance` for the Duke market bot from `9,000,000,000,000` (9T) Solari to `454,720,162,028` (~454.72B).

## Scope

- Single-line change in `app/server/lib/GameplayBot.ps1`.
- Operators who already have a saved `DuneBotConfig.json` keep their current value — the override path in `Read-DuneBotConfig` always wins. This only changes the seed for fresh installs and for users who haven't overridden the field in the Market Bot settings page.
- The marketbot port spec doc still references the old 9T figure as historical context — left intentionally unchanged.

## When to ship

Mark Ready for review and merge whenever the next batched release goes out.