### PR TITLE
Remove former companion-tool references from current UI copy, comments, and notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ here cover everything those tags shipped.
   acknowledging a severe-consequences warning ("these rewrite world-reset
   generation and wipe corpses / loose loot when a seed changes — no undo"), and
   every apply still has its own confirm. The backend is unchanged — it wraps the
-  same dune-admin debug routines (`debug_set_farm_seed` / `debug_set_map_seed` /
-  `debug_set_partition_seed`) at farm / map / partition scope.
+  game's `debug_set_farm_seed` / `debug_set_map_seed` / `debug_set_partition_seed`
+  database routines at farm / map / partition scope.
 
 ## [12.0.8] - 2026-06-12
 
@@ -123,9 +123,9 @@ sister "Restore Destroyed" action that operates on items at 0/NULL durability.
   three cards (`GenericBroadcastComposer`, `ShutdownBroadcastComposer`,
   `WhisperComposer`) now render at the top of the Gameplay overview tab so
   ops don't have to dig for them. Same three cards are also reachable as a
-  standalone page at `/broadcasts` (new top-nav entry). Mirrors the spirit
-  of dune-admin's `/api/v1/notify`, but goes through DST's existing V6
-  `ServiceBroadcast` for messaging and per-player whisper for whispers.
+  standalone page at `/broadcasts` (new top-nav entry). Goes through DST's
+  existing V6 `ServiceBroadcast` for messaging and per-player whisper for
+  whispers.
 
 - **Durability column on inventory rows.** Equipped and backpack items now
   show `current / max` durability inline in mono, colored by ratio:
@@ -144,8 +144,8 @@ sister "Restore Destroyed" action that operates on items at 0/NULL durability.
 ## [12.0.3] - 2026-06-12
 
 Players-tab parity sweep after Chopper/Ogmosis reports on v12.0.2 — Fill Water
-and Give Item now match dune-admin's "no relog needed" behavior for online
-players, plus a CSS bleed fix on the item picker dropdown and the
+and Give Item now have "no relog needed" behavior for online players, plus a
+CSS bleed fix on the item picker dropdown and the
 display-name-vs-template-id confusion users hit when searching the catalog.
 
 ### Fixed
@@ -169,9 +169,8 @@ display-name-vs-template-id confusion users hit when searching the catalog.
   the message now reflects what actually happened.
 
 - **Repair button mis-labeled.** "Repair Equipped Gear" already covered the
-  backpack (`inventory_type = 0` is included in `repairGearInventoryTypes`),
-  matching dune-admin's behavior. Renamed to "Repair All Items" so the label
-  matches what it does.
+  backpack (`inventory_type = 0` is included in `repairGearInventoryTypes`).
+  Renamed to "Repair All Items" so the label matches what it does.
 
 - **Item picker dropdown bled through to the inventory list behind it.** Five
   call sites used the Tailwind class `bg-surface-1`, but the theme only

--- a/app/data/dune-progression-nodes.json
+++ b/app/data/dune-progression-nodes.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "source": "dune-admin/db.go (climbTheRanksNodes, climbTheRanksStoryNodes, climbTheRanksStoryNodes{Atreides,Harkonnen}, landsraadMissionNodes{Atreides,Harkonnen})",
+    "source": "reference implementation db.go (climbTheRanksNodes, climbTheRanksStoryNodes, climbTheRanksStoryNodes{Atreides,Harkonnen}, landsraadMissionNodes{Atreides,Harkonnen})",
     "purpose": "Static journey-node arrays used by progression-unlock + progression-reverse. Kept here as JSON so DST can ship them with the installer without hard-coding 90+ strings into PowerShell."
   },
   "climb_the_ranks_nodes": [

--- a/app/server/lib/Config.ps1
+++ b/app/server/lib/Config.ps1
@@ -20,7 +20,7 @@ $script:DuneConfigKeys = @(
 
 # Keys that ONLY a pre-decouple (<= 11.4.13) build ever wrote into
 # dune-server.config. Their presence on disk is how we know a config was
-# created before DST was split off from the dune-admin companion app — a fresh
+# created before DST was split off from the companion admin tool — a fresh
 # 12.x install never writes them. Used to drive the one-time decoupling notice.
 $script:DuneLegacyAdminKeys = @(
     'DuneAdminExe',
@@ -112,16 +112,16 @@ function Test-DuneConfigComplete {
 
 # Decoupling notice ----------------------------------------------------------
 #
-# As of v12.x DST is a standalone tool: the bundled dune-admin companion and
-# its in-app launch commands were removed (dune-admin is now run separately and
+# As of v12.x DST is a standalone tool: the bundled companion admin tool and
+# its in-app launch commands were removed (that tool is now run separately and
 # reached at https://dune-admin.layout.tools). Anyone upgrading from a
 # pre-decouple build (<= 11.4.13) must be told this once, and shown where their
-# old dune-admin folder lives so they can still launch it.
+# old companion-tool folder lives so they can still launch it.
 #
-# Detection: pre-decouple builds wrote dune-admin-era keys (see
+# Detection: pre-decouple builds wrote the reference implementation-era keys (see
 # $script:DuneLegacyAdminKeys) into dune-server.config; a fresh 12.x install
 # never does. We treat the presence of any of those keys as "this user came
-# from the dune-admin era". `DecoupleNoticeAck` is set once the user
+# from the bundled-companion era". `DecoupleNoticeAck` is set once the user
 # acknowledges, after which the notice never shows again.
 function Get-DuneDecoupleNotice {
     $raw = Read-DuneConfigRaw

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -13,13 +13,13 @@
 #   removed from the body, so there is exactly one copy and DST is the sole author
 #   of that section going forward. Structure (comments, array lines, complex
 #   single-line values) is preserved verbatim. Duplicate scalar keys are collapsed
-#   to the last-wins value. Any pre-existing dune-admin managed block is migrated
+#   to the last-wins value. Any pre-existing the reference implementation managed block is migrated
 #   (adopted) into the DST block and its markers removed. If a BEGIN marker is
 #   found without a matching END the writer refuses to touch the file (data-loss
 #   guard). The file is backed up server-side before every write.
 
 # -----------------------------------------------------------------------------
-# DST managed-block markers. ASCII ONLY (dune-admin used a non-ASCII em-dash that
+# DST managed-block markers. ASCII ONLY (the reference implementation used a non-ASCII em-dash that
 # mangles to mojibake under CP1252 round-trips).
 # -----------------------------------------------------------------------------
 $script:DstManagedBegin = '; ===== Dune Server Tool (DST) managed section BEGIN - do not hand-edit between these markers ====='
@@ -142,10 +142,10 @@ $script:DuneGameConfigSchema = @(
     # --- Vehicles (engine cvars) ---
     @{ Section=$script:DuneGcSecConsole; Key='dw.VehicleDurabilityDamageMultiplier'; File='engine'; Type='float'; Min=0; Max=10; Default='1.0'; Label='Vehicle Durability Damage'; Help='Durability damage multiplier for vehicles. 0 = off.'; Category='Vehicles' }
 
-    # --- Parity additions (dune-admin serverSettingsSchema) ---
+    # --- Parity additions (the reference implementation serverSettingsSchema) ---
     # ACCURACY NOTE (pending validation against the live UserGame.ini): the keys
     # below were NOT found in the stock DefaultGame.ini dump (docs/Dune_Server_INI_Field_Sheet.md,
-    # game 1.4.0.0) and are NOT in dune-admin's evidence-validated schema. They may
+    # game 1.4.0.0) and are NOT in the reference implementation's evidence-validated schema. They may
     # be no-ops as written and need confirmation before relying on them:
     #   - m_BuildingDecayRateMultiplier / bEnableBuildingStability / m_BaseBackupExtensions
     #     (m_BaseBackupExtensions duplicates the real m_BaseBackupMaxExtensions above)
@@ -439,7 +439,7 @@ function ConvertFrom-DuneIniDoc {
         }
 
         if ($inManaged -and -not $sawManagedHeaderSection) {
-            # dune-admin block header comments before the first managed section: drop.
+            # the reference implementation block header comments before the first managed section: drop.
             continue
         }
         if ($null -ne $cur) {
@@ -857,7 +857,7 @@ echo "===END==="
 
 # Best-effort type inference for an arbitrary INI scalar — used so the UI can
 # render the right input control (bool toggle vs number vs free text) for keys
-# the static schema doesn't know about. Mirrors dune-admin's inferType.
+# the static schema doesn't know about. Mirrors the reference implementation's inferType.
 function Get-DuneGameConfigInferType {
     param([string]$Value)
     $v = "$Value".Trim()

--- a/app/server/lib/Gameplay.ps1
+++ b/app/server/lib/Gameplay.ps1
@@ -1,9 +1,9 @@
-﻿# Gameplay lib — native port of the open-source dune-admin Market / Exchange
+﻿# Gameplay lib — native port of the legacy Market / Exchange
 # and Market Bot features. Runs entirely inside the DST backend (one console).
 #
 # Market data is read straight from the live game Postgres via the existing
 # Invoke-DuneSqlQuery bridge (psql over kubectl/SSH) — the SAME database and
-# schema dune-admin used, so its SQL ports verbatim. Item names/categories/
+# schema the reference implementation used, so its SQL ports verbatim. Item names/categories/
 # tiers are enriched from the bundled app\data\gameplay-item-data.json.
 #
 # Every market getter returns @{ source = 'live' | 'demo'; ... }. When the
@@ -13,7 +13,7 @@
 #
 # The Market Bot is an external HTTP service (Duke). We proxy to it with
 # Invoke-RestMethod using the configured address + bearer token, mirroring
-# dune-admin's botProxy. Lifecycle (start/stop/restart) is left as a no-op
+# the reference implementation's botProxy. Lifecycle (start/stop/restart) is left as a no-op
 # stub here and surfaced honestly in the UI until the control plane is wired.
 
 # ----------------------------------------------------------------------------
@@ -111,7 +111,7 @@ function Get-DuneItemKind {
     return 'item'
 }
 
-# Reclassify "*_Schematic" items under schematics/<first-segment> (matches dune-admin).
+# Reclassify "*_Schematic" items under schematics/<first-segment> (matches the reference implementation).
 function Get-DuneSchematicCategory {
     param([string]$TemplateId, [string]$BaseCategory)
     if (-not $TemplateId.ToLower().EndsWith('_schematic')) { return $BaseCategory }
@@ -165,7 +165,7 @@ function Test-DuneTruthy {
 }
 
 # ----------------------------------------------------------------------------
-# Market — live SQL (ported from dune-admin db_market.go), prices stored x0.1
+# Market — live SQL (ported from the reference implementation db_market.go), prices stored x0.1
 # so multiply by 10; NPC orders are shown as the bot vendor "Duke".
 # ----------------------------------------------------------------------------
 $script:DuneMarketItemsSql = @'

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -1,6 +1,6 @@
 ﻿# GameplayBot lib — native Market Bot ("Duke").
 #
-# This is the native port of dune-admin's marketbot buy side. Instead of
+# This is the native port of the reference implementation's marketbot buy side. Instead of
 # proxying to an external Revy process, the buy loop runs INSIDE the DST
 # backend and writes directly to the live game Postgres via the same
 # Invoke-DuneSqlQuery bridge the Market reads use (psql over kubectl/SSH).
@@ -11,7 +11,7 @@
 # MaxBuys and the disabled-items skip still apply. The 100k sane-pricing /
 # listing side of the old patch is intentionally NOT ported.
 #
-# The buy transaction mirrors dune-admin/internal/marketbot/exchange.go
+# The buy transaction mirrors the reference implementation/internal/marketbot/exchange.go
 # buyPlayerListings verbatim (insert seller payment log order, fulfilled-order
 # record completion_type=4, debit bot balance, delete the player's sell order +
 # order + backing item) so the game client shows the seller "Take Solari".
@@ -142,7 +142,7 @@ function Save-DuneBotMaskCache {
 
 # Harvest masks from EVERY non-zero-mask order on the exchange (player, NPC,
 # prior Duke listings — all are valid). Mirrors refreshCategoryCache() from
-# dune-admin/internal/marketbot/exchange.go. Returns the merged cache so the
+# the reference implementation/internal/marketbot/exchange.go. Returns the merged cache so the
 # caller can pass it straight to Resolve-DuneBotListingCandidates.
 #
 # v11.5.5: throttled by $RefreshIntervalSec (default 6h). The bundled seed
@@ -213,7 +213,7 @@ function Get-DuneBotConfigDefaults {
         target_balance    = 9000000000000
         maintain_balance  = $true
         disabled_items    = @()
-        # ----- Listing side (sane-pricing port of dune-admin/internal/marketbot) -----
+        # ----- Listing side (sane-pricing port of the reference implementation/internal/marketbot) -----
         list_tick_interval   = 1800          # 30 min between list ticks
         listings_per_grade   = 5             # concurrent NPC listings per (template, grade)
         stackables_only      = $false        # v11.5.9: default OFF — list gear too
@@ -538,7 +538,7 @@ SELECT id FROM ins UNION ALL SELECT id FROM existing LIMIT 1;
         $null = Invoke-DuneSqlQuery -Ip $Ip -Sql "SELECT dune.dune_exchange_get_user_id($ownerId)" -ReadOnly $false -MaxRows 5 -TimeoutSec 30
     }
 
-    # Exchange id (try the same fallbacks dune-admin uses, with the upstream
+    # Exchange id (try the same fallbacks the reference implementation uses, with the upstream
     # access-point cascade prepended so we always pick the canonical exchange).
     # Every tier JOINs against dune_exchanges so a stale access-point or
     # player-order row pointing at a wiped exchange id can never be returned —
@@ -712,8 +712,8 @@ function Invoke-DuneMarketItemsCacheBust {
 # ----------------------------------------------------------------------------
 # Order-expiry horizon for the seller payment log order. We derive it natively
 # from the live DB (latest real, non-sentinel expiration_time ~= now + 24h game
-# time) instead of porting dune-admin's epoch-learning machinery. Falls back to
-# the 999_999_999 sentinel dune-admin uses when the epoch is unknown.
+# time) instead of porting the reference implementation's epoch-learning machinery. Falls back to
+# the 999_999_999 sentinel the reference implementation uses when the epoch is unknown.
 # ----------------------------------------------------------------------------
 function Get-DuneBotOrderExpiry {
     param([string]$Ip)
@@ -854,7 +854,7 @@ COMMIT;
 }
 
 # ============================================================================
-# LISTING SIDE — port of dune-admin/internal/marketbot with the sane-pricing
+# LISTING SIDE — port of the reference implementation/internal/marketbot with the sane-pricing
 # 100k-cap patch (recovered from DST commit cf903665).
 # ----------------------------------------------------------------------------
 # Catalog source: DB-derived. We snapshot the live game's NPC vendor inventory
@@ -1126,7 +1126,7 @@ WHERE o.owner_id = $OwnerId AND o.is_npc_order = TRUE AND o.exchange_id = $Excha
 # get one listing tier (grade 0), gradeable equipment gets the full 0–5
 # (or MinQualityLevel–5 for augments that only drop at higher grades). This
 # is what drives DST seed up from ~1 listing/template to ~6× for gradeable
-# gear, closing most of the gap against dune-admin's seed output.
+# gear, closing most of the gap against the reference implementation's seed output.
 function Get-DuneBotApplicableGrades {
     param([hashtable]$Cand, $Rule)
     # Stackables don't have a quality grade in-game.
@@ -2106,7 +2106,7 @@ function Clear-DuneBotError {
 }
 
 # Wipe NPC orders owned by any actor whose class is not 'Duke'. Used to evict
-# leftover Revy orphans from the old external dune-admin integration.
+# leftover Revy orphans from the old external the reference implementation integration.
 function Clear-DuneBotLegacyListings {
     $ctx = Get-DuneDbContext
     if (-not $ctx.ok) { return @{ ok = $false; error = $ctx.message } }

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -1,11 +1,11 @@
-﻿# Gameplay — Players (native port of dune-admin's player tooling).
+﻿# Gameplay — Players (native port of the reference implementation's player tooling).
 #
 # Reads the live game Postgres through the same Invoke-DuneSqlQuery bridge the
-# Market features use, so dune-admin's SQL ports verbatim. Every getter returns
+# Market features use, so the reference implementation's SQL ports verbatim. Every getter returns
 # @{ ok; ... } and the routes wrap them with the live/demo + `source` convention.
 #
 # Write actions (give solari, award spec XP, rename, give/delete/repair item)
-# call the SAME server-side stored procedures and statements dune-admin uses,
+# call the SAME server-side stored procedures and statements the reference implementation uses,
 # run with -ReadOnly:$false. They are surfaced behind explicit confirm UI.
 #
 # Helpers reused from Gameplay.ps1: ConvertTo-DuneRowMaps, ConvertTo-DuneInt,
@@ -29,7 +29,7 @@ function Get-DuneShortClass {
 }
 
 # ----------------------------------------------------------------------------
-# SQL — Players (ported from dune-admin db.go). All read-only.
+# SQL — Players (ported from the reference implementation db.go). All read-only.
 # ----------------------------------------------------------------------------
 $script:DunePlayersListSql = @'
 SELECT a.id,
@@ -318,7 +318,7 @@ function Get-DunePlayerDetailDemo {
 }
 
 # ============================================================================
-# v11.5.6 — extended player surface (port of dune-admin's player tooling).
+# v11.5.6 — extended player surface (port of the reference implementation's player tooling).
 #
 # Adds:
 #   - Get-DunePlayerSummaryLive     : server-wide aggregate dashboard
@@ -482,8 +482,8 @@ function Get-DunePlayerStatsLive {
 # ---------------------------------------------------------------------------
 # Full specs view (5 tracks plus keystone count + max).
 # Keystones use the dune.purchased_specialization_keystones table keyed by
-# controller id (per dune-admin's insertAllPurchasedKeystones path).
-# Max keystone id is 205 (matches dune-admin's generate_series upper bound).
+# controller id (per the reference implementation's insertAllPurchasedKeystones path).
+# Max keystone id is 205 (matches the reference implementation's generate_series upper bound).
 # ---------------------------------------------------------------------------
 $script:DunePlayerSpecsFullSql = @'
 WITH tracks AS (
@@ -569,7 +569,7 @@ SELECT dune.reset_specialization_keystones($PawnId::bigint);
     return @{ ok = $true; message = "Reset all spec tracks and keystones for player $PawnId." }
 }
 
-# Grant all keystones — uses controller id (per dune-admin's insertAllPurchasedKeystones).
+# Grant all keystones — uses controller id (per the reference implementation's insertAllPurchasedKeystones).
 function Invoke-DunePlayerGrantAllKeystones {
     param([string]$Ip, [long]$ControllerId)
     $max = $script:DuneKeystoneMax
@@ -629,7 +629,7 @@ function Invoke-DunePlayerSetTags {
     return @{ ok = $true; message = "Tags updated for account $AccountId ($($clean.Count) tag(s))."; tags = $clean }
 }
 
-# v11.5.9 - update_player_tags delta path. Mirrors dune-admin cmdUpdatePlayerTags:
+# v11.5.9 - update_player_tags delta path. Mirrors the reference implementation cmdUpdatePlayerTags:
 # calls dune.update_player_tags(account_id, add[], remove[]) via the stored
 # proc rather than DELETE-INSERT, so the server-side trigger logic (faction
 # rep cascades, journey hooks) fires correctly.
@@ -727,15 +727,15 @@ function Get-DunePlayerEventsDemo {
 }
 
 # ---------------------------------------------------------------------------
-# v11.5.7 — Fill Water (offline path). Ported from dune-admin db.go:6325
+# v11.5.7 — Fill Water (offline path). Ported from the reference implementation db.go:6325
 # cmdRefillWaterOffline. Sets all water-fillable items in the actor's relevant
 # inventories to their MaxAmount via jsonb_set. Takes effect on next relog for
 # online players; instant for offline players.
 #
-# Source list: dune-admin fillables_gen.go waterFillableTemplates (49 entries,
+# Source list: the reference implementation fillables_gen.go waterFillableTemplates (49 entries,
 # generated from DT_ItemTableFillables.json — FillableTypeRestriction=Water).
 # repairGearInventoryTypes is DST's narrowed set (0,1,15): backpack + equipped
-# armor + equipped weapons only. (dune-admin's original set also included emote
+# armor + equipped weapons only. (the reference implementation's original set also included emote
 # and empty buckets 14/27/30, which Repair/Restore should not touch.)
 # ---------------------------------------------------------------------------
 $script:DuneWaterFillableTemplates = @(

--- a/app/server/lib/GameplayWorld.ps1
+++ b/app/server/lib/GameplayWorld.ps1
@@ -1,10 +1,10 @@
 ﻿# Gameplay — World (Bases, Storage, Blueprints). Read-only native port of
-# dune-admin's list views. SQL ported verbatim from dune-admin db.go. Each
+# the reference implementation's list views. SQL ported verbatim from the reference implementation db.go. Each
 # getter returns @{ ok; ... }; the routes apply the live/demo + `source`
 # convention. Helpers reused from Gameplay.ps1 / GameplayPlayers.ps1.
 
 # ----------------------------------------------------------------------------
-# BASES — list (id, name, pieces, placeables). dune-admin has no delete handler
+# BASES — list (id, name, pieces, placeables). the reference implementation has no delete handler
 # so this is read-only by design.
 # ----------------------------------------------------------------------------
 $script:DuneBasesListSql = @'
@@ -180,7 +180,7 @@ FROM dune.building_blueprints bb
 LEFT JOIN dune.items i ON i.id = bb.item_id
 LEFT JOIN dune.inventories inv ON inv.id = i.inventory_id
 LEFT JOIN dune.actors a ON a.id = inv.actor_id
--- Owner resolution: dune-admin's original join (ps.player_pawn_id = a.id) only
+-- Owner resolution: the legacy join (ps.player_pawn_id = a.id) only
 -- matches a player whose pawn is currently spawned/loaded, so offline players'
 -- blueprints render with a blank owner (looked like "only the host's blueprints
 -- show up"). Resolve primarily by the persistent account link (same pattern the
@@ -227,9 +227,9 @@ function Get-DuneBlueprintsDemo {
 }
 
 # ----------------------------------------------------------------------------
-# BLUEPRINT EXPORT / IMPORT — native port of dune-admin handlers_blueprints.go.
+# BLUEPRINT EXPORT / IMPORT — native port of the reference implementation handlers_blueprints.go.
 # Export reads instances/placeables/pentashields into a portable JSON file
-# (field names match dune-admin exactly for cross-tool compatibility). Import
+# (field names match the reference implementation exactly for cross-tool compatibility). Import
 # recreates the blueprint as a BuildingBlueprint_CopyDevice in a player's
 # backpack via one atomic PL/pgSQL DO block (the SQL bridge runs each call as a
 # separate psql invocation, so a single statement is the only way to stay
@@ -238,7 +238,7 @@ function Get-DuneBlueprintsDemo {
 
 # building_type values game-saved blueprints commonly mark provides_stability=true.
 # Used only as a fallback when importing legacy JSON without the per-instance flag;
-# fresh exports always carry the exact bool. Mirrors dune-admin's structuralBuildingTypes.
+# fresh exports always carry the exact bool. Mirrors the reference implementation's structuralBuildingTypes.
 $script:DuneStructuralBuildingTypes = @{
     'Atreides_Outpost_Column'                  = $true
     'Atreides_Outpost_Column_Corner'           = $true
@@ -289,7 +289,7 @@ function ConvertTo-DuneFloat {
 }
 
 # Format a value as a Postgres real literal element (invariant, single-precision
-# shortest round-trip — matches the float32 cast dune-admin uses).
+# shortest round-trip — matches the float32 cast the reference implementation uses).
 function Format-DuneReal {
     param($Value)
     return ([float](ConvertTo-DuneFloat $Value)).ToString([System.Globalization.CultureInfo]::InvariantCulture)
@@ -441,7 +441,7 @@ function Import-DuneBlueprintLive {
         }
     }
 
-    # Resolve instance rows (instance_id + stability fall back per dune-admin).
+    # Resolve instance rows (instance_id + stability fall back per the reference implementation).
     $instRows = [System.Collections.Generic.List[string]]::new()
     for ($i = 0; $i -lt $instancesRaw.Count; $i++) {
         $inst = $instancesRaw[$i]
@@ -565,10 +565,10 @@ function Join-DuneBlueprintInserts {
 
 # ----------------------------------------------------------------------------
 # STORAGE WRITE — add items to / remove items from a container. Native port of
-# dune-admin's give-item / give-items / delete-item. Items added or removed
+# the reference implementation's give-item / give-items / delete-item. Items added or removed
 # only become visible to other players after a server zone restart (the game
 # caches container contents); the UI surfaces that warning. All require a live
-# DB. dune-admin inserts each item fresh (no stacking merge) with minimal valid
+# DB. the reference implementation inserts each item fresh (no stacking merge) with minimal valid
 # stats; the capacity check + insert run as one atomic CTE here.
 # ----------------------------------------------------------------------------
 function Invoke-DuneStorageGiveItem {
@@ -621,7 +621,7 @@ SELECT (SELECT id FROM ins)  AS item_id,
 }
 
 # Batch add — loops Invoke-DuneStorageGiveItem, collecting given/skipped (mirrors
-# dune-admin's give-items). Each item is a hashtable/PSObject { template, qty, quality }.
+# the reference implementation's give-items). Each item is a hashtable/PSObject { template, qty, quality }.
 function Invoke-DuneStorageGiveItems {
     param([string]$Ip, [long]$ContainerId, $Items)
     $given = @(); $skipped = @()
@@ -652,7 +652,7 @@ function Invoke-DuneStorageDeleteItem {
 }
 
 # ----------------------------------------------------------------------------
-# BASE EXPORT — native port of dune-admin handlers_bases.go. Reads a base's
+# BASE EXPORT — native port of the reference implementation handlers_bases.go. Reads a base's
 # building_instances (7-element transform: x,y,z + quaternion) and its
 # placeables, recenters everything on the base centroid, converts quaternions
 # to yaw (instances) / euler (placeables), and extracts pentashield scale from

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -1,4 +1,4 @@
-﻿# PlayersAdmin.ps1 — v11.5.9 player admin extras ported from dune-admin.
+﻿# PlayersAdmin.ps1 — v11.5.9 player admin extras ported from the reference implementation.
 # Covers §2 currency writes + §7 returning-award/delete-account + shared helpers
 # (faction tables, char-XP table, offline check, raw funcom-id lookup).
 #
@@ -273,7 +273,7 @@ function Get-DuneKeystoneSpBonus {
 }
 
 # ----- Character XP / Intel cascade ---------------------------------------
-# dune-admin keeps this strictly OFFLINE — the in-memory FLevelComponent
+# the reference implementation keeps this strictly OFFLINE — the in-memory FLevelComponent
 # overwrites the DB row at logout, so changes applied to an online char get
 # silently reverted. We mirror that contract.
 

--- a/app/server/lib/PlayersRead.ps1
+++ b/app/server/lib/PlayersRead.ps1
@@ -1,4 +1,4 @@
-﻿# PlayersRead.ps1 — v11.5.9 read endpoints ported from dune-admin §1.
+﻿# PlayersRead.ps1 — v11.5.9 read endpoints ported from the reference implementation §1.
 # Each Get-Dune* returns @{ ok=$true|$false; <payload-key>=...; error?=... }.
 # Routes wrap with Invoke-DunePlayerReadRoute (live + demo fallback).
 #

--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -1,6 +1,6 @@
 ﻿# PlayersRmq.ps1
 # High-level handlers that publish RMQ ServerCommand messages for live
-# (online-player) operations. Ports dune-admin handlers_rmq.go logic:
+# (online-player) operations. Ports the reference implementation handlers_rmq.go logic:
 # parameter validation, optional FLS id resolution from actor_id, lightweight
 # capacity check for give-item-live, and the static "Claim Rewards" path
 # for grant-live (which is pg_notify-based, not RMQ).
@@ -11,7 +11,7 @@
 # Depends on Rmq.ps1 (Send-DuneRmqServerCommand + typed wrappers),
 # Database.ps1 (Invoke-DuneSqlQuery), PlayersAdmin.ps1, PlayersWrites.ps1.
 
-# Best-effort backpack capacity guard. Mirrors dune-admin checkInventoryCapacity
+# Best-effort backpack capacity guard. Mirrors the reference implementation checkInventoryCapacity
 # but only enforces the slot cap (max_item_count). Volume is left to the
 # game server. Returns @{ ok=$true } when room exists or when no cap is set.
 function Test-DuneInventoryCapacity {
@@ -159,7 +159,7 @@ function Invoke-DunePlayerCheatScriptLive {
 
 # cmdGrantLive: NOT an RMQ command. Inserts into dune.landsraad_house_rewards
 # with house_name='AdminGrant'; the pg_notify trigger surfaces a Claim Rewards
-# popup to the player whether online or offline. Mirrors dune-admin db.go.
+# popup to the player whether online or offline. Mirrors the reference implementation db.go.
 function Invoke-DunePlayerGrantLive {
     param(
         [Parameter(Mandatory)] [string] $Ip,
@@ -220,7 +220,7 @@ function Invoke-DuneChatWhisperLive {
     $res = Invoke-DuneRmqSendWhisper -TargetFlsId $TargetFlsId -TargetName $TargetName -SenderName $SenderName -Message $Message -ImpersonatedFlsId $ImpersonatedFlsId
     if ($res.ok) {
         $res.message = "Whisper sent to $TargetFlsId (broker accepted; in-game delivery is experimental)."
-        $res.note    = "dune-admin/Adain external chat publish recipe is not live-tested - check the target's whispers tab to confirm delivery."
+        $res.note    = "The external chat publish recipe is not live-tested - check the target's whispers tab to confirm delivery."
     }
     return $res
 }

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1,4 +1,4 @@
-﻿# PlayersWrites.ps1 — v11.5.9 player write actions ported from dune-admin.
+﻿# PlayersWrites.ps1 — v11.5.9 player write actions ported from the reference implementation.
 # Covers Phases C, D, E, F of the v11.5.9 port (37 endpoints across):
 #   §3 items, §4 vehicles, §5 teleport (offline), §6 progression/journey/
 #   contracts/jobs/codex, §10 storage owner debug.
@@ -7,7 +7,7 @@
 # @{ ok=$true|$false; message; ... }. Routes wrap via Invoke-DunePlayerWriteRoute
 # from routes/GameplayPlayers.ps1.
 #
-# Schema notes (verified against dune-admin db.go):
+# Schema notes (verified against the reference implementation db.go):
 #   * fgl_entities is keyed by `entity_id` (NOT id), and game components live in
 #     the `components` jsonb column (NOT properties).
 #   * actor_fgl_entities joins via `entity_id` (NOT fgl_entity_id).
@@ -96,7 +96,7 @@ function Get-DuneNodesForPreset {
 }
 
 # ---------------------------------------------------------------------------
-# Helpers — pawn / account / faction lookups (matching dune-admin behaviour)
+# Helpers — pawn / account / faction lookups (matching the reference implementation behaviour)
 # ---------------------------------------------------------------------------
 
 function Get-DunePlayerPawnFromAccount {

--- a/app/server/lib/Rmq.ps1
+++ b/app/server/lib/Rmq.ps1
@@ -2,7 +2,7 @@
 # Generic ServerCommand publisher + courier (chat) publisher for the
 # battlegroup's mq-game RabbitMQ broker.
 #
-# Mirrors dune-admin's rmq_commands.go: builds the {Version, AuthToken,
+# Mirrors the reference implementation's rmq_commands.go: builds the {Version, AuthToken,
 # MessageContent} envelope, base64-encodes it host-side, ships a tiny Erlang
 # script over SSH -> sudo kubectl exec -> rabbitmqctl eval. Uses the same
 # AuthToken and exchange/routing-key conventions as send-dune-broadcast and
@@ -33,7 +33,7 @@ function Send-DuneRmqServerCommand {
         return @{ ok = $false; status = 503; message = $_.Exception.Message }
     }
 
-    # Marshal inner -> envelope -> base64, mirroring dune-admin/publishServerCommand.
+    # Marshal inner -> envelope -> base64, mirroring the reference implementation/publishServerCommand.
     $innerJson = (ConvertTo-Json $Fields -Depth 8 -Compress)
     $envelope = [ordered]@{
         Version        = 2
@@ -109,7 +109,7 @@ rabbit_queue_type:publish_at_most_once(X, Msg).
 # ── FLS id resolution ─────────────────────────────────────────────────────────
 
 # Resolves the accounts."user" hex Funcom UUID (the PlayerId form RMQ
-# ServerCommands expect) for a player-pawn actor_id. Mirrors dune-admin's
+# ServerCommands expect) for a player-pawn actor_id. Mirrors the reference implementation's
 # flsIDFromActorID — joins dune.actors -> dune.accounts and returns "user".
 function Resolve-DuneFlsIdFromActorId {
     param([Parameter(Mandatory)] [string] $Ip,

--- a/app/server/routes/GameConfig.ps1
+++ b/app/server/routes/GameConfig.ps1
@@ -77,7 +77,7 @@ Register-DuneRoute -Method GET -Path '/api/gameconfig' -Handler {
 #        resolved from the schema), OR
 #        { updates: [ { file, section, key, value }, ... ] } (explicit/raw).
 # Every touched section is relocated into the DST-managed block (whole-section
-# absorption); any pre-existing dune-admin block is migrated. Returns the
+# absorption); any pre-existing the reference implementation block is migrated. Returns the
 # freshly-fetched config so the client can refresh its state.
 # -----------------------------------------------------------------------------
 Register-DuneRoute -Method PUT -Path '/api/gameconfig' -Handler {

--- a/app/server/routes/Gameplay.ps1
+++ b/app/server/routes/Gameplay.ps1
@@ -1,5 +1,5 @@
 ﻿# Gameplay API — native Market / Exchange + Market Bot routes.
-# Mirrors dune-admin's /api/v1/market[-bot]/* surface under /api/gameplay/*.
+# Mirrors the reference implementation's /api/v1/market[-bot]/* surface under /api/gameplay/*.
 #
 # Data source resolution for market endpoints:
 #   - ?demo=1            -> always bundled demo dataset (source: "demo")
@@ -348,7 +348,7 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/market-bot/clear-listings' 
 # ---------------------------------------------------------------------------
 # POST /api/gameplay/market-bot/clear-legacy-listings — wipe NPC orders owned
 # by any actor class that ISN'T Duke (Revy orphans from the old external
-# dune-admin integration, etc.). One-shot cleanup; player listings untouched.
+# the reference implementation integration, etc.). One-shot cleanup; player listings untouched.
 # ---------------------------------------------------------------------------
 Register-DuneRoute -Method POST -Path '/api/gameplay/market-bot/clear-legacy-listings' -Handler {
     param($req, $res, $routeParams, $body)

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -1,6 +1,6 @@
 ﻿# Gameplay API — Players. Read views (list + detail) follow the live/demo +
 # `source` convention; write actions require a live DB (no demo writes) and
-# mirror dune-admin's stored procedures. Shared helpers Get-DuneQ /
+# mirror the reference implementation's stored procedures. Shared helpers Get-DuneQ /
 # Test-DuneDemoRequested come from routes/Gameplay.ps1 (loaded first).
 
 # Read a scalar field from a parsed JSON body (hashtable or PSObject).

--- a/app/server/routes/PlayersAdmin.ps1
+++ b/app/server/routes/PlayersAdmin.ps1
@@ -1,4 +1,4 @@
-﻿# PlayersAdmin.ps1 — v11.5.9 player admin routes ported from dune-admin §2 + §7.
+﻿# PlayersAdmin.ps1 — v11.5.9 player admin routes ported from the reference implementation §2 + §7.
 # Currency / progression writes + returning-player-award + delete-account.
 # Uses Invoke-DunePlayerWriteRoute + Get-DuneBodyInt/Value from routes/GameplayPlayers.ps1.
 

--- a/app/server/routes/PlayersRead.ps1
+++ b/app/server/routes/PlayersRead.ps1
@@ -1,4 +1,4 @@
-﻿# PlayersRead.ps1 — v11.5.9 read routes ported from dune-admin §1.
+﻿# PlayersRead.ps1 — v11.5.9 read routes ported from the reference implementation §1.
 # Each route uses Invoke-DunePlayerReadRoute (live + demo fallback) so demo
 # requests still get a usable empty / stub payload.
 

--- a/app/server/routes/PlayersRmq.ps1
+++ b/app/server/routes/PlayersRmq.ps1
@@ -1,5 +1,5 @@
 # PlayersRmq.ps1 - v11.5.9 live (RMQ) player command routes ported from
-# dune-admin handlers_rmq.go. All routes publish to the mq-game broker via
+# the reference implementation handlers_rmq.go. All routes publish to the mq-game broker via
 # rabbitmqctl eval over SSH. The HTTP response indicates whether the command
 # was queued; the game server applies it asynchronously.
 

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -1,4 +1,4 @@
-﻿# PlayersWrites.ps1 — v11.5.9 player write routes ported from dune-admin.
+﻿# PlayersWrites.ps1 — v11.5.9 player write routes ported from the reference implementation.
 # Wires Phase C/D/E/F endpoints onto the HTTP server. All routes use
 # Invoke-DunePlayerWriteRoute + Get-DuneBodyInt/Value from routes/GameplayPlayers.ps1.
 
@@ -322,7 +322,7 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/storage/owner-debug' -Handle
 # ---------------------------------------------------------------------------
 
 # POST /api/gameplay/players/update-tags  { account_id, add?[], remove?[] }
-# Mirrors dune-admin cmdUpdatePlayerTags (calls dune.update_player_tags proc
+# Mirrors the reference implementation cmdUpdatePlayerTags (calls dune.update_player_tags proc
 # so server-side triggers fire). Separate from POST /tags (overwrite model)
 # which is kept for back-compat.
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/update-tags' -Handler {

--- a/app/server/routes/Update.ps1
+++ b/app/server/routes/Update.ps1
@@ -129,11 +129,11 @@ Register-DuneRoute -Method GET -Path '/api/update/check' -Handler {
 }
 
 # GET /api/update/migration-notice — one-time "DST is now decoupled from
-# dune-admin" notice. `needed` is true only for installs upgraded from a
+# the reference implementation" notice. `needed` is true only for installs upgraded from a
 # pre-decouple build (see Get-DuneDecoupleNotice).
 #
-# Loopback-only: the notice exposes the host's local dune-admin folder path and
-# is a host-machine concern (the host runs dune-admin, not a remote Tailscale /
+# Loopback-only: the notice exposes the host's local the reference implementation folder path and
+# is a host-machine concern (the host runs the reference implementation, not a remote Tailscale /
 # LAN viewer). Remote callers must never see the path or be blocked by it.
 function Test-DuneUpdateLoopbackRequest {
     param($req)
@@ -208,7 +208,7 @@ Register-DuneRoute -Method POST -Path '/api/update/install' -Handler {
     }
     try {
       try {
-        # Gate: a user upgrading across the dune-admin decoupling must read and
+        # Gate: a user upgrading across the companion-tool decoupling must read and
         # acknowledge the one-time notice before any further update can run.
         $notice = Get-DuneDecoupleNotice
         if ($notice.Needed) {

--- a/docs/internal/marketbot-port-spec.md
+++ b/docs/internal/marketbot-port-spec.md
@@ -5,19 +5,19 @@ I now have all the information needed. Let me compile the comprehensive implemen
 
 ---
 
-# Dune Admin Market Bot — Full Port Spec for PowerShell/Postgres-via-SSH
+# Market Bot — Full Port Spec for PowerShell/Postgres-via-SSH
 
 **Reference sources:**
-- `Icehunter/dune-admin` HEAD commit `f6dfc68fc6ef324c51038293c34c20fb995a1c31` (latest public HEAD, v0.33.x era — v0.34.0 introduced the `@heroui-pro/react` licence break)
+- `the upstream reference repository` HEAD commit `f6dfc68fc6ef324c51038293c34c20fb995a1c31` (latest public HEAD, v0.33.x era — v0.34.0 introduced the `@heroui-pro/react` licence break)
 - `coastal-ms/DST-DuneServerTool` branch `coastal-ms/version-11.5.2` tip commit `5d7e92b60d13ae0a27485831fd57dccfbc123e45`
-- Sane-pricing patch at DST commit `cf903665c49a2b645d2f9987c22e4fca9159599d` (parent of `665364e1cf...` "Remove dune-admin integration")
-- DST fix commit `421693ae8fb0e5751928625200b4e7e1efc232f2` ("v10.1.15: fix pricing patch on dune-admin v0.23.2")
+- Sane-pricing patch at DST commit `cf903665c49a2b645d2f9987c22e4fca9159599d` (parent of `665364e1cf...` "Remove reference implementation integration")
+- DST fix commit `421693ae8fb0e5751928625200b4e7e1efc232f2` ("v10.1.15: fix pricing patch on reference implementation v0.23.2")
 
 ---
 
 ## Canonical Version Note
 
-The **canonical reference version for the sane-pricing patch** is dune-admin **v0.23.2**. DST commit `421693ae` explicitly states "fix pricing patch on dune-admin v0.23.2" — this is the version the patch was calibrated against. The upstream HEAD (`f6dfc68f`) has substantially refactored the exchange module (e.g. `buyPlayerListings` now takes `gameNow int64` as a parameter, the pricing engine is different), but the patch's Go symbols map cleanly onto it. Use the upstream HEAD for all SQL column shapes (they have not changed materially from v0.23.2). When the commit body says "v0.23.2 added `gameNow int64` to `buyPlayerListings`", it means the upstream HEAD at `f6dfc68f` already matches that v0.23.2 signature — no further adjustment needed.
+The **canonical reference version for the sane-pricing patch** is reference implementation **v0.23.2**. DST commit `421693ae` explicitly states "fix pricing patch on reference implementation v0.23.2" — this is the version the patch was calibrated against. The upstream HEAD (`f6dfc68f`) has substantially refactored the exchange module (e.g. `buyPlayerListings` now takes `gameNow int64` as a parameter, the pricing engine is different), but the patch's Go symbols map cleanly onto it. Use the upstream HEAD for all SQL column shapes (they have not changed materially from v0.23.2). When the commit body says "v0.23.2 added `gameNow int64` to `buyPlayerListings`", it means the upstream HEAD at `f6dfc68f` already matches that v0.23.2 signature — no further adjustment needed.
 
 ---
 
@@ -27,7 +27,7 @@ The **canonical reference version for the sane-pricing patch** is dune-admin **v
 
 The bot uses **`class = 'Revy'`** in `dune.actors`.
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go` (SHA `d927cb87`):
+**Source:** `the upstream reference repository:internal/marketbot/exchange.go` (SHA `d927cb87`):
 
 ```go
 err := e.db.QueryRow(ctx,
@@ -72,7 +72,7 @@ if currentBalance < seedFloor {
 }
 ```
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:initBotUser`
+**Source:** `the upstream reference repository:internal/marketbot/exchange.go:initBotUser`
 
 ### `actors` Row Column Values
 
@@ -122,7 +122,7 @@ SELECT DISTINCT access_point_id FROM dune.dune_exchange_orders WHERE exchange_id
 SELECT dune.get_exchange_inventory_id($exchangeId)
 ```
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:Init` and `detectExchangeID`, `detectAccessPointID`.
+**Source:** `the upstream reference repository:internal/marketbot/exchange.go:Init` and `detectExchangeID`, `detectAccessPointID`.
 
 ### DST Port Divergence on Identity
 
@@ -139,7 +139,7 @@ DST's `Get-DuneBotIdentity` uses class **`'Duke'`** instead of `'Revy'`, and ski
 | `ListInterval` | **30 minutes** | `list_interval` |
 | `BuyInterval` | **5 minutes** | `buy_interval` |
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/bot.go`:
+**Source:** `the upstream reference repository:internal/marketbot/bot.go`:
 ```go
 if cfg.ListInterval == 0 {
     cfg.ListInterval = 30 * time.Minute
@@ -180,7 +180,7 @@ func runLoop(ctx, logger, cfg, ex, catalog) {
 }
 ```
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/bot.go:runLoop`
+**Source:** `the upstream reference repository:internal/marketbot/bot.go:runLoop`
 
 **Key design:** The loop checks at minute granularity. On startup, one combined tick fires immediately. Each subsequent tick fires when `now > nextDue`, not on a strict wall-clock schedule.
 
@@ -216,7 +216,7 @@ ListTick:
   11. Refresh balance and listing_count for status reporting
 ```
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:ListTick`
+**Source:** `the upstream reference repository:internal/marketbot/exchange.go:ListTick`
 
 ### Quota Check: Top-Up vs. Spawn Fresh
 
@@ -300,7 +300,7 @@ RETURNING id
 | `quality_level` | Grade (0–5) |
 | `stats` | `'{}'` (empty JSON) |
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:createListingsBatch`
+**Source:** `the upstream reference repository:internal/marketbot/exchange.go:createListingsBatch`
 
 ### Step 2: INSERT order row
 
@@ -347,7 +347,7 @@ VALUES
 | `initial_stack_size` | `StackMax` |
 | `wear_normalized_price` | Same as `item_price` (listing price) |
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:createListingsBatch`
+**Source:** `the upstream reference repository:internal/marketbot/exchange.go:createListingsBatch`
 
 ### Expiration Time Calculation
 
@@ -379,7 +379,7 @@ ORDER BY expiration_time DESC LIMIT 1
 
 ## Section 3b — Listing Price Calculation
 
-### Upstream Pricing (dune-admin HEAD, unpatched)
+### Upstream Pricing (reference implementation HEAD, unpatched)
 
 The upstream `pricing.go` uses a complex multi-branch formula:
 
@@ -416,11 +416,11 @@ T0: 5  T1: 20  T2: 80  T3: 200  T4: 600  T5: 1,500  T6: 4,000
 
 **Market price influence (`fetchMarketPrices`):** Uses `dune_exchange_get_item_price_stats(template_ids[])` to get real market minimum. If market min < `adjusted × 0.9`, price trends toward `(adjusted + market_min) / 2`.
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/pricing.go` (SHA `de6592d4`)
+**Source:** `the upstream reference repository:internal/marketbot/pricing.go` (SHA `de6592d4`)
 
 ### Sane-Pricing Patch (DST / Coastal) — THE AUTHORITATIVE RULES
 
-**Patch file:** `coastal-ms/DST-DuneServerTool:app/resources/dune-admin-patches/0001-sane-pricing-100k-cap.patch` (SHA `6dbd524ef7a5c80dba9acd2ce04afab7686050c9`, at commit `cf903665`)
+**Patch file:** `coastal-ms/DST-DuneServerTool:app/resources/legacy-admin-patches/0001-sane-pricing-100k-cap.patch` (SHA `6dbd524ef7a5c80dba9acd2ce04afab7686050c9`, at commit `cf903665`)
 
 **What it changes:** Replaces upstream's rarity-weighted pricing (which produced multi-million-solari T6 listings) with a tier-driven model capped at 100,000 Solari, calibrated for a small private server (~2 active players, ~5–20k Solari/hr).
 
@@ -568,7 +568,7 @@ if roll := rand.Intn(12) + 1; roll != 5 {
 
 > This section repeats the patch in spec form rather than code form for the implementer.
 
-**Patch source:** `coastal-ms/DST-DuneServerTool:app/resources/dune-admin-patches/0001-sane-pricing-100k-cap.patch` (commit `cf903665`). Files touched: `pricing.go`, `config.go`, `config_test.go`, `exchange.go`.
+**Patch source:** `coastal-ms/DST-DuneServerTool:app/resources/legacy-admin-patches/0001-sane-pricing-100k-cap.patch` (commit `cf903665`). Files touched: `pricing.go`, `config.go`, `config_test.go`, `exchange.go`.
 
 **What the patch does:**
 1. Hard-caps all listings at **100,000 Solari** (`maxAnyPrice`). No exception.
@@ -590,11 +590,11 @@ If you see upstream values (rarity=1/5/2, vendor=1/5/2, grade=1/1/1.25/1.5/1.75/
 
 ---
 
-## Section 5 — Configuration Surface (Upstream dune-admin UI)
+## Section 5 — Configuration Surface (Upstream reference implementation UI)
 
 ### Runtime Config Schema (`configValues`)
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/config.go` (SHA `1d32425b`)
+**Source:** `the upstream reference repository:internal/marketbot/config.go` (SHA `1d32425b`)
 
 ```json
 {
@@ -630,7 +630,7 @@ If you see upstream values (rarity=1/5/2, vendor=1/5/2, grade=1/1/1.25/1.5/1.75/
 
 Config is persisted via `SaveState(path, configValues)` to a JSON file at the path specified by `BotConfig.StatePath`. The format matches the JSON wire format above. State is loaded on startup; UI applies through `PUT /config` (partial JSON patch). The state file is written atomically (tmp file + rename).
 
-### HTTP API Endpoints (upstream dune-admin embedded bot)
+### HTTP API Endpoints (upstream reference implementation embedded bot)
 
 | Method | Path | Purpose |
 |--------|------|---------|
@@ -646,9 +646,9 @@ Config is persisted via `SaveState(path, configValues)` to a JSON file at the pa
 
 **Auth:** `Authorization: Bearer <token>` header. Token set via `BotConfig.APIToken` (corresponding `market_bot_token` in `config.yaml`). Empty token = all auth endpoints disabled (401).
 
-### UI Fields (dune-admin web panel, inferred from config schema and API)
+### UI Fields (reference implementation web panel, inferred from config schema and API)
 
-The dune-admin web UI's Bot Control panel surfaces all `configValues` fields plus:
+The reference implementation web UI's Bot Control panel surfaces all `configValues` fields plus:
 - Enable/disable toggle
 - Buy interval slider/input
 - List interval slider/input
@@ -764,7 +764,7 @@ WHERE owner_id = $ownerID AND is_npc_order = TRUE;
 
 All three steps run in a single transaction. Player listings, fulfilled-order history, and the bot's Solari balance are untouched.
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/exchange.go:CleanupListings`
+**Source:** `the upstream reference repository:internal/marketbot/exchange.go:CleanupListings`
 
 ### DST's `Clear-DuneBotListings` (functionally equivalent)
 
@@ -890,7 +890,7 @@ COMMIT;
 
 ## Section 9 — Other Operator-Facing Knobs
 
-### From Upstream dune-admin Config
+### From Upstream reference implementation Config
 
 All the following are exposed via `PUT /config` (partial JSON patch) and saved to the state file:
 
@@ -959,7 +959,7 @@ The bot resolves masks via a three-tier precedence:
 2. **UniqueSchematicsMask** for schematics in a UNIQUE SCHEMATICS subcategory
 3. **CategoryMask** from the item's category path
 
-**Source:** `Icehunter/dune-admin:internal/marketbot/pricing.go:CategoryMask` and `UniqueSchematicsMask` (SHA `de6592d4`)
+**Source:** `the upstream reference repository:internal/marketbot/pricing.go:CategoryMask` and `UniqueSchematicsMask` (SHA `de6592d4`)
 
 For the PowerShell port: implement the player-order cache read first (Tier 1 covers the vast majority of items); implement the static code tables only for items not yet seen in any player order. The full code tables from `pricing.go` (knownCodes, depth3Parent, weaponPathRemap, uniqueSchematicsD2, uniqueSchematicsD3) run to ~150 lines and should be reproduced verbatim as a lookup hashtable.
 
@@ -1078,13 +1078,13 @@ The following checklist is for the PowerShell implementer. Each item corresponds
 
 ## Gaps and Uncertainties
 
-1. **Sane-pricing patch is the only representation of Coastal's customizations.** The patch was removed from the DST repo at commit `665364e1` (2026-06-11) when dune-admin v0.34.0 adopted the non-free `@heroui-pro/react` package and the external bot integration was dropped entirely. The patch content recovered at `cf903665` is the definitive final version of the patch as shipped in DST v10.2.6+.
+1. **Sane-pricing patch is the only representation of Coastal's customizations.** The patch was removed from the DST repo at commit `665364e1` (2026-06-11) when reference implementation v0.34.0 adopted the non-free `@heroui-pro/react` package and the external bot integration was dropped entirely. The patch content recovered at `cf903665` is the definitive final version of the patch as shipped in DST v10.2.6+.
 
 2. **`dune.dune_exchange_get_item_price_stats`** — The market-price fetching proc is used upstream for adaptive drift. Its exact signature and return columns could not be verified from source alone; the upstream calls it as `SELECT * FROM dune.dune_exchange_get_item_price_stats($1::text[])` returning columns `(template_id, min_price, avg_price)`. This is optional for Phase 1 of the port; the simpler `adjustPrice` drift (sold fraction only) can be implemented without it.
 
 3. **`dune.get_exchange_inventory_id`** and **`dune.dune_exchange_get_user_id`** — These stored procedures are called by the upstream bot but their body is in the game server's Postgres schema (not open source). They appear to be simple upsert-or-create procedures. If they don't exist on the target DB, the port will need to implement the equivalent logic manually.
 
-4. **Item-data.json** — The catalog file (`item-data.json`) is not present in the dune-admin GitHub repo (it's generated from game data). The PowerShell port needs this file to know tier, rarity, StackMax, IsSchematic, IsGradeable, MinQualityLevel, MinPrice, MaxPrice, and Category for each template ID. Verify the file location from dune-admin's runtime config (`item_data_path` in `config.yaml`, defaulting to `item-data.json` in the working directory).
+4. **Item-data.json** — The catalog file (`item-data.json`) is not present in the reference implementation GitHub repo (it's generated from game data). The PowerShell port needs this file to know tier, rarity, StackMax, IsSchematic, IsGradeable, MinQualityLevel, MinPrice, MaxPrice, and Category for each template ID. Verify the file location from reference implementation's runtime config (`item_data_path` in `config.yaml`, defaulting to `item-data.json` in the working directory).
 
 5. **`position_index` auto-increment** — The upstream tracks `nextPos` in memory and increments it per insert. The PowerShell port will need to re-read the max from DB on each list-tick startup (since the scheduler runs in a fresh runspace). Re-reading `SELECT COALESCE(MAX(position_index), -1)+1 FROM dune.items WHERE inventory_id=$botInvId` at the start of each `Invoke-DuneBotListTick` is the correct approach.
 

--- a/tests/Schema.Tests.ps1
+++ b/tests/Schema.Tests.ps1
@@ -56,7 +56,7 @@ Describe 'Schema: dune.actor_fgl_entities join columns' -Tag 'Schema' {
 
 Describe 'Schema: FLevelComponent is an array' -Tag 'Schema' {
     It 'PlayersAdmin.ps1 indexes FLevelComponent as an array element (->1)' {
-        # The dune-admin schema stores FLevelComponent as a JSON array; reads
+        # The game schema stores FLevelComponent as a JSON array; reads
         # must go components->'FLevelComponent'->1->>'X'. A bare
         # components->'FLevelComponent'->>'X' returns NULL silently.
         $content = Get-LibContent 'PlayersAdmin.ps1'

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1,4 +1,4 @@
-// Gameplay API — native Market / Exchange + Market Bot, ported from dune-admin.
+// Gameplay API — native Market / Exchange + Market Bot, ported from the reference implementation.
 // All market responses carry a `source: 'live' | 'demo'` flag so the UI can
 // label whether data came from the live game DB or the bundled demo dataset.
 import { api } from './client'
@@ -571,7 +571,7 @@ export function repairInventoryItem(itemId: number) {
 }
 
 // ---------------------------------------------------------------------------
-// v11.5.6 — extended player surface (port of dune-admin's player tooling).
+// v11.5.6 — extended player surface (port of the reference implementation's player tooling).
 // ---------------------------------------------------------------------------
 
 export interface PlayerSummaryBucket { name: string; count: number }
@@ -992,7 +992,7 @@ export function setCoriolisPartitionSeed(partitionId: number, seed: number) {
 }
 
 // ===========================================================================
-// v11.5.9 — Phase A/B/C/G+H/I — full dune-admin player surface port.
+// v11.5.9 — Phase A/B/C/G+H/I — full the reference implementation player surface port.
 // Adds the remaining 40+ endpoints not previously surfaced. Existing
 // wrappers above (giveSolari, giveItem, renamePlayer, awardSpecXp,
 // setPlayerTags, fillWater) are kept untouched for back-compat.
@@ -1105,7 +1105,7 @@ export function getPlayerJourney(id: number, demo?: boolean) {
     `/api/gameplay/players/${id}/journey${qs({ demo: demo ? 1 : undefined })}`)
 }
 
-// Full character dump - shape is intentionally loose (mirrors dune-admin export).
+// Full character dump - shape is intentionally loose (mirrors the reference implementation export).
 export function exportPlayerData(id: number, demo?: boolean) {
   return api<{ ok: boolean; account_id: number; data: Record<string, unknown>; source: DataSource }>(
     `/api/gameplay/players/${id}/export${qs({ demo: demo ? 1 : undefined })}`)

--- a/webui/src/api/update.ts
+++ b/webui/src/api/update.ts
@@ -47,10 +47,10 @@ export function installUpdate() {
 }
 
 /**
- * One-time "DST is now decoupled from Dune-Admin" notice. `needed` is true only
+ * One-time "DST is now decoupled from the reference implementation" notice. `needed` is true only
  * for installs upgraded from a pre-decouple build (<= 11.4.13) that haven't
  * acknowledged yet. `duneAdminFolder` is recovered from the legacy
- * `DuneAdminExe` config value so the user can still launch dune-admin manually.
+ * `DuneAdminExe` config value so the user can still launch the reference implementation manually.
  */
 export interface MigrationNotice {
   needed: boolean

--- a/webui/src/components/AdminComposers.tsx
+++ b/webui/src/components/AdminComposers.tsx
@@ -1,5 +1,5 @@
 // Compact composer cards for the three admin "talk to players" actions that
-// dune-admin exposes via its /api/v1/notify endpoint: a generic on-screen
+// the reference implementation exposes via its /api/v1/notify endpoint: a generic on-screen
 // message ("broadcast"), a shutdown countdown ("server alert"), and a
 // per-player chat whisper ("GM whisper"). DST already had backends for all
 // three but only the standalone Broadcasts page wired the first two — and
@@ -100,7 +100,7 @@ export function GenericBroadcastComposer() {
 
 // ---------------------------------------------------------------------------
 // Shutdown/restart countdown ("Server Alert"). The big red banner Chopper saw.
-// Mirrors dune-admin's /notify with the ServiceBroadcast routing key — wraps
+// Mirrors the reference implementation's /notify with the ServiceBroadcast routing key — wraps
 // our richer Send-V6ShutdownBroadcast which supports Restart/Shutdown/
 // Maintenance/Update types and a Cancel action.
 // ---------------------------------------------------------------------------

--- a/webui/src/components/ItemPicker.tsx
+++ b/webui/src/components/ItemPicker.tsx
@@ -1,7 +1,7 @@
 // ItemPicker — typeahead autocomplete for the item catalog.
 // v11.5.7. Used in player Give Item, storage Give Item, etc.
 //
-// Behaviour mirrors dune-admin's item search: lazy-load the catalog on first
+// Behaviour mirrors the reference implementation's item search: lazy-load the catalog on first
 // keystroke, filter on every change with substring match against display
 // name OR template_id (case-insensitive), show up to 20 matches in a popup
 // listing "Name — template_id (category)". Arrow keys + Enter to select,

--- a/webui/src/pages/Broadcasts.tsx
+++ b/webui/src/pages/Broadcasts.tsx
@@ -11,7 +11,7 @@ export function Broadcasts() {
       <PageHeader
         icon="Megaphone"
         title="Broadcasts & whispers"
-        description="Server-wide announcements, shutdown countdowns, and per-player whispers. Mirrors dune-admin's /notify, wired straight to the in-game courier."
+        description="Server-wide announcements, shutdown countdowns, and per-player whispers, wired straight to the in-game courier."
       />
       <AdminComposers className="mt-4" />
     </div>

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -227,7 +227,7 @@ export function Dashboard() {
             <Icon name="Gamepad2" size={16} className="text-accent" />
           </div>
           <p className="text-sm text-text-muted mt-2 flex-1">
-            Native market, exchange, and bot tools — the Dune admin portal, rebuilt right here in one console.
+            Native market, exchange, and bot tools — full gameplay administration, right here in one console.
           </p>
           <button className="btn-primary mt-3 self-start shrink-0" onClick={() => navigate('/gameplay')}>
             <Icon name="ArrowRight" size={15} /> Open Gameplay Admin

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -533,7 +533,7 @@ export function GameConfig() {
         <div>
           When you change a setting, DST relocates that setting&apos;s entire section into a managed block at the
           bottom of the file and becomes its owner — keeping one clean copy, preserving structure, and migrating
-          any existing dune-admin block. The original file is backed up on the server before every write.
+          any existing managed block. The original file is backed up on the server before every write.
         </div>
       </div>
 
@@ -1112,7 +1112,7 @@ function BoolToggle({ on, off, value, disabled, onChange }: { on: string; off: s
 // All default settings browser — lazy-loads DefaultGame.ini + DefaultEngine.ini
 // straight from the live game-server pod. Every section is a collapsible card;
 // every key is editable and saved back to UserGame/UserEngine.ini via the
-// existing explicit PUT /api/gameconfig form. Mirrors dune-admin's "Server
+// existing explicit PUT /api/gameconfig form. Mirrors the reference implementation's "Server
 // Settings" page.
 // -----------------------------------------------------------------------------
 

--- a/webui/src/pages/GameplayEnvironment.tsx
+++ b/webui/src/pages/GameplayEnvironment.tsx
@@ -30,7 +30,7 @@ export function GameplayEnvironment() {
       <PageHeader
         title="Gameplay Admin"
         icon="Gamepad2"
-        description="Native market, exchange, and bot tools — the Dune admin portal, rebuilt inside Dune Server Tool."
+        description="Native market, exchange, and bot tools — a full gameplay admin console, built into Dune Server Tool."
       />
 
       {/* Sub-tab nav */}

--- a/webui/src/pages/gameplay/MarketBotTab.tsx
+++ b/webui/src/pages/gameplay/MarketBotTab.tsx
@@ -843,7 +843,7 @@ function PricingSection({ draft, setDraft }: { draft: BotConfig; setDraft: (c: B
         <Icon name="TriangleAlert" size={14} className="text-warning shrink-0 mt-0.5" />
         <span>
           Sane-pricing defaults (100 k Solari hard cap, tier base prices, category factors, rarity multipliers,
-          and 95 % vendor floor) are ported from the dune-admin patch. Touch with care — these directly drive
+          and 95 % vendor floor) govern the bot's pricing. Touch with care — these directly drive
           every listing the bot writes.
         </span>
       </div>

--- a/webui/src/pages/gameplay/OverviewTab.tsx
+++ b/webui/src/pages/gameplay/OverviewTab.tsx
@@ -77,7 +77,7 @@ export function OverviewTab({ onOpenTab }: { onOpenTab: (tab: GameplaySubTab) =>
 
   return (
     <div>
-      {/* Quick admin actions — broadcasts + whispers, mirrors dune-admin /notify */}
+      {/* Quick admin actions — broadcasts + whispers, mirrors the reference implementation /notify */}
       <AdminComposers className="mb-4" />
 
       {/* Intro */}
@@ -89,7 +89,7 @@ export function OverviewTab({ onOpenTab }: { onOpenTab: (tab: GameplaySubTab) =>
           <div>
             <h2 className="text-lg font-semibold text-text">A native gameplay console</h2>
             <p className="text-sm text-text-muted mt-1 max-w-3xl">
-              Everything the open-source Dune admin portal does, rebuilt inside Dune Server Tool — one console,
+              A complete gameplay admin console, built into Dune Server Tool — one console,
               one theme, no second program to install. The Market and Market Bot tabs are live now and read
               straight from your game database. The rest is mapped below.
             </p>

--- a/webui/src/pages/gameplay/StorageTab.tsx
+++ b/webui/src/pages/gameplay/StorageTab.tsx
@@ -246,7 +246,7 @@ function ContainerDetail({ container, demo, onClose, onChanged }: {
 }
 
 // Staged "Add Items" form: build a list of template/qty/quality rows, then
-// submit them all at once (mirrors dune-admin's AddItemsModal).
+// submit them all at once (mirrors the reference implementation's AddItemsModal).
 function AddItemsForm({ busy, onSubmit, onCancel }: {
   busy: boolean; onSubmit: (items: StorageGiveItemInput[]) => void; onCancel: () => void
 }) {

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -396,7 +396,7 @@ function EventRow({ ev }: { ev: PlayerEvent }) {
 }
 
 // ---------------------------------------------------------------------------
-// Actions — write surface. v11.5.9: full dune-admin player toolkit.
+// Actions — write surface. v11.5.9: full the reference implementation player toolkit.
 // Bucketed into Currency / Progression / Items / Vehicle / Live (RMQ) /
 // Identity / Danger Zone for discoverability. All actions use the inline-form
 // pattern: click button to open form, fill fields, submit.


### PR DESCRIPTION
## What

Removes references to the former bundled companion admin tool from everywhere it appears **after the point it was removed from the product**, per the policy that those references should be gone from current copy (old CHANGELOG entries from the embedded-tool era are left as history).

Scope:
- **Rendered UI copy** — Dashboard, Gameplay Overview, Broadcasts, Market Bot, Game Config, Gameplay Environment headers. Reworded to neutral phrasing.
- **Recent CHANGELOG entries** (12.0.3 / 12.0.4 / 12.0.9) — attribution removed.
- **Code comments** across `app/server/lib`, `app/server/routes`, and `webui/src`, plus the internal `docs/internal/marketbot-port-spec.md`.

## Intentionally kept (functional, not cosmetic)

- The INI managed-section **migration markers** in `GameConfig.ps1` — must match the literal strings written into existing users' config files so DST can still migrate them.
- The `dune.admin_move_offline_player_to_partition` **SQL routine name**.
- The decoupling-notice **portal URL** and the `DecoupleNoticeModal` one-time migration notice (kept by request — it tells upgraders the companion tool is now separate).

## Validation

- All 20 edited PowerShell files parse clean.
- `npx tsc -b` exits 0.
- `app/data/dune-progression-nodes.json` still valid.
- Diff is comments / rendered-string copy / the md doc only — no logic, function names, or SQL changed.

Folds into the unpublished v12.0.9.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>