### PR TITLE
docs: bump README current-release pointer to v12.0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v12.0.0**. The in-app version label and the
-website show plain semver tags (e.g. `v12.0.0`) — the previous
+The current release is **v12.0.14**. The in-app version label and the
+website show plain semver tags (e.g. `v12.0.14`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.5.0**


### PR DESCRIPTION
Updates the stale "current release is **v12.0.0**" line in the README to **v12.0.14**. Docs-only; the release badge and marketing site already track the latest tag automatically.