### PR TITLE
v12.0.17: collapse duplicate client-INI keys so "Fix my client config" actually clears the mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.17] - 2026-06-13
+
+### Fixed
+
+- **"Fix my client config" now actually clears the mismatch when the same key
+  appears twice in your client `Game.ini`.** Some client files carry a setting
+  more than once in the same section (e.g. `PlayerInventoryStartingSize=100`
+  followed by `=145`). UE5 — and DST's own reader — use the *last* occurrence,
+  but the in-place writer was only updating the *first* one and leaving the
+  trailing duplicate behind. The result: clicking **Fix** appeared to do nothing
+  and the "client doesn't match the server" warning never went away. The writer
+  now collapses duplicate scalar keys to a single line carrying the written
+  value, so a fix takes effect and the mismatch clears.
+
 ## [12.0.16] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v12.0.16**. The in-app version label and the
-website show plain semver tags (e.g. `v12.0.16`) — the previous
+The current release is **v12.0.17**. The in-app version label and the
+website show plain semver tags (e.g. `v12.0.17`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.5.0**

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.16'
+$script:DuneToolVersion = '12.0.17'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.16',
+    [string]$Version = '12.0.17',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.16</Version>
+    <Version>12.0.17</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.16"
+#define MyAppVersion "12.0.17"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -288,15 +288,20 @@ function Set-DuneIniValuesInPlace {
             $target = @{ name = $secName; header = "[$secName]"; body = (New-Object 'System.Collections.Generic.List[string]'); managed = $false }
             $doc.sections.Add($target)
         }
-        $replaced = $false
+        # Replace the FIRST scalar occurrence and strip any later duplicates of the
+        # same key in this section. UE5 (and Get-DuneIniEffective) are last-wins, so
+        # leaving a trailing duplicate would shadow our write and the value would
+        # never appear to change. Collapsing to a single line keeps effective==written.
+        $replaced  = $false
+        $removeIdx = New-Object 'System.Collections.Generic.List[int]'
         for ($i = 0; $i -lt $target.body.Count; $i++) {
             $info = Get-DuneIniLineKey $target.body[$i]
             if ($info -and -not $info.isArray -and $info.key -eq $key) {
-                $target.body[$i] = $valLine
-                $replaced = $true
-                break
+                if (-not $replaced) { $target.body[$i] = $valLine; $replaced = $true }
+                else { $removeIdx.Add($i) }
             }
         }
+        for ($j = $removeIdx.Count - 1; $j -ge 0; $j--) { $target.body.RemoveAt($removeIdx[$j]) }
         if (-not $replaced) { $target.body.Add($valLine) }
     }
     $out = New-Object 'System.Collections.Generic.List[string]'

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.16"
+$script:ToolVersion = "12.0.17"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -154,6 +154,59 @@ KeyA=1
     }
 }
 
