### PR TITLE
config(marketbot): default Duke starting balance to 454,720,162,028

### DIFF
--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -210,10 +210,10 @@ function Get-DuneBotConfigDefaults {
         max_buys_per_tick = 25
         die_size          = 12
         die_target        = 5
-        target_balance    = 9000000000000
+        target_balance    = 454720162028
         maintain_balance  = $true
         disabled_items    = @()
-        # ----- Listing side (sane-pricing port of the reference implementation/internal/marketbot) -----
+        # ----- Listing side (sane-pricing port) -----
         list_tick_interval   = 1800          # 30 min between list ticks
         listings_per_grade   = 5             # concurrent NPC listings per (template, grade)
         stackables_only      = $false        # v11.5.9: default OFF — list gear too


### PR DESCRIPTION
**Staged for the next batched release — do not merge as a standalone hotfix.**

Lowers the Duke market bot's default `target_balance` from `9,000,000,000,000` (9T) to `454,720,162,028` (~454.72B) Solari in `Get-DuneBotConfigDefaults` (`app/server/lib/GameplayBot.ps1`).

## Scope
- Single-line config default.
- Operators with a saved `DuneBotConfig.json` keep their current value — the saved-override path in `Read-DuneBotConfig` always wins. Only changes the seed for fresh installs / users who haven't overridden the field.
- **No version-stamp bump** in this PR — the version will be set when the next batched release is cut and this is folded in.
- (Also tidied one awkward comment leftover in the same defaults block.)

Closes #155

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>