### PR TITLE
fix(gameconfig): de-dupe INI section headers so managed overrides apply

### DIFF
--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -556,9 +556,36 @@ function ConvertTo-DuneIniManaged {
         $managedByName[$name] = $entry
     }
     # Remaining body sections = those whose name is NOT a managed target.
+    # De-dupe: a section name may legitimately appear more than once in the input
+    # body (a pre-existing duplicate header). Emitting both copies leaves a
+    # duplicate header in the output, and UE5 honours the FIRST header while
+    # last-key-wins on values, silently dropping later keys. Collapse duplicates
+    # into a single section at the FIRST occurrence's position, appending later
+    # bodies in file order, so every section name appears exactly once.
     $remaining = New-Object 'System.Collections.Generic.List[object]'
+    $remainingByName = @{}
+    $remainingCount = @{}
     foreach ($s in $doc.sections) {
-        if (-not $targetSet.ContainsKey($s.name)) { $remaining.Add($s) }
+        if ($targetSet.ContainsKey($s.name)) { continue }
+        if ($remainingByName.ContainsKey($s.name)) {
+            $existing = $remainingByName[$s.name]
+            foreach ($l in $s.body) { $existing.body.Add($l) }
+            $remainingCount[$s.name] = $remainingCount[$s.name] + 1
+        } else {
+            $entry = @{ name = $s.name; header = $s.header; body = (New-Object 'System.Collections.Generic.List[string]') }
+            foreach ($l in $s.body) { $entry.body.Add($l) }
+            $remaining.Add($entry)
+            $remainingByName[$s.name] = $entry
+            $remainingCount[$s.name] = 1
+        }
+    }
+    # Only merge bodies for names that actually collapsed (>1 occurrence) so a
+    # normal single-occurrence section round-trips byte-for-byte. Merge keeps the
+    # first scalar-key position carrying the last-wins value (engine semantics).
+    foreach ($entry in $remaining) {
+        if ($remainingCount[$entry.name] -gt 1) {
+            $entry.body = Merge-DuneSectionBody -Lines $entry.body
+        }
     }
 
     # Apply updates into their managed sections.

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -1,0 +1,155 @@
+# Tests the pure INI-writer engine in GameConfig.ps1, focused on the
+# managed-block writer's guarantee that any section name appears EXACTLY ONCE
+# in the output. Regression coverage for the v12.0.13 duplicate-header bug where
+# DST's managed override was silently ignored by UE5 (first-header / last-key
+# wins) because a duplicate header survived in the body.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'GameConfig.ps1'
+
+    $script:SecBuilding  = '/Script/DuneSandbox.BuildingSettings'
+    $script:SecInventory = '/Script/DuneSandbox.InventorySystemSettings'
+
+    # Count how many times a given section header occurs in rendered output.
+    function Get-HeaderCount {
+        param([string] $Raw, [string] $Name)
+        $needle = '[' + $Name + ']'
+        $n = 0
+        foreach ($line in ($Raw -replace "`r", '' -split "`n")) {
+            if ($line.Trim() -eq $needle) { $n++ }
+        }
+        return $n
+    }
+
+    # Effective last-wins value for a section||key across the whole file.
+    function Get-EffectiveValue {
+        param([string] $Raw, [string] $Section, [string] $Key)
+        $cur = $null
+        $val = $null
+        foreach ($line in ($Raw -replace "`r", '' -split "`n")) {
+            $t = $line.Trim()
+            if ($t.StartsWith('[') -and $t.EndsWith(']')) {
+                $cur = $t.Substring(1, $t.Length - 2)
+                continue
+            }
+            if ($cur -eq $Section -and $t -match ('^' + [regex]::Escape($Key) + '\s*=')) {
+                $val = $t.Substring($t.IndexOf('=') + 1)
+            }
+        }
+        return $val
+    }
+}
+
+Describe 'ConvertTo-DuneIniManaged: duplicate-section de-dup' -Tag 'GameConfig' {
+
+    It 'collapses a pre-existing duplicate NON-target header to exactly one' {
+        $raw = @"
+[$script:SecBuilding]
+m_BuildingBlueprintMaxExtensions=10
+
+[/Script/DuneSandbox.OtherSettings]
+SomeKey=1
+
+[$script:SecBuilding]
+m_BuildingBlueprintMaxExtensions=20
+"@
+        $out = ConvertTo-DuneIniManaged -Raw $raw -Updates @() -QuotedKeys @{}
+        (Get-HeaderCount -Raw $out -Name $script:SecBuilding) | Should -Be 1
+        # last-wins on the duplicate scalar key
+        (Get-EffectiveValue -Raw $out -Section $script:SecBuilding -Key 'm_BuildingBlueprintMaxExtensions') | Should -Be '20'
+    }
+
+    It 'updating a section that already exists in the body yields exactly one header (in managed block) with managed value winning' {
+        $raw = @"
+[$script:SecBuilding]
+m_BuildingBlueprintMaxExtensions=10
+m_bBuildingRestrictionLimitsEnabled=False
+"@
+        $updates = @(@{ section = $script:SecBuilding; key = 'm_BuildingBlueprintMaxExtensions'; value = '99' })
+        $out = ConvertTo-DuneIniManaged -Raw $raw -Updates $updates -QuotedKeys @{}
+
+        (Get-HeaderCount -Raw $out -Name $script:SecBuilding) | Should -Be 1
+        # the single surviving copy must be inside the managed block
+        $beginIdx = $out.IndexOf($script:DstManagedBegin)
+        $hdrIdx   = $out.IndexOf('[' + $script:SecBuilding + ']')
+        $beginIdx | Should -BeGreaterThan -1
+        $hdrIdx   | Should -BeGreaterThan $beginIdx
+        # managed override wins; untouched key preserved
+        (Get-EffectiveValue -Raw $out -Section $script:SecBuilding -Key 'm_BuildingBlueprintMaxExtensions') | Should -Be '99'
+        (Get-EffectiveValue -Raw $out -Section $script:SecBuilding -Key 'm_bBuildingRestrictionLimitsEnabled') | Should -Be 'False'
+    }
+
+    It 'reported repro: body BuildingSettings + managed update -> single authoritative section with override applied' {
+        $raw = @"
+[/Script/DuneSandbox.DuneGameMode]
+m_Whatever=1
+
+[$script:SecBuilding]
+m_BuildingBlueprintMaxExtensions=10
+m_BaseBackupMaxExtensions=10
+m_bBuildingRestrictionLimitsEnabled=False
+"@
+        $updates = @(
+            @{ section = $script:SecBuilding; key = 'm_BuildingBlueprintMaxExtensions'; value = '50' },
+            @{ section = $script:SecBuilding; key = 'm_BaseBackupMaxExtensions';        value = '50' },
+            @{ section = $script:SecBuilding; key = 'm_bBuildingRestrictionLimitsEnabled'; value = 'True' }
+        )
+        $out = ConvertTo-DuneIniManaged -Raw $raw -Updates $updates -QuotedKeys @{}
+
+        (Get-HeaderCount -Raw $out -Name $script:SecBuilding) | Should -Be 1
+        (Get-EffectiveValue -Raw $out -Section $script:SecBuilding -Key 'm_BuildingBlueprintMaxExtensions') | Should -Be '50'
+        (Get-EffectiveValue -Raw $out -Section $script:SecBuilding -Key 'm_BaseBackupMaxExtensions') | Should -Be '50'
+        (Get-EffectiveValue -Raw $out -Section $script:SecBuilding -Key 'm_bBuildingRestrictionLimitsEnabled') | Should -Be 'True'
+    }
+
+    It 'InventorySystemSettings volume update lands as a single section (UI/file agree)' {
+        $raw = @"
+[$script:SecInventory]
+PlayerInventoryStartingVolumeCapacity=185
+"@
+        $updates = @(@{ section = $script:SecInventory; key = 'PlayerInventoryStartingVolumeCapacity'; value = '195' })
+        $out = ConvertTo-DuneIniManaged -Raw $raw -Updates $updates -QuotedKeys @{}
+
+        (Get-HeaderCount -Raw $out -Name $script:SecInventory) | Should -Be 1
+        (Get-EffectiveValue -Raw $out -Section $script:SecInventory -Key 'PlayerInventoryStartingVolumeCapacity') | Should -Be '195'
+    }
+
+    It 'de-dupes a duplicate header that spans the managed block (one body copy + one managed copy)' {
+        $managedBegin = $script:DstManagedBegin
+        $managedEnd   = $script:DstManagedEnd
+        $raw = @"
+[$script:SecBuilding]
+m_BuildingBlueprintMaxExtensions=10
+
+
+$managedBegin
+;
+[$script:SecBuilding]
+m_BuildingBlueprintMaxExtensions=42
+$managedEnd
+"@
+        # No new updates: the managed copy is adopted, the body copy must be absorbed too.
+        $out = ConvertTo-DuneIniManaged -Raw $raw -Updates @() -QuotedKeys @{}
+        (Get-HeaderCount -Raw $out -Name $script:SecBuilding) | Should -Be 1
+        (Get-EffectiveValue -Raw $out -Section $script:SecBuilding -Key 'm_BuildingBlueprintMaxExtensions') | Should -Be '42'
+    }
+}
+
+Describe 'ConvertTo-DuneIniManaged: non-duplicate round-trip' -Tag 'GameConfig' {
+
+    It 'leaves a normal single-occurrence body section structurally intact (no managed block when nothing changes)' {
+        $raw = @"
+[/Script/DuneSandbox.OtherSettings]
+KeyA=1
++ArrayKey=foo
++ArrayKey=bar
+"@
+        $out = ConvertTo-DuneIniManaged -Raw $raw -Updates @() -QuotedKeys @{}
+        (Get-HeaderCount -Raw $out -Name '/Script/DuneSandbox.OtherSettings') | Should -Be 1
+        $out | Should -Not -Match ([regex]::Escape($script:DstManagedBegin))
+        # array (+/-) lines preserved verbatim and not collapsed
+        $out | Should -Match '\+ArrayKey=foo'
+        $out | Should -Match '\+ArrayKey=bar'
+    }
+}


