### PR TITLE
v12.0.15: expand Game Config client-mirror flags + client mismatch popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.15] - 2026-06-13
+
+### Changed
+
+- **More Game Config settings are now flagged "also apply to your client."**
+  Some gameplay settings only take effect in-game when the matching value is
+  also present in the player's local client `Game.ini` — not just the server's
+  VM ini. Previously DST flagged only the two BuildingSettings keys that
+  Funcom's setup template calls out. Live in-game testing (corroborated by
+  community reverse-engineering notes) showed whole sections behave the same
+  way, so the client-mirror flag now covers 14 keys across **Building**,
+  **Inventory**, **Coriolis / Storm Cycle**, **Spice**, and **Sandworm**.
+
+### Added
+
+- **Client/server mismatch popup on the Game Config page.** When a client
+  config folder is set, DST now checks on page load whether your local client
+  `Game.ini` disagrees with the server on any *customized* client-mirror
+  setting (e.g. server says `5`, your client still says `4`). If so, a popup
+  lists each mismatch (Setting / Server / Your client) and offers **"Fix my
+  client config"**, which writes the server values into your client `Game.ini`
+  after backing the file up. If DST can't write the file, it shows a
+  copy-paste snippet so you can apply it yourself. No mismatch means no popup.
+
 ## [12.0.14] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v12.0.14**. The in-app version label and the
-website show plain semver tags (e.g. `v12.0.14`) — the previous
+The current release is **v12.0.15**. The in-app version label and the
+website show plain semver tags (e.g. `v12.0.15`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.5.0**

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.14'
+$script:DuneToolVersion = '12.0.15'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.14',
+    [string]$Version = '12.0.15',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.14</Version>
+    <Version>12.0.15</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.14"
+#define MyAppVersion "12.0.15"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -88,8 +88,8 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecBuilding; Key='m_bBuildingRestrictionLimitsEnabled'; File='game'; Type='bool'; Default='True'; Label='Building Restriction Limits'; Help='Enforce building restriction limits. Also needs client-side apply.'; ClientApply=$true; Category='Building' }
 
     # --- Inventory ---
-    @{ Section=$script:DuneGcSecInventory; Key='PlayerInventoryStartingSize'; File='game'; Type='int'; Min=1; Default='35'; Label='Starting Inventory Slots'; Help='Number of inventory slots at spawn.'; Category='Inventory' }
-    @{ Section=$script:DuneGcSecInventory; Key='PlayerInventoryStartingVolumeCapacity'; File='game'; Type='float'; Min=0; Default='175.0'; Label='Starting Inventory Volume'; Help='Volume capacity of the starting inventory.'; Category='Inventory' }
+    @{ Section=$script:DuneGcSecInventory; Key='PlayerInventoryStartingSize'; File='game'; Type='int'; Min=1; Default='35'; Label='Starting Inventory Slots'; Help='Number of inventory slots at spawn. Also needs client-side apply.'; ClientApply=$true; Category='Inventory' }
+    @{ Section=$script:DuneGcSecInventory; Key='PlayerInventoryStartingVolumeCapacity'; File='game'; Type='float'; Min=0; Default='175.0'; Label='Starting Inventory Volume'; Help='Volume capacity of the starting inventory. Also needs client-side apply.'; ClientApply=$true; Category='Inventory' }
 
     # --- Guilds & Economy ---
     @{ Section=$script:DuneGcSecGuilds; Key='m_MaxGuildMembersAllowed'; File='game'; Type='int'; Min=1; Default='32'; Label='Max Guild Members'; Help='Maximum players per guild.'; Category='Guilds & Economy' }
@@ -97,9 +97,9 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecGuilds; Key='m_GuildCreationCost'; File='game'; Type='int'; Min=0; Unit='Solari'; Default='1000'; Label='Guild Creation Cost'; Help='Solari required to create a guild.'; Category='Guilds & Economy' }
 
     # --- Storm Cycle ---
