### PR TITLE
release: v12.0.12 — spec-XP fix + marketbot balance + GM-bot label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.12] - 2026-06-12
+
+### Fixed
+
+- **Specialization XP now loads correctly on the Players → Specs tab.** Every
+  track previously showed **Lv 0/100 · 0 XP** even for maxed characters. The
+  Specs view was reading specialization tracks by the pawn/actor id, but the
+  game stores them (and purchased keystones) under the player's controller id —
+  so the lookup found nothing. All specialization reads and writes (award XP,
+  grant max, reset track, reset all, reset keystones) now key off the controller
+  id, matching how keystones already worked.
+
+### Changed
+
+- **Default Market Bot (Duke) starting balance** raised to 454,720,162,028
+  Solari so the bot can sustain large buy-side activity out of the box.
+- **Clearer GM bot labelling on the Players tab** — the built-in GM bot is now
+  explained as a Funcom system NPC, so it isn't mistaken for a real player.
+
 ## [12.0.11] - 2026-06-12
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.11'
+$script:DuneToolVersion = '12.0.12'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.11',
+    [string]$Version = '12.0.12',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.11</Version>
+    <Version>12.0.12</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.11"
+#define MyAppVersion "12.0.12"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.11"
+$script:ToolVersion = "12.0.12"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Release prep for **v12.0.12**. Rolls up three changes already merged to `main` since v12.0.11 and bumps all version stamps + CHANGELOG.

### Included
- **fix (#169):** specialization XP now loads on Players → Specs — reads/writes key off the controller id (was pawn id), matching how keystones already worked. Verified live: all 5 tracks return correctly.
- **config (#167):** default Market Bot (Duke) starting balance raised so the bot sustains large buy-side activity out of the box.
- **ux (#154):** the built-in GM bot is labelled as a Funcom system NPC on the Players tab so it isn't mistaken for a real player.

### Release mechanics
- All 5 version stamps bumped 12.0.11 → 12.0.12 (build script's stamp-sync check passes).
- CHANGELOG `[12.0.12]` entry added.
- Installer built locally: `DuneServerSetup.exe` (45.85 MB) — will be uploaded as the sole release asset after tag.

Holding on merge/tag/publish until approved.