### PR TITLE
ux(db): gate Restore Backup behind a typed RESTORE confirm

### DIFF
--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -49,6 +49,25 @@ export function Database() {
   }, [])
 
   async function runMaint(name: 'backup' | 'import') {
+    // Restore (import) is a full, destructive replace of the entire BG database —
+    // every player, base, inventory, storage, blueprint, and the market rolls back
+    // to the chosen snapshot and everything since is permanently lost. Gate it
+    // behind a typed confirmation so it can't be triggered by a stray click.
+    if (name === 'import') {
+      const typed = window.prompt(
+        'FULL DATABASE RESTORE — SEVERE, IRREVERSIBLE.\n\n' +
+        'This REPLACES the entire battlegroup database with the backup you pick in the console window. ' +
+        'ALL players, bases, inventories, storage, blueprints, and the market will be rolled back to that snapshot. ' +
+        'Everything created since the backup is permanently lost. This cannot be undone.\n\n' +
+        'Take a fresh backup first if you have not. The battlegroup must be stopped.\n\n' +
+        'Type RESTORE to continue:',
+      )
+      if (typed == null) return
+      if (typed.trim().toUpperCase() !== 'RESTORE') {
+        showToast('err', 'Restore cancelled — confirmation text did not match.')
+        return
+      }
+    }
     setLaunching(name)
     try {
       const r = await api<CmdLaunch>(`/api/commands/run/${name}`, { method: 'POST' })
@@ -241,7 +260,7 @@ export function Database() {
           title="Restore Backup"
           icon="Upload"
           tone="ibad"
-          description="Replace the BG database with a previously taken backup. The battlegroup must be stopped, and this operation cannot be undone."
+          description="Full destructive restore — REPLACES the entire BG database with a previously taken backup. All players, bases, inventories, storage, blueprints, and the market roll back to that snapshot; everything since is permanently lost. The battlegroup must be stopped, and this cannot be undone."
           hint={
             !vmRunning ? 'VM must be running to restore a backup.'
             : bgState === 'running' ? 'Stop the battlegroup first to avoid database corruption.'


### PR DESCRIPTION
## What

The **Database → Restore Backup** button runs a full, destructive `battlegroup import`: the operator **drops the live database** and replaces it wholesale from the chosen backup. Every player, base, inventory, storage container, blueprint, and the market rolls back to that snapshot — everything since is permanently lost.

Previously it launched on a **single click** with only a "cannot be undone" line in the card. That's too easy to trigger by accident for an irreversible whole-DB wipe.

## Change

- **Typed confirmation gate** — restoring now pops a warning prompt explaining the full scope and requires typing **`RESTORE`** to proceed. Cancel or any mismatch aborts with a toast. (Backup is untouched — only the `import` path is gated.)
- **Clearer card description** — rewritten to spell out that it replaces the *entire* DB and everything since the snapshot is lost, not just a vague "cannot be undone."

No behavior change to the actual backup/restore command — this is purely a guardrail in front of it. TypeScript verified clean.

**Staged for the next batched release** — not merged here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>