### PR TITLE
v12.0.5 — Fix storage "Add Items" not persisting in-game (acquisition_time)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.4"
+      placeholder: "v12.0.5"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.5] - 2026-06-12
+
+Hotfix for Ken's report that items added to a storage container via Gameplay
+Admin show up in DST's container contents but never appear in-game, even after
+a battlegroup restart.
+
+### Fixed
+
+- **Storage "Add Items" now persists to the game.** `Invoke-DuneStorageGiveItem`
+  was inserting `dune.items` rows with `acquisition_time = 0` (the column
+  default). The game treats a 1970-epoch item as fully decayed and drops it
+  from the container on zone load, so the row existed in the DB (and rendered
+  in DST's contents view) but never materialized in-game. The insert now sets
+  `acquisition_time` to the current epoch, matching game-native items. Also
+  switched `position_index` from a raw row count to `MAX(position_index) + 1`
+  so adds into a container with gaps can't collide with an existing slot
+  (mirrors the player give-item and market-bot inserts). Covers both the
+  single `give-item` and the batch `give-items` paths.
+
 ## [12.0.4] - 2026-06-12
 
 Follow-up to v12.0.3 after Chopper's "where are the broadcast / whisper boxes"

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.4'
+$script:DuneToolVersion = '12.0.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.4',
+    [string]$Version = '12.0.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.4</Version>
+    <Version>12.0.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.4"
+#define MyAppVersion "12.0.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayWorld.ps1
+++ b/app/server/lib/GameplayWorld.ps1
@@ -575,6 +575,9 @@ function Invoke-DuneStorageGiveItem {
     param([string]$Ip, [long]$ContainerId, [string]$Template, [long]$Qty, [long]$Quality)
     if ($Qty -le 0) { $Qty = 1 }
     $safeTmpl = ConvertTo-DuneSqlString $Template
+    # acquisition_time must be the current epoch: the game treats acquisition_time=0
+    # (1970) items as fully decayed and drops them from the container on zone load,
+    # so they show in DST but never appear in-game even after a restart.
     $sql = @"
 WITH inv AS (
     SELECT id, COALESCE(max_item_count, 0) AS maxc
@@ -588,8 +591,10 @@ cur AS (
     GROUP BY inv.id, inv.maxc
 ),
 ins AS (
-    INSERT INTO dune.items (inventory_id, template_id, stack_size, quality_level, position_index, stats)
-    SELECT cur.inv_id, '$safeTmpl', $Qty::bigint, $Quality::bigint, cur.cnt,
+    INSERT INTO dune.items (inventory_id, template_id, stack_size, quality_level, position_index, acquisition_time, stats)
+    SELECT cur.inv_id, '$safeTmpl', $Qty::bigint, $Quality::bigint,
+           COALESCE((SELECT MAX(position_index) + 1 FROM dune.items WHERE inventory_id = cur.inv_id), 0),
+           EXTRACT(EPOCH FROM now())::bigint,
            '{"FCustomizationStats":[[],{}],"FItemStackAndDurabilityStats":[[],{}]}'::jsonb
     FROM cur
     WHERE cur.maxc = 0 OR cur.cnt < cur.maxc

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.4"
+$script:ToolVersion = "12.0.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Problem

A user (Ken) reported that items added to a storage container via **Gameplay Admin → Storage → Add Items** show up in DST's container contents view but **never appear in-game**, even after a battlegroup restart.

## Root cause

`Invoke-DuneStorageGiveItem` (`app/server/lib/GameplayWorld.ps1`) inserted `dune.items` rows **without `acquisition_time`**, so the column fell back to its default of `0` (1970 epoch). The game treats a 1970-epoch item as fully decayed and drops it from the container on zone load — so the row existed in the DB (and rendered in DST, which aggregates every inventory of the placeable) but never materialized in the actual game container.

Confirmed against the live Dune DB: every game-native container item carries a real epoch `acquisition_time` (≈ today), while DST-inserted items all had `0`. The working **player give-item** and **market-bot** inserts don't hit this because they go through paths that set a real timestamp.

## Fix

- Set `acquisition_time = EXTRACT(EPOCH FROM now())::bigint` on the storage insert, matching game-native items.
- Switch `position_index` from a raw row count to `MAX(position_index) + 1` so an add into a container with gaps (after deletes) can't collide with an existing slot — mirrors the player give-item / market-bot inserts.
- Covers both the single `give-item` and batch `give-items` paths (the batch loops the single insert).

Bumps all version stamps to **12.0.5** and adds the CHANGELOG entry.

## Notes

- This bug is pre-existing (introduced in `318ba0c`), not a regression from v12.0.4.
- The offline player give-item and blueprint copy-device inserts share the same `acquisition_time=0` omission — left out of scope here; flagging as a possible follow-up.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>