-    @{ Section=$script:DuneGcSecCoriolis; Key='m_CycleDurationInDays'; File='game'; Type='int'; Min=1; Unit='days'; Default='7'; Label='Coriolis Cycle Length'; Help='In-game days between Coriolis storm / season events.'; Category='Storm Cycle' }
+    @{ Section=$script:DuneGcSecCoriolis; Key='m_CycleDurationInDays'; File='game'; Type='int'; Min=1; Unit='days'; Default='7'; Label='Coriolis Cycle Length'; Help='In-game days between Coriolis storm / season events. Also needs client-side apply.'; ClientApply=$true; Category='Storm Cycle' }
     @{ Section=$script:DuneGcSecStorm; Key='m_bCoriolisAutoSpawnEnabled'; File='game'; Type='bool'; Default='True'; Label='Coriolis Auto-Spawn'; Help='Whether Coriolis storms spawn automatically.'; Category='Storm Cycle' }
-    @{ Section=$script:DuneGcSecCoriolis; Key='m_bIsDbWipeEnabled'; File='game'; Type='bool'; Default='True'; Label='Database Wipe on Season End'; Help='Wipe the database when the season ends.'; Category='Storm Cycle' }
+    @{ Section=$script:DuneGcSecCoriolis; Key='m_bIsDbWipeEnabled'; File='game'; Type='bool'; Default='True'; Label='Database Wipe on Season End'; Help='Wipe the database when the season ends. Also needs client-side apply.'; ClientApply=$true; Category='Storm Cycle' }
     @{ Section=$script:DuneGcSecConsole; Key='Sandstorm.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Sandstorm'; Help='Enable rolling sandstorms.'; Category='Storm Cycle' }
     @{ Section=$script:DuneGcSecConsole; Key='Sandstorm.Treasure.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Sandstorm Treasure Spawns'; Help='Spawn treasure during sandstorms.'; Category='Storm Cycle' }
 
@@ -108,8 +108,8 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecSecurity; Key='m_bAreSecurityZonesEnabled'; File='game'; Type='bool'; Default='True'; Label='Security Zones Enabled'; Help='Off = PvP and ability usage allowed everywhere.'; Category='PvP & Security' }
 
     # --- Spice ---
-    @{ Section=$script:DuneGcSecSpice; Key='m_PrimeRateInSeconds'; File='game'; Type='float'; Min=0; Unit='sec'; Default='30.0'; Label='Spice Prime Rate'; Help='Seconds between spice node priming ticks.'; Category='Spice' }
-    @{ Section=$script:DuneGcSecSpice; Key='m_NodeValueToSpiceResourceRatio'; File='game'; Type='float'; Min=0; Default='10.0'; Label='Node Value to Spice Ratio'; Help='Converts node value into harvestable spice.'; Category='Spice' }
+    @{ Section=$script:DuneGcSecSpice; Key='m_PrimeRateInSeconds'; File='game'; Type='float'; Min=0; Unit='sec'; Default='30.0'; Label='Spice Prime Rate'; Help='Seconds between spice node priming ticks. Also needs client-side apply.'; ClientApply=$true; Category='Spice' }
+    @{ Section=$script:DuneGcSecSpice; Key='m_NodeValueToSpiceResourceRatio'; File='game'; Type='float'; Min=0; Default='10.0'; Label='Node Value to Spice Ratio'; Help='Converts node value into harvestable spice. Also needs client-side apply.'; ClientApply=$true; Category='Spice' }
 
     # --- Taxation ---
     @{ Section=$script:DuneGcSecTaxation; Key='m_bTaxationEnabled'; File='game'; Type='bool'; Default='False'; Label='Taxation Enabled'; Help='Whether the taxation system is active.'; Category='Taxation' }
@@ -121,8 +121,8 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecConsole; Key='Vehicle.SandwormCollisionInteraction'; File='engine'; Type='boolLower'; Default='true'; Label='Sandworm Pushes Vehicles'; Help='Sandworm can push / damage vehicles.'; Category='Sandworm' }
     @{ Section=$script:DuneGcSecConsole; Key='Vehicle.SandwormInvulnerabilitySecondsOnExit'; File='engine'; Type='float'; Min=0; Unit='sec'; Default='5.0'; Label='Invulnerability on Vehicle Exit'; Help='Seconds of sandworm invulnerability after exiting a vehicle.'; Category='Sandworm' }
     @{ Section=$script:DuneGcSecConsole; Key='Vehicle.SandwormInvulnerabilitySecondsOnServerRestart'; File='engine'; Type='float'; Min=0; Unit='sec'; Default='60.0'; Label='Invulnerability on Server Restart'; Help='Seconds of sandworm invulnerability after a server restart.'; Category='Sandworm' }
