### PR TITLE
v12.0.10 — Fix blueprint owners for container-held blueprints

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.9"
+      placeholder: "v12.0.10"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.10] - 2026-06-12
+
+### Fixed
+
+- **Blueprints now show the right owner instead of only one player.** The
+  Blueprints list resolved a blueprint's owner through the copy-device item's
+  inventory → actor → account. But most blueprints' copy-device items sit inside
+  a storage container, whose actor has no account link — so every container-held
+  blueprint rendered with a blank owner and the tab looked like only one player
+  had any (OWNERS: 1). Added a fallback that resolves the container's owner via
+  the same placeable-ownership chain the Storage view uses (placeable → entity →
+  permission rank → player → account), picking the lowest rank (base owner) on
+  shared bases. Verified against a live server: all blueprints now attribute to
+  their actual owners.
+
 ## [12.0.9] - 2026-06-12
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.9'
+$script:DuneToolVersion = '12.0.10'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.9',
+    [string]$Version = '12.0.10',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.9</Version>
+    <Version>12.0.10</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.9"
+#define MyAppVersion "12.0.10"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayWorld.ps1
+++ b/app/server/lib/GameplayWorld.ps1
@@ -171,7 +171,7 @@ function Get-DuneStorageItemsDemo {
 # ----------------------------------------------------------------------------
 $script:DuneBlueprintsListSql = @'
 SELECT bb.id,
-       COALESCE(NULLIF(ps_acct.character_name, ''), ps_pawn.character_name, '') AS owner_name,
+       COALESCE(NULLIF(ps_acct.character_name, ''), NULLIF(ps_pawn.character_name, ''), ps_plac.owner_name, '') AS owner_name,
        COALESCE(bb.item_id, 0)         AS item_id,
        COALESCE(inst.cnt, 0)           AS pieces,
        COALESCE(plac.cnt, 0)           AS placeables,
@@ -180,13 +180,31 @@ FROM dune.building_blueprints bb
 LEFT JOIN dune.items i ON i.id = bb.item_id
 LEFT JOIN dune.inventories inv ON inv.id = i.inventory_id
 LEFT JOIN dune.actors a ON a.id = inv.actor_id
--- Owner resolution: the legacy join (ps.player_pawn_id = a.id) only
--- matches a player whose pawn is currently spawned/loaded, so offline players'
--- blueprints render with a blank owner (looked like "only the host's blueprints
--- show up"). Resolve primarily by the persistent account link (same pattern the
--- Storage view uses), falling back to the live-pawn link for parity.
+-- Owner resolution: the legacy join (ps.player_pawn_id = a.id) only matches a
+-- player whose pawn is currently spawned/loaded, so offline players' blueprints
+-- render with a blank owner. Resolve primarily by the persistent account link,
+-- falling back to the live-pawn link. CRITICAL THIRD FALLBACK: most blueprints'
+-- copy-device items live INSIDE a storage container (placeable), not a player's
+-- character inventory — so `a` is the container actor, whose owner_account_id is
+-- NULL and the first two joins yield nothing (this made every container-held
+-- blueprint show a blank owner, looking like "only one player has blueprints").
+-- The ps_plac lateral resolves the container's owner via the same placeable
+-- ownership chain the Storage view uses (placeable -> fgl entity -> permission
+-- rank -> player -> account), picking the lowest rank (base owner) on shared bases.
 LEFT JOIN dune.player_state ps_acct ON ps_acct.account_id = a.owner_account_id
 LEFT JOIN dune.player_state ps_pawn ON ps_pawn.player_pawn_id = a.id
+LEFT JOIN dune.placeables pl ON pl.id = a.id
+LEFT JOIN LATERAL (
+    SELECT ps_p.character_name AS owner_name
+    FROM dune.actor_fgl_entities afe
+    JOIN dune.permission_actor_rank par ON par.permission_actor_id = afe.actor_id
+    JOIN dune.actors pa_p ON pa_p.id = par.player_id
+    JOIN dune.player_state ps_p ON ps_p.account_id = pa_p.owner_account_id
+    WHERE afe.entity_id = pl.owner_entity_id AND pl.owner_entity_id <> 0
+      AND NULLIF(ps_p.character_name, '') IS NOT NULL
+    ORDER BY par.rank ASC, par.player_id ASC
+    LIMIT 1
+) ps_plac ON true
 LEFT JOIN (
     SELECT building_blueprint_id, COUNT(*) AS cnt
     FROM dune.building_blueprint_instances

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.9"
+$script:ToolVersion = "12.0.10"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Problem

The Blueprints tab showed **OWNERS: 1** with almost every blueprint's owner blank ("—"). Not a regression — pre-existing.

The owner query resolved through the copy-device item's chain: `building_blueprints → items → inventories → actors → owner_account_id → player_state`. But most blueprints' copy-device items physically live **inside a storage container**, so `actors` is the container actor, whose `owner_account_id` is NULL — the chain dead-ends. Only the one blueprint sitting in a player's character inventory resolved. (`building_blueprints.player_id` is NULL for all rows, so it can't be used either.)

## Fix

Added a third fallback that resolves the container's owner via the **same placeable-ownership chain the Storage view uses**: `placeable → actor_fgl_entities → permission_actor_rank → actors → player_state`. On shared bases (multiple permission ranks) it picks the **lowest rank** (the base owner).

```
owner_name = COALESCE(account link, live-pawn link, placeable-owner link, '')
```

## Verified live

Read-only against a running server before/after: all 13 blueprints now attribute to their real owners (mix of Coastal + Hawk-i5), up from 1. Shared base `5361` correctly resolves to its rank-1 owner.

PowerShell parses clean. Bumps stamps to **12.0.10**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>