### PR TITLE
release: v12.0.13 — DB restore confirm + Spice Fields immediacy notice

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.11"
+      placeholder: "v12.0.13"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.13] - 2026-06-13
+
+### Changed
+
+- **Restore Backup is now gated behind a typed confirmation.** The Database tab's
+  Restore Backup runs a full destructive `battlegroup import` — it replaces the
+  entire BG database, rolling every player, base, inventory, storage container,
+  blueprint, and the market back to the chosen snapshot (everything since is
+  lost). It previously launched on a single click; it now requires typing
+  `RESTORE` to proceed, and the card text spells out the full-wipe scope.
+
+- **Spice Fields card clarifies its edits are immediate + non-persistent.** Added
+  a notice to Game Config → Spice Fields (`dune.spicefield_types`): the
+  adjustments take effect immediately and do not persist across BG restarts;
+  they're based on the last BG start of the SpiceField settings in the INI files
+  shown below.
+
 ## [12.0.12] - 2026-06-12
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.12'
+$script:DuneToolVersion = '12.0.13'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.12',
+    [string]$Version = '12.0.13',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.12</Version>
+    <Version>12.0.13</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.12"
+#define MyAppVersion "12.0.13"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.12"
+$script:ToolVersion = "12.0.13"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Rolls up the two changes merged to main since v12.0.12 and bumps all version stamps to **12.0.13**:

- **#171** — Restore Backup gated behind a typed `RESTORE` confirm + clearer full-wipe warning.
- **#172** — Spice Fields card notice: edits are immediate and do not persist across BG restarts.

Release prep only (5 version stamps + CHANGELOG). Installer built and verified at 12.0.13.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>