-    @{ Section=$script:DuneGcSecSandworm; Key='WormDetectionDistance'; File='game'; Type='float'; Min=0; Default='5000.0'; Label='Worm Detection Distance'; Help='Distance at which worms detect players.'; Category='Sandworm' }
-    @{ Section=$script:DuneGcSecSandworm; Key='m_MinWormSpawnInternal'; File='game'; Type='float'; Min=0; Unit='sec'; Default='300.0'; Label='Min Worm Spawn Interval'; Help='Minimum seconds between worm spawns.'; Category='Sandworm' }
+    @{ Section=$script:DuneGcSecSandworm; Key='WormDetectionDistance'; File='game'; Type='float'; Min=0; Default='5000.0'; Label='Worm Detection Distance'; Help='Distance at which worms detect players. Also needs client-side apply.'; ClientApply=$true; Category='Sandworm' }
+    @{ Section=$script:DuneGcSecSandworm; Key='m_MinWormSpawnInternal'; File='game'; Type='float'; Min=0; Unit='sec'; Default='300.0'; Label='Min Worm Spawn Interval'; Help='Minimum seconds between worm spawns. Also needs client-side apply.'; ClientApply=$true; Category='Sandworm' }
     @{ Section=$script:DuneGcSecHazards; Key='m_SandwormQuicksandSpeedModifier'; File='game'; Type='float'; Min=0; Default='0.25'; Label='Quicksand Speed Modifier'; Help='Movement speed multiplier in quicksand.'; Category='Sandworm' }
 
     # --- Vehicles (engine cvars) ---
@@ -155,13 +155,13 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecPvP; Key='bPvPEnabled'; File='game'; Type='bool'; Default='False'; Label='PvP Enabled'; Help='Allow player-vs-player combat globally across the server.'; Category='PvP & Security' }
     @{ Section=$script:DuneGcSecPvP; Key='bServerPVE'; File='game'; Type='bool'; Default='True'; Label='Server PvE Mode'; Help='Enables global PvE protection (inverse of PvP; both can be set independently).'; Category='PvP & Security' }
     # Spice
-    @{ Section=$script:DuneGcSecSpice; Key='m_bSpawningActive'; File='game'; Type='bool'; Default='True'; Label='Spice Spawning Active'; Help='Master switch - whether spice nodes spawn on the map at all.'; Category='Spice' }
-    @{ Section=$script:DuneGcSecSpice; Key='m_bPlayerMustWitnessBloom'; File='game'; Type='bool'; Default='False'; Label='Player Must Witness Bloom'; Help='If true, a player must be present in the area for a spice bloom to register / count.'; Category='Spice' }
+    @{ Section=$script:DuneGcSecSpice; Key='m_bSpawningActive'; File='game'; Type='bool'; Default='True'; Label='Spice Spawning Active'; Help='Master switch - whether spice nodes spawn on the map at all. Also needs client-side apply.'; ClientApply=$true; Category='Spice' }
+    @{ Section=$script:DuneGcSecSpice; Key='m_bPlayerMustWitnessBloom'; File='game'; Type='bool'; Default='False'; Label='Player Must Witness Bloom'; Help='If true, a player must be present in the area for a spice bloom to register / count. Also needs client-side apply.'; ClientApply=$true; Category='Spice' }
     # Taxation
     @{ Section=$script:DuneGcSecTaxation; Key='m_SpicePerHour'; File='game'; Type='float'; Min=0; Unit='spice/hr'; Default='11.904750'; Label='Spice Yield per Hour'; Help='Base spice amount generated per hour per active spice field under taxation.'; Category='Taxation' }
     # Sandworm
