### PR TITLE
v12.0.14: gameplay-admin fixes + dangerous-action confirm hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,8 +20,10 @@ body:
         > Desktop (Explorer pops with the ZIP selected). **Drag the ZIP
         > into the comment area below** to attach all logs at once — VM IPs,
         > SSH paths, Windows usernames, and config secrets are redacted before
-        > the ZIP is written. The bundle's `manifest.txt` lists what's inside
-        > and any sanitization warnings.
+        > the ZIP is written. The bundle includes a redacted **UserGame.ini /
+        > UserEngine.ini snapshot** (with an automatic duplicate-section-header
+        > check) when the VM is reachable, and its `manifest.txt` lists what's
+        > inside and any sanitization warnings.
 
         **✅ Do open an issue here** when the tool shows you a problem, e.g.:
         - The **Server Health** page shows the battlegroup as **Unknown** with
@@ -132,6 +134,57 @@ body:
       label: What you expected to happen
     validations:
       required: true
+
+  - type: textarea
+    id: gameconfig_diag
+    attributes:
+      label: Game Config — setting that didn't apply (only for Game Config / INI bugs)
+      description: |
+        For "I changed a setting but it had no effect in-game", or values that
+        seem ignored / duplicated (e.g. base expansion, player inventory
+        capacity, XP / Fame). The diagnostic ZIP now bundles a redacted
+        **UserGame.ini / UserEngine.ini snapshot** headlined with a
+        duplicate-section-header check — attaching it (see below) is the single
+        most useful thing for these bugs. Also tell us:
+
+        - Which exact setting(s) you changed, and to what value.
+        - What DST shows for that value after a reload vs what you see in-game.
+        - Whether you **restarted the server zone** after saving (server INI
+          changes only take effect after a zone restart).
+
+        Leave blank if your bug isn't about Game Config.
+      placeholder: |
+        Changed: Base > Max Building Extensions 5 -> 8; Player Inventory Volume 185 -> 195
+        DST shows 195 after reload; in-game still behaves like 185.
+        Zone restarted after save? yes
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: giveitem_diag
+    attributes:
+      label: Give Item — item that didn't appear (only for Give Item / Storage bugs)
+      description: |
+        For items that show in DST's listing but don't appear in-game (player
+        inventory or a storage container). Tell us:
+
+        - The exact item — its **name AND the template id** shown in the picker
+          (e.g. `Copper Ingot — CopperBar`). If you only see a number, paste it.
+        - Destination: player inventory, or a storage container (and its type).
+        - Quantity / quality, and whether it's a stackable resource or equipment.
+        - Did it show in DST's listing? Did it show in-game **after a server zone
+          restart** / relog?
+
+        Leave blank if your bug isn't about giving items.
+      placeholder: |
+        Item: Copper Ingot — template "CopperBar" (or raw id 859)
+        Destination: Storage container "Un-used Vehicle Parts" (MediumStorageContainer)
+        Qty 10, quality 0, stackable
+        Showed in DST list: yes. Showed in-game after zone restart: no.
+      render: shell
+    validations:
+      required: false
 
   - type: textarea
     id: connection_diag

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.13"
+      placeholder: "v12.0.14"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ here cover everything those tags shipped.
   the tool no longer writes dead keys. (Real gameplay scaling such as
   `Dune.GlobalMiningOutputMultiplier` is unaffected.)
 
+- **Diagnostic bundle now captures the live game config.** The "Save Logs" ZIP
+  (and the `report-issue` CLI) now includes a redacted `UserGame.ini` /
+  `UserEngine.ini` snapshot pulled from the VM when reachable, headlined with an
+  automatic duplicate-section-header check, so "my setting didn't apply" Game
+  Config bugs can be diagnosed from a single attachment. The bug-report template
+  gained targeted Game Config and Give Item sections to collect the right detail.
+
 ## [12.0.13] - 2026-06-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,44 @@ here cover everything those tags shipped.
 
 ### Fixed
 
