### PR TITLE
v12.0.9 — Restore Coriolis Storm Seeds panel behind a risk lock

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.8"
+      placeholder: "v12.0.9"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.9] - 2026-06-12
+
+### Added
+
+- **Coriolis Storm Seeds panel is back on the Players → Server Overview** (shown
+  when no player is selected). It was trimmed in post-v12 polish; restored and
+  now **locked behind an explicit risk gate**. The controls render only after
+  acknowledging a severe-consequences warning ("these rewrite world-reset
+  generation and wipe corpses / loose loot when a seed changes — no undo"), and
+  every apply still has its own confirm. The backend is unchanged — it wraps the
+  same dune-admin debug routines (`debug_set_farm_seed` / `debug_set_map_seed` /
+  `debug_set_partition_seed`) at farm / map / partition scope.
+
 ## [12.0.8] - 2026-06-12
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.8'
+$script:DuneToolVersion = '12.0.9'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.8',
+    [string]$Version = '12.0.9',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.8</Version>
+    <Version>12.0.9</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.8"
+#define MyAppVersion "12.0.9"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.8"
+$script:ToolVersion = "12.0.9"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/gameplay/PlayersTab.tsx
+++ b/webui/src/pages/gameplay/PlayersTab.tsx
@@ -13,6 +13,7 @@ import { fmtNum, SourceBadge, StatCard, DemoNotice } from './shared'
 import {
   SECTIONS, SECTION_COMPONENTS, type SectionId,
 } from './players/sections'
+import { CoriolisAdmin } from './players/coriolis'
 
 type OnlineFilter = '' | 'online' | 'offline'
 
@@ -262,7 +263,12 @@ export function PlayersTab() {
               />
             </div>
           ) : (
-            <ServerOverview summary={displaySummary} />
+            <>
+              <ServerOverview summary={displaySummary} />
+              <div className="mt-3">
+                <CoriolisAdmin flash={(msg, kind = 'ok') => setFlash({ msg, kind })} />
+              </div>
+            </>
           )}
         </section>
       </div>

--- a/webui/src/pages/gameplay/players/coriolis.tsx
+++ b/webui/src/pages/gameplay/players/coriolis.tsx
@@ -28,6 +28,7 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
   const [parts, setParts]       = useState<CoriolisPartition[]>([])
   const [busy, setBusy]         = useState(false)
   const [tick, setTick]         = useState(0)
+  const [unlocked, setUnlocked] = useState(false)
 
   // Per-scope draft inputs.
   const [farmDraft, setFarmDraft]               = useState('')
@@ -125,6 +126,38 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
         lock the layout across resets, or <em>Reroll</em> to pick a fresh random one.
       </p>
 
+      {/* Severe-consequences warning + lock gate. These settings rewrite world-reset
+          generation and cascade cleanup of corpses / loose loot — there is no undo. */}
+      <div className="rounded-lg border border-danger/40 bg-danger/10 p-3 text-xs space-y-1.5">
+        <div className="flex items-center gap-2 font-semibold text-danger">
+          <Icon name="AlertTriangle" size={14} /> Advanced — world-altering. Severe consequences if misused.
+        </div>
+        <p className="text-text-dim">
+          These are <strong className="text-text">world-reset (Coriolis storm) seeds</strong>. Changing one
+          re-rolls the storm layout and <strong className="text-text">wipes corpses and loose loot</strong> on
+          the next tick — farm scope hits every map and partition. There is <strong className="text-text">no
+          undo</strong>. If you don't know exactly what these do, leave them alone.
+        </p>
+        {unlocked ? (
+          <button className="btn-secondary text-xs" disabled={busy} onClick={() => setUnlocked(false)}>
+            <Icon name="Lock" size={12} /> Lock controls
+          </button>
+        ) : (
+          <button
+            className="btn-secondary text-xs text-danger border-danger/50"
+            disabled={busy}
+            onClick={() => {
+              if (confirm('Unlock Coriolis storm seed controls?\n\nThese rewrite world-reset generation and wipe corpses / loose loot when a seed changes. There is no undo. Only continue if you fully understand the consequences.')) {
+                setUnlocked(true)
+              }
+            }}
+          >
+            <Icon name="Unlock" size={12} /> I understand the risks — unlock controls
+          </button>
+        )}
+      </div>
+
+      {unlocked && (<>
       {/* Farm scope */}
       <div className="rounded-lg border border-border bg-surface-2/40 p-3 space-y-2">
         <div className="flex items-center justify-between">
@@ -207,6 +240,7 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
           </div>
         </details>
       )}
+      </>)}
     </div>
   )
 }


### PR DESCRIPTION
## What

Restores the **Coriolis Storm Seeds** panel to **Players → Server Overview** (shown when no player is selected). It was trimmed in `746ab23` ("post-v12 polish"); the component (`coriolis.tsx`) and backend (`CoriolisAdmin.ps1`) were still present — only the render call was removed.

## Risk lock (per request)

The controls are now **locked behind an explicit acknowledgment**:
- A red **severe-consequences warning** banner is always shown: these are world-reset (Coriolis storm) seeds; changing one re-rolls the storm layout and **wipes corpses + loose loot** on the next tick (farm scope hits every map/partition), with **no undo**.
- The farm/map/partition editors render **only after** the admin clicks "I understand the risks — unlock controls" (which itself pops a confirm). A "Lock controls" button re-hides them.
- Every individual apply keeps its own confirm dialog.

## Framework parity with dune-admin

Backend unchanged. It wraps the **same dune-admin debug routines** at the same scopes/signatures (verified against `Icehunter/dune-admin` `db-routines`): `debug_set_farm_seed(integer)`, `debug_set_map_seed(text, integer)`, `debug_set_partition_seed(bigint, integer)`, read via `debug_get_coriolis_seeds()`, with the same cascade-cleanup semantics.

Frontend-only change. TypeScript verified clean. Bumps stamps to **12.0.9**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>