### PR TITLE
Fix Give Item numeric template_id leak (items invisible in-game)

### DIFF
--- a/app/server/lib/Gameplay.ps1
+++ b/app/server/lib/Gameplay.ps1
@@ -123,6 +123,25 @@ function Get-DuneGiveItemStatsJson {
     return '{"FCustomizationStats":[[],{}],"FItemStackAndDurabilityStats":[[],{}]}'
 }
 
+# Validate a give-item template id before it reaches an INSERT. The game's
+# dune.items.template_id is a class string (e.g. CopperBar, Buggy_Booster_Mk6);
+# a purely-numeric id ("859") can never resolve, so the row is inserted but the
+# item is invisible in-game and dropped on zone/login load. Reject empty and
+# numeric ids with a clear message. Non-numeric unknowns are allowed through
+# (class strings legitimately exist that aren't in the bundled catalog), since
+# numeric is the proven, unambiguous failure mode.
+function Test-DuneValidGiveTemplate {
+    param([string]$TemplateId)
+    $t = if ($null -ne $TemplateId) { $TemplateId.Trim() } else { '' }
+    if (-not $t) {
+        return @{ ok = $false; error = 'Item id is required.' }
+    }
+    if ($t -match '^\d+$') {
+        return @{ ok = $false; error = "Invalid item id '$t' — expected a class name (e.g. CopperBar), not a number. Pick the item from the search list." }
+    }
+    return @{ ok = $true }
+}
+
 # Classify an inventory item as a normal 'item', an 'emote', or a 'contract'
 # (quest) item so the Players view can separate clutter from real gear/loot.
 # Emotes and contract turn-in items are not in the catalog metadata (no

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -245,6 +245,8 @@ WHERE i.id = $ItemId::bigint AND t.val > 0;
 # vanish on the player's next login.
 function Invoke-DunePlayerGiveItem {
     param([string]$Ip, [long]$PawnId, [string]$Template, [long]$Qty, [long]$Quality)
+    $tv = Test-DuneValidGiveTemplate -TemplateId $Template
+    if (-not $tv.ok) { return @{ ok = $false; error = $tv.error } }
     $safeTmpl = ConvertTo-DuneSqlString $Template
     $statsJson = ConvertTo-DuneSqlString (Get-DuneGiveItemStatsJson -TemplateId $Template)
     $sql = @"

--- a/app/server/lib/GameplayWorld.ps1
+++ b/app/server/lib/GameplayWorld.ps1
@@ -591,6 +591,8 @@ function Join-DuneBlueprintInserts {
 # ----------------------------------------------------------------------------
 function Invoke-DuneStorageGiveItem {
     param([string]$Ip, [long]$ContainerId, [string]$Template, [long]$Qty, [long]$Quality)
+    $tv = Test-DuneValidGiveTemplate -TemplateId $Template
+    if (-not $tv.ok) { return @{ ok = $false; error = $tv.error } }
     if ($Qty -le 0) { $Qty = 1 }
     $safeTmpl = ConvertTo-DuneSqlString $Template
     $statsJson = ConvertTo-DuneSqlString (Get-DuneGiveItemStatsJson -TemplateId $Template)

--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -130,6 +130,9 @@ function Invoke-DunePlayerGiveItemLive {
     if ($Quantity -le 0)   { $Quantity = 1 }
     if ($Durability -le 0) { $Durability = 1.0 }
 
+    $tv = Test-DuneValidGiveTemplate -TemplateId $Template
+    if (-not $tv.ok) { return @{ ok = $false; error = $tv.error } }
+
     if ($ActorId -gt 0) {
         $cap = Test-DuneInventoryCapacity -Ip $Ip -PawnId $ActorId -Template $Template -Quantity $Quantity
         if (-not $cap.ok) { return $cap }

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -132,6 +132,9 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-item' -Handler
         if (-not $tmpl) { Write-DuneError -Response $res -Status 400 -Message 'template is required.'; return }
         if ($null -eq $qty -or $qty -le 0) { Write-DuneError -Response $res -Status 400 -Message 'qty must be a positive integer.'; return }
 
+        $tv = Test-DuneValidGiveTemplate -TemplateId $tmpl
+        if (-not $tv.ok) { Write-DuneError -Response $res -Status 400 -Message $tv.error; return }
+
         Invoke-DunePlayerWriteRoute -Response $res -Action {
             param($ip)
             $off = Test-DunePlayerOffline -Ip $ip -PawnId $pawn

--- a/app/server/routes/GameplayWorld.ps1
+++ b/app/server/routes/GameplayWorld.ps1
@@ -194,6 +194,8 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/storage/give-item' -Handler
         if ($null -eq $cid -or $cid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'container_id is required.'; return }
         if (-not $tmpl) { Write-DuneError -Response $res -Status 400 -Message 'template is required.'; return }
         if ($null -eq $qty -or $qty -le 0) { $qty = 1L }
+        $tv = Test-DuneValidGiveTemplate -TemplateId $tmpl
+        if (-not $tv.ok) { Write-DuneError -Response $res -Status 400 -Message $tv.error; return }
         Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DuneStorageGiveItem -Ip $ip -ContainerId $cid -Template $tmpl -Qty $qty -Quality $qual }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Storage give item failed: $($_.Exception.Message)"

--- a/tests/GiveItemTemplateGuard.Tests.ps1
+++ b/tests/GiveItemTemplateGuard.Tests.ps1
@@ -1,0 +1,71 @@
+# Tests the numeric-template give-item guard (Test-DuneValidGiveTemplate) and
+# that the player + storage give functions reject a numeric template_id ("859")
+# BEFORE touching the DB. A numeric id can never resolve to a game class string,
+# so the row inserts but the item is invisible in-game and dropped on zone/login
+# load — the exact bug confirmed on the live DB (one stray row template_id='859').
+# No DB / network: Invoke-DuneSqlQuery is stubbed to throw, so any DB round-trip
+# fails the test loudly, proving the guard short-circuits first.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'Gameplay.ps1'
+    Import-DstLib 'GameplayPlayers.ps1'
+    Import-DstLib 'GameplayWorld.ps1'
+
+    # Any give path that reaches the DB is a bug for a numeric/empty template.
+    function global:Invoke-DuneSqlQuery {
+        throw 'DB must not be called for an invalid template'
+    }
+}
+
+Describe 'Test-DuneValidGiveTemplate' -Tag 'Pure' {
+    It 'accepts real class-string template ids' {
+        foreach ($t in @('CopperBar', 'Buggy_Booster_Mk6', 'BuildingBlueprint_CopyDevice', 'Combat_Light_SpiceMask')) {
+            (Test-DuneValidGiveTemplate -TemplateId $t).ok | Should -BeTrue
+        }
+    }
+
+    It 'rejects a purely-numeric id (the "859" leak)' {
+        $r = Test-DuneValidGiveTemplate -TemplateId '859'
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match '859'
+        $r.error | Should -Match 'class name'
+    }
+
+    It 'rejects numeric ids with surrounding whitespace' {
+        (Test-DuneValidGiveTemplate -TemplateId '  859  ').ok | Should -BeFalse
+        (Test-DuneValidGiveTemplate -TemplateId '0').ok       | Should -BeFalse
+    }
+
+    It 'rejects empty / whitespace-only ids' {
+        (Test-DuneValidGiveTemplate -TemplateId '').ok    | Should -BeFalse
+        (Test-DuneValidGiveTemplate -TemplateId '   ').ok | Should -BeFalse
+        (Test-DuneValidGiveTemplate -TemplateId $null).ok | Should -BeFalse
+    }
+}
+
+Describe 'Invoke-DunePlayerGiveItem — rejects numeric template without DB' -Tag 'Pure' {
+    It 'returns ok=$false for a numeric template and never calls the DB' {
+        $r = Invoke-DunePlayerGiveItem -Ip '1.2.3.4' -PawnId 1 -Template '859' -Qty 10 -Quality 0
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match '859'
+    }
+
+    It 'returns ok=$false for an empty template' {
+        $r = Invoke-DunePlayerGiveItem -Ip '1.2.3.4' -PawnId 1 -Template '' -Qty 1 -Quality 0
+        $r.ok | Should -BeFalse
+    }
+}
+
+Describe 'Invoke-DuneStorageGiveItem — rejects numeric template without DB' -Tag 'Pure' {
+    It 'returns ok=$false for a numeric template and never calls the DB' {
+        $r = Invoke-DuneStorageGiveItem -Ip '1.2.3.4' -ContainerId 3630 -Template '859' -Qty 10 -Quality 0
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match '859'
+    }
+
+    It 'returns ok=$false for an empty template' {
+        $r = Invoke-DuneStorageGiveItem -Ip '1.2.3.4' -ContainerId 3630 -Template '' -Qty 1 -Quality 0
+        $r.ok | Should -BeFalse
+    }
+}

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -881,6 +881,19 @@ export function downloadBlueprintFile(blueprint: BlueprintFile, filename: string
 // v11.5.7 — Item catalog (for autocomplete), Fill Water, Coriolis admin.
 // ---------------------------------------------------------------------------
 
+/**
+ * A valid give-item template id is a game class string (e.g. "CopperBar"),
+ * never a bare number. The game's dune.items.template_id can't resolve a numeric
+ * id, so such rows are inserted but render invisible and get dropped on zone/login
+ * load. Reject empty and purely-numeric ids so they can't reach a give request.
+ */
+export function isValidTemplateId(t: string): boolean {
+  const s = (t ?? '').trim()
+  if (!s) return false
+  if (/^\d+$/.test(s)) return false
+  return /[A-Za-z]/.test(s)
+}
+
 export interface CatalogItem {
   template_id: string
   name: string

--- a/webui/src/components/ItemPicker.tsx
+++ b/webui/src/components/ItemPicker.tsx
@@ -9,7 +9,7 @@
 
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { Icon } from './Icon'
-import { filterCatalog, getItemCatalog, type CatalogItem } from '../api/gameplay'
+import { filterCatalog, getItemCatalog, isValidTemplateId, type CatalogItem } from '../api/gameplay'
 
 interface Props {
   value: string
@@ -142,6 +142,13 @@ export function ItemPicker({ value, onChange, displayValue, label, placeholder, 
               )}
             </button>
           ))}
+        </div>
+      )}
+
+      {!open && value.trim().length > 0 && !isValidTemplateId(value) && (
+        <div className="mt-1 text-[11px] text-warning flex items-center gap-1">
+          <Icon name="AlertTriangle" size={11} className="shrink-0" />
+          Numbers aren't valid item ids — pick an item from the list.
         </div>
       )}
     </div>

--- a/webui/src/pages/gameplay/StorageTab.tsx
+++ b/webui/src/pages/gameplay/StorageTab.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import { ItemPicker } from '../../components/ItemPicker'
 import {
-  getStorage, getStorageItems, giveItemsToStorage, deleteStorageItem,
+  getStorage, getStorageItems, giveItemsToStorage, deleteStorageItem, isValidTemplateId,
   type StorageContainer, type InventoryItem, type DataSource, type StorageGiveItemInput,
 } from '../../api/gameplay'
 import { fmtNum, SourceBadge, StatCard, DemoNotice, qualityClass } from './shared'
@@ -258,7 +258,7 @@ function AddItemsForm({ busy, onSubmit, onCancel }: {
 
   const add = () => {
     const t = template.trim()
-    if (!t) return
+    if (!t || !isValidTemplateId(t)) return
     setStaged(s => [...s, { template: t, qty: Math.max(1, Number(qty) || 1), quality: Math.max(0, Number(quality) || 0) }])
     setTemplate(''); setTemplateName(''); setQty('1'); setQuality('0')
   }
@@ -284,7 +284,7 @@ function AddItemsForm({ busy, onSubmit, onCancel }: {
             className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
         </div>
       </div>
-      <button className="btn-secondary w-full" onClick={add} disabled={busy || !template.trim()}>
+      <button className="btn-secondary w-full" onClick={add} disabled={busy || !isValidTemplateId(template)}>
         <Icon name="Plus" size={14} /> Add to list
       </button>
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -21,7 +21,7 @@ import {
   restoreDestroyed,
   returningPlayerAward, setFactionTier, setPlayerTags, setSkillPoints,
   setStarterClass, teleportToPlayer, updatePlayerTags, wipeCodex, wipeJourney,
-  chatWhisper,
+  chatWhisper, isValidTemplateId,
   type Player, type PlayerEvent, type PlayerStats, type SpecTrackFull,
 } from '../../../api/gameplay'
 import { fmtNum, fmtSolari } from '../shared'
@@ -662,7 +662,7 @@ export function ActionsSection({ player, canWrite, flash, onChanged }: SectionPr
                           className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
                       </div>
                     </div>
-                    <button className="btn-primary w-full" disabled={busy || !giveTpl.trim()}
+                    <button className="btn-primary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
                       onClick={() => runAction(def, () => def.custom === 'give-item-live'
                         ? giveItemLive({ actor_id: player.id }, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0)
                         : giveItem(player.id, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0))}>
@@ -786,7 +786,7 @@ function ItemsActionBlock({ player, canWrite, flash, onChanged }: {
                     className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
                 </div>
               </div>
-              <button className="btn-primary w-full" disabled={busy || !giveTpl.trim()}
+              <button className="btn-primary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
                 onClick={() => runAction(def, () => def.custom === 'give-item-live'
                   ? giveItemLive({ actor_id: player.id }, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0)
                   : giveItem(player.id, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0))}>

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -375,3 +375,23 @@ describe('error path', () => {
     })
   })
 })
+
+describe('isValidTemplateId — numeric give-item guard', () => {
+  it('accepts real class-string template ids', () => {
+    for (const t of ['CopperBar', 'Buggy_Booster_Mk6', 'BuildingBlueprint_CopyDevice', 'Combat_Light_SpiceMask']) {
+      expect(gp.isValidTemplateId(t)).toBe(true)
+    }
+  })
+
+  it('rejects a purely-numeric id (the "859" leak)', () => {
+    expect(gp.isValidTemplateId('859')).toBe(false)
+    expect(gp.isValidTemplateId('  859  ')).toBe(false)
+    expect(gp.isValidTemplateId('0')).toBe(false)
+  })
+
+  it('rejects empty / whitespace-only ids', () => {
+    expect(gp.isValidTemplateId('')).toBe(false)
+    expect(gp.isValidTemplateId('   ')).toBe(false)
+  })
+})
+


### PR DESCRIPTION
## Problem
Items given via Gameplay Admin showed in DST's listing but never appeared in-game and were dropped on the next zone/login load. Live-DB inspection (read-only, SSH) found the root cause: `dune.items.template_id` is a TEXT **class string** for 16,840 of 16,841 rows. Exactly one row was numeric — `template_id='859'` (the DST-inserted storage item). The game can't resolve class `859` → the row exists but the item is invisible.

This is distinct from the earlier #178 fix (which corrected the `stats` JSON shape). A numeric id was reaching the insert; the stats selector couldn't help because stack-max lookup fails for a numeric id.

## Where the numeric leaked in
`ItemPicker.tsx` emits whatever free text is typed as the `template` on every keystroke; the storage `AddItemsForm.add()` and player Give buttons submitted it with no validation. The bundled catalogs have zero numeric keys, so a *picked* item is always a class string — only typed/pasted junk (e.g. `859`) is numeric. The player online-give RMQ path is partly shielded (the game validates), but the SQL fallback shared the hole.

## Fix (defense in depth — reject numeric, not full catalog membership, to avoid false-rejecting valid class strings outside the bundled catalog like `Corpse`)
- **Backend (authoritative):** new `Test-DuneValidGiveTemplate` (rejects empty + `^\d+$`), called in `Invoke-DunePlayerGiveItem`, `Invoke-DuneStorageGiveItem`, `Invoke-DunePlayerGiveItemLive` — covers player + storage, single + bulk + live. Early 400s in the give-item and storage routes.
- **Frontend:** `isValidTemplateId()` gates the player Give + storage Add-to-list buttons and shows an inline hint in `ItemPicker` on numeric input. Paste-exact-class-string preserved.

## Tests
Pester 172/172 (8 new guard cases proving `859`/empty are rejected without a DB call). vitest 40/40 (3 new `isValidTemplateId`). tsc clean. Lint: only pre-existing errors in untouched lines, zero new.

## ⚠️ Owed to live-VM re-test (could not self-prove)
1. Stackable → player inventory → zone restart → renders in-game.
2. Equipment → player inventory → zone restart → renders.
3. Stackable → storage container → zone restart → renders.
4. Equipment → storage container → zone restart → renders.

All four must appear **in-game** (not just in DST's list).

**Cleanup:** delete the stray live row `id 65705043` (`template_id '859'`) — investigation was read-only, no live-DB writes were made.

Branch `coastal-ms/fix-give-item-id-rendering` @ `da294a2` (off main).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>