### PR TITLE
fix(gameplay): pull specialization XP via controller id, not pawn id

### DIFF
--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -68,7 +68,9 @@ WHERE player_controller_id = {0}::bigint
 ORDER BY currency_id
 '@
 
-# Specialization tracks for one pawn id ($1).
+# Specialization tracks for one controller id ($1).
+# NOTE: dune.specialization_tracks.player_id stores the player CONTROLLER id,
+# not the pawn/actor id (matches purchased_specialization_keystones).
 $script:DunePlayerSpecsSql = @'
 SELECT track_type::text AS track_type, xp_amount, level
 FROM dune.specialization_tracks
@@ -100,7 +102,7 @@ function Get-DunePlayersLive {
 function Get-DunePlayerDetailLive {
     param([string]$Ip, [long]$PawnId, [long]$ControllerId)
     $invSql  = [string]::Format($script:DunePlayerInventorySql, $PawnId)
-    $specSql = [string]::Format($script:DunePlayerSpecsSql, $PawnId)
+    $specSql = [string]::Format($script:DunePlayerSpecsSql, $ControllerId)
     $curSql  = [string]::Format($script:DunePlayerCurrencySql, $ControllerId)
 
     $invRes  = Invoke-DuneSqlQuery -Ip $Ip -Sql $invSql  -ReadOnly $true -MaxRows 5000 -TimeoutSec 30
@@ -173,14 +175,15 @@ function Invoke-DunePlayerRename {
 }
 
 # Award specialization XP (award-xp): UPDATE, INSERT if no row. Hard cap 44182.
+# Keyed by controller id (specialization_tracks.player_id = controller id).
 function Invoke-DunePlayerAwardXp {
-    param([string]$Ip, [long]$PawnId, [string]$TrackType, [int]$Delta)
+    param([string]$Ip, [long]$ControllerId, [string]$TrackType, [int]$Delta)
     $safeTrack = ConvertTo-DuneSqlString $TrackType
     $cap = 44182
     $updSql = @"
 UPDATE dune.specialization_tracks
 SET xp_amount = GREATEST(LEAST(xp_amount + ($Delta)::integer, $cap::integer), 0)
-WHERE player_id = $PawnId::bigint AND track_type::text = '$safeTrack';
+WHERE player_id = $ControllerId::bigint AND track_type::text = '$safeTrack';
 "@
     $upd = Invoke-DuneSqlQuery -Ip $Ip -Sql $updSql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $upd.ok) { return @{ ok = $false; error = $upd.error } }
@@ -188,7 +191,7 @@ WHERE player_id = $PawnId::bigint AND track_type::text = '$safeTrack';
         $start = [Math]::Max(0, [Math]::Min($Delta, $cap))
         $insSql = @"
 INSERT INTO dune.specialization_tracks (player_id, track_type, xp_amount, level)
-VALUES ($PawnId::bigint, '$safeTrack'::dune.specializationtracktype, $start::integer, 0::real);
+VALUES ($ControllerId::bigint, '$safeTrack'::dune.specializationtracktype, $start::integer, 0::real);
 "@
         $ins = Invoke-DuneSqlQuery -Ip $Ip -Sql $insSql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
         if (-not $ins.ok) { return @{ ok = $false; error = $ins.error } }
@@ -481,15 +484,16 @@ function Get-DunePlayerStatsLive {
 
 # ---------------------------------------------------------------------------
 # Full specs view (5 tracks plus keystone count + max).
-# Keystones use the dune.purchased_specialization_keystones table keyed by
-# controller id (per the reference implementation's insertAllPurchasedKeystones path).
+# Both dune.specialization_tracks and dune.purchased_specialization_keystones
+# key off the player CONTROLLER id (player_id column = controller id), NOT the
+# pawn/actor id (per the reference implementation's insertAllPurchasedKeystones path).
 # Max keystone id is 205 (matches the reference implementation's generate_series upper bound).
 # ---------------------------------------------------------------------------
 $script:DunePlayerSpecsFullSql = @'
 WITH tracks AS (
     SELECT track_type::text AS track_type, xp_amount, level
     FROM dune.specialization_tracks
-    WHERE player_id = {0}::bigint
+    WHERE player_id = {1}::bigint
 ),
 ks_total AS (
     SELECT COUNT(*)::bigint AS n
@@ -539,34 +543,34 @@ function Get-DunePlayerSpecsFullLive {
 
 # Grant max — set xp=44182 level=100 for one track. Uses dune.set_specialization_xp_and_level.
 function Invoke-DunePlayerGrantMaxSpec {
-    param([string]$Ip, [long]$PawnId, [string]$TrackType)
+    param([string]$Ip, [long]$ControllerId, [string]$TrackType)
     $safeTrack = ConvertTo-DuneSqlString $TrackType
-    $sql = "SELECT dune.set_specialization_xp_and_level($PawnId::bigint, '$safeTrack'::dune.specializationtracktype, $($script:DuneSpecXpMax)::integer, $($script:DuneSpecLevelMax)::real);"
+    $sql = "SELECT dune.set_specialization_xp_and_level($ControllerId::bigint, '$safeTrack'::dune.specializationtracktype, $($script:DuneSpecXpMax)::integer, $($script:DuneSpecLevelMax)::real);"
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
     return @{ ok = $true; message = "Granted max XP for '$TrackType' (xp=$($script:DuneSpecXpMax), level=$($script:DuneSpecLevelMax))." }
 }
 
-# Reset one track — DELETE the row.
+# Reset one track — DELETE the row (keyed by controller id).
 function Invoke-DunePlayerResetSpec {
-    param([string]$Ip, [long]$PawnId, [string]$TrackType)
+    param([string]$Ip, [long]$ControllerId, [string]$TrackType)
     $safeTrack = ConvertTo-DuneSqlString $TrackType
-    $sql = "DELETE FROM dune.specialization_tracks WHERE player_id = $PawnId::bigint AND track_type::text = '$safeTrack';"
+    $sql = "DELETE FROM dune.specialization_tracks WHERE player_id = $ControllerId::bigint AND track_type::text = '$safeTrack';"
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
-    return @{ ok = $true; message = "Reset '$TrackType' track for player $PawnId." }
+    return @{ ok = $true; message = "Reset '$TrackType' track for controller $ControllerId." }
 }
 
-# Reset ALL spec tracks (and ALL keystones) — runs both reset functions.
+# Reset ALL spec tracks (and ALL keystones) — runs both reset functions (keyed by controller id).
 function Invoke-DunePlayerResetAllSpecs {
-    param([string]$Ip, [long]$PawnId)
+    param([string]$Ip, [long]$ControllerId)
     $sql = @"
-SELECT dune.reset_specialization_tracks($PawnId::bigint);
-SELECT dune.reset_specialization_keystones($PawnId::bigint);
+SELECT dune.reset_specialization_tracks($ControllerId::bigint);
+SELECT dune.reset_specialization_keystones($ControllerId::bigint);
 "@
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
-    return @{ ok = $true; message = "Reset all spec tracks and keystones for player $PawnId." }
+    return @{ ok = $true; message = "Reset all spec tracks and keystones for controller $ControllerId." }
 }
 
 # Grant all keystones — uses controller id (per the reference implementation's insertAllPurchasedKeystones).
@@ -583,13 +587,13 @@ ON CONFLICT DO NOTHING;
     return @{ ok = $true; message = "Granted all $max keystones for controller $ControllerId." }
 }
 
-# Reset all keystones — dune.reset_specialization_keystones.
+# Reset all keystones — dune.reset_specialization_keystones (keyed by controller id).
 function Invoke-DunePlayerResetAllKeystones {
-    param([string]$Ip, [long]$PawnId)
-    $sql = "SELECT dune.reset_specialization_keystones($PawnId::bigint);"
+    param([string]$Ip, [long]$ControllerId)
+    $sql = "SELECT dune.reset_specialization_keystones($ControllerId::bigint);"
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
-    return @{ ok = $true; message = "Reset all keystones for player $PawnId." }
+    return @{ ok = $true; message = "Reset all keystones for controller $ControllerId." }
 }
 
 # ---------------------------------------------------------------------------

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -171,17 +171,17 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/rename' -Handler {
     }
 }
 
-# POST /api/gameplay/players/award-xp  { pawn_id, track_type, delta }
+# POST /api/gameplay/players/award-xp  { controller_id, track_type, delta }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/award-xp' -Handler {
     param($req, $res, $routeParams, $body)
     try {
-        $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        $cid = Get-DuneBodyInt -Body $body -Name 'controller_id'
         $track = [string](Get-DuneBodyValue -Body $body -Name 'track_type')
         $delta = Get-DuneBodyInt -Body $body -Name 'delta'
-        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
+        if ($null -eq $cid -or $cid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'controller_id is required.'; return }
         if (-not $track) { Write-DuneError -Response $res -Status 400 -Message 'track_type is required.'; return }
         if ($null -eq $delta) { Write-DuneError -Response $res -Status 400 -Message 'delta must be an integer.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerAwardXp -Ip $ip -PawnId $pawn -TrackType $track -Delta ([int]$delta) }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerAwardXp -Ip $ip -ControllerId $cid -TrackType $track -Delta ([int]$delta) }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Award XP failed: $($_.Exception.Message)"
     }
@@ -294,41 +294,41 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/players/specs' -Handler {
     }
 }
 
-# POST /api/gameplay/players/grant-max-spec  { pawn_id, track_type }
+# POST /api/gameplay/players/grant-max-spec  { controller_id, track_type }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/grant-max-spec' -Handler {
     param($req, $res, $routeParams, $body)
     try {
-        $pawn  = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        $cid   = Get-DuneBodyInt -Body $body -Name 'controller_id'
         $track = [string](Get-DuneBodyValue -Body $body -Name 'track_type')
-        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
+        if ($null -eq $cid -or $cid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'controller_id is required.'; return }
         if (-not $track) { Write-DuneError -Response $res -Status 400 -Message 'track_type is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerGrantMaxSpec -Ip $ip -PawnId $pawn -TrackType $track }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerGrantMaxSpec -Ip $ip -ControllerId $cid -TrackType $track }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Grant max spec failed: $($_.Exception.Message)"
     }
 }
 
-# POST /api/gameplay/players/reset-spec  { pawn_id, track_type }
+# POST /api/gameplay/players/reset-spec  { controller_id, track_type }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/reset-spec' -Handler {
     param($req, $res, $routeParams, $body)
     try {
-        $pawn  = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        $cid   = Get-DuneBodyInt -Body $body -Name 'controller_id'
         $track = [string](Get-DuneBodyValue -Body $body -Name 'track_type')
-        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
+        if ($null -eq $cid -or $cid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'controller_id is required.'; return }
         if (-not $track) { Write-DuneError -Response $res -Status 400 -Message 'track_type is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetSpec -Ip $ip -PawnId $pawn -TrackType $track }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetSpec -Ip $ip -ControllerId $cid -TrackType $track }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Reset spec failed: $($_.Exception.Message)"
     }
 }
 
-# POST /api/gameplay/players/reset-all-specs  { pawn_id } — tracks + keystones.
+# POST /api/gameplay/players/reset-all-specs  { controller_id } — tracks + keystones.
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/reset-all-specs' -Handler {
     param($req, $res, $routeParams, $body)
     try {
-        $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
-        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetAllSpecs -Ip $ip -PawnId $pawn }
+        $cid = Get-DuneBodyInt -Body $body -Name 'controller_id'
+        if ($null -eq $cid -or $cid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'controller_id is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetAllSpecs -Ip $ip -ControllerId $cid }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Reset all specs failed: $($_.Exception.Message)"
     }
@@ -346,13 +346,13 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/grant-all-keystones
     }
 }
 
