### PR TITLE
fix(gameplay-admin): Give Intel + Give XP id resolution (#176)

### DIFF
--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -308,7 +308,7 @@ LIMIT 1;
 
 function Get-DunePlayerControllerFromPawn {
     param([string]$Ip, [long]$PawnId)
-    $sql = "SELECT actor_id::text AS cid FROM dune.player_state WHERE player_pawn_id = $PawnId::bigint LIMIT 1;"
+    $sql = "SELECT player_controller_id::text AS cid FROM dune.player_state WHERE player_pawn_id = $PawnId::bigint LIMIT 1;"
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
     if (-not $r.ok) { return $null }
     $maps = ConvertTo-DuneRowMaps -Result $r

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1044,7 +1044,7 @@ export function awardCharXp(pawnId: number, delta: number) {
 
 export function awardIntel(controllerId: number, amount: number) {
   return api<WriteResult>('/api/gameplay/players/award-intel', {
-    method: 'POST', body: JSON.stringify({ controller_id: controllerId, amount }),
+    method: 'POST', body: JSON.stringify({ actor_id: controllerId, delta: amount }),
   })
 }
 

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -78,9 +78,9 @@ describe('Phase A — currency / progression writes', () => {
     expect(last().body).toEqual({ pawn_id: 99, delta: 10_000 })
   })
 
-  it('awardIntel uses controller_id + amount', async () => {
+  it('awardIntel sends actor_id + delta (backend award-intel contract)', async () => {
     await gp.awardIntel(123, 50)
-    expect(last().body).toEqual({ controller_id: 123, amount: 50 })
+    expect(last().body).toEqual({ actor_id: 123, delta: 50 })
   })
 
   it('returningPlayerAward + dismiss... only need account_id', async () => {


### PR DESCRIPTION
Fixes two bugs from #176, both ID-resolution issues in the Gameplay Admin "Players" feature.

## Bug A — Give Intel: `actor_id or pawn_id is required.`
Frontend `awardIntel()` was POSTing `{ controller_id, amount }` but the `award-intel` route reads `actor_id`/`pawn_id` + `delta`. Since `Invoke-DunePlayerAwardIntel` uses the actor/controller id directly as the `dune.actors WHERE id = $controller` write target (and `Player.controller_id` *is* that id), the frontend now sends `{ actor_id: controllerId, delta: amount }`. Frontend-only; no pawn resolution needed.

## Bug B — Give XP: `Could not resolve player_controller from pawn N.`
`Get-DunePlayerControllerFromPawn` selected nonexistent column `actor_id` from `dune.player_state`; changed to `player_controller_id` (matches `PlayersWrites.ps1` + `GameplayPlayers.ps1`).

## Verification
- webui: `tsc -b` clean; `vitest run` 37/37 pass (updated the one test that encoded the old buggy contract); lint shows only pre-existing errors in untouched `ThemeContext.tsx`.
- Pester: `PlayersWrites.Tests.ps1` + `Helpers.Tests.ps1` 36/36 pass.

## Still owed (live-DB)
- Confirm Give Intel increments TechKnowledgePoints on the correct actor.
- Confirm Give XP resolves controller from pawn and applies XP/level/SP to the right player.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>