### PR TITLE
fix(gameconfig): remove fictional no-op multiplier keys (XP/Fame/Progression)

### DIFF
--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -54,7 +54,7 @@ $script:DuneGcSecUrl       = 'URL'
 
 # Category display order (UI renders in this order; unknown categories appended).
 $script:DuneGameConfigCategoryOrder = @(
-    'Server Identity','Network','Survival','Progression','Harvesting',
+    'Server Identity','Network','Survival',
     'Resources & Economy','Building','Inventory','Guilds & Economy',
     'Storm Cycle','PvP & Security','Spice','Taxation','Sandworm','Vehicles'
 )
@@ -69,24 +69,12 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecUrl; Key='IGWPort'; File='engine'; Type='int'; Min=1024; Max=65535; Default='7780'; Label='IGW Port (starting)'; Help='Starting inter-server port; must not overlap the game port range.'; Category='Network' }
 
     # --- Survival ---
-    @{ Section=$script:DuneGcSecGame; Key='m_GlobalHealthMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Global Health Multiplier'; Help='Scales the health pool of all entities (players + NPCs).'; Category='Survival' }
-    @{ Section=$script:DuneGcSecGame; Key='m_GlobalDamageToNpcsMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Damage to NPCs Multiplier'; Help='Scales damage dealt to NPCs.'; Category='Survival' }
-    @{ Section=$script:DuneGcSecGame; Key='m_GlobalDamageToPlayersMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Damage to Players Multiplier'; Help='Scales damage dealt to players.'; Category='Survival' }
     @{ Section=$script:DuneGcSecGame; Key='m_WaterConsumptionRate'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Water Consumption Rate'; Help='How quickly players consume water.'; Category='Survival' }
     @{ Section=$script:DuneGcSecGame; Key='m_WaterConsumptionInStormMultiplier'; File='game'; Type='float'; Min=0; Default='2.0'; Label='Water Consumption in Storm'; Help='Additional water drain during sandstorms.'; Category='Survival' }
     @{ Section=$script:DuneGcSecGame; Key='m_PlayerStartingWater'; File='game'; Type='float'; Min=0; Default='100.0'; Label='Player Starting Water'; Help='Water amount when a player spawns.'; Category='Survival' }
     @{ Section=$script:DuneGcSecOnline; Key='m_DefaultReconnectGracePeriodSeconds'; File='game'; Type='int'; Min=0; Unit='sec'; Default='300'; Label='Reconnect Grace Period'; Help="Seconds a player's corpse persists after disconnect."; Category='Survival' }
     @{ Section=$script:DuneGcSecDurab; Key='m_ItemDurabilityLossMultiplier'; File='game'; Type='float'; Min=0; Max=10; Default='1.0'; Label='Item Durability Loss Multiplier'; Help='Scales durability loss for all items. 0 = off.'; Category='Survival' }
     @{ Section=$script:DuneGcSecDurab; Key='UpdateRateInSeconds'; File='game'; Type='float'; Min=0; Max=10; Unit='sec'; Default='1.0'; Label='Item Decay Rate'; Help='Deterioration tick rate. 0 = off, 1-10 typical.'; Category='Survival' }
-
-    # --- Progression ---
-    @{ Section=$script:DuneGcSecGame; Key='m_GlobalXPMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='XP Multiplier'; Help='Scales XP gained from all sources.'; Category='Progression' }
-    @{ Section=$script:DuneGcSecGame; Key='m_GlobalProgressionSpeedMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Progression Speed Multiplier'; Help='Scales overall progression speed.'; Category='Progression' }
-    @{ Section=$script:DuneGcSecGame; Key='m_GlobalFameMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Fame Multiplier'; Help='Scales fame gained from all sources.'; Category='Progression' }
-
-    # --- Harvesting ---
-    @{ Section=$script:DuneGcSecGame; Key='m_GlobalHarvestAmountMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Harvest Amount Multiplier'; Help='Scales resource yield from harvesting.'; Category='Harvesting' }
-    @{ Section=$script:DuneGcSecGame; Key='m_GlobalHarvestHealthMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Harvest Health Multiplier'; Help='Scales node health (how long nodes last).'; Category='Harvesting' }
 
     # --- Resources & Economy (engine ConsoleVariables) ---
     @{ Section=$script:DuneGcSecConsole; Key='Dune.GlobalMiningOutputMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Global Mining Multiplier'; Help='Scales hand-mining resource output.'; Category='Resources & Economy' }
@@ -98,12 +86,10 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecBuilding; Key='m_BuildingBlueprintMaxExtensions'; File='game'; Type='int'; Min=0; Default='4'; Label='Blueprint Max Extensions'; Help='Maximum blueprint extension slots.'; Category='Building' }
     @{ Section=$script:DuneGcSecBuilding; Key='m_BaseBackupMaxExtensions'; File='game'; Type='int'; Min=0; Default='8'; Label='Base Backup Max Extensions'; Help='Backup (reconstruction) extension slots per base.'; Category='Building' }
     @{ Section=$script:DuneGcSecBuilding; Key='m_bBuildingRestrictionLimitsEnabled'; File='game'; Type='bool'; Default='True'; Label='Building Restriction Limits'; Help='Enforce building restriction limits. Also needs client-side apply.'; ClientApply=$true; Category='Building' }
-    @{ Section=$script:DuneGcSecBuilding; Key='m_GlobalBuildingDamageMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Building Damage Multiplier'; Help='Scales damage dealt to player buildings.'; Category='Building' }
 
     # --- Inventory ---
     @{ Section=$script:DuneGcSecInventory; Key='PlayerInventoryStartingSize'; File='game'; Type='int'; Min=1; Default='35'; Label='Starting Inventory Slots'; Help='Number of inventory slots at spawn.'; Category='Inventory' }
     @{ Section=$script:DuneGcSecInventory; Key='PlayerInventoryStartingVolumeCapacity'; File='game'; Type='float'; Min=0; Default='175.0'; Label='Starting Inventory Volume'; Help='Volume capacity of the starting inventory.'; Category='Inventory' }
-    @{ Section=$script:DuneGcSecGame; Key='m_InventoryWeightMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Inventory Weight Multiplier'; Help='Scales item weight across all inventories.'; Category='Inventory' }
 
     # --- Guilds & Economy ---
     @{ Section=$script:DuneGcSecGuilds; Key='m_MaxGuildMembersAllowed'; File='game'; Type='int'; Min=1; Default='32'; Label='Max Guild Members'; Help='Maximum players per guild.'; Category='Guilds & Economy' }

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -153,3 +153,30 @@ KeyA=1
         $out | Should -Match '\+ArrayKey=bar'
     }
 }
