### PR TITLE
v12.0.7 — Repair to item's true max durability + inventory refresh button

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.6"
+      placeholder: "v12.0.7"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.7] - 2026-06-12
+
+Fixes the durability target used by the repair actions, which capped items to a
+catalog value (often 100) instead of their real maximum.
+
+### Fixed
+
+- **Repair now restores items to their true maximum durability.** Repair All
+  Items, the per-item repair (wrench), and Restore Destroyed Items all derived
+  the target durability from the item catalog (falling back to `100`). But a
+  player's in-game stats/perks raise an item's durability cap, so the real
+  maximum is per-player and only the item's own `MaxDurability` knows it. All
+  three actions now set `MaxDurability`, `CurrentDurability`, and
+  `DecayedMaxDurability` equal to the **highest of the item's own three values**
+  — no catalog, no hard-coded default. (Restore Destroyed keeps the catalog max
+  only as a floor for items whose stats block is missing entirely.)
+
+### Added
+
+- **Refresh inventory button** on the player Inventory section, so you can
+  re-pull the item list (and see updated durability after a repair) without
+  reselecting the player.
+
 ## [12.0.6] - 2026-06-12
 
 Follow-up to v12.0.5: applies the same `acquisition_time` fix to the two other

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.6'
+$script:DuneToolVersion = '12.0.7'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.6',
+    [string]$Version = '12.0.7',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.6</Version>
+    <Version>12.0.7</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.6"
+#define MyAppVersion "12.0.7"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -206,27 +206,29 @@ function Invoke-DunePlayerDeleteItem {
     return @{ ok = $true; message = "Deleted item $ItemId." }
 }
 
-# Repair item (repair-item): restore CurrentDurability/DecayedMaxDurability to MaxDurability.
+# Repair item (repair-item): set MaxDurability/CurrentDurability/DecayedMaxDurability
+# all equal to the HIGHEST of the item's own three values ("highest number wins").
+# No catalog lookup, no hard-coded default — the item's own MaxDurability is the
+# true cap (decay only lowers Current + DecayedMax, never Max).
 function Invoke-DunePlayerRepairItem {
     param([string]$Ip, [long]$ItemId)
     $sql = @"
 UPDATE dune.items i
-SET stats = jsonb_set(
-    jsonb_set(i.stats,
-        '{FItemStackAndDurabilityStats,1,CurrentDurability}',
-        to_jsonb(t.val), true),
-    '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}',
-    to_jsonb(t.val), true)
+SET stats = jsonb_set(jsonb_set(jsonb_set(i.stats,
+        '{FItemStackAndDurabilityStats,1,MaxDurability}',        to_jsonb(t.val), true),
+        '{FItemStackAndDurabilityStats,1,CurrentDurability}',    to_jsonb(t.val), true),
+        '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}', to_jsonb(t.val), true)
 FROM (
-    SELECT COALESCE(
-        (stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8,
-        100.0
+    SELECT GREATEST(
+        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0),
+        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0),
+        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0)
     ) AS val
     FROM dune.items
     WHERE id = $ItemId::bigint
       AND stats ? 'FItemStackAndDurabilityStats'
 ) AS t
-WHERE i.id = $ItemId::bigint;
+WHERE i.id = $ItemId::bigint AND t.val > 0;
 "@
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -394,8 +394,11 @@ function Invoke-DunePlayerGiveItemsBulk {
     return @{ ok = $ok; message = $msg; results = @($results); failures = $failures; total = $total }
 }
 
