### PR TITLE
ux(gameconfig): note Spice Fields edits are immediate + non-persistent

### DIFF
--- a/webui/src/pages/gameconfig/SpicefieldsCard.tsx
+++ b/webui/src/pages/gameconfig/SpicefieldsCard.tsx
@@ -243,6 +243,15 @@ export function SpicefieldsCard({ vmRunning }: Props) {
         read-only and reflect what is on the map right now.
       </p>
 
+      <div className="mb-3 px-3 py-2 rounded border border-info/40 bg-info/10 text-info text-xs flex items-start gap-2">
+        <Icon name="Info" size={13} className="mt-0.5 shrink-0" />
+        <span>
+          These Spice adjustments take effect immediately and do not persist across BG
+          restarts. They are based on the last BG start of the SpiceField settings in the
+          ini files below.
+        </span>
+      </div>
+
       {err && (
         <div className="mb-3 px-3 py-2 rounded border border-danger/40 bg-danger/10 text-danger text-xs flex items-center gap-2">
           <Icon name="AlertCircle" size={13} /> {err}


### PR DESCRIPTION
## What

Adds a clarifying notice to the **Game Config → Spice Fields** card (`dune.spicefield_types`):

> These Spice adjustments take effect immediately and do not persist across BG restarts. They are based on the last BG start of the SpiceField settings in the ini files below.

Rendered as an info banner directly under the card's description, above the rows. Text-only change — no behavior change to the spicefield edit/toggle endpoints.

TypeScript verified clean. **Staged for the next batched release** — not merged here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>