### PR TITLE
Scope Repair All / Restore Destroyed to player gear only (0, 1, 15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ Follow-up to v12.0.5: applies the same `acquisition_time` fix to the two other
   `BuildingBlueprint_CopyDevice` it inserts into the player's backpack, for the
   same reason.
 
+### Changed
+
+- **Repair All Items / Restore Destroyed Items now scope to the player's own
+  gear only** (inventory types `0, 1, 15` — backpack, equipped armor, equipped
+  weapons). The previous set also included the emote and empty buckets
+  (`14, 27, 30`); Restore Destroyed in particular would rebuild a durability
+  stats block on items that should never have one (e.g. emotes). Both actions
+  now leave those untouched.
+
 ## [12.0.5] - 2026-06-12
 
 Hotfix for Ken's report that items added to a storage container via Gameplay

--- a/app/data/dune-progression-nodes.json
+++ b/app/data/dune-progression-nodes.json
@@ -119,5 +119,5 @@
     "Swordmaster":   "Skills.Ability.DeflectionSlow",
     "Trooper":       "Skills.Ability.SuspensorGrenade_Reduction"
   },
-  "repair_gear_inventory_types": [0, 1, 14, 15, 27, 30]
+  "repair_gear_inventory_types": [0, 1, 15]
 }

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -732,7 +732,9 @@ function Get-DunePlayerEventsDemo {
 #
 # Source list: dune-admin fillables_gen.go waterFillableTemplates (49 entries,
 # generated from DT_ItemTableFillables.json — FillableTypeRestriction=Water).
-# repairGearInventoryTypes mirrors dune-admin's set (0,1,14,15,27,30).
+# repairGearInventoryTypes is DST's narrowed set (0,1,15): backpack + equipped
+# armor + equipped weapons only. (dune-admin's original set also included emote
+# and empty buckets 14/27/30, which Repair/Restore should not touch.)
 # ---------------------------------------------------------------------------
 $script:DuneWaterFillableTemplates = @(
     'advancedstillsuit','combat_nati_fremenexile04_top','decajon','dewpack',

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -45,7 +45,7 @@ function _Load-DuneProgressionNodesCatalog {
         landsraadMissionNodesAtreides   = @()
         landsraadMissionNodesHarkonnen  = @()
         starterAbilityByJob             = @{}
-        repairGearInventoryTypes        = @(0, 1, 14, 15, 27, 30)
+        repairGearInventoryTypes        = @(0, 1, 15)
     }
     $p = _Resolve-DuneCatalog 'dune-progression-nodes.json'
     if (-not $p) { $script:DuneProgressionNodesCatalog = $empty; return }
@@ -59,7 +59,7 @@ function _Load-DuneProgressionNodesCatalog {
             landsraadMissionNodesAtreides   = @($json.landsraad_mission_nodes_atreides   | ForEach-Object { [string]$_ })
             landsraadMissionNodesHarkonnen  = @($json.landsraad_mission_nodes_harkonnen  | ForEach-Object { [string]$_ })
             starterAbilityByJob             = @{}
-            repairGearInventoryTypes        = @(0, 1, 14, 15, 27, 30)
+            repairGearInventoryTypes        = @(0, 1, 15)
         }
         if ($json.starter_ability_by_job) {
             foreach ($prop in $json.starter_ability_by_job.PSObject.Properties) {


### PR DESCRIPTION
## Problem

**Repair All Items** and **Restore Destroyed Items** pulled their inventory scope from `repair_gear_inventory_types = [0, 1, 14, 15, 27, 30]` (ported from dune-admin). On a player actor those types decode (confirmed against the live DB) as:

- `0` backpack · `1` equipped armor · `15` equipped weapons/hotbar — gear with durability ✅
- `14`, `27` emotes (cosmetic) · `30` empty — should never be repaired ❌

Repair All filters on a durability stats block so emotes were skipped, but **Restore Destroyed selects every item regardless and rebuilds a durability block** — so it could graft `FItemStackAndDurabilityStats` onto emotes in types 14/27.

## Fix

Narrow the set to **`[0, 1, 15]`** (backpack + equipped armor + equipped weapons) in the data file (`app/data/dune-progression-nodes.json`) and both hardcoded catalog defaults (`app/server/lib/PlayersWrites.ps1`). Both actions now touch only the player's own gear.

Ships in **v12.0.6** (folded into the unpublished release alongside the `acquisition_time` fixes).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>