-    @{ Section=$script:DuneGcSecSandworm; Key='m_MinDistanceBetweenSandworms'; File='game'; Type='float'; Min=0; Unit='UU'; Default='80000.0'; Label='Min Distance Between Sandworms'; Help='Minimum world-unit separation required between two simultaneously active sandworms.'; Category='Sandworm' }
-    @{ Section=$script:DuneGcSecSandworm; Key='m_GiantWormMinimumPlayersOnSpiceField'; File='game'; Type='int'; Min=0; Unit='players'; Default='4'; Label='Giant Worm Min Players on Field'; Help='Minimum number of players on a spice field to trigger a giant sandworm spawn.'; Category='Sandworm' }
+    @{ Section=$script:DuneGcSecSandworm; Key='m_MinDistanceBetweenSandworms'; File='game'; Type='float'; Min=0; Unit='UU'; Default='80000.0'; Label='Min Distance Between Sandworms'; Help='Minimum world-unit separation required between two simultaneously active sandworms. Also needs client-side apply.'; ClientApply=$true; Category='Sandworm' }
+    @{ Section=$script:DuneGcSecSandworm; Key='m_GiantWormMinimumPlayersOnSpiceField'; File='game'; Type='int'; Min=0; Unit='players'; Default='4'; Label='Giant Worm Min Players on Field'; Help='Minimum number of players on a spice field to trigger a giant sandworm spawn. Also needs client-side apply.'; ClientApply=$true; Category='Sandworm' }
 )
 
 # -----------------------------------------------------------------------------
@@ -177,8 +177,14 @@ $script:DuneGameConfigResolvedEngine = $null
 
 # Where each player applies the "client-side too" settings. These keys are read
 # by BOTH server and client; changing them server-side only takes full effect
-# once each player mirrors them in their LOCAL client config (Funcom flags these
-# in DefaultGame.ini as "!Needs to also be applied to each client!").
+# once each player mirrors them in their LOCAL client config. Funcom's setup
+# template flags some keys as "!Needs to also be applied to each client!"
+# (corroborated for the two BuildingSettings keys by the snapetech RE index of
+# Funcom's shipped DefaultGame.ini). The remaining flagged keys were confirmed by
+# live in-game testing on a self-hosted server: the change had NO effect until the
+# same value was also set in the client Game.ini. Sections currently flagged
+# ClientApply=$true above: BuildingSettings, InventorySystemSettings,
+# CoriolisSubsystem, SpiceHarvestingSystem, SandwormSettings.
 $script:DuneGameConfigClientPath = '%LOCALAPPDATA%\DuneSandbox\Saved\Config\WindowsClient\Game.ini'
 
 # Build the post-save "apply this on each client too" reminder from a set of

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.14"
+$script:ToolVersion = "12.0.15"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -34,6 +34,15 @@ import { SpicefieldsCard } from './gameconfig/SpicefieldsCard'
 
 type LoadState = 'idle' | 'loading' | 'ready' | 'error' | 'unavailable'
 
+// One server-vs-client disagreement for a customised ClientApply setting.
+type ClientMismatch = {
+  key: string
+  label: string
+  section: string
+  serverValue: string
+  clientValue: string | null
+}
+
 const SANDWORM_ENABLED_KEY = 'sandworm.dune.Enabled'
 
 // Bool literal pairs per type so toggles emit exactly what UE expects.
