### PR TITLE
v12.0.6 — Stamp acquisition_time on offline player give-item + blueprint inserts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.5"
+      placeholder: "v12.0.6"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.6] - 2026-06-12
+
+Follow-up to v12.0.5: applies the same `acquisition_time` fix to the two other
+`dune.items` insert paths that shared the bug.
+
+### Fixed
+
+- **Offline player "Give Item" now persists across login.**
+  `Invoke-DunePlayerGiveItem` (the SQL path used for offline players, and for
+  online players given a custom quality) inserted new backpack items with
+  `acquisition_time = 0`, so the game could drop them as fully-decayed on the
+  player's next login. Now stamped with the current epoch. Online default-quality
+  gives are unaffected — they go through the RMQ server command, which sets the
+  timestamp game-side. Also covers the bulk give-items path, which loops this.
+
+- **Blueprint import / copy-device item** now stamps `acquisition_time` on the
+  `BuildingBlueprint_CopyDevice` it inserts into the player's backpack, for the
+  same reason.
+
 ## [12.0.5] - 2026-06-12
 
 Hotfix for Ken's report that items added to a storage container via Gameplay

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.5'
+$script:DuneToolVersion = '12.0.6'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.5',
+    [string]$Version = '12.0.6',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.5</Version>
+    <Version>12.0.6</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.5"
+#define MyAppVersion "12.0.6"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -234,7 +234,10 @@ WHERE i.id = $ItemId::bigint;
 }
 
 # Give item (give-item): stack onto a matching backpack stack or insert a new one.
-# Single data-modifying CTE so it runs atomically in one psql call.
+# Single data-modifying CTE so it runs atomically in one psql call. New rows must
+# stamp acquisition_time with the current epoch — the game treats acquisition_time=0
+# (1970) items as fully decayed and drops them on load, so an offline give would
+# vanish on the player's next login.
 function Invoke-DunePlayerGiveItem {
     param([string]$Ip, [long]$PawnId, [string]$Template, [long]$Qty, [long]$Quality)
     $safeTmpl = ConvertTo-DuneSqlString $Template
@@ -257,10 +260,10 @@ upd AS (
     RETURNING id
 ),
 ins AS (
-    INSERT INTO dune.items (inventory_id, stack_size, position_index, template_id, quality_level, stats)
+    INSERT INTO dune.items (inventory_id, stack_size, position_index, template_id, quality_level, acquisition_time, stats)
     SELECT inv.id, $Qty::bigint,
         (SELECT COALESCE(MAX(position_index), -1) + 1 FROM dune.items WHERE inventory_id = inv.id),
-        '$safeTmpl', $Quality::bigint, '{}'::jsonb
+        '$safeTmpl', $Quality::bigint, EXTRACT(EPOCH FROM now())::bigint, '{}'::jsonb
     FROM inv
     WHERE NOT EXISTS (SELECT 1 FROM existing)
     RETURNING id

--- a/app/server/lib/GameplayWorld.ps1
+++ b/app/server/lib/GameplayWorld.ps1
@@ -514,8 +514,8 @@ BEGIN
     SELECT COALESCE(MAX(position_index), -1) + 1 INTO v_pos
     FROM dune.items WHERE inventory_id = v_inv;
 
-    INSERT INTO dune.items (inventory_id, stack_size, position_index, template_id, quality_level, stats)
-    VALUES (v_inv, 1, v_pos, 'BuildingBlueprint_CopyDevice', 0, '$placeholder'::jsonb)
+    INSERT INTO dune.items (inventory_id, stack_size, position_index, template_id, quality_level, acquisition_time, stats)
+    VALUES (v_inv, 1, v_pos, 'BuildingBlueprint_CopyDevice', 0, EXTRACT(EPOCH FROM now())::bigint, '$placeholder'::jsonb)
     RETURNING id INTO v_item;
 
     INSERT INTO dune.building_blueprints (item_id, player_id, building_blueprint_map)

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.5"
+$script:ToolVersion = "12.0.6"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Context

Follow-up to #157 / v12.0.5, which fixed `acquisition_time = 0` on the **storage** give-item insert. The same omission existed on two other `dune.items` insert paths.

## Fix

- **Offline player give-item** — `Invoke-DunePlayerGiveItem` (`app/server/lib/GameplayPlayers.ps1`) is the SQL path used for offline players (and online players given a custom quality). It inserted new backpack items with `acquisition_time = 0`, so the game could drop them as fully decayed on the player's next login. Now stamped with the current epoch. The bulk give-items path (`Invoke-DunePlayerGiveItemsBulk`) loops this, so it's covered too. Online default-quality gives are unaffected — they route through the RMQ `AddItemToInventory` server command, which sets the timestamp game-side.
- **Blueprint import / copy-device** — the `BuildingBlueprint_CopyDevice` insert (`app/server/lib/GameplayWorld.ps1`) now stamps `acquisition_time` for the same reason.

Bumps all version stamps to **12.0.6** and adds the CHANGELOG entry.

## Notes

- Only the new-row INSERTs were touched; the give-item stacking UPDATE path keeps the existing item's timestamp (correct).
- `position_index` on these paths already used `MAX(position_index)+1`, so no change needed there.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>