-# POST /api/gameplay/players/reset-all-keystones  { pawn_id }
+# POST /api/gameplay/players/reset-all-keystones  { controller_id }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/reset-all-keystones' -Handler {
     param($req, $res, $routeParams, $body)
     try {
-        $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
-        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetAllKeystones -Ip $ip -PawnId $pawn }
+        $cid = Get-DuneBodyInt -Body $body -Name 'controller_id'
+        if ($null -eq $cid -or $cid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'controller_id is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetAllKeystones -Ip $ip -ControllerId $cid }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Reset all keystones failed: $($_.Exception.Message)"
     }

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -470,9 +470,9 @@ export function getBotVendorSnapshot() {
 // Players
 // ---------------------------------------------------------------------------
 export interface Player {
-  id: number            // pawn actor id (inventory / spec writes)
+  id: number            // pawn actor id (inventory writes)
   account_id: number    // rename, tags
-  controller_id: number // currency writes
+  controller_id: number // currency + specialization (tracks/keystones) writes
   name: string
   class: string
   map: string
@@ -552,9 +552,9 @@ export function renamePlayer(accountId: number, name: string) {
   })
 }
 
-export function awardSpecXp(pawnId: number, trackType: string, delta: number) {
+export function awardSpecXp(controllerId: number, trackType: string, delta: number) {
   return api<WriteResult>('/api/gameplay/players/award-xp', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, track_type: trackType, delta }),
+    method: 'POST', body: JSON.stringify({ controller_id: controllerId, track_type: trackType, delta }),
   })
 }
 
