### PR TITLE
v12.0.11 — Drop redundant overview composers + taller default window

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.10"
+      placeholder: "v12.0.11"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.11] - 2026-06-12
+
+### Changed
+
+- **Removed the broadcast / shutdown / whisper composer cards from the top of
+  Gameplay → Overview.** They're now reached from the dedicated **Broadcasts**
+  left-nav item (and its `/broadcasts` page), so the duplicate cards on the
+  overview were just taking up space.
+- **Taller default app window.** Bumped the default window height so the added
+  Broadcasts nav item no longer pushes the sidebar into a frame scrollbar on a
+  fresh launch. (Only affects installs with no saved window size.)
+
 ## [12.0.10] - 2026-06-12
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.10'
+$script:DuneToolVersion = '12.0.11'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.10',
+    [string]$Version = '12.0.11',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.10</Version>
+    <Version>12.0.11</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -518,7 +518,7 @@ internal sealed class MainForm : Form
 
     private void ApplyStartupBounds()
     {
-        var def = new Size(2000, 1196);
+        var def = new Size(2000, 1300);
         var saved = LoadWindowState();
 
         Rectangle bounds;

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.10"
+#define MyAppVersion "12.0.11"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.10"
+$script:ToolVersion = "12.0.11"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/gameplay/OverviewTab.tsx
+++ b/webui/src/pages/gameplay/OverviewTab.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from 'react-router-dom'
 import { Icon } from '../../components/Icon'
-import { AdminComposers } from '../../components/AdminComposers'
 import { useApi } from '../../hooks/useApi'
 import type { GameplayStatus } from '../../api/gameplay'
 import type { GameplaySubTab } from '../GameplayEnvironment'
@@ -77,9 +76,6 @@ export function OverviewTab({ onOpenTab }: { onOpenTab: (tab: GameplaySubTab) =>
 
   return (
     <div>
-      {/* Quick admin actions — broadcasts + whispers, mirrors the reference implementation /notify */}
-      <AdminComposers className="mb-4" />
-
       {/* Intro */}
       <div className="card p-5 mb-4">
         <div className="flex items-start gap-3">


### PR DESCRIPTION
## Changes

Two small UI tweaks requested for the next release:

1. **Removed the broadcast / shutdown / whisper composer cards** from the top of **Gameplay → Overview** (`OverviewTab.tsx`). They're now reached from the dedicated **Broadcasts** left-nav item and its `/broadcasts` page, so the cards on the overview were redundant. The `AdminComposers` component is unchanged and still used by the Broadcasts page.
2. **Taller default app window** (`MainForm.cs`): default size `2000×1196` → `2000×1300`, so the newly added Broadcasts nav item no longer pushes the sidebar into a frame scrollbar on a fresh launch. Only affects installs with **no saved window state** — existing users' saved sizes are untouched.

TypeScript verified clean. Bumps stamps to **12.0.11**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>