-# Repair equipped gear — OFFLINE only. Loops items in repair_gear_inventory_types,
-# sets CurrentDurability AND DecayedMaxDurability to the catalog max.
+# Repair equipped gear — OFFLINE only. Sets every durability item in the gear
+# inventory types to the HIGHEST of its own three durability fields
+# (Max/Current/DecayedMax) and makes all three match. The item's own
+# MaxDurability already bakes in that player's stat/perk durability bonuses
+# (which differ per player), so it — not the catalog — is the source of truth.
 function Invoke-DunePlayerRepairGear {
     param([string]$Ip, [long]$PawnId)
     if ($PawnId -le 0) { return @{ ok = $false; error = 'pawn_id is required.' } }
@@ -407,51 +410,38 @@ function Invoke-DunePlayerRepairGear {
     $invTypesArr = '(' + (($invTypes | ForEach-Object { "$_::int" }) -join ',') + ')'
 
     $sql = @"
-SELECT i.id::text AS item_id, i.template_id AS template,
-       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0)::text AS stat_max
-FROM dune.items i
-JOIN dune.inventories inv ON inv.id = i.inventory_id
-WHERE inv.actor_id = $PawnId::bigint
-  AND inv.inventory_type IN $invTypesArr
-  AND i.stats ? 'FItemStackAndDurabilityStats';
+WITH tgt AS (
+    SELECT i.id AS item_id,
+           GREATEST(
+               COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0),
+               COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0),
+               COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0)
+           ) AS val
+    FROM dune.items i
+    JOIN dune.inventories inv ON inv.id = i.inventory_id
+    WHERE inv.actor_id = $PawnId::bigint
+      AND inv.inventory_type IN $invTypesArr
+      AND i.stats ? 'FItemStackAndDurabilityStats'
+)
+UPDATE dune.items i
+SET stats = jsonb_set(jsonb_set(jsonb_set(i.stats,
+        '{FItemStackAndDurabilityStats,1,MaxDurability}',        to_jsonb(tgt.val), true),
+        '{FItemStackAndDurabilityStats,1,CurrentDurability}',    to_jsonb(tgt.val), true),
+        '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}', to_jsonb(tgt.val), true)
+FROM tgt
+WHERE i.id = tgt.item_id AND tgt.val > 0
+RETURNING i.id::text AS item_id;
 "@
-    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1000 -TimeoutSec 30
-    if (-not $r.ok) { return @{ ok = $false; error = "list equipped items: $($r.error)" } }
-    $items = ConvertTo-DuneRowMaps -Result $r
-    if ($items.Count -eq 0) {
-        return @{ ok = $true; message = 'No equipped items with durability stats — nothing to repair.'; repaired = 0 }
-    }
-
-    $repaired = 0; $skipped = 0
-    foreach ($row in $items) {
-        $itemId = [int64](ConvertTo-DuneInt $row['item_id'])
-        $tmpl = [string]$row['template']
-        $rule = Get-DuneGameplayItemRule -TemplateId $tmpl
-        $max = [double]$rule.max_durability
-        if ($max -le 0) {
-            $statMax = 0.0
-            [double]::TryParse([string]$row['stat_max'], [ref]$statMax) | Out-Null
-            if ($statMax -gt 0) { $max = $statMax } else { $max = 100.0 }
-        }
-        $upd = @"
-UPDATE dune.items
-SET stats = jsonb_set(
-    jsonb_set(stats,
-        '{FItemStackAndDurabilityStats,1,CurrentDurability}',
-        to_jsonb($max::float8)),
-    '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}',
-    to_jsonb($max::float8))
-WHERE id = $itemId::bigint;
-"@
-        $ur = Invoke-DuneSqlQuery -Ip $Ip -Sql $upd -ReadOnly $false -MaxRows 1 -TimeoutSec 30
-        if (-not $ur.ok) { $skipped++; continue }
-        $repaired++
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 5000 -TimeoutSec 60
+    if (-not $r.ok) { return @{ ok = $false; error = "repair gear: $($r.error)" } }
+    $repaired = @(ConvertTo-DuneRowMaps -Result $r).Count
+    if ($repaired -eq 0) {
+        return @{ ok = $true; message = 'No gear with durability stats — nothing to repair.'; repaired = 0 }
     }
     return @{
         ok = $true
-        message = "Repaired $repaired item(s) on pawn $PawnId (skipped $skipped)."
+        message = "Repaired $repaired item(s) to full durability on pawn $PawnId."
         repaired = $repaired
-        skipped = $skipped
     }
 }
 