### PR DESCRIPTION
Fixes DST writing duplicate INI section headers into UserGame.ini, which caused the engine to honor the first (stale) header and silently ignore DST's managed overrides. Reported by Discord (Skullrazor) on v12.0.13.

## Root cause
`ConvertTo-DuneIniManaged` (app/server/lib/GameConfig.ps1) already absorbed all occurrences of any updated/managed (target) section into the managed block. The surviving bug was the `` loop: it emitted every non-target body section as-is with no de-dup, so a section name present twice in the input body (a pre-existing duplicate header DST isn't updating) survived twice in the output. UE5 honors the first header + last-key-wins, shadowing DST's intended values — the on-disk 185-vs-UI-195 mismatch and ignored base-expansion settings.

## Fix (surgical, one function)
Rewrote only the `` construction: de-dupe non-target sections by name — first occurrence keeps its position + header; later occurrences' bodies are appended in file order and run through the existing `Merge-DuneSectionBody` for last-wins scalar semantics. Single-occurrence sections are left byte-identical (untouched files round-trip unchanged). Guarantee: every section name appears **exactly once** in output — in the managed block (targets) or the body (non-targets). No change to managed-block build, markers, ordering, or render.

## Tests
Added `tests/GameConfig.Tests.ps1` (Pester 5, existing harness), 6 cases: pre-existing duplicate collapse w/ last-wins; updating an existing body section → single header inside managed block; BuildingSettings repro; InventorySystemSettings 185→195 single section; duplicate spanning the managed block; non-duplicate round-trip regression. **Full suite 163/163 pass** (157 baseline + 6 new).

## Still owed (live)
On a server whose UserGame.ini already had a duplicate section, save a BuildingSettings + InventorySystemSettings change via the UI; confirm each header appears exactly once, the managed block holds the override, and UI matches disk after reload. Frontend/route untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>