+Describe 'Set-DuneIniValuesInPlace: client-file duplicate-key collapse' -Tag 'GameConfig' {
+
+    # Regression for the v12.0.16 report: the client Game.ini carried the same
+    # scalar key TWICE in one section (e.g. PlayerInventoryStartingSize=100 then
+    # =145). The in-place writer replaced only the FIRST occurrence, but UE5 and
+    # Get-DuneIniEffective are last-wins, so the trailing duplicate shadowed the
+    # write and the "Fix" never cleared the mismatch.
+    It 'collapses a duplicate scalar key to a single line carrying the written value' {
+        $raw = @"
+[/Script/DuneSandbox.InventorySystemSettings]
+PlayerInventoryStartingSize=100
+PlayerInventoryStartingSize=145
+"@
+        $out = Set-DuneIniValuesInPlace -Raw $raw `
+            -Updates @(@{ section = $script:SecInventory; key = 'PlayerInventoryStartingSize'; value = '100' }) `
+            -QuotedKeys @{}
+
+        # exactly one occurrence of the key remains...
+        $hits = @(($out -replace "`r", '' -split "`n") | Where-Object { $_.Trim() -match '^PlayerInventoryStartingSize\s*=' })
+        $hits.Count | Should -Be 1
+        # ...and the effective (last-wins) value is the one we wrote
+        (Get-EffectiveValue -Raw $out -Section $script:SecInventory -Key 'PlayerInventoryStartingSize') | Should -Be '100'
+        (Get-DuneIniEffective -Raw $out)["$($script:SecInventory)||PlayerInventoryStartingSize"] | Should -Be '100'
+    }
+
+    It 'upserts a brand-new key into an existing section without duplicating it' {
+        $raw = "[/Script/DuneSandbox.InventorySystemSettings]`nOtherKey=1`n"
+        $out = Set-DuneIniValuesInPlace -Raw $raw `
+            -Updates @(@{ section = $script:SecInventory; key = 'PlayerInventoryStartingSize'; value = '50' }) `
+            -QuotedKeys @{}
+        $hits = @(($out -replace "`r", '' -split "`n") | Where-Object { $_.Trim() -match '^PlayerInventoryStartingSize\s*=' })
+        $hits.Count | Should -Be 1
+        (Get-DuneIniEffective -Raw $out)["$($script:SecInventory)||PlayerInventoryStartingSize"] | Should -Be '50'
+    }
+
+    It 'leaves array (+/-) lines untouched when collapsing a scalar duplicate' {
+        $raw = @"
+[/Script/DuneSandbox.InventorySystemSettings]
++SomeArray=a
+PlayerInventoryStartingSize=100
++SomeArray=b
+PlayerInventoryStartingSize=145
+"@
+        $out = Set-DuneIniValuesInPlace -Raw $raw `
+            -Updates @(@{ section = $script:SecInventory; key = 'PlayerInventoryStartingSize'; value = '100' }) `
+            -QuotedKeys @{}
+        $out | Should -Match '\+SomeArray=a'
+        $out | Should -Match '\+SomeArray=b'
+        $hits = @(($out -replace "`r", '' -split "`n") | Where-Object { $_.Trim() -match '^PlayerInventoryStartingSize\s*=' })
+        $hits.Count | Should -Be 1
+    }
+}
+
 Describe 'DuneGameConfigSchema: no fictional no-op keys' -Tag 'GameConfig' {
 
     # Guards against regressing the m_Global*Multiplier keys that the reference


### PR DESCRIPTION
## Summary

Follow-up to v12.0.16. The "client config doesn't match the server" warning **never cleared** for some users even after clicking **Fix my client config**.

## Root cause
Some client `Game.ini` files carry the same scalar key **twice in one section** — e.g. left over from manual pak-extraction edits:

```
[/Script/DuneSandbox.InventorySystemSettings]
PlayerInventoryStartingSize=100
PlayerInventoryStartingSize=145
```

UE5 (and DST's own `Get-DuneIniEffective`) are **last-wins**, so the effective value is `145`. But `Set-DuneIniValuesInPlace` only replaced the **first** occurrence and `break`ed, leaving the trailing `=145` behind. Every **Fix** rewrote the first line to `100` (no visible change) while `145` survived — so the mismatch detector kept flagging it and the warning never went away.

## Fix
The in-place writer now replaces the first occurrence **and strips any later duplicate scalar lines** for that key in the target section, so `effective == written`. Array (`+`/`-`) lines are left untouched.

## Tests
Adds 3 regression tests to `tests/GameConfig.Tests.ps1`:
- collapses a duplicate scalar key to a single line carrying the written value
- upserts a brand-new key into an existing section without duplicating it
- leaves array (+/-) lines untouched when collapsing a scalar duplicate

`Invoke-Pester tests/GameConfig.Tests.ps1` → **10/10 pass**. `GameConfig.ps1` parses clean under PS 5.1 (installer runtime).

## Version
Bumped all 5 version stamps to `12.0.17`; CHANGELOG + README updated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>