### PR TITLE
v12.0.16: fix folder-picker z-order + stop client-mismatch popup re-nagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.16] - 2026-06-13
+
+### Fixed
+
+- **Native folder/file picker no longer opens behind the DST window.** DST's UI
+  is hosted in a separate process (the WebView2 app window), so when you clicked
+  a "Browse…" button the picker was created by the backend process and Windows'
+  foreground lock pushed it *behind* the app — you had to alt-tab to find it. The
+  picker now briefly attaches to the foreground thread and forces itself to the
+  front, so it appears on top where you'd expect.
+- **The "your client config doesn't match the server" popup no longer re-nags on
+  every page load.** Once you dismiss it ("Not now" / close) for a given
+  mismatch, it stays dismissed (remembered across reloads) and only the small
+  inline banner remains, which you can click to reopen it. It auto-surfaces again
+  only if the underlying server/client values actually change. Fixing the
+  mismatch (or it otherwise resolving) clears the dismissal so a future genuine
+  mismatch can still alert you.
+
 ## [12.0.15] - 2026-06-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v12.0.15**. The in-app version label and the
-website show plain semver tags (e.g. `v12.0.15`) — the previous
+The current release is **v12.0.16**. The in-app version label and the
+website show plain semver tags (e.g. `v12.0.16`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.5.0**

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.15'
+$script:DuneToolVersion = '12.0.16'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.15',
+    [string]$Version = '12.0.16',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.15</Version>
+    <Version>12.0.16</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.15"
+#define MyAppVersion "12.0.16"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/routes/Browse.ps1
+++ b/app/server/routes/Browse.ps1
@@ -37,8 +37,46 @@ function Invoke-DunePathPicker {
             Add-Type -AssemblyName System.Windows.Forms | Out-Null
             Add-Type -AssemblyName System.Drawing | Out-Null
 
+            # Win32 interop to force our owner window to the foreground. A plain
+            # TopMost owner form is NOT enough here: DST's UI is hosted in a
+            # separate process (DuneShell.exe / WebView2), so when the user
+            # clicks Browse that process holds the foreground. Windows'
+            # foreground lock then prevents this (DuneServer.exe) process from
+            # raising a new window above it, so the picker opens BEHIND the app.
+            # AttachThreadInput briefly ties our input queue to the current
+            # foreground thread, which lets SetForegroundWindow actually take.
+            if (-not ('DuneFg' -as [type])) {
+                Add-Type -Namespace '' -Name 'DuneFg' -MemberDefinition @'
+[DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+[DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint pid);
+[DllImport("user32.dll")] public static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
+[DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
+[DllImport("user32.dll")] public static extern bool BringWindowToTop(IntPtr hWnd);
+[DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+[DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
+'@
+            }
+
+            $forceForeground = {
+                param($hWnd)
+                try {
+                    $fg = [DuneFg]::GetForegroundWindow()
+                    $procId = [uint32]0
+                    $fgThread  = [DuneFg]::GetWindowThreadProcessId($fg, [ref]$procId)
+                    $myThread  = [DuneFg]::GetCurrentThreadId()
+                    $attached  = $false
+                    if ($fgThread -ne 0 -and $fgThread -ne $myThread) {
+                        $attached = [DuneFg]::AttachThreadInput($myThread, $fgThread, $true)
+                    }
+                    [void][DuneFg]::ShowWindow($hWnd, 5)   # SW_SHOW
+                    [void][DuneFg]::BringWindowToTop($hWnd)
+                    [void][DuneFg]::SetForegroundWindow($hWnd)
+                    if ($attached) { [void][DuneFg]::AttachThreadInput($myThread, $fgThread, $false) }
+                } catch { }
+            }
+
             # Hidden, off-screen, top-most owner so the picker is forced to
-            # the foreground instead of opening behind the browser.
+            # the foreground instead of opening behind the app window.
             $owner = New-Object System.Windows.Forms.Form
             $owner.TopMost       = $true
             $owner.ShowInTaskbar = $false
@@ -47,6 +85,7 @@ function Invoke-DunePathPicker {
             $owner.Size          = New-Object System.Drawing.Size(1, 1)
             $owner.Show()
             $owner.Activate()
+            & $forceForeground $owner.Handle
 
             $result = [pscustomobject]@{ cancelled = $true; path = '' }
             try {
@@ -64,10 +103,11 @@ function Invoke-DunePathPicker {
                         }
                         if ($dir -and (Test-Path -LiteralPath $dir)) { $dlg.InitialDirectory = $dir }
                     }
-                    if ($dlg.ShowDialog($owner) -eq [System.Windows.Forms.DialogResult]::OK) {
-                        $result.cancelled = $false
-                        $result.path      = $dlg.FileName
-                    }
+                        & $forceForeground $owner.Handle
+                        if ($dlg.ShowDialog($owner) -eq [System.Windows.Forms.DialogResult]::OK) {
+                            $result.cancelled = $false
+                            $result.path      = $dlg.FileName
+                        }
                 } else {
                     $dlg = New-Object System.Windows.Forms.FolderBrowserDialog
                     if ($Title) { $dlg.Description = $Title }
@@ -77,6 +117,7 @@ function Invoke-DunePathPicker {
                         if (Test-Path -LiteralPath $InitialPath -PathType Leaf) { $dir = Split-Path -Parent $InitialPath }
                         if ($dir -and (Test-Path -LiteralPath $dir)) { $dlg.SelectedPath = $dir }
                     }
+                    & $forceForeground $owner.Handle
                     if ($dlg.ShowDialog($owner) -eq [System.Windows.Forms.DialogResult]::OK) {
                         $result.cancelled = $false
                         $result.path      = $dlg.SelectedPath

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.15"
+$script:ToolVersion = "12.0.16"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -154,6 +154,20 @@ export function GameConfig() {
   const [mismatchMsg, setMismatchMsg] = useState<string | null>(null)
   const [mismatchFallback, setMismatchFallback] = useState(false)
   const [mismatchCopied, setMismatchCopied] = useState(false)
+  // Signature of the mismatch set the user last dismissed ("Not now"/close),
+  // persisted so we don't re-nag with the modal on every page load for the same
+  // unchanged values. A successful fix clears it; a genuinely new/changed
+  // mismatch produces a different signature and surfaces again.
+  const [mismatchDismissedSig, setMismatchDismissedSig] = useState<string>(() => {
+    try { return window.localStorage.getItem('dst.gameconfig.mismatchDismissed') ?? '' } catch { return '' }
+  })
+  const persistMismatchDismissed = useCallback((sig: string) => {
+    setMismatchDismissedSig(sig)
+    try {
+      if (sig) window.localStorage.setItem('dst.gameconfig.mismatchDismissed', sig)
+      else window.localStorage.removeItem('dst.gameconfig.mismatchDismissed')
+    } catch { /* localStorage may be unavailable; in-memory state still applies */ }
+  }, [])
 
   // INI text the admin can hand to OTHER players (who don't run DST) to paste
   // into their own client Game.ini — grouped by section, last-write-wins order.
@@ -214,6 +228,16 @@ export function GameConfig() {
       .join('\n\n')
   }, [clientMismatches])
 
+  // Stable signature of the current mismatch set: changes only when the set of
+  // keys or their server/client values change. Drives "don't re-nag" logic.
+  const mismatchSignature = useMemo(() => {
+    if (clientMismatches.length === 0) return ''
+    return clientMismatches
+      .map(m => `${m.section}||${m.key}=${m.serverValue}>${m.clientValue ?? ''}`)
+      .sort()
+      .join('|')
+  }, [clientMismatches])
+
   const onCopyMismatchSnippet = useCallback(async () => {
     if (!mismatchSnippet) return
     try {
@@ -223,17 +247,31 @@ export function GameConfig() {
     } catch { /* clipboard may be unavailable; the snippet is still shown */ }
   }, [mismatchSnippet])
 
-  // Auto-surface the popup once per detected mismatch set; reset when it clears.
+  // Auto-surface the popup once per detected mismatch set, but NOT if the user
+  // already dismissed this exact set (persisted across reloads). When the
+  // mismatch clears (e.g. after a fix), drop any saved dismissal so a future
+  // genuine mismatch can surface again.
   useEffect(() => {
-    if (clientMismatches.length > 0 && !mismatchAutoShown) {
+    if (mismatchSignature === '') {
+      if (mismatchAutoShown) setMismatchAutoShown(false)
+      if (mismatchOpen) setMismatchOpen(false)
+      if (mismatchDismissedSig) persistMismatchDismissed('')
+      return
+    }
+    if (!mismatchAutoShown && mismatchSignature !== mismatchDismissedSig) {
       setMismatchOpen(true)
       setMismatchAutoShown(true)
     }
-    if (clientMismatches.length === 0 && mismatchAutoShown) {
-      setMismatchAutoShown(false)
-      setMismatchOpen(false)
-    }
-  }, [clientMismatches.length, mismatchAutoShown])
+  }, [mismatchSignature, mismatchAutoShown, mismatchOpen, mismatchDismissedSig, persistMismatchDismissed])
+
+  // Close the modal without fixing; remember this exact mismatch set so it
+  // doesn't auto-pop again until the underlying values change.
+  const onDismissMismatch = useCallback(() => {
+    persistMismatchDismissed(mismatchSignature)
+    setMismatchOpen(false)
+    setMismatchFallback(false)
+    setMismatchErr(null)
+  }, [mismatchSignature, persistMismatchDismissed])
 
   // Write the server's values into the local client Game.ini. The click itself is
   // the user's consent to edit that file; DST backs it up first. Falls back to a
@@ -799,7 +837,7 @@ export function GameConfig() {
       {mismatchOpen && clientMismatches.length > 0 && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
-          onClick={() => setMismatchOpen(false)}
+          onClick={() => onDismissMismatch()}
         >
           <div
             className="card w-full max-w-xl max-h-[85vh] overflow-y-auto border-warning/40 bg-surface text-sm"
@@ -862,7 +900,7 @@ export function GameConfig() {
                       <Icon name={mismatchFixing ? 'Loader2' : 'MonitorCog'} size={14} className={mismatchFixing ? 'animate-spin' : ''} />
                       {mismatchFixing ? 'Fixing…' : 'Fix my client config'}
                     </button>
-                    <button type="button" onClick={() => setMismatchOpen(false)} className="btn-ghost text-xs">
+                    <button type="button" onClick={() => onDismissMismatch()} className="btn-ghost text-xs">
                       Not now
                     </button>
                   </div>
@@ -885,7 +923,7 @@ export function GameConfig() {
                       <span className="font-mono break-all">{clientInfo?.path ?? 'your client Game.ini'}</span>:
                     </p>
                     <pre className="px-2 py-1.5 rounded bg-surface-2 text-text text-xs whitespace-pre-wrap break-all overflow-x-auto">{mismatchSnippet}</pre>
-                    <button type="button" onClick={() => setMismatchOpen(false)} className="btn-ghost text-xs mt-2">
+                    <button type="button" onClick={() => onDismissMismatch()} className="btn-ghost text-xs mt-2">
                       Close
                     </button>
                   </div>
@@ -900,7 +938,7 @@ export function GameConfig() {
                 type="button"
                 className="btn-icon shrink-0"
                 title="Dismiss"
-                onClick={() => setMismatchOpen(false)}
+                onClick={() => onDismissMismatch()}
               >
                 <Icon name="X" size={14} />
               </button>


### PR DESCRIPTION
## Summary

Two fixes reported after v12.0.15, shipping as **v12.0.16**.

### Folder/file picker opened behind the DST window
DST's UI is hosted in a separate process (the WebView2 app window), so when you clicked a **Browse…** button, the native picker was created by the backend process and Windows' foreground lock pushed it *behind* the app — you had to alt-tab to find it. The picker now briefly attaches to the current foreground thread and forces itself to the front (`AttachThreadInput` + `SetForegroundWindow`), so it appears on top.

### Client/server mismatch popup re-nagged every page load
The "your client config doesn't match the server" popup auto-opened on every page load. Now, once you dismiss it (**Not now** / close) for a given mismatch, it stays dismissed (persisted across reloads, keyed by the mismatch signature) and only the small inline banner remains — click it to reopen. It auto-surfaces again only if the underlying server/client values actually change. Fixing the mismatch clears the dismissal so future genuine mismatches still alert you.

## Version
Bumped all 5 version stamps to `12.0.16`; added CHANGELOG + README entries.

## Testing
- `webui` `tsc -b && vite build` — clean
- `tests/GameConfig.Tests.ps1` — 7/7 pass
- `Browse.ps1` parses clean under PS7 **and** PS 5.1 (installer runtime); P/Invoke type compiles & calls in both; UTF-8 BOM intact
- In-place client-INI writer round-trip verified (145→100 persists and reads back), confirming a successful "Fix" clears the mismatch

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>