@@ -74,6 +83,19 @@ function isCustomized(data: GameConfigResponse | null, field: GameConfigField): 
 function currentValue(data: GameConfigResponse | null, field: GameConfigField): string {
   const lv = liveValue(data, field)
   return lv !== '' ? lv : fieldDefault(field)
+}
+
+// Numeric-aware, case-insensitive equality so 4 vs 4.0 and True vs true don't
+// register as mismatches between the server and client INI values.
+function valuesEqual(a: string, b: string): boolean {
+  const ta = (a ?? '').trim()
+  const tb = (b ?? '').trim()
+  if (ta !== '' && tb !== '') {
+    const na = Number(ta)
+    const nb = Number(tb)
+    if (Number.isFinite(na) && Number.isFinite(nb)) return na === nb
+  }
+  return ta.toLowerCase() === tb.toLowerCase()
 }
 
 function sectionIsManaged(data: GameConfigResponse, field: GameConfigField): boolean {
@@ -123,6 +145,16 @@ export function GameConfig() {
   const [applying, setApplying] = useState(false)
   const [clientSnippetCopied, setClientSnippetCopied] = useState(false)
 
+  // Server-vs-client mismatch popup. Auto-shown on load when a configured client
+  // Game.ini disagrees with the server on a customised ClientApply setting.
+  const [mismatchOpen, setMismatchOpen] = useState(false)
+  const [mismatchAutoShown, setMismatchAutoShown] = useState(false)
+  const [mismatchFixing, setMismatchFixing] = useState(false)
+  const [mismatchErr, setMismatchErr] = useState<string | null>(null)
+  const [mismatchMsg, setMismatchMsg] = useState<string | null>(null)
+  const [mismatchFallback, setMismatchFallback] = useState(false)
+  const [mismatchCopied, setMismatchCopied] = useState(false)
+
   // INI text the admin can hand to OTHER players (who don't run DST) to paste
   // into their own client Game.ini — grouped by section, last-write-wins order.
   const clientSnippet = useMemo(() => {
@@ -146,6 +178,86 @@ export function GameConfig() {
       setTimeout(() => setClientSnippetCopied(false), 1500)
     } catch { /* clipboard may be unavailable; the snippet is still shown */ }
   }, [clientSnippet])
+
+  // Client-mirror mismatch detector. For every ClientApply field the admin has
+  // CUSTOMISED on the server (value present and != default), compare the server's
+  // effective value against the player's local client Game.ini. Any that differ
+  // (or are missing client-side) won't take full effect until mirrored locally.
+  const clientMismatches = useMemo<ClientMismatch[]>(() => {
+    if (!schema || !cfg || !clientInfo || !clientInfo.exists) return []
+    const out: ClientMismatch[] = []
+    for (const cat of schema) {
+      for (const f of cat?.fields ?? []) {
+        if (!f?.clientApply || !f.key) continue
+        if (!isCustomized(cfg, f)) continue
+        const serverValue = currentValue(cfg, f)
+        const raw = clientInfo.effective?.[`${f.section}||${f.key}`]
+        const clientValue = raw === undefined || raw === null ? null : String(raw)
+        if (clientValue !== null && valuesEqual(clientValue, serverValue)) continue
+        out.push({ key: f.key, label: f.label, section: f.section, serverValue, clientValue })
+      }
+    }
+    return out
+  }, [schema, cfg, clientInfo])
+
+  // INI snippet of the SERVER values for the mismatched keys (manual-merge / share).
+  const mismatchSnippet = useMemo(() => {
+    if (clientMismatches.length === 0) return ''
+    const bySection = new Map<string, string[]>()
+    for (const m of clientMismatches) {
+      const lines = bySection.get(m.section) ?? []
+      lines.push(`${m.key}=${m.serverValue}`)
+      bySection.set(m.section, lines)
+    }
+    return [...bySection.entries()]
+      .map(([section, lines]) => [`[${section}]`, ...lines].join('\n'))
+      .join('\n\n')
+  }, [clientMismatches])
+
+  const onCopyMismatchSnippet = useCallback(async () => {
+    if (!mismatchSnippet) return
+    try {
+      await navigator.clipboard.writeText(mismatchSnippet)
+      setMismatchCopied(true)
+      setTimeout(() => setMismatchCopied(false), 1500)
+    } catch { /* clipboard may be unavailable; the snippet is still shown */ }
+  }, [mismatchSnippet])
+
+  // Auto-surface the popup once per detected mismatch set; reset when it clears.
+  useEffect(() => {
+    if (clientMismatches.length > 0 && !mismatchAutoShown) {
+      setMismatchOpen(true)
+      setMismatchAutoShown(true)
+    }
+    if (clientMismatches.length === 0 && mismatchAutoShown) {
+      setMismatchAutoShown(false)
+      setMismatchOpen(false)
+    }
+  }, [clientMismatches.length, mismatchAutoShown])
+
+  // Write the server's values into the local client Game.ini. The click itself is
+  // the user's consent to edit that file; DST backs it up first. Falls back to a
+  // copy-box if DST can't write (no folder / permission).
+  const onFixClientMismatch = useCallback(async () => {
+    if (clientMismatches.length === 0) return
+    setMismatchErr(null)
+    setMismatchMsg(null)
+    setMismatchFixing(true)
+    try {
+      const items = clientMismatches.map(m => ({ key: m.key, label: m.label, section: m.section, value: m.serverValue }))
+      const r = await applyGameConfigClient(items, clientInfo?.dir)
+      setClientInfo(r.client)
+      setMismatchMsg(`Synced ${r.applied} setting${r.applied === 1 ? '' : 's'} to your client Game.ini (${r.path}).${r.backup ? ' Previous file backed up.' : ''}`)
+      window.setTimeout(() => setMismatchMsg(null), 8000)
+      setMismatchOpen(false)
+      setMismatchFallback(false)
+    } catch (e) {
+      setMismatchErr(e instanceof Error ? e.message : String(e))
+      setMismatchFallback(true)
+    } finally {
+      setMismatchFixing(false)
+    }
+  }, [clientMismatches, clientInfo])
 
   const refreshClient = useCallback(async () => {
     try {
@@ -667,6 +779,133 @@ export function GameConfig() {
       {savedMsg && (
         <div className="card p-3 mb-4 border-success/40 bg-success/10 text-success text-sm flex items-center gap-2">
           <Icon name="CheckCircle2" size={14} /> {savedMsg}
+        </div>
+      )}
+      {mismatchMsg && (
+        <div className="card p-3 mb-4 border-success/40 bg-success/10 text-success text-sm flex items-center gap-2">
+          <Icon name="CheckCircle2" size={14} /> {mismatchMsg}
+        </div>
+      )}
+      {clientMismatches.length > 0 && !mismatchOpen && (
+        <button
+          type="button"
+          onClick={() => { setMismatchFallback(false); setMismatchErr(null); setMismatchOpen(true) }}
+          className="card p-3 mb-4 w-full text-left border-warning/40 bg-warning/10 text-warning text-sm flex items-center gap-2 hover:bg-warning/15"
+        >
+          <Icon name="MonitorSmartphone" size={14} />
+          {clientMismatches.length} client setting{clientMismatches.length === 1 ? '' : 's'} {clientMismatches.length === 1 ? "doesn't" : "don't"} match the server — review &amp; fix
+        </button>
+      )}
+      {mismatchOpen && clientMismatches.length > 0 && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+          onClick={() => setMismatchOpen(false)}
+        >
+          <div
+            className="card w-full max-w-xl max-h-[85vh] overflow-y-auto border-warning/40 bg-surface text-sm"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-start gap-2 p-4">
+              <Icon name="MonitorSmartphone" size={18} className="text-warning mt-0.5 shrink-0" />
+              <div className="flex-1 min-w-0">
+                <div className="font-semibold text-text mb-1">
+                  Your client config doesn&apos;t match the server
+                </div>
+                <p className="text-text-muted mb-3">
+                  {clientMismatches.length === 1 ? 'This setting is' : 'These settings are'} read by both the
+                  server and the game client. Your server uses {clientMismatches.length === 1 ? 'this value' : 'these values'},
+                  but your local client{' '}
+                  <span className="font-mono break-all">{clientInfo?.path ?? 'Game.ini'}</span>{' '}
+                  {clientMismatches.length === 1 ? 'has a different one' : 'has different ones'}. Until they match,
+                  the change won&apos;t take full effect for you in-game.
+                </p>
+
+                <div className="rounded border border-border overflow-hidden mb-3">
+                  <table className="w-full text-xs">
+                    <thead className="bg-surface-2 text-text-muted">
+                      <tr>
+                        <th className="text-left font-medium px-2 py-1">Setting</th>
+                        <th className="text-left font-medium px-2 py-1">Server (VM)</th>
+                        <th className="text-left font-medium px-2 py-1">Your client</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {clientMismatches.map(m => (
+                        <tr key={m.key} className="border-t border-border">
+                          <td className="px-2 py-1">
+                            <div className="text-text">{m.label}</div>
+                            <div className="font-mono text-text-dim text-[11px] break-all">[{m.section}] {m.key}</div>
+                          </td>
+                          <td className="px-2 py-1 font-mono text-success whitespace-nowrap">{m.serverValue}</td>
+                          <td className="px-2 py-1 font-mono text-danger whitespace-nowrap">{m.clientValue ?? '(not set)'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                {mismatchErr && (
+                  <div className="mb-2 text-danger text-xs flex items-start gap-1">
+                    <Icon name="AlertCircle" size={13} className="mt-0.5 shrink-0" /> {mismatchErr}
+                  </div>
+                )}
+
+                {!mismatchFallback ? (
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void onFixClientMismatch()}
+                      disabled={mismatchFixing}
+                      className="btn-primary"
+                      title="Let DST write the server's values into your own client's Game.ini on this PC"
+                    >
+                      <Icon name={mismatchFixing ? 'Loader2' : 'MonitorCog'} size={14} className={mismatchFixing ? 'animate-spin' : ''} />
+                      {mismatchFixing ? 'Fixing…' : 'Fix my client config'}
+                    </button>
+                    <button type="button" onClick={() => setMismatchOpen(false)} className="btn-ghost text-xs">
+                      Not now
+                    </button>
+                  </div>
+                ) : (
+                  <div>
+                    <div className="flex items-center justify-between gap-2 mb-1">
+                      <span className="font-medium text-text">DST couldn&apos;t write the file — paste this in yourself</span>
+                      <button
+                        type="button"
+                        onClick={() => void onCopyMismatchSnippet()}
+                        className="btn-ghost text-xs"
+                        title="Copy the correct INI lines"
+                      >
+                        <Icon name={mismatchCopied ? 'Check' : 'Copy'} size={13} />
+                        {mismatchCopied ? 'Copied' : 'Copy'}
+                      </button>
+                    </div>
+                    <p className="text-text-muted mb-1">
+                      Merge these under the matching section headers in{' '}
+                      <span className="font-mono break-all">{clientInfo?.path ?? 'your client Game.ini'}</span>:
+                    </p>
+                    <pre className="px-2 py-1.5 rounded bg-surface-2 text-text text-xs whitespace-pre-wrap break-all overflow-x-auto">{mismatchSnippet}</pre>
+                    <button type="button" onClick={() => setMismatchOpen(false)} className="btn-ghost text-xs mt-2">
+                      Close
+                    </button>
+                  </div>
+                )}
+                <p className="text-[11px] text-text-dim mt-2">
+                  “Fix my client config” only changes{' '}
+                  <span className="font-mono break-all">{clientInfo?.path ?? 'your local client Game.ini'}</span>{' '}
+                  on this machine (backed up first). It never touches other players&apos; configs.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="btn-icon shrink-0"
+                title="Dismiss"
+                onClick={() => setMismatchOpen(false)}
+              >
+                <Icon name="X" size={14} />
+              </button>
+            </div>
+          </div>
         </div>
       )}
       {clientApply && (


### PR DESCRIPTION
## Summary

Two related Game Config improvements, shipping as **v12.0.15**.

### Expanded client-mirror flags
Some gameplay settings only take effect in-game when the matching value is also present in the player's local client `Game.ini`, not just the server VM ini. DST previously flagged only the 2 BuildingSettings keys that Funcom's setup template calls out. Live in-game testing (corroborated by community reverse-engineering notes) showed whole sections behave the same way, so the client-mirror flag now covers **14 keys** across Building, Inventory, Coriolis / Storm Cycle, Spice, and Sandworm.

### Client/server mismatch popup
When a client config folder is set, the Game Config page now checks on load whether your local client `Game.ini` disagrees with the server on any *customized* client-mirror setting (e.g. server `5`, client still `4`). On a mismatch it shows a popup listing each difference (Setting / Server / Your client) and offers **"Fix my client config"**, which writes the server values into your client ini after backing it up. If DST can't write the file, it shows a copy-paste snippet instead. No mismatch = no popup.

## Version
Bumped all 5 version stamps to `12.0.15`; added CHANGELOG + README pointer entries.

## Testing
- `webui` `tsc -b && vite build` — clean
- `tests/GameConfig.Tests.ps1` — 7/7 pass
- `GameConfig.ps1` parses clean; 14 keys flagged `ClientApply`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>