+
+Describe 'DuneGameConfigSchema: no fictional no-op keys' -Tag 'GameConfig' {
+
+    # Guards against regressing the m_Global*Multiplier keys that the reference
+    # implementation (Icehunter/dune-admin #122 / #139) proved are no-ops: they are
+    # absent from the real engine DefaultGame.ini, so DST writing them under any
+    # section header does nothing in-game (Discord report: XP / Fame / Progression
+    # multipliers had no effect). DST must not ship these dead, misleading keys.
+    It 'excludes every fictional m_Global*Multiplier key from the schema' {
+        $fictional = @(
+            'm_GlobalHealthMultiplier'
+            'm_GlobalDamageToNpcsMultiplier'
+            'm_GlobalDamageToPlayersMultiplier'
+            'm_GlobalXPMultiplier'
+            'm_GlobalProgressionSpeedMultiplier'
+            'm_GlobalFameMultiplier'
+            'm_GlobalHarvestAmountMultiplier'
+            'm_GlobalHarvestHealthMultiplier'
+            'm_GlobalBuildingDamageMultiplier'
+            'm_InventoryWeightMultiplier'
+        )
+        $keys = $script:DuneGameConfigSchema | ForEach-Object { $_.Key }
+        foreach ($f in $fictional) {
+            $keys | Should -Not -Contain $f -Because "$f is a proven no-op key and must not be written"
+        }
+    }
+}


### PR DESCRIPTION
Removes 10 fictional no-op multiplier keys from the Game Config schema. Reported via Discord: an "XP multiplier" set in DST had no effect and appeared in UserGame.ini with no section header.

## Verdict — there is no correct header
The 3 reported keys (`m_GlobalXPMultiplier`, `m_GlobalProgressionSpeedMultiplier`, `m_GlobalFameMultiplier`) — and 7 sibling `m_Global*Multiplier` keys — are **fictional**. They don't exist in the real engine `DefaultGame.ini`, so Unreal ignores them under any section. Evidence:
- Absent from all 224 sections in `docs/Dune_Server_INI_Field_Sheet.md`; `[/Script/DuneSandbox.DuneGameMode]` never appears there.
- The reference dune-admin tool ships a regression test (`handlers_server_settings_schema_test.go`) with a `fictional` map listing exactly these DST keys, citing issue #122 ("no-ops — absent from the real DefaultGame.ini") fixed by PR #139 which removed them.
- The only proven gameplay multiplier is the CVar `Dune.GlobalMiningOutputMultiplier`, which DST already maps correctly.

## Changes (surgical)
- Removed 10 fictional keys from `\` (Health / DamageToNpcs / DamageToPlayers / XP / ProgressionSpeed / Fame / HarvestAmount / HarvestHealth / BuildingDamage multipliers + `m_InventoryWeightMultiplier`).
- Dropped now-empty Progression & Harvesting from `\`.
- Kept `\` (DuneGameMode) — still used by real Water/Survival keys.
- Frontend untouched (schema-driven; fields disappear automatically).
- Added Pester guard "no fictional no-op keys" mirroring dune-admin's NoFictionalKeys.

## Tests
Full Pester **164/164** green (incl. new guard); webui vitest **37/37** green.

## Still owed (live)
Confirm on the live server there's no real INI/CVar equivalent for XP/Fame/Progression scaling (dune-admin concluded these are AMP-API/control-plane only). If a real CVar surfaces, add it later as a proper ConsoleVariables.* entry.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>