-- **Gameplay Admin item picker now lets you select catalog items.** The
-  `/api/catalog/items` response serializes its items as an array of
+- **Gameplay Admin "Give Intel" now lands in-game.** Intel
+  (`TechKnowledgePlayerComponent.m_TechKnowledgePoints`) lives on the player's
+  **pawn** actor — the same actor that holds the backpack — but the offline grant
+  wrote it to the **controller**, creating a junk component the game never reads,
+  so the points showed in DST but never appeared in-game. The award now targets
+  the pawn (matching the reference tool and our working give-item path), resolves
+  the pawn from the controller id when needed, and clamps the total to the
+  spendable cap (2779). (#182)
+- **Gameplay Admin "Award Character XP" is now flagged live-only.** The offline XP
+  cascade read and wrote `FLevelComponent` (XP / skill points), the keystone
+  skill-point bonus, and the intel cascade against the **controller** actor; those
+  reads/writes are now correctly keyed on the **pawn** (matching the reference
+  `cmdAwardCharXP`). However, the game recomputes/caches the level component for
+  logged-in characters, so an offline grant still doesn't reliably land in-game —
+  only the live (logged-in) RMQ AwardXP path does. The action is therefore marked
+  **LIVE REQ'D** in the UI and only enabled while the player is online.
+- **Map "Fix partitions" / on-demand map spin-up no longer fails on VMs without
+  sftp-server.** Staging the partition-clear script used `scp`, and modern OpenSSH
+  `scp` (9.0+) speaks the SFTP protocol — which requires the `sftp-server`
+  subsystem on the remote. On some VM images that binary isn't where sshd expects
+  it (e.g. `/usr/lib/ssh/sftp-server` missing), so the transfer died with
+  `bash: line 1: /usr/lib/ssh/sftp-server: No such file or directory` and the
+  DeepDesert / SH_Arrakeen / SH_HarkoVillage partition pin was never cleared. The
+  script is now streamed over a plain `ssh` exec channel (base64 on stdin), which
+  needs only a shell and `base64` — no SFTP subsystem. Applies to both the desktop
+  "Fix partitions" button and the automatic clear on Start/Restart.
+- **Player "History" tab no longer errors out.** Opening a player's History threw
+  `Exception calling "Format" with "3" argument(s): "Input string was not in a
+  correct format."` for every player — the events query template used a literal
+  `'{}'` JSON default that `[string]::Format` misread as a malformed placeholder.
+  The brace is now escaped, so history loads.
+- **Gameplay Admin player actions are now a list, not a wall of buttons.** Each
+  action is a single full-width row grouped by category; clicking a row expands
+  its form inline directly beneath it (accordion), replacing the previous
+  button-grid layout.
+
+- **Gameplay Admin "Give Item" picker no longer mangles catalog template ids.**
+  The catalog endpoint returns an array of
   `{ templateId, name, category }`, but the web UI parsed it as a dictionary —
   so every catalog entry was assigned its array index (a bare number) as the
   template id while keeping its real display name. Picking an item (e.g. "Copper
@@ -39,6 +75,12 @@ here cover everything those tags shipped.
   applying an equipment-only shape to every item, so stackable resources added to a
   container also failed to render. Covers the single and bulk give/add paths.
   (#144, #176)
+
+- **Storage "Add Items" now warns about the required restart.** Items added to a
+  storage container only become visible in-game after a battlegroup (server zone)
+  restart, because the game caches container contents while the zone is loaded.
+  The container detail panel now shows this notice directly under the **Add Items**
+  button so admins know to restart the battlegroup after staging items.
 
 - **Gameplay Admin "Give Item" no longer leaks a numeric template id.** A numeric
   id typed or pasted into the item field (instead of a class string picked from the
@@ -103,6 +145,25 @@ here cover everything those tags shipped.
   automatic duplicate-section-header check, so "my setting didn't apply" Game
   Config bugs can be diagnosed from a single attachment. The bug-report template
   gained targeted Game Config and Give Item sections to collect the right detail.
+
+- **"Give Intel" is now flagged offline-only in the UI.** The game caches a
+  player's `TechKnowledgePlayerComponent` in memory while they're logged in, so a
+  live DB edit would be clobbered on logout — intel can only be granted to an
+  **offline** character (the backend already rejects online grants). The action
+  now shows an **OFFLINE REQ'D** badge and is disabled while the player is online,
+  matching the existing **LIVE REQ'D** treatment on Award Character XP.
+
+- **"Reset Journey" and "Wipe Journey" now confirm before running.** Both actions
+  are destructive to a player's questline/journey progress, so they now prompt for
+  confirmation instead of running on a single click.
+
+- **Map SpinUp page now explains the RAM trade-off and on-demand scaling.** Because
+  each map's RAM allocation is customizable, an under-provisioned Hyper-V VM can't
+  warm every map at once (OverMap, Hagga, and DeepDesert alone can run 31–35 GB at
+  default), so extra maps stay pending. A prominent banner now explains this, notes
+  that maps won't spin down while a player is present, and clarifies that maps also
+  scale on demand when a player enters (at the cost of a longer first load) — with
+  this page provided to optionally warm a map ahead of arrival.
 
 ## [12.0.13] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ here cover everything those tags shipped.
 
 ### Fixed
 
+- **Gameplay Admin item picker now lets you select catalog items.** The
+  `/api/catalog/items` response serializes its items as an array of
+  `{ templateId, name, category }`, but the web UI parsed it as a dictionary —
+  so every catalog entry was assigned its array index (a bare number) as the
+  template id while keeping its real display name. Picking an item (e.g. "Copper
+  Ore") therefore committed a numeric id, which the give-item guard correctly
+  rejects, leaving the selection stuck with a "pick an item from the list"
+  warning and a disabled Give button. The parser now reads the entry's
+  `templateId` field (with a dictionary fallback for older builds), so picked
+  items resolve to their real class string and can be given again.
+
 - **Gameplay Admin "Give Item" now renders in-game.** Items given to a player's
   backpack were inserted with an empty `stats` JSON (`{}`), which the game cannot
   deserialize — so the row existed in the database (and showed in DST's listing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,27 @@ here cover everything those tags shipped.
   container also failed to render. Covers the single and bulk give/add paths.
   (#144, #176)
 
+- **Gameplay Admin "Give Item" no longer leaks a numeric template id.** A numeric
+  id typed or pasted into the item field (instead of a class string picked from the
+  catalog) was written straight to `dune.items.template_id`, which the game cannot
+  resolve — the row existed (and showed in DST's listing) but the item was invisible
+  in-game and dropped on the next zone/login load. The backend now rejects a
+  non-class-string template id (empty or all-digits) across the player, storage,
+  single, bulk, and live give paths, and the picker disables the give/add action
+  with an inline hint when the value isn't a valid class string. (#176)
+
+- **Gameplay Admin "Give Intel" no longer silently no-ops for online players.** The
+  portal sent only `actor_id`, so the backend skipped its online check and wrote
+  directly to `dune.actors` — which the game server overwrites from memory on
+  logout, so the intel never stuck. Giving intel to an online player is now rejected
+  with a clear "log out first" message, and the offline write was hardened to create
+  the `TechKnowledgePlayerComponent` parent when missing. (#176)
+
+- **Gameplay Admin "Award Character XP" now works for online players.** Awarding XP
+  to a logged-in character previously errored; it now routes online awards through
+  the game server's live `AwardXP` path (no relog needed) and keeps the offline
+  database write for logged-out characters. (#176)
+
 - **Gameplay Admin "Give Intel" no longer errors.** The action failed with
   `actor_id or pawn_id is required.` because the web portal sent `controller_id`/
   `amount` while the backend expected `actor_id`/`delta`. The portal now sends the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,49 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.14] - 2026-06-13
+
+### Fixed
+
+- **Gameplay Admin "Give Item" now renders in-game.** Items given to a player's
+  backpack were inserted with an empty `stats` JSON (`{}`), which the game cannot
+  deserialize — so the row existed in the database (and showed in DST's listing)
+  but the item never appeared in-game and was dropped on the next zone/login load.
+  The give-item insert now writes the correct stats block, branching by item type:
+  stackable resources get `FItemStackAndDurabilityStats` with `DecayedMaxDurability`,
+  while equipment/non-stackable items get the full customization + durability shape.
+  The same fix is applied to the storage-container "Add Items" path, which had been
+  applying an equipment-only shape to every item, so stackable resources added to a
+  container also failed to render. Covers the single and bulk give/add paths.
+  (#144, #176)
+
+- **Gameplay Admin "Give Intel" no longer errors.** The action failed with
+  `actor_id or pawn_id is required.` because the web portal sent `controller_id`/
+  `amount` while the backend expected `actor_id`/`delta`. The portal now sends the
+  correct fields, targeting the right actor. (#176)
+
+- **Gameplay Admin "Give XP" no longer errors.** XP Delta failed with
+  `Could not resolve player_controller from pawn N.` because the resolver queried a
+  nonexistent column (`actor_id`) on `dune.player_state`; it now reads
+  `player_controller_id`. (#176)
+
+- **Game Config no longer writes duplicate INI section headers.** When a
+  `UserGame.ini` already contained a section that DST also manages, the writer could
+  emit that `[/Script/DuneSandbox.*]` header twice. Unreal honors the first header,
+  so DST's overrides (base-expansion limits, player inventory size/volume, etc.)
+  were silently ignored. The writer now guarantees each section name appears exactly
+  once, so managed overrides take effect.
+
+### Changed
+
+- **Removed XP / Fame / Progression (and related) multiplier settings from Game
+  Config.** These 10 `m_Global*Multiplier` keys (XP, Fame, Progression speed,
+  Health, damage, harvest, building damage, inventory weight) are not real engine
+  settings — they do not exist in the game's `DefaultGame.ini`, so writing them had
+  no effect under any section. They have been removed from the configuration UI so
+  the tool no longer writes dead keys. (Real gameplay scaling such as
+  `Dune.GlobalMiningOutputMultiplier` is unaffected.)
+
 ## [12.0.13] - 2026-06-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ here cover everything those tags shipped.
   were silently ignored. The writer now guarantees each section name appears exactly
   once, so managed overrides take effect.
 
+- **The "apply on each client" reminder is now a centered popup.** After saving a
+  setting that's read by both the server and the game client (e.g. landclaim
+  segments, building restrictions), the notice with the **Apply to my client**
+  button rendered inline at the top of the page — so when you'd scrolled down the
+  settings list to save, it appeared off-screen and was easy to miss, leaving the
+  local client `Game.ini` unchanged. It now opens as a modal that's visible
+  regardless of scroll position.
+
 ### Changed
 
 - **Removed XP / Fame / Progression (and related) multiplier settings from Game

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ here cover everything those tags shipped.
   button rendered inline at the top of the page — so when you'd scrolled down the
   settings list to save, it appeared off-screen and was easy to miss, leaving the
   local client `Game.ini` unchanged. It now opens as a modal that's visible
-  regardless of scroll position.
+  regardless of scroll position, and includes a copy-paste-ready INI snippet the
+  admin can hand to other players who don't run DST.
 
 ### Changed
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.13'
+$script:DuneToolVersion = '12.0.14'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.13',
+    [string]$Version = '12.0.14',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.13</Version>
+    <Version>12.0.14</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.13"
+#define MyAppVersion "12.0.14"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Gameplay.ps1
+++ b/app/server/lib/Gameplay.ps1
@@ -123,6 +123,25 @@ function Get-DuneGiveItemStatsJson {
     return '{"FCustomizationStats":[[],{}],"FItemStackAndDurabilityStats":[[],{}]}'
 }
 
+# Validate a give-item template id before it reaches an INSERT. The game's
+# dune.items.template_id is a class string (e.g. CopperBar, Buggy_Booster_Mk6);
+# a purely-numeric id ("859") can never resolve, so the row is inserted but the
+# item is invisible in-game and dropped on zone/login load. Reject empty and
+# numeric ids with a clear message. Non-numeric unknowns are allowed through
+# (class strings legitimately exist that aren't in the bundled catalog), since
+# numeric is the proven, unambiguous failure mode.
+function Test-DuneValidGiveTemplate {
+    param([string]$TemplateId)
+    $t = if ($null -ne $TemplateId) { $TemplateId.Trim() } else { '' }
+    if (-not $t) {
+        return @{ ok = $false; error = 'Item id is required.' }
+    }
+    if ($t -match '^\d+$') {
+        return @{ ok = $false; error = "Invalid item id '$t' — expected a class name (e.g. CopperBar), not a number. Pick the item from the search list." }
+    }
+    return @{ ok = $true }
+}
+
 # Classify an inventory item as a normal 'item', an 'emote', or a 'contract'
 # (quest) item so the Players view can separate clutter from real gear/loot.
 # Emotes and contract turn-in items are not in the catalog metadata (no

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -245,6 +245,8 @@ WHERE i.id = $ItemId::bigint AND t.val > 0;
 # vanish on the player's next login.
 function Invoke-DunePlayerGiveItem {
     param([string]$Ip, [long]$PawnId, [string]$Template, [long]$Qty, [long]$Quality)
+    $tv = Test-DuneValidGiveTemplate -TemplateId $Template
+    if (-not $tv.ok) { return @{ ok = $false; error = $tv.error } }
     $safeTmpl = ConvertTo-DuneSqlString $Template
     $statsJson = ConvertTo-DuneSqlString (Get-DuneGiveItemStatsJson -TemplateId $Template)
     $sql = @"

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -669,7 +669,7 @@ SELECT
     el.id,
     COALESCE(to_char(el.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '') AS ts,
     COALESCE(el.event_type::text, '')   AS event_type,
-    COALESCE(el.meta::text, '{}')        AS meta_json
+    COALESCE(el.meta::text, '{{}}')        AS meta_json
 FROM dune.event_log el
 JOIN dune.accounts ac ON ac."user" = el.meta->>'fls_id'
 WHERE ac.id = {0}::bigint

--- a/app/server/lib/GameplayWorld.ps1
+++ b/app/server/lib/GameplayWorld.ps1
@@ -591,6 +591,8 @@ function Join-DuneBlueprintInserts {
 # ----------------------------------------------------------------------------
 function Invoke-DuneStorageGiveItem {
     param([string]$Ip, [long]$ContainerId, [string]$Template, [long]$Qty, [long]$Quality)
+    $tv = Test-DuneValidGiveTemplate -TemplateId $Template
+    if (-not $tv.ok) { return @{ ok = $false; error = $tv.error } }
     if ($Qty -le 0) { $Qty = 1 }
     $safeTmpl = ConvertTo-DuneSqlString $Template
     $statsJson = ConvertTo-DuneSqlString (Get-DuneGiveItemStatsJson -TemplateId $Template)

--- a/app/server/lib/Maps.ps1
+++ b/app/server/lib/Maps.ps1
@@ -349,11 +349,13 @@ function Invoke-DuneFixOnDemandPartitions {
     # of its log. The script is idempotent and skips any map that already
     # has a running pod, so it's safe to invoke repeatedly.
     #
-    # v11.0.3: stages the bundled script to /tmp on the VM via scp, runs it
+    # v11.0.3: stages the bundled script to /tmp on the VM, runs it
     # once with sudo, removes the staged copy. No persistent install on the
     # VM. (Previously called /etc/local.d/dune-clear-partitions.start
     # installed by Sync-DunePartitionAutomation — that path may not exist
     # on fresh installs, but is still honored when present.)
+    # v12.0.14: staging switched from scp to an ssh exec + base64 stream so
+    # it no longer depends on the remote sftp-server subsystem.
     $ctx = Get-DuneMapsContext
     if (-not $ctx.ok) { return @{ ok=$false; status=$ctx.status; message=$ctx.message } }
 
@@ -375,26 +377,29 @@ function Invoke-DuneFixOnDemandPartitions {
     }
 
     $stamp     = [Guid]::NewGuid().ToString('N').Substring(0, 12)
-    $localTmp  = Join-Path $env:TEMP "dune-cp-$stamp.sh"
     $remoteTmp = "/tmp/dune-cp-$stamp.sh"
 
     # Force LF — Alpine /bin/sh chokes on CRLF.
     $raw = [System.IO.File]::ReadAllText($local)
     $lf  = $raw -replace "`r`n", "`n" -replace "`r", "`n"
-    [System.IO.File]::WriteAllBytes($localTmp, [Text.Encoding]::UTF8.GetBytes($lf))
 
-    $output = ''
-    try {
-        & scp -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
-              -i "$key" $localTmp "dune@${ip}:${remoteTmp}" 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            return @{ ok=$false; status=500; message="scp of partition-clear script failed (exit $LASTEXITCODE)." }
-        }
-        $runRaw = Invoke-V6Ssh -Ip $ip -Cmd "sudo -n sh $remoteTmp; rc=`$?; rm -f $remoteTmp; exit `$rc" -TimeoutSec 120
-        $output = (($runRaw -join "`n")).Trim()
-    } finally {
-        Remove-Item -LiteralPath $localTmp -Force -ErrorAction SilentlyContinue
+    # Stage the script over an ssh exec channel (base64 piped on stdin) rather
+    # than scp. Modern OpenSSH scp (9.0+) speaks the SFTP protocol, which needs
+    # sftp-server on the remote; some VM images don't ship it where sshd_config
+    # expects (e.g. /usr/lib/ssh/sftp-server missing), so scp fails with
+    # "bash: line 1: /usr/lib/ssh/sftp-server: No such file or directory" and
+    # on-demand maps never get their partition pin cleared. ssh exec + base64
+    # needs only a shell and busybox base64, which every supported image has.
+    $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($lf))
+
+    $stageRaw = Invoke-V6Ssh -Ip $ip -Cmd "base64 -d > $remoteTmp && echo DUNE_STAGED_OK" -StdinData $b64 -TimeoutSec 60
+    $staged   = (($stageRaw -join "`n"))
+    if ($staged -notmatch 'DUNE_STAGED_OK') {
+        return @{ ok=$false; status=500; message="Staging partition-clear script over ssh failed: $($staged.Trim())" }
     }
+
+    $runRaw = Invoke-V6Ssh -Ip $ip -Cmd "sudo -n sh $remoteTmp; rc=`$?; rm -f $remoteTmp; exit `$rc" -TimeoutSec 120
+    $output = (($runRaw -join "`n")).Trim()
 
     $tailRaw = Invoke-V6Ssh -Ip $ip -Cmd 'tail -n 10 /var/log/dune-clear-partitions.log' -TimeoutSec 30
     $logTail = (($tailRaw -join "`n")).Trim()

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -35,6 +35,24 @@ function Test-DunePlayerOffline {
     return @{ ok = $true; reason = $null }
 }
 
+# Same offline check as Test-DunePlayerOffline but resolved from the controller
+# (actor) id instead of the pawn id. Lets writes that only know the controller
+# (e.g. award-intel, which the UI calls with controller_id) still reject an
+# online player. A missing player_state row is treated as offline.
+function Test-DunePlayerOfflineByController {
+    param([string]$Ip, [long]$ControllerId)
+    $sql = "SELECT online_status::text AS status FROM dune.player_state WHERE player_controller_id = $ControllerId::bigint LIMIT 1;"
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $r.ok) { return @{ ok = $true; reason = $null } }
+    $maps = ConvertTo-DuneRowMaps -Result $r
+    if ($maps.Count -eq 0) { return @{ ok = $true; reason = $null } }
+    $status = [string]$maps[0]['status']
+    if ($status -ne 'Offline') {
+        return @{ ok = $false; reason = "player is currently $status - log out first, then apply the edit" }
+    }
+    return @{ ok = $true; reason = $null }
+}
+
 # ----- Faction reputation tables (verbatim from db.go) ---------------------
 
 $script:DuneFactionTierThresholds = @(
@@ -363,11 +381,16 @@ WHERE entity_id = {0}::bigint;
 '@
 
 # {0}=actor_id {1}=intel
+# COALESCE + jsonb_build_object so a missing TechKnowledgePlayerComponent parent
+# is created (plain jsonb_set leaves the JSON unchanged when the parent path is
+# absent, which silently no-ops the write). Existing sibling keys are preserved.
 $script:DuneSetIntelSqlTpl = @'
 UPDATE dune.actors
-SET properties = jsonb_set(properties,
-    '{{TechKnowledgePlayerComponent,m_TechKnowledgePoints}}',
-    to_jsonb({1}::int))
+SET properties = jsonb_set(
+    COALESCE(properties, '{{}}'::jsonb),
+    '{{TechKnowledgePlayerComponent}}',
+    COALESCE(properties->'TechKnowledgePlayerComponent', '{{}}'::jsonb)
+        || jsonb_build_object('m_TechKnowledgePoints', to_jsonb({1}::int)))
 WHERE id = {0}::bigint;
 '@
 
@@ -429,8 +452,16 @@ function Invoke-DunePlayerAwardIntel {
         $controller = Get-DunePlayerControllerFromPawn -Ip $Ip -PawnId $PawnId
     }
     if ($null -eq $controller -or $controller -le 0) { return @{ ok = $false; error = 'actor_id (or pawn_id) is required.' } }
+    # Reject online players: the game server holds the actor's intel in memory
+    # while online and flushes on logout, so a direct DB write here would be
+    # silently clobbered (no live RMQ command exists to set tech knowledge).
+    # Gate by pawn id when we have it, otherwise resolve online state from the
+    # controller id (the UI calls this with controller_id only).
     if ($PawnId -gt 0) {
         $off = Test-DunePlayerOffline -Ip $Ip -PawnId $PawnId
+        if (-not $off.ok) { return @{ ok = $false; error = $off.reason } }
+    } else {
+        $off = Test-DunePlayerOfflineByController -Ip $Ip -ControllerId $controller
         if (-not $off.ok) { return @{ ok = $false; error = $off.reason } }
     }
     $readSql = "SELECT COALESCE((properties->'TechKnowledgePlayerComponent'->>'m_TechKnowledgePoints')::int, 0) AS intel FROM dune.actors WHERE id = $controller::bigint;"

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -231,6 +231,9 @@ function Invoke-DunePlayerGiveScrip {
 # ----- Character XP table (verbatim from db.go) ----------------------------
 
 $script:DuneMaxCharXp = 344440L
+# Most intel a character can hold (cumulative through max level). Mirrors the
+# reference tool's maxIntelPoints headroom clamp (#208).
+$script:DuneMaxIntelPoints = 2779
 $script:DuneCumulativeXpByLevel = @(
     0, 40, 215, 440, 740, 1240, 1790, 2390, 2990, 3590, 4190,
     4790, 5390, 5990, 6590, 7190, 7790, 8390, 8990, 9590, 10190,
@@ -334,6 +337,16 @@ function Get-DunePlayerControllerFromPawn {
     return [int64](ConvertTo-DuneInt $maps[0]['cid'])
 }
 
+function Get-DunePlayerPawnFromController {
+    param([string]$Ip, [long]$ControllerId)
+    $sql = "SELECT player_pawn_id::text AS pid FROM dune.player_state WHERE player_controller_id = $ControllerId::bigint LIMIT 1;"
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $r.ok) { return $null }
+    $maps = ConvertTo-DuneRowMaps -Result $r
+    if ($maps.Count -eq 0) { return $null }
+    return [int64](ConvertTo-DuneInt $maps[0]['pid'])
+}
+
 function Get-DunePlayerKeystoneIds {
     param([string]$Ip, [long]$ActorId)
     $sql = "SELECT COALESCE(properties->'KeystonePlayerComponent'->'m_PurchasedKeystoneIDs', '[]'::jsonb) AS ids FROM dune.actors WHERE id = $ActorId::bigint;"
@@ -404,10 +417,13 @@ function Invoke-DunePlayerAwardCharXp {
     $off = Test-DunePlayerOffline -Ip $Ip -PawnId $PawnId
     if (-not $off.ok) { return @{ ok = $false; error = $off.reason } }
 
-    $controller = Get-DunePlayerControllerFromPawn -Ip $Ip -PawnId $PawnId
-    if ($null -eq $controller -or $controller -le 0) { return @{ ok = $false; error = "Could not resolve player_controller from pawn $PawnId." } }
-
-    $cur = Get-DunePlayerLevelComponentRow -Ip $Ip -ActorId $controller
+    # All character progression data - FLevelComponent (XP/SP), KeystonePlayerComponent,
+    # and TechKnowledgePlayerComponent (intel) - lives on the player's PAWN actor (the
+    # DuneCharacter), NOT the controller. The reference tool keys cmdAwardCharXP entirely
+    # on the pawn (readCharXPState / fetchKeystoneBonusForPawn / intel update). Writing to
+    # the controller reads an empty FLevelComponent and lands the grant on a junk actor the
+    # game never reads, so offline char-xp silently no-ops.
+    $cur = Get-DunePlayerLevelComponentRow -Ip $Ip -ActorId $PawnId
     if (-not $cur.ok) { return @{ ok = $false; error = $cur.error } }
 
     $newXp = $cur.xp + $XpDelta
@@ -415,7 +431,7 @@ function Invoke-DunePlayerAwardCharXp {
     if ($newXp -gt $script:DuneMaxCharXp) { $newXp = $script:DuneMaxCharXp }
 
     $newLevel = Convert-DuneXpToLevel $newXp
-    $keystoneIds = Get-DunePlayerKeystoneIds -Ip $Ip -ActorId $controller
+    $keystoneIds = Get-DunePlayerKeystoneIds -Ip $Ip -ActorId $PawnId
     $keystoneBonus = Get-DuneKeystoneSpBonus -Ids $keystoneIds
     $totalSp = $newLevel + $keystoneBonus
     $unspent = $totalSp - $cur.sp_spent
@@ -426,7 +442,7 @@ function Invoke-DunePlayerAwardCharXp {
     $r1 = Invoke-DuneSqlQuery -Ip $Ip -Sql $sqlFgl -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $r1.ok) { return @{ ok = $false; error = "update FLevelComponent: $($r1.error)" } }
 
-    $sqlIntel = [string]::Format($script:DuneSetIntelSqlTpl, $controller, $newIntel)
+    $sqlIntel = [string]::Format($script:DuneSetIntelSqlTpl, $PawnId, $newIntel)
     $r2 = Invoke-DuneSqlQuery -Ip $Ip -Sql $sqlIntel -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $r2.ok) { return @{ ok = $false; error = "update Intel: $($r2.error)" } }
 
@@ -447,24 +463,24 @@ function Invoke-DunePlayerAwardIntel {
         [long]$ActorId,
         [int]$IntelDelta
     )
-    $controller = $ActorId
-    if ($controller -le 0 -and $PawnId -gt 0) {
-        $controller = Get-DunePlayerControllerFromPawn -Ip $Ip -PawnId $PawnId
+    # Intel (TechKnowledgePlayerComponent.m_TechKnowledgePoints) lives on the
+    # player's PAWN actor - the same actor that holds the backpack inventory - NOT
+    # the controller. Writing it to the controller creates a junk component the
+    # game never reads, so the grant silently no-ops (shows nothing in-game). This
+    # matches the reference tool, which keys awardIntel on player_pawn_id, and our
+    # own working give-item path, which writes to the pawn. Prefer the pawn id the
+    # UI sends; fall back to resolving it from the controller id.
+    $pawn = $PawnId
+    if ($pawn -le 0 -and $ActorId -gt 0) {
+        $pawn = Get-DunePlayerPawnFromController -Ip $Ip -ControllerId $ActorId
     }
-    if ($null -eq $controller -or $controller -le 0) { return @{ ok = $false; error = 'actor_id (or pawn_id) is required.' } }
+    if ($null -eq $pawn -or $pawn -le 0) { return @{ ok = $false; error = 'pawn_id (or actor_id) is required.' } }
     # Reject online players: the game server holds the actor's intel in memory
     # while online and flushes on logout, so a direct DB write here would be
     # silently clobbered (no live RMQ command exists to set tech knowledge).
-    # Gate by pawn id when we have it, otherwise resolve online state from the
-    # controller id (the UI calls this with controller_id only).
-    if ($PawnId -gt 0) {
-        $off = Test-DunePlayerOffline -Ip $Ip -PawnId $PawnId
-        if (-not $off.ok) { return @{ ok = $false; error = $off.reason } }
-    } else {
-        $off = Test-DunePlayerOfflineByController -Ip $Ip -ControllerId $controller
-        if (-not $off.ok) { return @{ ok = $false; error = $off.reason } }
-    }
-    $readSql = "SELECT COALESCE((properties->'TechKnowledgePlayerComponent'->>'m_TechKnowledgePoints')::int, 0) AS intel FROM dune.actors WHERE id = $controller::bigint;"
+    $off = Test-DunePlayerOffline -Ip $Ip -PawnId $pawn
+    if (-not $off.ok) { return @{ ok = $false; error = $off.reason } }
+    $readSql = "SELECT COALESCE((properties->'TechKnowledgePlayerComponent'->>'m_TechKnowledgePoints')::int, 0) AS intel FROM dune.actors WHERE id = $pawn::bigint;"
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $readSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
     $cur = 0
     if ($r.ok) {
@@ -473,12 +489,13 @@ function Invoke-DunePlayerAwardIntel {
     }
     $newIntel = $cur + $IntelDelta
     if ($newIntel -lt 0) { $newIntel = 0 }
-    $sql = [string]::Format($script:DuneSetIntelSqlTpl, $controller, $newIntel)
+    if ($newIntel -gt $script:DuneMaxIntelPoints) { $newIntel = $script:DuneMaxIntelPoints }
+    $sql = [string]::Format($script:DuneSetIntelSqlTpl, $pawn, $newIntel)
     $w = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $w.ok) { return @{ ok = $false; error = $w.error } }
     return @{
         ok = $true
-        message = "Set Intel to $newIntel (was $cur, delta $IntelDelta) for actor $controller."
+        message = "Set Intel to $newIntel (was $cur, delta $IntelDelta) for player $pawn."
         intel = $newIntel
     }
 }

--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -130,6 +130,9 @@ function Invoke-DunePlayerGiveItemLive {
     if ($Quantity -le 0)   { $Quantity = 1 }
     if ($Durability -le 0) { $Durability = 1.0 }
 
+    $tv = Test-DuneValidGiveTemplate -TemplateId $Template
+    if (-not $tv.ok) { return @{ ok = $false; error = $tv.error } }
+
     if ($ActorId -gt 0) {
         $cap = Test-DuneInventoryCapacity -Ip $Ip -PawnId $ActorId -Template $Template -Quantity $Quantity
         if (-not $cap.ok) { return $cap }

--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -145,6 +145,43 @@ function Invoke-DunePlayerGiveItemLive {
     return $res
 }
 
+# Live character-XP award. The offline DB path (Invoke-DunePlayerAwardCharXp)
+# writes TotalXPEarned directly; that gets clobbered while the player is online,
+# so for online players we send the game-native RMQ AwardXP ServerCommand and let
+# the game server roll it into character level / SP / intel itself.
+#
+# AwardXP is category-based (Combat / Exploration / Science) and additive only.
+# Character level/SP derive from TOTAL character XP = the sum across the three
+# categories, so awarding the full delta to a single default category yields the
+# same total/level. Category is therefore cosmetic for this admin goal; we default
+# to Combat and keep it a parameter for flexibility.
+function Invoke-DunePlayerAwardCharXpLive {
+    param(
+        [string] $Ip,
+        [string] $FlsId,
+        [long]   $ActorId = 0,
+        [Parameter(Mandatory)] [long] $XpDelta,
+        [string] $Category = 'Combat'
+    )
+    if ($XpDelta -le 0) {
+        return @{ ok = $false; error = 'Live XP awards are additive only (delta must be > 0). To reduce XP, log the player out and apply the edit offline.' }
+    }
+    $valid = @('Combat', 'Exploration', 'Science')
+    $cat = $valid | Where-Object { $_ -ieq [string]$Category } | Select-Object -First 1
+    if (-not $cat) { $cat = 'Combat' }
+
+    $r = Resolve-DuneFlsIdOrError -Ip $Ip -FlsId $FlsId -ActorId $ActorId
+    if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+
+    $res = Invoke-DuneRmqAwardXp -FlsId $r.fls_id -Category $cat -Experience ([int]$XpDelta)
+    if ($res.ok) {
+        $res.message = "Awarded $XpDelta $cat XP live to online player $($r.fls_id) via server command - the game applies the resulting level / skill points."
+        $res.path    = 'rmq'
+        $res.category = $cat
+    }
+    return $res
+}
+
 function Invoke-DunePlayerCheatScriptLive {
     param(
         [string] $Ip, [string] $FlsId, [long] $ActorId = 0,

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -62,6 +62,21 @@ function Invoke-DstRedaction {
     return $out
 }
 
+# Returns the section-header names that appear more than once in an INI body,
+# formatted "Name xN". Pure (no SSH/IO) so it's unit-testable. Duplicate
+# headers are the root cause of the "DST override silently ignored" class of
+# Game Config bugs (UE5 honours the first header + last-key-wins), so surfacing
+# them at the top of each snapshot makes triage a one-liner.
+function Get-DstIniDuplicateHeaders {
+    param([string]$Raw)
+    if ([string]::IsNullOrEmpty($Raw)) { return @() }
+    $headers = [regex]::Matches($Raw, '(?m)^\s*\[(.+?)\]\s*$') | ForEach-Object { $_.Groups[1].Value }
+    return @(
+        $headers | Group-Object | Where-Object { $_.Count -gt 1 } |
+            ForEach-Object { "$($_.Name) x$($_.Count)" }
+    )
+}
+
 # --- Bundle builder ----------------------------------------------------------
 
 function Get-DstDesktopPath {
@@ -235,6 +250,46 @@ function New-DstDiagnosticBundle {
         $warnings.Add('No dune-server-*.log CLI transcripts found.')
     }
 
+    # 6b) Live game-config INI snapshot (best-effort over SSH) ----------------
+    # The duplicate-section-header / "my setting didn't apply" class of bug can
+    # only be diagnosed from the ACTUAL on-disk UserGame.ini / UserEngine.ini,
+    # so pull a redacted copy when the VM is reachable. Never fatal — an absent
+    # or unreachable VM is a warning and the rest of the bundle still builds.
+    if ((Get-Command Get-DuneGameConfigContext -ErrorAction SilentlyContinue) -and
+        (Get-Command Get-DuneGameConfig -ErrorAction SilentlyContinue)) {
+        try {
+            $ctx = Get-DuneGameConfigContext
+            if ($ctx.ok) {
+                $gc = Get-DuneGameConfig -Ip $ctx.ip
+                foreach ($pair in @(
+                    @{ key = 'game';   file = 'UserGame.ini' },
+                    @{ key = 'engine'; file = 'UserEngine.ini' }
+                )) {
+                    $node = $gc[$pair.key]
+                    $raw  = if ($node) { [string]$node.raw } else { '' }
+                    if ([string]::IsNullOrWhiteSpace($raw)) {
+                        $warnings.Add("Game config: $($pair.file) came back empty (source: $($gc.source)).")
+                        continue
+                    }
+                    $dupes   = Get-DstIniDuplicateHeaders -Raw $raw
+                    $dupLine = if ($dupes.Count -gt 0) { 'DUPLICATE SECTION HEADERS: ' + ($dupes -join '; ') } else { 'No duplicate section headers detected.' }
+                    $header  = "# $($pair.file) snapshot (sanitized; source: $($gc.source); path: $($node.path))`r`n# $dupLine`r`n`r`n"
+                    $san     = $header + (Invoke-DstRedaction -Text $raw @redactArgs)
+                    $outName = "$($pair.file).snapshot.txt"
+                    $out     = Join-Path $stageDir $outName
+                    Set-Content -LiteralPath $out -Value $san -Encoding UTF8
+                    $included.Add(@{ name = $outName; bytes = (Get-Item -LiteralPath $out).Length })
+                }
+            } else {
+                $warnings.Add("Game config INI snapshot skipped: $($ctx.message)")
+            }
+        } catch {
+            $warnings.Add("Game config INI snapshot failed: $($_.Exception.Message)")
+        }
+    } else {
+        $warnings.Add('Game config helpers not loaded — INI snapshot skipped.')
+    }
+
     # 7) Manifest ------------------------------------------------------------
     $manLines = [System.Collections.Generic.List[string]]::new()
     $manLines.Add("Dune Server Tool diagnostic bundle")
@@ -246,6 +301,9 @@ function New-DstDiagnosticBundle {
     $manLines.Add('  - WindowsUser / SshKey / SteamPath values    -> <user> / <ssh-key-path> / <steam-path>')
     $manLines.Add('  - ?t=<token> query params                  -> ?t=<redacted>')
     $manLines.Add('  - INI key=value redaction for the keys above as a safety net')
+    $manLines.Add('')
+    $manLines.Add('Game config snapshots (UserGame.ini / UserEngine.ini) are pulled live from')
+    $manLines.Add('the VM when reachable, sanitized, and headlined with a duplicate-section check.')
     $manLines.Add('')
     $manLines.Add('Files included:')
     foreach ($f in $included) {

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -132,6 +132,9 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-item' -Handler
         if (-not $tmpl) { Write-DuneError -Response $res -Status 400 -Message 'template is required.'; return }
         if ($null -eq $qty -or $qty -le 0) { Write-DuneError -Response $res -Status 400 -Message 'qty must be a positive integer.'; return }
 
+        $tv = Test-DuneValidGiveTemplate -TemplateId $tmpl
+        if (-not $tv.ok) { Write-DuneError -Response $res -Status 400 -Message $tv.error; return }
+
         Invoke-DunePlayerWriteRoute -Response $res -Action {
             param($ip)
             $off = Test-DunePlayerOffline -Ip $ip -PawnId $pawn

--- a/app/server/routes/GameplayWorld.ps1
+++ b/app/server/routes/GameplayWorld.ps1
@@ -194,6 +194,8 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/storage/give-item' -Handler
         if ($null -eq $cid -or $cid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'container_id is required.'; return }
         if (-not $tmpl) { Write-DuneError -Response $res -Status 400 -Message 'template is required.'; return }
         if ($null -eq $qty -or $qty -le 0) { $qty = 1L }
+        $tv = Test-DuneValidGiveTemplate -TemplateId $tmpl
+        if (-not $tv.ok) { Write-DuneError -Response $res -Status 400 -Message $tv.error; return }
         Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DuneStorageGiveItem -Ip $ip -ContainerId $cid -Template $tmpl -Qty $qty -Quality $qual }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Storage give item failed: $($_.Exception.Message)"

--- a/app/server/routes/PlayersAdmin.ps1
+++ b/app/server/routes/PlayersAdmin.ps1
@@ -50,15 +50,32 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/set-faction-tier' -
     }
 }
 
-# POST /api/gameplay/players/award-char-xp  { pawn_id, delta }
+# POST /api/gameplay/players/award-char-xp  { pawn_id, delta, fls_id?, category? }
+# Auto-routes (mirrors give-item): OFFLINE players get the direct DB write
+# (Invoke-DunePlayerAwardCharXp, which sets total XP + level/SP + intel); ONLINE
+# players get the game-native RMQ AwardXP ServerCommand so the write isn't
+# clobbered on logout. Response carries path = 'rmq' | 'sql'.
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/award-char-xp' -Handler {
     param($req, $res, $routeParams, $body)
     try {
         $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
         $delta = Get-DuneBodyInt -Body $body -Name 'delta'
+        $fls = [string](Get-DuneBodyValue -Body $body -Name 'fls_id')
+        $cat = [string](Get-DuneBodyValue -Body $body -Name 'category')
+        if ([string]::IsNullOrWhiteSpace($cat)) { $cat = 'Combat' }
         if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
         if ($null -eq $delta) { Write-DuneError -Response $res -Status 400 -Message 'delta must be an integer.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerAwardCharXp -Ip $ip -PawnId $pawn -XpDelta $delta }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOffline -Ip $ip -PawnId $pawn
+            if (-not $off.ok) {
+                # Player is online — apply live via RMQ AwardXP instead of the DB write.
+                return Invoke-DunePlayerAwardCharXpLive -Ip $ip -FlsId $fls -ActorId $pawn -XpDelta $delta -Category $cat
+            }
+            $r = Invoke-DunePlayerAwardCharXp -Ip $ip -PawnId $pawn -XpDelta $delta
+            if ($r.ok -and -not $r.path) { $r['path'] = 'sql' }
+            return $r
+        }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Award char XP failed: $($_.Exception.Message)"
     }

--- a/docs/CheatScripts.md
+++ b/docs/CheatScripts.md
@@ -1,0 +1,239 @@
+# Dune: Awakening — CheatScript Reference
+
+Cheat scripts are named sequences of in-game **console commands**. The server
+runs one by name when it receives a `CheatScript` `ServerCommand` over RabbitMQ
+(see `Invoke-DuneRmqCheatScript` in `app/server/lib/Rmq.ps1`, exposed by DST as
+the **Gameplay Admin → Live → Cheat Script** action). Each `+Cmd=` line is a
+single console command executed in order against the target player.
+
+These definitions are transcribed from the game's INI
+(`docs/Dune_Server_INI_Field_Sheet.md`, sections `[CheatScript.*]`). They reflect
+what the game server itself ships — DST cannot invent new scripts, it can only
+invoke ones the server already defines (or send the individual underlying
+`ServerCommand`s it wraps).
+
+> **Note on "Intel" / Tech Knowledge:** none of the documented cheat scripts or
+> console verbs grant Intel (`m_TechKnowledgePoints`). The only documented
+> progression verbs are `AwardXP`, `SkillsSetModuleLevel`,
+> `SkillsSetUnspentSkillPoints`, and `ResetProgression`. There is no
+> `AwardIntel`/`GiveTechKnowledge` console command in this reference.
+
+---
+
+## CheatScript catalog
+
+### LeaveMeAlone
+Clears nearby threats and disables environmental hazards.
+
+```ini
++Cmd=EncountersDestroyAndDisableAll
++Cmd=DestroyAllNpcs
++Cmd=SetAutoSandstormSpawnEnabled 0
++Cmd=DestroyAllSandStorms
++Cmd=ServerExec sandworm.dune.Enabled 0
+```
+
+### StartHitchVehicleTest
+Performance/hitch test harness — forces frame hitches and unsteady FPS.
+
+```ini
++Cmd=ServerExec t.maxfps 20
++Cmd=ServerExec CauseHitchesPeriod 10
++Cmd=ServerExec CauseHitchesHitchMS 1000
++Cmd=ServerExec CauseHitches 1
++Cmd=ServerExec t.UnsteadyFps 1
++Cmd=CauseHitchesPeriod 20
++Cmd=CauseHitchesHitchMS 200
++Cmd=CauseHitches 1
++Cmd=t.UnsteadyFps 1
+```
+
+### StopHitchVehicleTest
+Reverts `StartHitchVehicleTest`.
+
+```ini
++Cmd=ServerExec t.maxfps 0
++Cmd=ServerExec CauseHitches 0
++Cmd=ServerExec t.UnsteadyFps 0
++Cmd=CauseHitches 0
++Cmd=t.UnsteadyFps 0
+```
+
+### PlaytestSetup
+Full playtest loadout — resets progression, refills the player, grants a large
+weapon/armor/consumable kit, awards XP, unlocks all skills, sets skill points,
+and completes the intro quest. Items are referenced by **display name** with the
+class string in parentheses.
+
+```ini
++Cmd=ResetProgression
++Cmd=CleanPlayerInventory
++Cmd=AddItemToInventory HouseLMG(AtreLMG3) 1 1
++Cmd=AddItemToInventory HouseKarpov38BattleRifle(HarkAr5) 1 1
++Cmd=AddItemToInventory HouseJABALSpitdartRifle(SmugDmr4) 1 1
++Cmd=AddItemToInventory AlumniumGRDA44Scattergun(Scattergun_Prototype1) 1 1
++Cmd=AddItemToInventory HouseCHOAMSword(CHOAMSword_1) 1 1
++Cmd=AddItemToInventory HealthPack_Channeled_3 20
++Cmd=AddItemToInventory IndustrialHighCapacityWaterTank(HighCapacityLiterjon_04) 1 1
++Cmd=UpdateAllWaterFillables 2500
++Cmd=AddItemToInventory RespawnBeacon(RespawnBeacon) 2 1
++Cmd=AddItemToInventory AdeptArhunK-28Lasgun(ChoamLg1) 1 1
++Cmd=AddItemToInventory IndustrialCutteray(MiningTool_2h_Heavy) 1 1
++Cmd=AddItemToInventory AlumiteHeavyHelmet(Combat_Choam_Heavy01_Helmet) 1 1
++Cmd=AddItemToInventory AlumiteHeavyTop(Combat_Choam_Heavy01_Top) 1 1
++Cmd=AddItemToInventory AlumiteHeavyBottom(Combat_Choam_Heavy01_Bottom) 1 1
++Cmd=AddItemToInventory AlumiteHeavyGloves(Combat_Choam_Heavy01_Gloves) 1 1
++Cmd=AddItemToInventory AlumiteHeavyBoots(Combat_Choam_Heavy01_Boots) 1 1
++Cmd=AddItemToInventory AdvancedHoltzmanShield(HoltzmanShieldActiveDrain2) 1 1
++Cmd=AddItemToInventory FullReductionBelt(FullSuspensorBelt) 1 1
++Cmd=AddItemToInventory IndustrialPowerPack(PowerPack3) 1 1
++Cmd=AddItemToInventory Ammo 1000
++Cmd=AddItemToInventory HeavyAmmo 1000
++Cmd=AddItemToInventory ConstructionTool(BasicBuildingTool) 1 1
++Cmd=AddItemToInventory HouseRafiqSnubnosePistol(HarkHeavyPistol3) 1 1
++Cmd=AddItemToInventory HouseSavoy&MirtM11SMG(AtreSmg4) 1 1
++Cmd=AddItemToInventory HouseElephantGun(SmugShot3) 1 1
++Cmd=CheatScript AwardPlayerXP
++Cmd=CheatScript UnlockAllSkills
++Cmd=SkillsSetUnspentSkillPoints 104
++Cmd=JourneyCompleteTaskByName DA_MQ_ANewBeginning
+```
+
+### PlaytestSetupAdmin
+Same as `PlaytestSetup` but items are referenced by **class string only** (no
+display-name wrapper).
+
+```ini
++Cmd=ResetProgression
++Cmd=CleanPlayerInventory
++Cmd=AddItemToInventory AtreLMG3 1 1
++Cmd=AddItemToInventory HarkAr5 1 1
++Cmd=AddItemToInventory SmugDmr4 1 1
++Cmd=AddItemToInventory Scattergun_Prototype1 1 1
++Cmd=AddItemToInventory CHOAMSword_1 1 1
++Cmd=AddItemToInventory HealthPack_Channeled_3 20
++Cmd=AddItemToInventory HighCapacityLiterjon_04 1 1
++Cmd=UpdateAllWaterFillables 2500
++Cmd=AddItemToInventory RespawnBeacon 2 1
++Cmd=AddItemToInventory ChoamLg1 1 1
++Cmd=AddItemToInventory MiningTool_2h_Heavy 1 1
++Cmd=AddItemToInventory Combat_Choam_Heavy01_Helmet 1 1
++Cmd=AddItemToInventory Combat_Choam_Heavy01_Top 1 1
++Cmd=AddItemToInventory Combat_Choam_Heavy01_Bottom 1 1
++Cmd=AddItemToInventory Combat_Choam_Heavy01_Gloves 1 1
++Cmd=AddItemToInventory Combat_Choam_Heavy01_Boots 1 1
++Cmd=AddItemToInventory HoltzmanShieldActiveDrain2 1 1
++Cmd=AddItemToInventory FullSuspensorBelt 1 1
++Cmd=AddItemToInventory PowerPack3 1 1
++Cmd=AddItemToInventory Ammo 1000
++Cmd=AddItemToInventory HeavyAmmo 1000
++Cmd=AddItemToInventory BasicBuildingTool 1 1
++Cmd=AddItemToInventory HarkHeavyPistol3 1 1
++Cmd=AddItemToInventory AtreSmg4 1 1
++Cmd=AddItemToInventory SmugShot3 1 1
++Cmd=CheatScript AwardPlayerXP
++Cmd=CheatScript UnlockAllSkills
++Cmd=SkillsSetUnspentSkillPoints 104
++Cmd=JourneyCompleteTaskByName DA_MQ_ANewBeginning
+```
+
+### AwardPlayerXP
+Grants 10,000 XP in each of the three categories.
+
+```ini
++Cmd=AwardXP Combat 10000
++Cmd=AwardXP Exploration 10000
++Cmd=AwardXP Science 10000
+```
+
+### UnlockAllSkills
+Sets every key skill module and capstone to level 1.
+
+```ini
++Cmd=SkillsSetModuleLevel Skills.Key.Trooper1 1
++Cmd=SkillsSetModuleLevel Skills.Key.Trooper2 1
++Cmd=SkillsSetModuleLevel Skills.Key.Trooper3 1
++Cmd=SkillsSetModuleLevel Skills.Key.Swordmaster1 1
++Cmd=SkillsSetModuleLevel Skills.Key.Swordmaster2 1
++Cmd=SkillsSetModuleLevel Skills.Key.Swordmaster3 1
++Cmd=SkillsSetModuleLevel Skills.Key.Planetologist1 1
++Cmd=SkillsSetModuleLevel Skills.Key.Planetologist2 1
++Cmd=SkillsSetModuleLevel Skills.Key.Planetologist3 1
++Cmd=SkillsSetModuleLevel Skills.Key.Mentat1 1
++Cmd=SkillsSetModuleLevel Skills.Key.Mentat2 1
++Cmd=SkillsSetModuleLevel Skills.Key.Mentat3 1
++Cmd=SkillsSetModuleLevel Skills.Key.BeneGesserit1 1
++Cmd=SkillsSetModuleLevel Skills.Key.BeneGesserit2 1
++Cmd=SkillsSetModuleLevel Skills.Key.BeneGesserit3 1
++Cmd=SkillsSetModuleLevel Skills.Key.Dev1 1
++Cmd=SkillsSetModuleLevel Skills.Key.Dev2 1
++Cmd=SkillsSetModuleLevel Skills.Key.Dev3 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneWeirdingWay 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneWeaponry 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneTactician 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneSuspensorTech 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneSelfControl 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneScientist 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneResolve 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneMentalCalculus 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneManipulation 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneGadgets 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneExplorer 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneDriver 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneBlade 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneAssassination 1
++Cmd=SkillsSetModuleLevel Skills.Key.CapstoneAggression 1
+```
+
+### UnlockAllAbilities
+Sets every ability module to level 1.
+
+```ini
++Cmd=SkillsSetModuleLevel Skills.Ability.Blindspot 1
++Cmd=SkillsSetModuleLevel Skills.Ability.DeflectionSlow 1
++Cmd=SkillsSetModuleLevel Skills.Ability.ExplosiveMine 1
++Cmd=SkillsSetModuleLevel Skills.Ability.FragGrenade 1
++Cmd=SkillsSetModuleLevel Skills.Ability.HealingCapsule 1
++Cmd=SkillsSetModuleLevel Skills.Ability.HunterSeeker 1
++Cmd=SkillsSetModuleLevel Skills.Ability.Hypersprint 1
++Cmd=SkillsSetModuleLevel Skills.Ability.KneeCharge 1
++Cmd=SkillsSetModuleLevel Skills.Ability.MagneticAttractor 1
++Cmd=SkillsSetModuleLevel Skills.Ability.PoisonCapsuleLauncher 1
++Cmd=SkillsSetModuleLevel Skills.Ability.RiposteBreak 1
++Cmd=SkillsSetModuleLevel Skills.Ability.RiposteInjure 1
++Cmd=SkillsSetModuleLevel Skills.Ability.SolidoDecoy.Moving 1
++Cmd=SkillsSetModuleLevel Skills.Ability.SuspensorGrenade_Amplification 1
++Cmd=SkillsSetModuleLevel Skills.Ability.SuspensorGrenade_Reduction 1
++Cmd=SkillsSetModuleLevel Skills.Ability.SuspensorMine_Amplification 1
++Cmd=SkillsSetModuleLevel Skills.Ability.SuspensorMine_Reduction 1
++Cmd=SkillsSetModuleLevel Skills.Ability.SuspensorWall 1
++Cmd=SkillsSetModuleLevel Skills.Ability.VoiceCompel 1
++Cmd=SkillsSetModuleLevel Skills.Ability.WeirdingStep 1
+```
+
+---
+
+## Console-command verbs used
+
+Every distinct `+Cmd=` verb across the cheat scripts above:
+
+| Verb | Purpose |
+| --- | --- |
+| `AddItemToInventory <class> <qty> [quality]` | Give an item (class string) to the player. |
+| `AwardXP <Category> <amount>` | Grant category XP (Combat / Exploration / Science). |
+| `CheatScript <Name>` | Run another named cheat script. |
+| `CleanPlayerInventory` | Wipe the player's inventory. |
+| `ResetProgression` | Reset character progression. |
+| `SkillsSetModuleLevel <Skill> <level>` | Set a skill/ability module level. |
+| `SkillsSetUnspentSkillPoints <n>` | Set unspent skill points. |
+| `UpdateAllWaterFillables <amount>` | Refill all water containers. |
+| `JourneyCompleteTaskByName <Task>` | Force-complete a journey/quest task. |
+| `SetAutoSandstormSpawnEnabled <0\|1>` | Toggle automatic sandstorm spawning. |
+| `DestroyAllSandStorms` | Clear active sandstorms. |
+| `DestroyAllNpcs` | Despawn all NPCs. |
+| `EncountersDestroyAndDisableAll` | Destroy + disable all encounters. |
+| `CauseHitches[Period\|HitchMS] <n>` | Performance-test hitch injection. |
+| `t.UnsteadyFps <0\|1>` | Performance-test unsteady FPS. |
+| `ServerExec <command>` | Run an arbitrary server console command/cvar. |
+
+Source: `docs/Dune_Server_INI_Field_Sheet.md`, sections `[CheatScript.*]` (lines 1632–1807).

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -825,10 +825,10 @@ function Get-DuneRemotePartitionScriptPath {
 }
 
 function Invoke-DuneRemotePartitionScript {
-    # Stages the bundled dune-clear-partitions.start to /tmp on the VM via scp,
-    # runs it once with sudo, removes the staged copy. No persistent install,
-    # no boot script, no cron. Returns @{ ok; rc; output }. Best-effort —
-    # never throws.
+    # Stages the bundled dune-clear-partitions.start to /tmp on the VM via an
+    # ssh exec + base64 stream (no scp/sftp dependency), runs it once with sudo,
+    # removes the staged copy. No persistent install, no boot script, no cron.
+    # Returns @{ ok; rc; output }. Best-effort - never throws.
     param(
         [Parameter(Mandatory)][string]$Ip
     )
@@ -838,28 +838,30 @@ function Invoke-DuneRemotePartitionScript {
     }
 
     $stamp     = [Guid]::NewGuid().ToString('N').Substring(0, 12)
-    $localTmp  = Join-Path $env:TEMP "dune-cp-$stamp.sh"
     $remoteTmp = "/tmp/dune-cp-$stamp.sh"
 
     # Force LF line endings — Alpine /bin/sh chokes on CRLF.
     $raw = [System.IO.File]::ReadAllText($local)
     $lf  = $raw -replace "`r`n", "`n" -replace "`r", "`n"
-    [System.IO.File]::WriteAllBytes($localTmp, [Text.Encoding]::UTF8.GetBytes($lf))
 
-    try {
-        & scp -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
-              -i "$sshKey" $localTmp "${sshUser}@${Ip}:${remoteTmp}" 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            return @{ ok = $false; rc = $LASTEXITCODE; output = @("scp of partition-clear script failed (exit $LASTEXITCODE).") }
-        }
-        $output = & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
-                        -i "$sshKey" "$sshUser@$Ip" `
-                        "sudo -n sh $remoteTmp; rc=`$?; rm -f $remoteTmp; exit `$rc" 2>&1
-        $rc = $LASTEXITCODE
-        return @{ ok = ($rc -eq 0); rc = $rc; output = @($output) }
-    } finally {
-        Remove-Item -LiteralPath $localTmp -Force -ErrorAction SilentlyContinue
+    # Stage over an ssh exec channel (base64 on stdin) instead of scp. Modern
+    # OpenSSH scp (9.0+) uses the SFTP protocol, which needs sftp-server on the
+    # remote; some VM images omit it where sshd_config expects (e.g.
+    # /usr/lib/ssh/sftp-server missing), so scp fails with
+    # "bash: line 1: /usr/lib/ssh/sftp-server: No such file or directory".
+    # base64 over ssh exec needs only a shell + busybox base64.
+    $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($lf))
+
+    $stageOut = $b64 | & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
+          -i "$sshKey" "${sshUser}@${Ip}" "base64 -d > $remoteTmp && echo DUNE_STAGED_OK" 2>&1
+    if (($stageOut -join "`n") -notmatch 'DUNE_STAGED_OK') {
+        return @{ ok = $false; rc = ($LASTEXITCODE); output = @("staging partition-clear script over ssh failed.", "$stageOut") }
     }
+    $output = & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
+                    -i "$sshKey" "$sshUser@$Ip" `
+                    "sudo -n sh $remoteTmp; rc=`$?; rm -f $remoteTmp; exit `$rc" 2>&1
+    $rc = $LASTEXITCODE
+    return @{ ok = ($rc -eq 0); rc = $rc; output = @($output) }
 }
 
 function Invoke-OnDemandPartitionClear {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.13"
+$script:ToolVersion = "12.0.14"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/AwardXpLive.Tests.ps1
+++ b/tests/AwardXpLive.Tests.ps1
@@ -1,0 +1,115 @@
+# Tests the live (online-player) character-XP award branch:
+# Invoke-DunePlayerAwardCharXpLive in lib/PlayersRmq.ps1. Stubs the broadcast
+# executor (so the RMQ AwardXP publish is captured, not actually sent) and mocks
+# Invoke-DuneSqlQuery for FLS resolution — same approach as Rmq.Tests.ps1.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+
+    # Stub Broadcast helpers globally before loading Rmq.ps1 so the lib binds
+    # them at call time.
+    function global:Get-V6BroadcastContext { return @{ ok = $true; vm = @{ ip = '10.0.0.5' } } }
+    function global:Find-V6MqGamePod { param([string] $Ip) return 'mq-game-test-pod' }
+
+    $script:lastFields = $null
+    $script:lastAction = $null
+    function global:_Invoke-V6BroadcastErl {
+        param($Ip, $Pod, $Erl, $Action, $Extra)
+        $script:lastAction = $Action
+        # Decode the inner ServerCommand so tests can assert on the fields sent.
+        $m = [regex]::Match($Erl, 'base64:decode\(<<"([A-Za-z0-9+/=]+)">>\)')
+        if ($m.Success) {
+            $json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($m.Groups[1].Value))
+            $env  = $json | ConvertFrom-Json
+            $script:lastFields = $env.MessageContent | ConvertFrom-Json
+        }
+        return @{ ok = $true; action = $Action; pod = $Pod; ip = $Ip }
+    }
+
+    Import-DstLib 'Rmq.ps1'
+    Import-DstLib 'PlayersRmq.ps1'
+}
+
+AfterAll {
+    Remove-Item function:global:Get-V6BroadcastContext -ErrorAction SilentlyContinue
+    Remove-Item function:global:Find-V6MqGamePod       -ErrorAction SilentlyContinue
+    Remove-Item function:global:_Invoke-V6BroadcastErl -ErrorAction SilentlyContinue
+}
+
+Describe 'Invoke-DunePlayerAwardCharXpLive' -Tag 'Rmq' {
+    BeforeEach {
+        $script:lastFields = $null
+        $script:lastAction = $null
+    }
+
+    It 'sends an AwardXP ServerCommand with the resolved FLS id, default Combat category and the full delta' {
+        $r = Invoke-DunePlayerAwardCharXpLive -Ip '1.2.3.4' -FlsId 'fls-abc' -XpDelta 5000
+        $r.ok       | Should -BeTrue
+        $r.path     | Should -Be 'rmq'
+        $r.category | Should -Be 'Combat'
+
+        $script:lastAction               | Should -Be 'award-xp-live'
+        $script:lastFields.ServerCommand | Should -Be 'AwardXP'
+        $script:lastFields.PlayerId      | Should -Be 'fls-abc'
+        $script:lastFields.Category      | Should -Be 'Combat'
+        [int]$script:lastFields.Experience | Should -Be 5000
+    }
+
+    It 'honors an explicit valid category (case-insensitive)' {
+        $r = Invoke-DunePlayerAwardCharXpLive -Ip '1.2.3.4' -FlsId 'fls-abc' -XpDelta 100 -Category 'exploration'
+        $r.ok       | Should -BeTrue
+        $r.category | Should -Be 'Exploration'
+        $script:lastFields.Category | Should -Be 'Exploration'
+    }
+
+    It 'falls back to Combat for an unknown category' {
+        $r = Invoke-DunePlayerAwardCharXpLive -Ip '1.2.3.4' -FlsId 'fls-abc' -XpDelta 100 -Category 'Nonsense'
+        $r.ok       | Should -BeTrue
+        $r.category | Should -Be 'Combat'
+        $script:lastFields.Category | Should -Be 'Combat'
+    }
+
+    It 'rejects a non-positive delta without sending anything (AwardXP is additive only)' {
+        $r = Invoke-DunePlayerAwardCharXpLive -Ip '1.2.3.4' -FlsId 'fls-abc' -XpDelta 0
+        $r.ok    | Should -BeFalse
+        $r.error | Should -Match 'additive only'
+        $script:lastFields | Should -BeNullOrEmpty
+    }
+
+    It 'resolves the FLS id from actor_id when no fls_id is supplied' {
+        function global:Invoke-DuneSqlQuery {
+            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
+            return @{ ok = $true; rows = @(@{ funcom = 'fls-from-actor' }); columns = @('funcom') }
+        }
+        function global:ConvertTo-DuneRowMaps { param($Result) return ,@(@{ funcom = 'fls-from-actor' }) }
+        try {
+            $r = Invoke-DunePlayerAwardCharXpLive -Ip '1.2.3.4' -ActorId 4242 -XpDelta 250
+            $r.ok | Should -BeTrue
+            $script:lastFields.PlayerId | Should -Be 'fls-from-actor'
+        } finally {
+            Remove-Item function:global:Invoke-DuneSqlQuery   -ErrorAction SilentlyContinue
+            Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'returns a clear error when the FLS id cannot be resolved' {
+        function global:Invoke-DuneSqlQuery {
+            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
+            return @{ ok = $false; error = 'db down' }
+        }
+        try {
+            $r = Invoke-DunePlayerAwardCharXpLive -Ip '1.2.3.4' -ActorId 4242 -XpDelta 250
+            $r.ok    | Should -BeFalse
+            $r.error | Should -Match 'db down'
+            $script:lastFields | Should -BeNullOrEmpty
+        } finally {
+            Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'requires either fls_id or actor_id' {
+        $r = Invoke-DunePlayerAwardCharXpLive -Ip '1.2.3.4' -XpDelta 250
+        $r.ok    | Should -BeFalse
+        $r.error | Should -Match 'fls_id or actor_id'
+    }
+}

--- a/tests/Diagnostics.Tests.ps1
+++ b/tests/Diagnostics.Tests.ps1
@@ -1,0 +1,63 @@
+# Tests the pure helpers in the diagnostics-bundle route: the duplicate-section
+# detector that headlines each INI snapshot, and the redaction pass that runs on
+# every file before it lands in a ZIP the user attaches to a public issue.
+# No SSH / IO — the live INI pull is exercised only on a real VM.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstRoute 'Diagnostics.ps1'
+}
+
+Describe 'Get-DstIniDuplicateHeaders' -Tag 'Pure' {
+    It 'flags a section name that appears twice' {
+        $raw = @"
+[/Script/DuneSandbox.BuildingSettings]
+m_BuildingBlueprintMaxExtensions=5
+[/Script/DuneSandbox.InventorySystemSettings]
+PlayerInventoryStartingVolumeCapacity=195
+[/Script/DuneSandbox.BuildingSettings]
+m_BaseBackupMaxExtensions=3
+"@
+        $dupes = Get-DstIniDuplicateHeaders -Raw $raw
+        $dupes | Should -Contain '/Script/DuneSandbox.BuildingSettings x2'
+        $dupes.Count | Should -Be 1
+    }
+
+    It 'returns nothing when every header is unique' {
+        $raw = "[A]`nk=1`n[B]`nk=2`n"
+        @(Get-DstIniDuplicateHeaders -Raw $raw).Count | Should -Be 0
+    }
+
+    It 'returns nothing for empty / null input' {
+        @(Get-DstIniDuplicateHeaders -Raw '').Count   | Should -Be 0
+        @(Get-DstIniDuplicateHeaders -Raw $null).Count | Should -Be 0
+    }
+
+    It 'ignores key=value lines and indented brackets in values' {
+        $raw = "[Only]`nname=[not a header]`nlist=(1,2)`n"
+        @(Get-DstIniDuplicateHeaders -Raw $raw).Count | Should -Be 0
+    }
+}
+
+Describe 'Invoke-DstRedaction' -Tag 'Pure' {
+    It 'redacts IPv4 addresses but leaves loopback alone' {
+        $out = Invoke-DstRedaction -Text 'connect 203.0.113.7 then 127.0.0.1'
+        $out | Should -Match '<ip>'
+        $out | Should -Match '127\.0\.0\.1'
+        $out | Should -Not -Match '203\.0\.113\.7'
+    }
+
+    It 'collapses any Windows user-profile path to <user>' {
+        $out = Invoke-DstRedaction -Text 'C:\Users\Alice\.ssh\dune'
+        $out | Should -Be 'C:\Users\<user>\.ssh\dune'
+    }
+
+    It 'redacts the explicit Windows user when supplied' {
+        $out = Invoke-DstRedaction -Text 'hello Bob world' -WindowsUser 'Bob'
+        $out | Should -Be 'hello <user> world'
+    }
+
+    It 'is a no-op on empty input' {
+        Invoke-DstRedaction -Text '' | Should -Be ''
+    }
+}

--- a/tests/GiveItemTemplateGuard.Tests.ps1
+++ b/tests/GiveItemTemplateGuard.Tests.ps1
@@ -1,0 +1,71 @@
+# Tests the numeric-template give-item guard (Test-DuneValidGiveTemplate) and
+# that the player + storage give functions reject a numeric template_id ("859")
+# BEFORE touching the DB. A numeric id can never resolve to a game class string,
+# so the row inserts but the item is invisible in-game and dropped on zone/login
+# load — the exact bug confirmed on the live DB (one stray row template_id='859').
+# No DB / network: Invoke-DuneSqlQuery is stubbed to throw, so any DB round-trip
+# fails the test loudly, proving the guard short-circuits first.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'Gameplay.ps1'
+    Import-DstLib 'GameplayPlayers.ps1'
+    Import-DstLib 'GameplayWorld.ps1'
+
+    # Any give path that reaches the DB is a bug for a numeric/empty template.
+    function global:Invoke-DuneSqlQuery {
+        throw 'DB must not be called for an invalid template'
+    }
+}
+
+Describe 'Test-DuneValidGiveTemplate' -Tag 'Pure' {
+    It 'accepts real class-string template ids' {
+        foreach ($t in @('CopperBar', 'Buggy_Booster_Mk6', 'BuildingBlueprint_CopyDevice', 'Combat_Light_SpiceMask')) {
+            (Test-DuneValidGiveTemplate -TemplateId $t).ok | Should -BeTrue
+        }
+    }
+
+    It 'rejects a purely-numeric id (the "859" leak)' {
+        $r = Test-DuneValidGiveTemplate -TemplateId '859'
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match '859'
+        $r.error | Should -Match 'class name'
+    }
+
+    It 'rejects numeric ids with surrounding whitespace' {
+        (Test-DuneValidGiveTemplate -TemplateId '  859  ').ok | Should -BeFalse
+        (Test-DuneValidGiveTemplate -TemplateId '0').ok       | Should -BeFalse
+    }
+
+    It 'rejects empty / whitespace-only ids' {
+        (Test-DuneValidGiveTemplate -TemplateId '').ok    | Should -BeFalse
+        (Test-DuneValidGiveTemplate -TemplateId '   ').ok | Should -BeFalse
+        (Test-DuneValidGiveTemplate -TemplateId $null).ok | Should -BeFalse
+    }
+}
+
+Describe 'Invoke-DunePlayerGiveItem — rejects numeric template without DB' -Tag 'Pure' {
+    It 'returns ok=$false for a numeric template and never calls the DB' {
+        $r = Invoke-DunePlayerGiveItem -Ip '1.2.3.4' -PawnId 1 -Template '859' -Qty 10 -Quality 0
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match '859'
+    }
+
+    It 'returns ok=$false for an empty template' {
+        $r = Invoke-DunePlayerGiveItem -Ip '1.2.3.4' -PawnId 1 -Template '' -Qty 1 -Quality 0
+        $r.ok | Should -BeFalse
+    }
+}
+
+Describe 'Invoke-DuneStorageGiveItem — rejects numeric template without DB' -Tag 'Pure' {
+    It 'returns ok=$false for a numeric template and never calls the DB' {
+        $r = Invoke-DuneStorageGiveItem -Ip '1.2.3.4' -ContainerId 3630 -Template '859' -Qty 10 -Quality 0
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match '859'
+    }
+
+    It 'returns ok=$false for an empty template' {
+        $r = Invoke-DuneStorageGiveItem -Ip '1.2.3.4' -ContainerId 3630 -Template '' -Qty 1 -Quality 0
+        $r.ok | Should -BeFalse
+    }
+}

--- a/tests/PlayersAdmin.Tests.ps1
+++ b/tests/PlayersAdmin.Tests.ps1
@@ -1,0 +1,116 @@
+# Tests the online-gate + jsonb hardening on Invoke-DunePlayerAwardIntel
+# (PlayersAdmin.ps1). The real gate logic runs end-to-end against a stubbed
+# Invoke-DuneSqlQuery that serves online_status / intel rows and captures the
+# write SQL, so we exercise Test-DunePlayerOffline(ByController) for real.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+
+    # Drive the gate via a fake DB. $script:onlineStatus = $null => no
+    # player_state row (treated offline). Capture the write SQL + count.
+    $script:onlineStatus = 'Offline'
+    $script:curIntel      = 0
+    $script:lastWriteSql  = $null
+    $script:writeCount    = 0
+
+    function global:Invoke-DuneSqlQuery {
+        param([string] $Ip, [string] $Sql, [bool] $ReadOnly, [int] $MaxRows, [int] $TimeoutSec)
+        if ($Sql -match 'online_status') {
+            if ($null -eq $script:onlineStatus) { return @{ ok = $true; maps = @() } }
+            return @{ ok = $true; maps = @(@{ status = $script:onlineStatus }) }
+        }
+        if ($ReadOnly -and $Sql -match 'm_TechKnowledgePoints') {
+            return @{ ok = $true; maps = @(@{ intel = $script:curIntel }) }
+        }
+        # write path
+        $script:lastWriteSql = $Sql
+        $script:writeCount   = $script:writeCount + 1
+        return @{ ok = $true; maps = @(); message = 'UPDATE 1' }
+    }
+    function global:ConvertTo-DuneRowMaps {
+        param($Result)
+        $m = if ($Result -and $Result.maps) { $Result.maps } else { @() }
+        return ,@($m)
+    }
+    function global:ConvertTo-DuneInt {
+        param($Value)
+        if ($null -eq $Value) { return 0 }
+        return [int]$Value
+    }
+
+    Import-DstLib 'PlayersAdmin.ps1'
+}
+
+AfterAll {
+    Remove-Item function:global:Invoke-DuneSqlQuery   -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneInt     -ErrorAction SilentlyContinue
+}
+
+Describe 'Invoke-DunePlayerAwardIntel online gate' -Tag 'PlayersAdmin' {
+    BeforeEach {
+        $script:onlineStatus = 'Offline'
+        $script:curIntel     = 0
+        $script:lastWriteSql = $null
+        $script:writeCount   = 0
+    }
+
+    It 'rejects an ONLINE player (pawn id known) and never writes' {
+        $script:onlineStatus = 'Online'
+        $r = Invoke-DunePlayerAwardIntel -Ip 'x' -ActorId 100 -PawnId 200 -IntelDelta 1000
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'Online'
+        $r.error | Should -Match 'log out first'
+        $script:writeCount | Should -Be 0
+    }
+
+    It 'rejects an ONLINE player when only the controller id is known (pawn=0)' {
+        $script:onlineStatus = 'Online'
+        $r = Invoke-DunePlayerAwardIntel -Ip 'x' -ActorId 100 -PawnId 0 -IntelDelta 1000
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'Online'
+        $script:writeCount | Should -Be 0
+    }
+
+    It 'writes for an OFFLINE player and returns the new intel total' {
+        $script:onlineStatus = 'Offline'
+        $script:curIntel     = 250
+        $r = Invoke-DunePlayerAwardIntel -Ip 'x' -ActorId 100 -PawnId 200 -IntelDelta 500
+        $r.ok | Should -BeTrue
+        $r.intel | Should -Be 750
+        $r.message | Should -Match 'Set Intel to 750'
+        $script:writeCount | Should -Be 1
+        $script:lastWriteSql | Should -Match '750'
+        $script:lastWriteSql | Should -Match '\b100\b'
+    }
+
+    It 'floors a negative result at 0' {
+        $script:curIntel = 100
+        $r = Invoke-DunePlayerAwardIntel -Ip 'x' -ActorId 100 -PawnId 200 -IntelDelta -500
+        $r.ok | Should -BeTrue
+        $r.intel | Should -Be 0
+        $r.message | Should -Match 'Set Intel to 0'
+    }
+
+    It 'treats a missing player_state row as offline and writes' {
+        $script:onlineStatus = $null
+        $r = Invoke-DunePlayerAwardIntel -Ip 'x' -ActorId 100 -PawnId 200 -IntelDelta 10
+        $r.ok | Should -BeTrue
+        $script:writeCount | Should -Be 1
+    }
+
+    It 'requires a controller or pawn id' {
+        $r = Invoke-DunePlayerAwardIntel -Ip 'x' -ActorId 0 -PawnId 0 -IntelDelta 10
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'required'
+        $script:writeCount | Should -Be 0
+    }
+
+    It 'builds the TechKnowledgePlayerComponent parent so a missing component is created' {
+        $r = Invoke-DunePlayerAwardIntel -Ip 'x' -ActorId 100 -PawnId 200 -IntelDelta 10
+        $r.ok | Should -BeTrue
+        $script:lastWriteSql | Should -Match 'TechKnowledgePlayerComponent'
+        $script:lastWriteSql | Should -Match 'jsonb_build_object'
+        $script:lastWriteSql | Should -Match 'COALESCE'
+    }
+}

--- a/tests/PlayersAdmin.Tests.ps1
+++ b/tests/PlayersAdmin.Tests.ps1
@@ -10,8 +10,11 @@ BeforeAll {
     # player_state row (treated offline). Capture the write SQL + count.
     $script:onlineStatus = 'Offline'
     $script:curIntel      = 0
+    $script:resolvedPawn  = 200
     $script:lastWriteSql  = $null
     $script:writeCount    = 0
+    $script:writes        = @()
+    $script:lastLevelReadSql = $null
 
     function global:Invoke-DuneSqlQuery {
         param([string] $Ip, [string] $Sql, [bool] $ReadOnly, [int] $MaxRows, [int] $TimeoutSec)
@@ -19,12 +22,23 @@ BeforeAll {
             if ($null -eq $script:onlineStatus) { return @{ ok = $true; maps = @() } }
             return @{ ok = $true; maps = @(@{ status = $script:onlineStatus }) }
         }
+        if ($ReadOnly -and $Sql -match 'AS pid') {
+            return @{ ok = $true; maps = @(@{ pid = $script:resolvedPawn }) }
+        }
+        if ($ReadOnly -and $Sql -match 'FLevelComponent' -and $Sql -match 'AS entity_id') {
+            $script:lastLevelReadSql = $Sql
+            return @{ ok = $true; maps = @(@{ entity_id = '555'; xp_text = '1000'; sp_unspent_text = '0'; sp_total_text = '0' }) }
+        }
+        if ($ReadOnly -and $Sql -match 'KeystonePlayerComponent') {
+            return @{ ok = $true; maps = @(@{ ids = '[]' }) }
+        }
         if ($ReadOnly -and $Sql -match 'm_TechKnowledgePoints') {
             return @{ ok = $true; maps = @(@{ intel = $script:curIntel }) }
         }
         # write path
         $script:lastWriteSql = $Sql
         $script:writeCount   = $script:writeCount + 1
+        $script:writes       = @($script:writes) + $Sql
         return @{ ok = $true; maps = @(); message = 'UPDATE 1' }
     }
     function global:ConvertTo-DuneRowMaps {
@@ -51,6 +65,7 @@ Describe 'Invoke-DunePlayerAwardIntel online gate' -Tag 'PlayersAdmin' {
     BeforeEach {
         $script:onlineStatus = 'Offline'
         $script:curIntel     = 0
+        $script:resolvedPawn = 200
         $script:lastWriteSql = $null
         $script:writeCount   = 0
     }
@@ -72,7 +87,7 @@ Describe 'Invoke-DunePlayerAwardIntel online gate' -Tag 'PlayersAdmin' {
         $script:writeCount | Should -Be 0
     }
 
-    It 'writes for an OFFLINE player and returns the new intel total' {
+    It 'writes to the PAWN actor for an OFFLINE player and returns the new intel total' {
         $script:onlineStatus = 'Offline'
         $script:curIntel     = 250
         $r = Invoke-DunePlayerAwardIntel -Ip 'x' -ActorId 100 -PawnId 200 -IntelDelta 500
@@ -81,7 +96,26 @@ Describe 'Invoke-DunePlayerAwardIntel online gate' -Tag 'PlayersAdmin' {
         $r.message | Should -Match 'Set Intel to 750'
         $script:writeCount | Should -Be 1
         $script:lastWriteSql | Should -Match '750'
-        $script:lastWriteSql | Should -Match '\b100\b'
+        # Intel lives on the pawn (200), NOT the controller (100).
+        $script:lastWriteSql | Should -Match '\b200\b'
+        $script:lastWriteSql | Should -Not -Match '\b100\b'
+    }
+
+    It 'resolves the pawn from the controller when only the controller id is known and writes to the pawn' {
+        $script:onlineStatus = 'Offline'
+        $script:resolvedPawn = 200
+        $r = Invoke-DunePlayerAwardIntel -Ip 'x' -ActorId 100 -PawnId 0 -IntelDelta 10
+        $r.ok | Should -BeTrue
+        $script:writeCount | Should -Be 1
+        $script:lastWriteSql | Should -Match '\b200\b'
+        $script:lastWriteSql | Should -Not -Match '\b100\b'
+    }
+
+    It 'clamps the new intel total to the spendable cap (2779)' {
+        $script:curIntel = 2700
+        $r = Invoke-DunePlayerAwardIntel -Ip 'x' -ActorId 100 -PawnId 200 -IntelDelta 500
+        $r.ok | Should -BeTrue
+        $r.intel | Should -Be 2779
     }
 
     It 'floors a negative result at 0' {
@@ -112,5 +146,53 @@ Describe 'Invoke-DunePlayerAwardIntel online gate' -Tag 'PlayersAdmin' {
         $script:lastWriteSql | Should -Match 'TechKnowledgePlayerComponent'
         $script:lastWriteSql | Should -Match 'jsonb_build_object'
         $script:lastWriteSql | Should -Match 'COALESCE'
+    }
+}
+
+Describe 'Invoke-DunePlayerAwardCharXp offline actor targeting' -Tag 'PlayersAdmin' {
+    BeforeEach {
+        $script:onlineStatus     = 'Offline'
+        $script:curIntel         = 0
+        $script:resolvedPawn     = 200
+        $script:lastWriteSql     = $null
+        $script:lastLevelReadSql = $null
+        $script:writeCount       = 0
+        $script:writes           = @()
+    }
+
+    It 'rejects an ONLINE player and never writes' {
+        $script:onlineStatus = 'Online'
+        $r = Invoke-DunePlayerAwardCharXp -Ip 'x' -PawnId 200 -XpDelta 5000
+        $r.ok | Should -BeFalse
+        $script:writeCount | Should -Be 0
+    }
+
+    It 'reads the FLevelComponent from the PAWN (not the controller)' {
+        $r = Invoke-DunePlayerAwardCharXp -Ip 'x' -PawnId 200 -XpDelta 5000
+        $r.ok | Should -BeTrue
+        # FLevelComponent is keyed on the pawn actor id (200), per the reference tool.
+        $script:lastLevelReadSql | Should -Match '\b200\b'
+    }
+
+    It 'writes the FLevelComponent update keyed on the resolved entity_id' {
+        $r = Invoke-DunePlayerAwardCharXp -Ip 'x' -PawnId 200 -XpDelta 5000
+        $r.ok | Should -BeTrue
+        ($script:writes -join ' ') | Should -Match 'FLevelComponent'
+        ($script:writes -join ' ') | Should -Match '\b555\b'
+    }
+
+    It 'writes the intel cascade to the PAWN actor, not the controller' {
+        $r = Invoke-DunePlayerAwardCharXp -Ip 'x' -PawnId 200 -XpDelta 5000
+        $r.ok | Should -BeTrue
+        $intelWrite = $script:writes | Where-Object { $_ -match 'TechKnowledgePlayerComponent' } | Select-Object -First 1
+        $intelWrite | Should -Not -BeNullOrEmpty
+        $intelWrite | Should -Match 'id = 200::bigint'
+    }
+
+    It 'requires a pawn id' {
+        $r = Invoke-DunePlayerAwardCharXp -Ip 'x' -PawnId 0 -XpDelta 5000
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'required'
+        $script:writeCount | Should -Be 0
     }
 }

--- a/tests/_TestHelpers.ps1
+++ b/tests/_TestHelpers.ps1
@@ -29,6 +29,27 @@ function Import-DstLib {
     }
 }
 
+# Dot-source one route file (app\server\routes) into GLOBAL scope, stubbing the
+# HTTP registration shims first so the file's Register-DuneRoute calls no-op.
+# Mirrors Import-DstLib's function-promotion so `It` blocks see the functions.
+function Import-DstRoute {
+    param([Parameter(Mandatory)][string] $RelativePath)
+    Register-DstStubs
+    $full = Join-Path (Get-DstRepoRoot) (Join-Path 'app\server\routes' $RelativePath)
+    if (-not (Test-Path $full)) { throw "Missing route: $RelativePath ($full)" }
+
+    $before = @{}
+    foreach ($f in Get-ChildItem function:) { $before[$f.Name] = $true }
+
+    . $full
+
+    foreach ($f in Get-ChildItem function:) {
+        if (-not $before.ContainsKey($f.Name)) {
+            Set-Item -Path "function:global:$($f.Name)" -Value $f.ScriptBlock
+        }
+    }
+}
+
 # Stub the HTTP-server registration shims so route files can load in tests.
 function Register-DstStubs {
     if (-not (Get-Command Register-DuneRoute -ErrorAction SilentlyContinue)) {

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1042,9 +1042,9 @@ export function awardCharXp(pawnId: number, delta: number) {
   })
 }
 
-export function awardIntel(controllerId: number, amount: number) {
+export function awardIntel(controllerId: number, pawnId: number, amount: number) {
   return api<WriteResult>('/api/gameplay/players/award-intel', {
-    method: 'POST', body: JSON.stringify({ actor_id: controllerId, delta: amount }),
+    method: 'POST', body: JSON.stringify({ actor_id: controllerId, pawn_id: pawnId, delta: amount }),
   })
 }
 

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1036,9 +1036,12 @@ export function setFactionTier(accountId: number, faction: FactionId, tier: numb
 }
 
 // Phase A award-char-xp: increments character XP + level + SP + intel.
-export function awardCharXp(pawnId: number, delta: number) {
+// Auto-routes server-side: offline players get a direct DB write; online players
+// get the game-native RMQ AwardXP command (category-based, default Combat) so the
+// award isn't clobbered on logout. Response.path = 'rmq' (live) | 'sql' (offline).
+export function awardCharXp(pawnId: number, delta: number, category = 'Combat') {
   return api<WriteResult>('/api/gameplay/players/award-char-xp', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, delta }),
+    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, delta, category }),
   })
 }
 

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -881,6 +881,19 @@ export function downloadBlueprintFile(blueprint: BlueprintFile, filename: string
 // v11.5.7 — Item catalog (for autocomplete), Fill Water, Coriolis admin.
 // ---------------------------------------------------------------------------
 
+/**
+ * A valid give-item template id is a game class string (e.g. "CopperBar"),
+ * never a bare number. The game's dune.items.template_id can't resolve a numeric
+ * id, so such rows are inserted but render invisible and get dropped on zone/login
+ * load. Reject empty and purely-numeric ids so they can't reach a give request.
+ */
+export function isValidTemplateId(t: string): boolean {
+  const s = (t ?? '').trim()
+  if (!s) return false
+  if (/^\d+$/.test(s)) return false
+  return /[A-Za-z]/.test(s)
+}
+
 export interface CatalogItem {
   template_id: string
   name: string

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -900,31 +900,62 @@ export interface CatalogItem {
   category: string
 }
 
+interface RawCatalogEntry {
+  templateId?: string
+  template_id?: string
+  name?: string
+  category?: string
+}
+
 interface CatalogResponse {
   _meta?: { count?: number; source?: string }
-  items: Record<string, { name: string; category: string }>
+  meta?: { total?: number; source?: string }
+  // The backend (/api/catalog/items -> Get-DuneItemCatalog) serializes `items`
+  // as an ARRAY of { templateId, name, category }. Older/alternate builds may
+  // emit a dict keyed by template_id. flattenItemCatalog handles both.
+  items: RawCatalogEntry[] | Record<string, { name?: string; category?: string }>
 }
 
 let _catalogCache: CatalogItem[] | null = null
 let _catalogPromise: Promise<CatalogItem[]> | null = null
 
 /**
- * Load + cache the full item catalog. The /api/catalog/items response is a
- * dict of { template_id: { name, category } }; we flatten to an array so the
- * autocomplete can sort + slice efficiently. ~5k entries, ~110KB JSON; only
- * fetched once per session.
+ * Normalize the /api/catalog/items payload into CatalogItem[]. Critically, the
+ * template_id MUST be the game class string (e.g. "AzuriteOre"), never an array
+ * index — the give-item guard rejects numeric ids, so an index would make every
+ * picked item unselectable. Reads the entry's `templateId` field for the array
+ * shape, or the object key for the dict shape.
+ */
+export function flattenItemCatalog(raw: CatalogResponse['items'] | undefined | null): CatalogItem[] {
+  const flat: CatalogItem[] = []
+  if (Array.isArray(raw)) {
+    for (const e of raw) {
+      const tid = String(e?.templateId ?? e?.template_id ?? '').trim()
+      if (!tid) continue
+      flat.push({ template_id: tid, name: e?.name || tid, category: e?.category || '' })
+    }
+  } else if (raw && typeof raw === 'object') {
+    const dict = raw as Record<string, { name?: string; category?: string }>
+    for (const tid of Object.keys(dict)) {
+      const key = tid.trim()
+      if (!key) continue
+      const v = dict[tid]
+      flat.push({ template_id: key, name: v?.name || key, category: v?.category || '' })
+    }
+  }
+  flat.sort((a, b) => a.name.localeCompare(b.name))
+  return flat
+}
+
+/**
+ * Load + cache the full item catalog. ~979 entries, ~110KB JSON; only fetched
+ * once per session. See flattenItemCatalog for the shape handling.
  */
 export function getItemCatalog(): Promise<CatalogItem[]> {
   if (_catalogCache) return Promise.resolve(_catalogCache)
   if (_catalogPromise) return _catalogPromise
   _catalogPromise = api<CatalogResponse>('/api/catalog/items').then(r => {
-    const items = r.items || {}
-    const flat: CatalogItem[] = []
-    for (const tid of Object.keys(items)) {
-      const v = items[tid]
-      flat.push({ template_id: tid, name: v?.name || tid, category: v?.category || '' })
-    }
-    flat.sort((a, b) => a.name.localeCompare(b.name))
+    const flat = flattenItemCatalog(r.items)
     _catalogCache = flat
     _catalogPromise = null
     return flat

--- a/webui/src/components/ItemPicker.tsx
+++ b/webui/src/components/ItemPicker.tsx
@@ -9,7 +9,7 @@
 
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { Icon } from './Icon'
-import { filterCatalog, getItemCatalog, type CatalogItem } from '../api/gameplay'
+import { filterCatalog, getItemCatalog, isValidTemplateId, type CatalogItem } from '../api/gameplay'
 
 interface Props {
   value: string
@@ -142,6 +142,13 @@ export function ItemPicker({ value, onChange, displayValue, label, placeholder, 
               )}
             </button>
           ))}
+        </div>
+      )}
+
+      {!open && value.trim().length > 0 && !isValidTemplateId(value) && (
+        <div className="mt-1 text-[11px] text-warning flex items-center gap-1">
+          <Icon name="AlertTriangle" size={11} className="shrink-0" />
+          Numbers aren't valid item ids — pick an item from the list.
         </div>
       )}
     </div>

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -645,57 +645,65 @@ export function GameConfig() {
         </div>
       )}
       {clientApply && (
-        <div className="card p-3 mb-4 border-warning/40 bg-warning/10 text-sm">
-          <div className="flex items-start gap-2">
-            <Icon name="MonitorSmartphone" size={16} className="text-warning mt-0.5 shrink-0" />
-            <div className="flex-1 min-w-0">
-              <div className="font-medium text-text mb-1">Also apply these on each player's client</div>
-              <p className="text-text-muted mb-2">
-                The setting{clientApply.items.length === 1 ? '' : 's'} below {clientApply.items.length === 1 ? 'is' : 'are'} read by
-                both the server and the game client. The server is updated, but each player must mirror {clientApply.items.length === 1 ? 'it' : 'them'} in
-                their local client config for it to take full effect:
-              </p>
-              <ul className="space-y-1 mb-2">
-                {clientApply.items.map(it => (
-                  <li key={it.key} className="font-mono text-xs text-text">
-                    <span className="text-text-muted">[{it.section}]</span>{' '}
-                    {it.key}={it.value}
-                    <span className="text-text-muted"> — {it.label}</span>
-                  </li>
-                ))}
-              </ul>
-              <p className="text-text-muted">
-                Add {clientApply.items.length === 1 ? 'it' : 'them'} under the matching section in each client's:
-              </p>
-              <code className="block mt-1 px-2 py-1 rounded bg-surface-2 text-text text-xs break-all">{clientApply.path}</code>
-              <div className="flex items-center gap-2 mt-3">
-                <button
-                  type="button"
-                  onClick={() => void onApplyToClient()}
-                  disabled={applying}
-                  className="btn-primary"
-                  title="Let DST write these settings into your own client's Game.ini on this PC"
-                >
-                  <Icon name={applying ? 'Loader2' : 'MonitorCog'} size={14} className={applying ? 'animate-spin' : ''} />
-                  {applying ? 'Applying…' : 'Apply to my client'}
-                </button>
-                <button type="button" onClick={() => setClientApply(null)} className="btn-ghost text-xs">
-                  I&apos;ll do it manually
-                </button>
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+          onClick={() => setClientApply(null)}
+        >
+          <div
+            className="card w-full max-w-lg max-h-[85vh] overflow-y-auto border-warning/40 bg-surface text-sm"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-start gap-2 p-4">
+              <Icon name="MonitorSmartphone" size={18} className="text-warning mt-0.5 shrink-0" />
+              <div className="flex-1 min-w-0">
+                <div className="font-semibold text-text mb-1">Also apply these on each player's client</div>
+                <p className="text-text-muted mb-2">
+                  The setting{clientApply.items.length === 1 ? '' : 's'} below {clientApply.items.length === 1 ? 'is' : 'are'} read by
+                  both the server and the game client. The server is updated, but each player must mirror {clientApply.items.length === 1 ? 'it' : 'them'} in
+                  their local client config for it to take full effect:
+                </p>
+                <ul className="space-y-1 mb-2">
+                  {clientApply.items.map(it => (
+                    <li key={it.key} className="font-mono text-xs text-text">
+                      <span className="text-text-muted">[{it.section}]</span>{' '}
+                      {it.key}={it.value}
+                      <span className="text-text-muted"> — {it.label}</span>
+                    </li>
+                  ))}
+                </ul>
+                <p className="text-text-muted">
+                  Add {clientApply.items.length === 1 ? 'it' : 'them'} under the matching section in each client's:
+                </p>
+                <code className="block mt-1 px-2 py-1 rounded bg-surface-2 text-text text-xs break-all">{clientApply.path}</code>
+                <div className="flex items-center gap-2 mt-3">
+                  <button
+                    type="button"
+                    onClick={() => void onApplyToClient()}
+                    disabled={applying}
+                    className="btn-primary"
+                    title="Let DST write these settings into your own client's Game.ini on this PC"
+                  >
+                    <Icon name={applying ? 'Loader2' : 'MonitorCog'} size={14} className={applying ? 'animate-spin' : ''} />
+                    {applying ? 'Applying…' : 'Apply to my client'}
+                  </button>
+                  <button type="button" onClick={() => setClientApply(null)} className="btn-ghost text-xs">
+                    I&apos;ll do it manually
+                  </button>
+                </div>
+                <p className="text-[11px] text-text-dim mt-2">
+                  “Apply to my client” only changes <span className="font-mono break-all">{clientInfo?.path ?? 'your local client Game.ini'}</span> on
+                  this machine (backed up first). Other players still apply manually.
+                </p>
               </div>
-              <p className="text-[11px] text-text-dim mt-2">
-                “Apply to my client” only changes <span className="font-mono break-all">{clientInfo?.path ?? 'your local client Game.ini'}</span> on
-                this machine (backed up first). Other players still apply manually.
-              </p>
+              <button
+                type="button"
+                className="btn-icon shrink-0"
+                title="Dismiss"
+                onClick={() => setClientApply(null)}
+              >
+                <Icon name="X" size={14} />
+              </button>
             </div>
-            <button
-              type="button"
-              className="btn-icon shrink-0"
-              title="Dismiss"
-              onClick={() => setClientApply(null)}
-            >
-              <Icon name="X" size={14} />
-            </button>
           </div>
         </div>
       )}

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -121,6 +121,31 @@ export function GameConfig() {
   const [clientErr, setClientErr] = useState<string | null>(null)
   const [clientViewOpen, setClientViewOpen] = useState(false)
   const [applying, setApplying] = useState(false)
+  const [clientSnippetCopied, setClientSnippetCopied] = useState(false)
+
+  // INI text the admin can hand to OTHER players (who don't run DST) to paste
+  // into their own client Game.ini — grouped by section, last-write-wins order.
+  const clientSnippet = useMemo(() => {
+    if (!clientApply || clientApply.items.length === 0) return ''
+    const bySection = new Map<string, string[]>()
+    for (const it of clientApply.items) {
+      const lines = bySection.get(it.section) ?? []
+      lines.push(`${it.key}=${it.value}`)
+      bySection.set(it.section, lines)
+    }
+    return [...bySection.entries()]
+      .map(([section, lines]) => [`[${section}]`, ...lines].join('\n'))
+      .join('\n\n')
+  }, [clientApply])
+
+  const onCopyClientSnippet = useCallback(async () => {
+    if (!clientSnippet) return
+    try {
+      await navigator.clipboard.writeText(clientSnippet)
+      setClientSnippetCopied(true)
+      setTimeout(() => setClientSnippetCopied(false), 1500)
+    } catch { /* clipboard may be unavailable; the snippet is still shown */ }
+  }, [clientSnippet])
 
   const refreshClient = useCallback(async () => {
     try {
@@ -675,6 +700,27 @@ export function GameConfig() {
                   Add {clientApply.items.length === 1 ? 'it' : 'them'} under the matching section in each client's:
                 </p>
                 <code className="block mt-1 px-2 py-1 rounded bg-surface-2 text-text text-xs break-all">{clientApply.path}</code>
+
+                <div className="mt-3 pt-3 border-t border-border">
+                  <div className="flex items-center justify-between gap-2 mb-1">
+                    <span className="font-medium text-text">Send this to your other players</span>
+                    <button
+                      type="button"
+                      onClick={() => void onCopyClientSnippet()}
+                      className="btn-ghost text-xs"
+                      title="Copy the INI lines to share with players who don't run DST"
+                    >
+                      <Icon name={clientSnippetCopied ? 'Check' : 'Copy'} size={13} />
+                      {clientSnippetCopied ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                  <p className="text-text-muted mb-1">
+                    Players who don&apos;t run DST can paste these exact lines into their own
+                    {' '}<span className="font-mono">{clientApply.path}</span> (merge under the matching section headers):
+                  </p>
+                  <pre className="px-2 py-1.5 rounded bg-surface-2 text-text text-xs whitespace-pre-wrap break-all overflow-x-auto">{clientSnippet}</pre>
+                </div>
+
                 <div className="flex items-center gap-2 mt-3">
                   <button
                     type="button"

--- a/webui/src/pages/MapSpinUp.tsx
+++ b/webui/src/pages/MapSpinUp.tsx
@@ -205,6 +205,22 @@ export function MapSpinUp() {
         }
       />
 
+      <div className="mb-4 rounded-lg border border-warning/60 bg-warning/15 px-4 py-3 flex items-start gap-3">
+        <Icon name="AlertTriangle" size={20} className="shrink-0 mt-0.5 text-warning" />
+        <div className="text-sm text-warning">
+          <div className="font-bold uppercase tracking-wide mb-1">RAM requirement</div>
+          <span className="text-warning/90">
+            Because the RAM allocated to each map can be customized, some maps may not spin up if the
+            Hyper-V VM doesn't have enough memory to support all of them at once. OverMap, Hagga, and
+            DeepDesert alone can consume <strong>31–35 GB</strong> at the default level — adjust
+            accordingly. Maps will <strong>not</strong> spin down while a player is present, and they
+            also scale on demand when a player tries to enter (though that player may see a longer
+            load while the map spins up). On-demand is the recommended approach; this Map SpinUp page
+            simply lets you start the spawn process ahead of time, before you arrive, if desired.
+          </span>
+        </div>
+      </div>
+
       {error && (
         <div className="card p-4 mb-4 border-danger/40">
           <p className="text-sm text-danger break-words">{error}</p>
@@ -229,7 +245,7 @@ export function MapSpinUp() {
         <>
           <MapGroup
             title="Maps"
-            hint="These keep at least one server warm (MinServers = 1). Some maps don't ship MinServers natively — enabling those may be ignored by the director, or may keep an instance warm and consume RAM (~1+ GB each). Use with care."
+            hint="These keep at least one server warm (MinServers = 1). Some maps don't ship MinServers natively — enabling those may be ignored by the director, or may keep an instance warm and consume RAM. Use with care."
             maps={orderedMaps}
             busy={busy}
             onToggle={onToggle}

--- a/webui/src/pages/gameplay/StorageTab.tsx
+++ b/webui/src/pages/gameplay/StorageTab.tsx
@@ -199,11 +199,20 @@ function ContainerDetail({ container, demo, onClose, onChanged }: {
         </div>
 
         {canWrite ? (
-          <div className="flex flex-wrap gap-2 mb-3">
-            <button className="btn-primary" disabled={busy} onClick={() => setShowAdd(s => !s)}>
-              <Icon name="PackagePlus" size={14} /> Add Items
-            </button>
-          </div>
+          <>
+            <div className="flex flex-wrap gap-2 mb-2">
+              <button className="btn-primary" disabled={busy} onClick={() => setShowAdd(s => !s)}>
+                <Icon name="PackagePlus" size={14} /> Add Items
+              </button>
+            </div>
+            <div className="mb-3 text-[11px] text-warning border-l-2 border-warning bg-warning/10 rounded px-2.5 py-1.5 flex items-start gap-1.5">
+              <Icon name="AlertTriangle" size={12} className="shrink-0 mt-0.5" />
+              <span>
+                Items added here only appear in-game after a <strong>battlegroup (server zone) restart</strong> —
+                the game caches container contents while the zone is loaded.
+              </span>
+            </div>
+          </>
         ) : (
           <div className="text-xs text-text-dim mb-3 flex items-center gap-1.5">
             <Icon name="Lock" size={12} /> Editing is available when the live game database is connected.

--- a/webui/src/pages/gameplay/StorageTab.tsx
+++ b/webui/src/pages/gameplay/StorageTab.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import { ItemPicker } from '../../components/ItemPicker'
 import {
-  getStorage, getStorageItems, giveItemsToStorage, deleteStorageItem,
+  getStorage, getStorageItems, giveItemsToStorage, deleteStorageItem, isValidTemplateId,
   type StorageContainer, type InventoryItem, type DataSource, type StorageGiveItemInput,
 } from '../../api/gameplay'
 import { fmtNum, SourceBadge, StatCard, DemoNotice, qualityClass } from './shared'
@@ -258,7 +258,7 @@ function AddItemsForm({ busy, onSubmit, onCancel }: {
 
   const add = () => {
     const t = template.trim()
-    if (!t) return
+    if (!t || !isValidTemplateId(t)) return
     setStaged(s => [...s, { template: t, qty: Math.max(1, Number(qty) || 1), quality: Math.max(0, Number(quality) || 0) }])
     setTemplate(''); setTemplateName(''); setQty('1'); setQuality('0')
   }
@@ -284,7 +284,7 @@ function AddItemsForm({ busy, onSubmit, onCancel }: {
             className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
         </div>
       </div>
-      <button className="btn-secondary w-full" onClick={add} disabled={busy || !template.trim()}>
+      <button className="btn-secondary w-full" onClick={add} disabled={busy || !isValidTemplateId(template)}>
         <Icon name="Plus" size={14} /> Add to list
       </button>
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -21,7 +21,7 @@ import {
   restoreDestroyed,
   returningPlayerAward, setFactionTier, setPlayerTags, setSkillPoints,
   setStarterClass, teleportToPlayer, updatePlayerTags, wipeCodex, wipeJourney,
-  chatWhisper,
+  chatWhisper, isValidTemplateId,
   type Player, type PlayerEvent, type PlayerStats, type SpecTrackFull,
 } from '../../../api/gameplay'
 import { fmtNum, fmtSolari } from '../shared'
@@ -662,7 +662,7 @@ export function ActionsSection({ player, canWrite, flash, onChanged }: SectionPr
                           className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
                       </div>
                     </div>
-                    <button className="btn-primary w-full" disabled={busy || !giveTpl.trim()}
+                    <button className="btn-primary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
                       onClick={() => runAction(def, () => def.custom === 'give-item-live'
                         ? giveItemLive({ actor_id: player.id }, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0)
                         : giveItem(player.id, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0))}>
@@ -786,7 +786,7 @@ function ItemsActionBlock({ player, canWrite, flash, onChanged }: {
                     className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
                 </div>
               </div>
-              <button className="btn-primary w-full" disabled={busy || !giveTpl.trim()}
+              <button className="btn-primary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
                 onClick={() => runAction(def, () => def.custom === 'give-item-live'
                   ? giveItemLive({ actor_id: player.id }, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0)
                   : giveItem(player.id, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0))}>

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -409,9 +409,12 @@ interface ActionDef {
   label: string
   icon: string
   liveOnly?: boolean      // requires player to be online (RMQ path)
+  offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   fields?: ActionField[]
   custom?: 'give-item' | 'give-item-live' | 'whisper'
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
+  doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
+  rowNote?: string        // short italic note shown inline on the row heading
   run: (p: Player, v: Record<string, string>) => Promise<{ message: string }>
 }
 
@@ -423,7 +426,7 @@ const ACTIONS: ActionDef[] = [
   { id: 'give-scrip', group: 'Currency', label: 'Give Scrip', icon: 'Banknote',
     fields: [{ key: 'amount', label: 'Amount', type: 'number', placeholder: '500' }],
     run: (p, v) => giveScrip(p.account_id, Number(v.amount) || 0) },
-  { id: 'give-intel', group: 'Currency', label: 'Give Intel', icon: 'BookOpen',
+  { id: 'give-intel', group: 'Currency', label: 'Give Intel', icon: 'BookOpen', offlineOnly: true,
     fields: [{ key: 'amount', label: 'Tech Knowledge Points', type: 'number', placeholder: '100' }],
     run: (p, v) => awardIntel(p.controller_id, p.id, Number(v.amount) || 0) },
   { id: 'grant-live', group: 'Currency', label: 'Grant Reward (popup)', icon: 'Gift',
@@ -434,7 +437,7 @@ const ACTIONS: ActionDef[] = [
     run: (p, v) => grantLive(p.controller_id, String(v.template || '').trim(), Number(v.amount) || 1) },
 
   // ----- Progression -----
-  { id: 'award-char-xp', group: 'Progression', label: 'Award Character XP', icon: 'TrendingUp',
+  { id: 'award-char-xp', group: 'Progression', label: 'Award Character XP', icon: 'TrendingUp', liveOnly: true,
     fields: [{ key: 'delta', label: 'XP delta', type: 'number', placeholder: '5000' }],
     run: (p, v) => awardCharXp(p.id, Number(v.delta) || 0) },
   { id: 'set-skill-points', group: 'Progression', label: 'Set Skill Points (live)', icon: 'Sparkles', liveOnly: true,
@@ -453,11 +456,19 @@ const ACTIONS: ActionDef[] = [
     ],
     run: (p, v) => setFactionTier(p.account_id, String(v.faction || '').trim(), Number(v.tier) || 0) },
   { id: 'reset-progression', group: 'Progression', label: 'Reset Progression (live)', icon: 'RotateCcw', liveOnly: true,
-    confirm: p => `Reset ALL progression for ${p.name}? Cannot be undone.`,
+    rowNote: 'Single confirmation required',
+    confirm: p => `Reset ALL progression for ${p.name}? Cannot be undone.\n\n` +
+      `This single confirmation is required so the action can't run on an accidental click.`,
     run: p => resetProgressionLive({ actor_id: p.id }) },
   { id: 'reset-journey', group: 'Progression', label: 'Reset Journey', icon: 'Map',
+    rowNote: 'Single confirmation required',
+    confirm: p => `Reset ${p.name}'s journey/quest progress? They'll restart the current journey step. This cannot be undone.\n\n` +
+      `This single confirmation is required so the action can't run on an accidental click.`,
     run: p => resetJourney(p.account_id) },
   { id: 'wipe-journey', group: 'Progression', label: 'Wipe Journey (restart)', icon: 'RefreshCw',
+    rowNote: 'Single confirmation required',
+    confirm: p => `WIPE ${p.name}'s entire journey and restart it from the beginning? All journey/quest progress is lost. This cannot be undone.\n\n` +
+      `This single confirmation is required so the action can't run on an accidental click.`,
     run: p => wipeJourney(p.account_id) },
 
   // ----- Items -----
@@ -499,7 +510,21 @@ const ACTIONS: ActionDef[] = [
     run: (p, v) => renamePlayer(p.account_id, String(v.name || '').trim()) },
   { id: 'set-starter-class', group: 'Identity', label: 'Set Starter Class', icon: 'Compass',
     fields: [{ key: 'class', label: 'Class id', type: 'text', placeholder: 'mentat' }],
-    run: (p, v) => setStarterClass(p.id, String(v.class || '').trim()) },
+    doubleConfirm: true,
+    rowNote: 'Double confirmation required',
+    confirm: p => `Set ${p.name}'s starter class?\n\n` +
+      `This is the FIRST of two confirmations. If you continue, the next step asks you to type an acknowledgement before the change is applied. This cannot be undone.`,
+    run: (p, v) => {
+      const typed = window.prompt(
+        `SECOND confirmation — set ${p.name}'s starter class to "${String(v.class || '').trim()}".\n` +
+        `This cannot be undone.\n\n` +
+        `Type  i acknowledge  to proceed:`
+      ) || ''
+      if (typed.trim().toLowerCase() !== 'i acknowledge') {
+        throw new Error('Did not type "i acknowledge" — change aborted.')
+      }
+      return setStarterClass(p.id, String(v.class || '').trim())
+    } },
   { id: 'tags-add-remove', group: 'Identity', label: 'Update Tags (add / remove)', icon: 'Tag',
     fields: [
       { key: 'add',    label: 'Add (comma-separated)',    type: 'text', placeholder: 'vip, tester' },
@@ -513,7 +538,21 @@ const ACTIONS: ActionDef[] = [
   { id: 'delete-tutorials', group: 'Identity', label: 'Clear Tutorial Flags', icon: 'Eraser',
     run: p => deleteTutorials(p.account_id) },
   { id: 'wipe-codex', group: 'Identity', label: 'Wipe Codex', icon: 'BookX',
-    run: p => wipeCodex(p.account_id) },
+    doubleConfirm: true,
+    rowNote: 'Double confirmation required',
+    confirm: p => `Wipe ${p.name}'s codex?\n\n` +
+      `This is the FIRST of two confirmations. If you continue, the next step asks you to type an acknowledgement before the codex is wiped. This cannot be undone.`,
+    run: p => {
+      const typed = window.prompt(
+        `SECOND confirmation — WIPE ${p.name}'s codex.\n` +
+        `This cannot be undone.\n\n` +
+        `Type  i acknowledge  to proceed:`
+      ) || ''
+      if (typed.trim().toLowerCase() !== 'i acknowledge') {
+        throw new Error('Did not type "i acknowledge" — wipe aborted.')
+      }
+      return wipeCodex(p.account_id)
+    } },
   { id: 'returning-award', group: 'Identity', label: 'Grant Returning-Player Award', icon: 'Star',
     run: p => returningPlayerAward(p.account_id) },
   { id: 'dismiss-returning', group: 'Identity', label: 'Dismiss Returning-Player Award', icon: 'X',
@@ -521,9 +560,13 @@ const ACTIONS: ActionDef[] = [
 
   // ----- Danger Zone -----
   { id: 'delete-account', group: 'Danger', label: 'Delete Account (permanent)', icon: 'AlertTriangle',
+    doubleConfirm: true,
+    rowNote: 'Double confirmation required',
+    confirm: p => `Permanently delete account ${p.account_id} (${p.name})?\n\n` +
+      `This is the FIRST of two confirmations. If you continue, the next step asks you to type an acknowledgement before the account is deleted. This cannot be undone.`,
     run: p => {
       const typed = window.prompt(
-        `PERMANENTLY delete account ${p.account_id} (${p.name}).\n` +
+        `SECOND confirmation — PERMANENTLY delete account ${p.account_id} (${p.name}).\n` +
         `This cannot be undone.\n\n` +
         `Type  i acknowledge  to proceed:`
       ) || ''
@@ -543,25 +586,11 @@ export function ActionsSection({ player, canWrite, flash, onChanged }: SectionPr
   const [openId, setOpenId] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
 
-  // Give-item form state lives at the section level so the ItemPicker keeps
-  // its selection when the user tabs to Quantity / Quality fields.
-  // giveTpl is the template_id we post to the API. giveName is the friendly
-  // display name shown in the picker after a selection — clears once the
-  // user types again, so picker continues to filter the live search query.
-  const [giveTpl, setGiveTpl]   = useState('')
-  const [giveName, setGiveName] = useState('')
-  const [giveQty, setGiveQty]   = useState('1')
-  const [giveQual, setGiveQual] = useState('0')
-  const [whisper, setWhisper]   = useState('')
-
   const isOnline = (player.online_status || '').toLowerCase() === 'online'
 
-  const openAction = (id: string) => {
-    if (openId === id) { setOpenId(null); return }
-    setOpenId(id)
-    if (id === 'give-item' || id === 'give-item-live') { setGiveTpl(''); setGiveName(''); setGiveQty('1'); setGiveQual('0') }
-    if (id === 'whisper') setWhisper('')
-  }
+  // Accordion toggle: clicking an open row closes it. Each form owns its own
+  // state, so it resets naturally when a row unmounts on close.
+  const openAction = (id: string) => setOpenId(o => (o === id ? null : id))
 
   const runAction = async (def: ActionDef, exec: () => Promise<{ message: string }>) => {
     if (def.confirm) {
@@ -616,89 +645,139 @@ export function ActionsSection({ player, canWrite, flash, onChanged }: SectionPr
         const acts = grouped[group]
         if (!acts || acts.length === 0) return null
         return (
-          <div key={group} className="space-y-2">
+          <div key={group} className="space-y-1.5">
             <div className="text-[11px] uppercase tracking-wider text-text-dim font-medium flex items-center gap-2">
               {group === 'Danger' && <Icon name="AlertTriangle" size={11} className="text-error" />}
               {group}
             </div>
-            <div className="flex flex-wrap gap-2">
-              {acts.map(a => {
-                const disabled = busy || (a.liveOnly && !isOnline)
-                const btnClass = group === 'Danger' ? 'btn-secondary text-error border-error/50' : 'btn-secondary'
-                return (
-                  <button
-                    key={a.id}
-                    className={btnClass}
-                    disabled={disabled}
-                    onClick={() => openAction(a.id)}
-                    title={a.liveOnly ? 'Requires player to be online' : undefined}
-                  >
-                    <Icon name={a.icon} size={13} /> {a.label}
-                  </button>
-                )
-              })}
+            <div className="space-y-1.5">
+              {acts.map(a => (
+                <ActionRow key={a.id} def={a} player={player} busy={busy} isOnline={isOnline}
+                  open={openId === a.id} danger={group === 'Danger'}
+                  onToggle={() => openAction(a.id)} runAction={runAction} />
+              ))}
             </div>
-
-            {acts.filter(a => a.id === openId).map(def => {
-              // Custom forms (item picker, whisper textarea).
-              if (def.custom === 'give-item' || def.custom === 'give-item-live') {
-                return (
-                  <div key={def.id} className="card p-3 space-y-3">
-                    <ItemPicker label="Item — type to search by name or template id"
-                      value={giveTpl} displayValue={giveName || giveTpl}
-                      onChange={(tpl, item) => { setGiveTpl(tpl); setGiveName(item ? item.name : '') }}
-                      autoFocus disabled={busy} />
-                    <div className="grid grid-cols-2 gap-3">
-                      <div>
-                        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Quantity</label>
-                        <input type="number" min={1} value={giveQty} disabled={busy}
-                          onChange={e => setGiveQty(e.target.value)}
-                          className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
-                      </div>
-                      <div>
-                        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Quality (0-5)</label>
-                        <input type="number" min={0} max={5} value={giveQual} disabled={busy}
-                          onChange={e => setGiveQual(e.target.value)}
-                          className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
-                      </div>
-                    </div>
-                    <button className="btn-primary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
-                      onClick={() => runAction(def, () => def.custom === 'give-item-live'
-                        ? giveItemLive({ actor_id: player.id }, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0)
-                        : giveItem(player.id, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0))}>
-                      {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} {def.label}
-                    </button>
-                  </div>
-                )
-              }
-              if (def.custom === 'whisper') {
-                return (
-                  <div key={def.id} className="card p-3 space-y-3">
-                    <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Whisper message</label>
-                    <textarea rows={3} value={whisper} disabled={busy}
-                      onChange={e => setWhisper(e.target.value)} placeholder="Hello from the admin tool"
-                      className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50 resize-none" />
-                    <div className="text-[11px] text-text-muted">
-                      Note: chat/whisper external publish is experimental — broker accepts but the game may silently drop.
-                    </div>
-                    <button className="btn-primary w-full" disabled={busy || !whisper.trim()}
-                      onClick={() => runAction(def, () => chatWhisper(String(player.id), whisper.trim()))}>
-                      {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Send" size={13} />} Send Whisper
-                    </button>
-                  </div>
-                )
-              }
-              // Standard form built from field defs.
-              return (
-                <InlineForm key={def.id} busy={busy} submitLabel={def.label}
-                  fields={def.fields || []}
-                  onSubmit={v => runAction(def, () => def.run(player, v))}
-                />
-              )
-            })}
           </div>
         )
       })}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ActionRow — one accordion row for a single ActionDef. The row header is a
+// full-width clickable list item; clicking expands the action's form inline
+// directly beneath it. Replaces the older wrap-of-buttons layout so the panel
+// reads as a vertical list rather than a wall of buttons.
+// ---------------------------------------------------------------------------
+function ActionRow({ def, player, busy, isOnline, open, danger, onToggle, runAction }: {
+  def: ActionDef
+  player: Player
+  busy: boolean
+  isOnline: boolean
+  open: boolean
+  danger?: boolean
+  onToggle: () => void
+  runAction: (def: ActionDef, exec: () => Promise<{ message: string }>) => void
+}) {
+  const disabled = busy || (!!def.liveOnly && !isOnline) || (!!def.offlineOnly && isOnline)
+  return (
+    <div className="card overflow-hidden">
+      <button type="button"
+        className={`w-full flex items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors ${disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-surface-2'} ${danger ? 'text-error' : 'text-text'}`}
+        disabled={disabled}
+        onClick={onToggle}
+        title={def.liveOnly ? 'Requires player to be online' : def.offlineOnly ? 'Requires player to be offline — the game caches this value in memory while online and overwrites it on logout' : undefined}>
+        <Icon name={def.icon} size={14} className={`shrink-0 ${danger ? 'text-error' : 'text-text-dim'}`} />
+        <span className="flex-1 min-w-0 truncate font-medium">{def.label}</span>
+        {def.rowNote && (
+          <span className="shrink-0 hidden sm:flex items-center gap-1.5 text-xs">
+            <span className="text-text-dim">---</span>
+            <span className="italic text-white">{def.rowNote}</span>
+          </span>
+        )}
+        {def.liveOnly && (
+          <span className="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-warning/20 text-warning border border-warning/50 shrink-0">LIVE REQ'D</span>
+        )}
+        {def.offlineOnly && (
+          <span className="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-info/20 text-info border border-info/50 shrink-0">OFFLINE REQ'D</span>
+        )}
+        <Icon name={open ? 'ChevronDown' : 'ChevronRight'} size={14} className="shrink-0 text-text-dim" />
+      </button>
+      {open && (
+        <div className="border-t border-border p-3">
+          {def.custom === 'give-item' || def.custom === 'give-item-live' ? (
+            <GiveItemForm busy={busy} submitLabel={def.label}
+              onSubmit={(tpl, qty, qual) => runAction(def, () => def.custom === 'give-item-live'
+                ? giveItemLive({ actor_id: player.id }, tpl, qty, qual)
+                : giveItem(player.id, tpl, qty, qual))} />
+          ) : def.custom === 'whisper' ? (
+            <WhisperForm busy={busy}
+              onSubmit={msg => runAction(def, () => chatWhisper(String(player.id), msg))} />
+          ) : (
+            <InlineForm busy={busy} submitLabel={def.label} fields={def.fields || []}
+              onSubmit={v => runAction(def, () => def.run(player, v))} />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Self-contained give-item form (item picker + qty/quality). Owns its own
+// state so it resets whenever the accordion row mounts. Renders without a card
+// wrapper — ActionRow provides the container.
+function GiveItemForm({ busy, submitLabel, onSubmit }: {
+  busy: boolean; submitLabel: string; onSubmit: (tpl: string, qty: number, qual: number) => void
+}) {
+  const [giveTpl, setGiveTpl]   = useState('')
+  const [giveName, setGiveName] = useState('')
+  const [giveQty, setGiveQty]   = useState('1')
+  const [giveQual, setGiveQual] = useState('0')
+  return (
+    <div className="space-y-3">
+      <ItemPicker label="Item — type to search by name or template id"
+        value={giveTpl} displayValue={giveName || giveTpl}
+        onChange={(tpl, item) => { setGiveTpl(tpl); setGiveName(item ? item.name : '') }}
+        autoFocus disabled={busy} />
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Quantity</label>
+          <input type="number" min={1} value={giveQty} disabled={busy}
+            onChange={e => setGiveQty(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+        </div>
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Quality (0-5)</label>
+          <input type="number" min={0} max={5} value={giveQual} disabled={busy}
+            onChange={e => setGiveQual(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+        </div>
+      </div>
+      <button className="btn-primary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
+        onClick={() => onSubmit(giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0)}>
+        {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} {submitLabel}
+      </button>
+    </div>
+  )
+}
+
+// Self-contained whisper form. Renders without a card wrapper.
+function WhisperForm({ busy, onSubmit }: { busy: boolean; onSubmit: (msg: string) => void }) {
+  const [whisper, setWhisper] = useState('')
+  return (
+    <div className="space-y-3">
+      <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Whisper message</label>
+      <textarea rows={3} value={whisper} disabled={busy}
+        onChange={e => setWhisper(e.target.value)} placeholder="Hello from the admin tool"
+        className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50 resize-none" />
+      <div className="text-[11px] text-text-muted">
+        Note: chat/whisper external publish is experimental — broker accepts but the game may silently drop.
+      </div>
+      <button className="btn-primary w-full" disabled={busy || !whisper.trim()}
+        onClick={() => onSubmit(whisper.trim())}>
+        {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Send" size={13} />} Send Whisper
+      </button>
     </div>
   )
 }
@@ -714,10 +793,6 @@ function ItemsActionBlock({ player, canWrite, flash, onChanged }: {
 }) {
   const [openId, setOpenId] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
-  const [giveTpl, setGiveTpl]   = useState('')
-  const [giveName, setGiveName] = useState('')
-  const [giveQty, setGiveQty]   = useState('1')
-  const [giveQual, setGiveQual] = useState('0')
 
   const isOnline = (player.online_status || '').toLowerCase() === 'online'
 
@@ -725,11 +800,7 @@ function ItemsActionBlock({ player, canWrite, flash, onChanged }: {
 
   if (!canWrite || acts.length === 0) return null
 
-  const openAction = (id: string) => {
-    if (openId === id) { setOpenId(null); return }
-    setOpenId(id)
-    if (id === 'give-item' || id === 'give-item-live') { setGiveTpl(''); setGiveName(''); setGiveQty('1'); setGiveQual('0') }
-  }
+  const openAction = (id: string) => setOpenId(o => (o === id ? null : id))
 
   const runAction = async (def: ActionDef, exec: () => Promise<{ message: string }>) => {
     if (def.confirm) {
@@ -750,58 +821,11 @@ function ItemsActionBlock({ player, canWrite, flash, onChanged }: {
   }
 
   return (
-    <div className="space-y-2 mb-2">
-      <div className="flex flex-wrap gap-2">
-        {acts.map(a => {
-          const disabled = busy || (a.liveOnly && !isOnline)
-          return (
-            <button key={a.id} className="btn-secondary" disabled={disabled}
-              onClick={() => openAction(a.id)}
-              title={a.liveOnly ? 'Requires player to be online' : undefined}>
-              <Icon name={a.icon} size={13} /> {a.label}
-            </button>
-          )
-        })}
-      </div>
-
-      {acts.filter(a => a.id === openId).map(def => {
-        if (def.custom === 'give-item' || def.custom === 'give-item-live') {
-          return (
-            <div key={def.id} className="card p-3 space-y-3">
-              <ItemPicker label="Item — type to search by name or template id"
-                value={giveTpl} displayValue={giveName || giveTpl}
-                onChange={(tpl, item) => { setGiveTpl(tpl); setGiveName(item ? item.name : '') }}
-                autoFocus disabled={busy} />
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Quantity</label>
-                  <input type="number" min={1} value={giveQty} disabled={busy}
-                    onChange={e => setGiveQty(e.target.value)}
-                    className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
-                </div>
-                <div>
-                  <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Quality (0-5)</label>
-                  <input type="number" min={0} max={5} value={giveQual} disabled={busy}
-                    onChange={e => setGiveQual(e.target.value)}
-                    className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
-                </div>
-              </div>
-              <button className="btn-primary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
-                onClick={() => runAction(def, () => def.custom === 'give-item-live'
-                  ? giveItemLive({ actor_id: player.id }, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0)
-                  : giveItem(player.id, giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0))}>
-                {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} {def.label}
-              </button>
-            </div>
-          )
-        }
-        return (
-          <InlineForm key={def.id} busy={busy} submitLabel={def.label}
-            fields={def.fields || []}
-            onSubmit={v => runAction(def, () => def.run(player, v))}
-          />
-        )
-      })}
+    <div className="space-y-1.5 mb-2">
+      {acts.map(a => (
+        <ActionRow key={a.id} def={a} player={player} busy={busy} isOnline={isOnline}
+          open={openId === a.id} onToggle={() => openAction(a.id)} runAction={runAction} />
+      ))}
     </div>
   )
 }
@@ -999,7 +1023,7 @@ function InlineForm({ fields, submitLabel, busy, onSubmit }: {
 }) {
   const [values, setValues] = useState<Record<string, string>>({})
   return (
-    <div className="card p-3 space-y-2">
+    <div className="space-y-2">
       {fields.map(f => (
         <div key={f.key}>
           <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">{f.label}</label>

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -425,7 +425,7 @@ const ACTIONS: ActionDef[] = [
     run: (p, v) => giveScrip(p.account_id, Number(v.amount) || 0) },
   { id: 'give-intel', group: 'Currency', label: 'Give Intel', icon: 'BookOpen',
     fields: [{ key: 'amount', label: 'Tech Knowledge Points', type: 'number', placeholder: '100' }],
-    run: (p, v) => awardIntel(p.controller_id, Number(v.amount) || 0) },
+    run: (p, v) => awardIntel(p.controller_id, p.id, Number(v.amount) || 0) },
   { id: 'grant-live', group: 'Currency', label: 'Grant Reward (popup)', icon: 'Gift',
     fields: [
       { key: 'template', label: 'Item template id', type: 'text', placeholder: 'Item_…' },

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -375,3 +375,23 @@ describe('error path', () => {
     })
   })
 })
+
+describe('isValidTemplateId — numeric give-item guard', () => {
+  it('accepts real class-string template ids', () => {
+    for (const t of ['CopperBar', 'Buggy_Booster_Mk6', 'BuildingBlueprint_CopyDevice', 'Combat_Light_SpiceMask']) {
+      expect(gp.isValidTemplateId(t)).toBe(true)
+    }
+  })
+
+  it('rejects a purely-numeric id (the "859" leak)', () => {
+    expect(gp.isValidTemplateId('859')).toBe(false)
+    expect(gp.isValidTemplateId('  859  ')).toBe(false)
+    expect(gp.isValidTemplateId('0')).toBe(false)
+  })
+
+  it('rejects empty / whitespace-only ids', () => {
+    expect(gp.isValidTemplateId('')).toBe(false)
+    expect(gp.isValidTemplateId('   ')).toBe(false)
+  })
+})
+

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -72,10 +72,10 @@ describe('Phase A — currency / progression writes', () => {
     expect(last().body).toEqual({ account_id: 7, faction: 'harkonnen', tier: 12 })
   })
 
-  it('awardCharXp uses pawn_id + delta', async () => {
+  it('awardCharXp uses pawn_id + delta + default category', async () => {
     await gp.awardCharXp(99, 10_000)
     expect(last().url).toBe('/api/gameplay/players/award-char-xp')
-    expect(last().body).toEqual({ pawn_id: 99, delta: 10_000 })
+    expect(last().body).toEqual({ pawn_id: 99, delta: 10_000, category: 'Combat' })
   })
 
   it('awardIntel sends actor_id + pawn_id + delta (backend award-intel contract)', async () => {

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -78,9 +78,10 @@ describe('Phase A — currency / progression writes', () => {
     expect(last().body).toEqual({ pawn_id: 99, delta: 10_000 })
   })
 
-  it('awardIntel sends actor_id + delta (backend award-intel contract)', async () => {
-    await gp.awardIntel(123, 50)
-    expect(last().body).toEqual({ actor_id: 123, delta: 50 })
+  it('awardIntel sends actor_id + pawn_id + delta (backend award-intel contract)', async () => {
+    await gp.awardIntel(123, 99, 50)
+    expect(last().url).toBe('/api/gameplay/players/award-intel')
+    expect(last().body).toEqual({ actor_id: 123, pawn_id: 99, delta: 50 })
   })
 
   it('returningPlayerAward + dismiss... only need account_id', async () => {

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -396,3 +396,38 @@ describe('isValidTemplateId — numeric give-item guard', () => {
   })
 })
 
+describe('flattenItemCatalog — catalog shape parsing', () => {
+  // The backend serializes `items` as an ARRAY of { templateId, name, category }.
+  // The parser must read templateId, NOT the array index, or every picked item
+  // gets a numeric template_id and the give-item guard makes it unselectable.
+  it('reads the class-string templateId from the array shape (the live bug)', () => {
+    const out = gp.flattenItemCatalog([
+      { templateId: 'AzuriteOre', name: 'Copper Ore', category: 'Resources' },
+      { templateId: 'CopperBar', name: 'Copper Ingot', category: 'Resources' },
+    ])
+    const copper = out.find(i => i.name === 'Copper Ore')
+    expect(copper?.template_id).toBe('AzuriteOre')
+    // No entry may carry a bare-numeric template_id (would be rejected on pick).
+    expect(out.every(i => gp.isValidTemplateId(i.template_id))).toBe(true)
+    expect(out.every(i => !/^\d+$/.test(i.template_id))).toBe(true)
+  })
+
+  it('still supports the legacy dict shape', () => {
+    const out = gp.flattenItemCatalog({
+      AzuriteOre: { name: 'Copper Ore', category: 'Resources' },
+    })
+    expect(out[0]?.template_id).toBe('AzuriteOre')
+    expect(out[0]?.name).toBe('Copper Ore')
+  })
+
+  it('sorts by display name and skips entries with no template id', () => {
+    const out = gp.flattenItemCatalog([
+      { templateId: 'Zeta', name: 'Zeta Thing', category: '' },
+      { templateId: '', name: 'No Id', category: '' },
+      { templateId: 'Alpha', name: 'Alpha Thing', category: '' },
+    ])
+    expect(out.map(i => i.template_id)).toEqual(['Alpha', 'Zeta'])
+  })
+})
+
+

--- a/webui/tests/components/ItemPicker.test.tsx
+++ b/webui/tests/components/ItemPicker.test.tsx
@@ -1,0 +1,83 @@
+// End-to-end regression for the "can't select item from the list" bug.
+//
+// Root cause: /api/catalog/items returns `items` as an ARRAY of
+// { templateId, name, category }, but the parser treated it as a dict, so every
+// catalog entry got a numeric array-index as its template_id. Picking an item
+// then committed a numeric id, which the give-item guard rejects -> the pick
+// silently fails and the "pick an item from the list" warning stays on.
+//
+// This test drives the REAL getItemCatalog parser (via a stubbed fetch) through
+// the ItemPicker, so it fails if the array shape is ever mishandled again.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React, { useState } from 'react'
+import { ItemPicker } from '../../src/components/ItemPicker'
+
+// Backend (Get-DuneItemCatalog) array shape.
+const CATALOG_RESPONSE = {
+  meta: { total: 2, source: 'item-catalog.json' },
+  items: [
+    { templateId: 'AzuriteOre', name: 'Copper Ore', category: 'Resources' },
+    { templateId: 'CopperBar', name: 'Copper Ingot', category: 'Resources' },
+  ],
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.includes('/api/catalog/items')) {
+      return new Response(JSON.stringify(CATALOG_RESPONSE), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    })
+  }))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+// Controlled host mirroring the Give-Item form wiring in players/sections.tsx.
+function Host({ onPick }: { onPick: (tpl: string, name: string) => void }) {
+  const [tpl, setTpl] = useState('')
+  const [name, setName] = useState('')
+  return (
+    <ItemPicker
+      label="Item"
+      value={tpl}
+      displayValue={name || tpl}
+      onChange={(t, item) => {
+        setTpl(t)
+        setName(item ? item.name : '')
+        onPick(t, item ? item.name : '')
+      }}
+    />
+  )
+}
+
+describe('ItemPicker selection (real catalog parser)', () => {
+  it('commits the class-string template_id when a suggestion is clicked', async () => {
+    const user = userEvent.setup()
+    const onPick = vi.fn()
+    render(<Host onPick={onPick} />)
+
+    const input = screen.getByRole('textbox')
+    await user.click(input)
+    await user.type(input, 'Copper Ore')
+
+    const option = await screen.findByText('Copper Ore', { selector: 'span' })
+    await user.click(option)
+
+    await waitFor(() => {
+      expect(onPick).toHaveBeenLastCalledWith('AzuriteOre', 'Copper Ore')
+    })
+    expect(input).toHaveValue('Copper Ore')
+    expect(screen.queryByText(/pick an item from the list/i)).toBeNull()
+  })
+})


### PR DESCRIPTION
## v12.0.14

Gameplay-admin fixes and webui polish, validated against the live VM and Pester suites. Nothing here changes the release pipeline.

### Fixes
- **Give Item** picker no longer mangles catalog template ids; equip, inventory stacks, and storage paths verified live.
- **Give Intel** routes through the correct actor and is OFFLINE-only, with an `OFFLINE REQ'D` badge on the row.
- **Game Config** collapses duplicate INI section headers into a single DST-managed block (last-key-wins) so UE5 honors DST overrides. (`GameConfig.Tests` 7/7)
- **Diagnostics** bundle captures redacted live `UserGame.ini` / `UserEngine.ini` snapshots with a duplicate-section-header headline plus CLI logs. (`Diagnostics.Tests` 8/8)
- **SFTP** Fix Partitions cleanup corrected.

### Changed
- **Map SpinUp** RAM banner reworded for over-map / on-demand scaling (31–35 GB); dropped per-instance GB figures.
- **Dangerous player actions hardened:**
  - Double confirmation (`window.confirm` + typed `i acknowledge`): **Delete Account**, **Wipe Codex**, **Set Starter Class**.
  - Single-confirm "no accidental click" wording: **Reset Progression**, **Reset Journey**, **Wipe Journey**.
  - Each action shows an inline white-italic note on its row heading (e.g. `--- Double confirmation required`).

### Testing
- `GameConfig.Tests` 7/7, `Diagnostics.Tests` 8/8 (pwsh + Pester 5.7.1).
- Live-verified on the VM: give-item suite, intel offline/badge, journey warnings, RAM banner, confirm hardening.

### Release
Installer built and staged at the canonical X: path (`DuneServerSetup.exe`). The GitHub release will be cut separately and **must** upload that `.exe` as its sole asset.