### PR TITLE
fix(gameplay-admin): give-item stats block so items render in-game (#144, #176)

### DIFF
--- a/app/server/lib/Gameplay.ps1
+++ b/app/server/lib/Gameplay.ps1
@@ -95,6 +95,34 @@ function Get-DuneGameplayItemName {
     return $TemplateId
 }
 
+# Stats blob for a freshly-inserted give-item row. The game cannot deserialize an
+# item with empty stats ('{}') and silently drops it on zone/login load, so the
+# row exists in the DB but never materializes in-game. It also needs the SHAPE
+# that matches the item kind:
+#   * stackable resources (stack_max > 1, e.g. Copper Ingot, Basalt) require
+#     "FItemStackAndDurabilityStats":[[],{"DecayedMaxDurability":0.0}] — without
+#     the DecayedMaxDurability key the game drops them (Discord/SpiceSilo report).
+#   * equipment / non-stackables use the FCustomizationStats + empty-durability
+#     shape, which is the shipped-safe default for everything else.
+# Mirrors the proven icehunter port (Add-V6InventoryItem) and app\data\stat-reference.json.
+# stack_max comes from gameplay-item-data.json; the dead Test-DuneIsEquipmentCategory
+# heuristic is NOT used (its prefix list is never initialized). Returns a bare
+# JSON literal (no SQL quoting) — the value is one of two fixed constants.
+function Get-DuneGiveItemStatsJson {
+    param([string]$TemplateId)
+    $stackMax = 0
+    if ($TemplateId -and (Get-Command Get-DuneGameplayItemRule -ErrorAction SilentlyContinue)) {
+        try {
+            $rule = Get-DuneGameplayItemRule -TemplateId $TemplateId
+            if ($null -ne $rule -and $null -ne $rule.stack_max) { $stackMax = [int]$rule.stack_max }
+        } catch {}
+    }
+    if ($stackMax -gt 1) {
+        return '{"FItemStackAndDurabilityStats":[[],{"DecayedMaxDurability":0.0}]}'
+    }
+    return '{"FCustomizationStats":[[],{}],"FItemStackAndDurabilityStats":[[],{}]}'
+}
+
 # Classify an inventory item as a normal 'item', an 'emote', or a 'contract'
 # (quest) item so the Players view can separate clutter from real gear/loot.
 # Emotes and contract turn-in items are not in the catalog metadata (no

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -246,6 +246,7 @@ WHERE i.id = $ItemId::bigint AND t.val > 0;
 function Invoke-DunePlayerGiveItem {
     param([string]$Ip, [long]$PawnId, [string]$Template, [long]$Qty, [long]$Quality)
     $safeTmpl = ConvertTo-DuneSqlString $Template
+    $statsJson = ConvertTo-DuneSqlString (Get-DuneGiveItemStatsJson -TemplateId $Template)
     $sql = @"
 WITH inv AS (
     SELECT id FROM dune.inventories
@@ -268,7 +269,7 @@ ins AS (
     INSERT INTO dune.items (inventory_id, stack_size, position_index, template_id, quality_level, acquisition_time, stats)
     SELECT inv.id, $Qty::bigint,
         (SELECT COALESCE(MAX(position_index), -1) + 1 FROM dune.items WHERE inventory_id = inv.id),
-        '$safeTmpl', $Quality::bigint, EXTRACT(EPOCH FROM now())::bigint, '{}'::jsonb
+        '$safeTmpl', $Quality::bigint, EXTRACT(EPOCH FROM now())::bigint, '$statsJson'::jsonb
     FROM inv
     WHERE NOT EXISTS (SELECT 1 FROM existing)
     RETURNING id

--- a/app/server/lib/GameplayWorld.ps1
+++ b/app/server/lib/GameplayWorld.ps1
@@ -593,6 +593,7 @@ function Invoke-DuneStorageGiveItem {
     param([string]$Ip, [long]$ContainerId, [string]$Template, [long]$Qty, [long]$Quality)
     if ($Qty -le 0) { $Qty = 1 }
     $safeTmpl = ConvertTo-DuneSqlString $Template
+    $statsJson = ConvertTo-DuneSqlString (Get-DuneGiveItemStatsJson -TemplateId $Template)
     # acquisition_time must be the current epoch: the game treats acquisition_time=0
     # (1970) items as fully decayed and drops them from the container on zone load,
     # so they show in DST but never appear in-game even after a restart.
@@ -613,7 +614,7 @@ ins AS (
     SELECT cur.inv_id, '$safeTmpl', $Qty::bigint, $Quality::bigint,
            COALESCE((SELECT MAX(position_index) + 1 FROM dune.items WHERE inventory_id = cur.inv_id), 0),
            EXTRACT(EPOCH FROM now())::bigint,
-           '{"FCustomizationStats":[[],{}],"FItemStackAndDurabilityStats":[[],{}]}'::jsonb
+           '$statsJson'::jsonb
     FROM cur
     WHERE cur.maxc = 0 OR cur.cnt < cur.maxc
     RETURNING id

--- a/tests/GiveItemStats.Tests.ps1
+++ b/tests/GiveItemStats.Tests.ps1
@@ -1,0 +1,44 @@
+# Tests the give-item stats-shape classifier (Get-DuneGiveItemStatsJson) that
+# selects the stackable vs equipment FItemStackAndDurabilityStats blob. A wrong
+# shape makes the game drop the item on load (it renders in DST but never in-game).
+# No DB / network — uses the bundled gameplay-item-data.json for stack_max.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'Gameplay.ps1'
+}
+
+Describe 'Get-DuneGiveItemStatsJson' -Tag 'Pure' {
+    BeforeAll {
+        $script:stackable = '{"FItemStackAndDurabilityStats":[[],{"DecayedMaxDurability":0.0}]}'
+        $script:equipment = '{"FCustomizationStats":[[],{}],"FItemStackAndDurabilityStats":[[],{}]}'
+    }
+
+    It 'returns the stackable shape (with DecayedMaxDurability) for a stackable resource' {
+        # CopperBar (Copper Ingot) has stack_max=500 in gameplay-item-data.json.
+        Get-DuneGiveItemStatsJson -TemplateId 'CopperBar' | Should -Be $script:stackable
+    }
+
+    It 'returns the stackable shape for another stackable resource (Basalt)' {
+        Get-DuneGiveItemStatsJson -TemplateId 'Basalt' | Should -Be $script:stackable
+    }
+
+    It 'returns the equipment shape for a non-stackable equipment item' {
+        # Combat_Light_SpiceMask is garment/head, stack_max=1.
+        Get-DuneGiveItemStatsJson -TemplateId 'Combat_Light_SpiceMask' | Should -Be $script:equipment
+    }
+
+    It 'defaults to the equipment shape for an unknown template' {
+        Get-DuneGiveItemStatsJson -TemplateId 'NotARealTemplate_xyz' | Should -Be $script:equipment
+    }
+
+    It 'defaults to the equipment shape for an empty template' {
+        Get-DuneGiveItemStatsJson -TemplateId '' | Should -Be $script:equipment
+    }
+
+    It 'never returns an empty stats blob' {
+        foreach ($t in @('CopperBar', 'Combat_Light_SpiceMask', 'Unknown_zzz', '')) {
+            Get-DuneGiveItemStatsJson -TemplateId $t | Should -Not -Be '{}'
+        }
+    }
+}


### PR DESCRIPTION
Fixes admin-given items that report delivered and exist in the DB but never render in-game. Reported by #144, the give-item portion of #176, and Discord (Ken).

## Root cause (two paths)
- `Invoke-DunePlayerGiveItem` (GameplayPlayers.ps1) inserted `stats '{}'::jsonb` — the game can't deserialize empty stats and drops the item on zone/login load.
- `Invoke-DuneStorageGiveItem` (GameplayWorld.ps1) inserted a **fixed equipment-only** stats shape for every item, so stackable resources had no `DecayedMaxDurability` and didn't render even on v12.0.13 (a remaining gap, not just pre-fix leftovers).

## Fix
New pure helper `Get-DuneGiveItemStatsJson` (Gameplay.ps1) branches by item type; both insert sites call it:
- **stackable** (gameplay-item-data `stack_max > 1` — e.g. Copper Ingot/Basalt/Plastone): `{"FItemStackAndDurabilityStats":[[],{"DecayedMaxDurability":0.0}]}`
- **equipment / non-stackable / unknown** (e.g. Sandcrawler Cabin Mk6): `{"FCustomizationStats":[[],{}],"FItemStackAndDurabilityStats":[[],{}]}`

Branching (not one universal shape) matches the proven icehunter port `Add-V6InventoryItem` and `app/data/stat-reference.json`. Equipment shape is the safe default for unknowns (what storage has shipped for non-stackables since v12.0.5). Bulk paths loop the single functions → covered. Online RMQ give-item-live path untouched (game-native).

## Tests
- Added `tests/GiveItemStats.Tests.ps1` (6 classifier cases). Full Pester suite **157/157 pass**.
- webui untouched (3 backend .ps1 + 1 test only).

## Still owed (live-VM)
Give BOTH a stackable resource (Copper Ingot) AND an equipment item (Sandcrawler Cabin Mk6) to (1) a player backpack and (2) a storage container, restart battlegroup, confirm each renders in-game.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>