@@ -638,21 +638,21 @@ export function getPlayerSpecs(pawnId: number, controllerId: number, demo?: bool
   })}`)
 }
 
-export function grantMaxSpec(pawnId: number, trackType: string) {
+export function grantMaxSpec(controllerId: number, trackType: string) {
   return api<WriteResult>('/api/gameplay/players/grant-max-spec', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, track_type: trackType }),
+    method: 'POST', body: JSON.stringify({ controller_id: controllerId, track_type: trackType }),
   })
 }
 
-export function resetSpec(pawnId: number, trackType: string) {
+export function resetSpec(controllerId: number, trackType: string) {
   return api<WriteResult>('/api/gameplay/players/reset-spec', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, track_type: trackType }),
+    method: 'POST', body: JSON.stringify({ controller_id: controllerId, track_type: trackType }),
   })
 }
 
-export function resetAllSpecs(pawnId: number) {
+export function resetAllSpecs(controllerId: number) {
   return api<WriteResult>('/api/gameplay/players/reset-all-specs', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId }),
+    method: 'POST', body: JSON.stringify({ controller_id: controllerId }),
   })
 }
 
@@ -662,9 +662,9 @@ export function grantAllKeystones(controllerId: number) {
   })
 }
 
-export function resetAllKeystones(pawnId: number) {
+export function resetAllKeystones(controllerId: number) {
   return api<WriteResult>('/api/gameplay/players/reset-all-keystones', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId }),
+    method: 'POST', body: JSON.stringify({ controller_id: controllerId }),
   })
 }
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -146,11 +146,11 @@ export function SpecsSection({ player, canWrite, demo, refreshKey, flash, onChan
                 <Icon name="Star" size={13} /> Grant Max Keystones
               </button>
               <button className="btn-secondary text-warning" disabled={busy}
-                onClick={() => { if (window.confirm(`Reset ALL keystones for ${player.name}? Cannot be undone.`)) void run(() => resetAllKeystones(player.id), 'Reset all keystones') }}>
+                onClick={() => { if (window.confirm(`Reset ALL keystones for ${player.name}? Cannot be undone.`)) void run(() => resetAllKeystones(player.controller_id), 'Reset all keystones') }}>
                 <Icon name="RotateCcw" size={13} /> Reset All Keystones
               </button>
               <button className="btn-secondary text-danger" disabled={busy}
-                onClick={() => { if (window.confirm(`Reset ALL spec tracks + keystones for ${player.name}? Cannot be undone.`)) void run(() => resetAllSpecs(player.id), 'Reset all specs') }}>
+                onClick={() => { if (window.confirm(`Reset ALL spec tracks + keystones for ${player.name}? Cannot be undone.`)) void run(() => resetAllSpecs(player.controller_id), 'Reset all specs') }}>
                 <Icon name="AlertTriangle" size={13} /> Reset All
               </button>
             </>
@@ -173,9 +173,9 @@ export function SpecsSection({ player, canWrite, demo, refreshKey, flash, onChan
             const t = tracks.find(x => x.track_type.toLowerCase() === name.toLowerCase())
             return (
               <SpecRow key={name} name={name} track={t} canWrite={canWrite} busy={busy}
-                onGrantMax={() => void run(() => grantMaxSpec(player.id, name), 'Grant max')}
-                onReset={() => void run(() => resetSpec(player.id, name), 'Reset')}
-                onAdd5k={() => run(() => awardSpecXp(player.id, name, 5000), '+5000 XP')}
+                onGrantMax={() => void run(() => grantMaxSpec(player.controller_id, name), 'Grant max')}
+                onReset={() => void run(() => resetSpec(player.controller_id, name), 'Reset')}
+                onAdd5k={() => run(() => awardSpecXp(player.controller_id, name, 5000), '+5000 XP')}
               />
             )
           })}


### PR DESCRIPTION
## Problem

The Players → Specs tab showed every specialization track at **Lv 0/100 · 0 XP** even for maxed characters. DST wasn't pulling specialization XP from the character.

## Root cause

`dune.specialization_tracks` (and `dune.purchased_specialization_keystones`) key their `player_id` column off the player **controller id**, not the pawn/actor id. The Specs read queried tracks by pawn id (604) so it found nothing, while keystones already (correctly) used the controller id — which is why keystones showed 205/205 but every track read 0.

Verified against the live DB: track rows for Coastal live at `player_id = 593` (controller), not `604` (pawn).

## Fix

Repoint every specialization track / keystone read and write to the controller id:

- **Read:** `Get-DunePlayerSpecsFullLive` tracks CTE + the player-detail specs query.
- **Writes:** `award-xp`, `grant-max-spec`, `reset-spec`, `reset-all-specs`, `reset-all-keystones` routes + lib functions now take `controller_id` (the write paths were silently no-op/orphaning rows on the wrong key for the same reason).
- **Frontend:** `awardSpecXp` / `grantMaxSpec` / `resetSpec` / `resetAllSpecs` / `resetAllKeystones` send `controller_id`; `SpecsSection` passes `player.controller_id`.

## Verification

- Live DB: the fixed full-specs query for controller 593 now returns all 5 tracks at 44,182 XP / Lv 100 plus keystones_total 205.
- `tsc -b` clean, vitest 37/37 pass, both PowerShell files parse clean.

No version/CHANGELOG bump here — left for release prep.