@@ -515,19 +505,26 @@ WHERE inv.actor_id = $PawnId::bigint
         if ($curVal -gt 0) { $alreadyOk++; continue }
 
         if ($hasBlk) {
-            # Stats block is present — just re-seed CurrentDurability and
-            # DecayedMaxDurability the same way Invoke-DunePlayerRepairGear
-            # does. jsonb_set defaults to create_if_missing=true so this also
-            # handles the case where only the inner keys went missing.
+            # Stats block is present but durability is zeroed — re-seed all three
+            # fields to the HIGHEST of the item's own Max/Current/DecayedMax
+            # (which already include this player's stat/perk durability bonuses),
+            # with the catalog max only as a floor in case every field was zeroed.
             $upd = @"
-UPDATE dune.items
-SET stats = jsonb_set(
-    jsonb_set(stats,
-        '{FItemStackAndDurabilityStats,1,CurrentDurability}',
-        to_jsonb($max::float8)),
-    '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}',
-    to_jsonb($max::float8))
-WHERE id = $itemId::bigint;
+UPDATE dune.items i
+SET stats = jsonb_set(jsonb_set(jsonb_set(i.stats,
+        '{FItemStackAndDurabilityStats,1,MaxDurability}',        to_jsonb(t.val), true),
+        '{FItemStackAndDurabilityStats,1,CurrentDurability}',    to_jsonb(t.val), true),
+        '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}', to_jsonb(t.val), true)
+FROM (
+    SELECT GREATEST(
+        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0),
+        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0),
+        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0),
+        $max::float8
+    ) AS val
+    FROM dune.items WHERE id = $itemId::bigint
+) AS t
+WHERE i.id = $itemId::bigint AND t.val > 0;
 "@
         } else {
             # Stats block missing entirely — graft a fresh one in. The shape

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.6"
+$script:ToolVersion = "12.0.7"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -858,6 +858,11 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
 
   return (
     <div className="space-y-4">
+      <div className="flex items-center justify-end">
+        <button className="btn-secondary" disabled={loading || busy} onClick={() => setTick(t => t + 1)}>
+          <Icon name="RefreshCw" size={13} className={loading ? 'animate-spin' : ''} /> Refresh inventory
+        </button>
+      </div>
       <ItemList title={`Inventory (${fmtNum(groups.gear.length)})`} icon="Backpack" items={groups.gear}
         canWrite={canWrite} busy={busy} run={run}
         extra={<ItemsActionBlock player={player} canWrite={canWrite} flash={flash} onChanged={() => { onChanged(); setTick(t => t + 1) }} />} />


### PR DESCRIPTION
## Problem

A user reported Repair wasn't restoring inventory items properly — items stayed capped (e.g. `100/200`, and a `100/999999` literjon stuck at 100). Root cause: all three repair actions derived the **target durability from the item catalog** (`Get-DuneGameplayItemRule`, falling back to `100.0`). But in-game **stats/perks raise an item's durability cap per player**, so the real maximum is unique per player+item and only the item's own `MaxDurability` field knows it. The catalog can't.

Confirmed against the live DB — the durability block looks like:
`{"MaxDurability": 999999.0, "CurrentDurability": 100, "DecayedMaxDurability": 100}`. The catalog path was overwriting these to ~100.

## Fix

`Invoke-DunePlayerRepairItem`, `Invoke-DunePlayerRepairGear` (Repair All), and `Invoke-DunePlayerRestoreDestroyedGear` now set `MaxDurability`, `CurrentDurability`, and `DecayedMaxDurability` all equal to the **`GREATEST` of the item's own three values** — no catalog, no `100` fallback. ("Highest number wins.") Restore Destroyed keeps the catalog max only as a *floor*, and only for items whose stats block is missing entirely (nothing to read). Repair All is also simplified to a single set-based UPDATE.

Validated read-only against live data: targets resolve to the true caps (`999999`, `200`), not `100`.

## Also

- **Refresh inventory button** on the player Inventory section, so durability updates after a repair are visible without reselecting the player.

Bumps stamps to **12.0.7**. PowerShell + TypeScript both verified clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>