### PR TITLE
v12.0.18: mirror Survival settings to the client INI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.18] - 2026-06-13
+
+### Changed
+
+- **Survival settings are now client-mirrored.** The six **Survival** options
+  (Water Consumption Rate, Water Consumption in Storm, Player Starting Water,
+  Reconnect Grace Period, Item Durability Loss Multiplier, Item Decay Rate) are
+  read by the game client as well as the server, so they now flow through the
+  same client-apply path as Building/Inventory/Spice/etc.: DST can mirror them
+  into your local client `Game.ini`, and the client/server mismatch check now
+  covers them too.
+
 ## [12.0.17] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v12.0.17**. The in-app version label and the
-website show plain semver tags (e.g. `v12.0.17`) — the previous
+The current release is **v12.0.18**. The in-app version label and the
+website show plain semver tags (e.g. `v12.0.18`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.5.0**

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.17'
+$script:DuneToolVersion = '12.0.18'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -1,4 +1,4 @@
-# Build-Exe.ps1 - Compiles app/DuneServer.ps1 into DuneServer.exe via ps2exe.
+﻿# Build-Exe.ps1 - Compiles app/DuneServer.ps1 into DuneServer.exe via ps2exe.
 #
 # Output: app/build/output/DuneServer.exe
 #
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.17',
+    [string]$Version = '12.0.18',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.17</Version>
+    <Version>12.0.18</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.17"
+#define MyAppVersion "12.0.18"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -69,12 +69,12 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecUrl; Key='IGWPort'; File='engine'; Type='int'; Min=1024; Max=65535; Default='7780'; Label='IGW Port (starting)'; Help='Starting inter-server port; must not overlap the game port range.'; Category='Network' }
 
     # --- Survival ---
-    @{ Section=$script:DuneGcSecGame; Key='m_WaterConsumptionRate'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Water Consumption Rate'; Help='How quickly players consume water.'; Category='Survival' }
-    @{ Section=$script:DuneGcSecGame; Key='m_WaterConsumptionInStormMultiplier'; File='game'; Type='float'; Min=0; Default='2.0'; Label='Water Consumption in Storm'; Help='Additional water drain during sandstorms.'; Category='Survival' }
-    @{ Section=$script:DuneGcSecGame; Key='m_PlayerStartingWater'; File='game'; Type='float'; Min=0; Default='100.0'; Label='Player Starting Water'; Help='Water amount when a player spawns.'; Category='Survival' }
-    @{ Section=$script:DuneGcSecOnline; Key='m_DefaultReconnectGracePeriodSeconds'; File='game'; Type='int'; Min=0; Unit='sec'; Default='300'; Label='Reconnect Grace Period'; Help="Seconds a player's corpse persists after disconnect."; Category='Survival' }
-    @{ Section=$script:DuneGcSecDurab; Key='m_ItemDurabilityLossMultiplier'; File='game'; Type='float'; Min=0; Max=10; Default='1.0'; Label='Item Durability Loss Multiplier'; Help='Scales durability loss for all items. 0 = off.'; Category='Survival' }
-    @{ Section=$script:DuneGcSecDurab; Key='UpdateRateInSeconds'; File='game'; Type='float'; Min=0; Max=10; Unit='sec'; Default='1.0'; Label='Item Decay Rate'; Help='Deterioration tick rate. 0 = off, 1-10 typical.'; Category='Survival' }
+    @{ Section=$script:DuneGcSecGame; Key='m_WaterConsumptionRate'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Water Consumption Rate'; Help='How quickly players consume water. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
+    @{ Section=$script:DuneGcSecGame; Key='m_WaterConsumptionInStormMultiplier'; File='game'; Type='float'; Min=0; Default='2.0'; Label='Water Consumption in Storm'; Help='Additional water drain during sandstorms. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
+    @{ Section=$script:DuneGcSecGame; Key='m_PlayerStartingWater'; File='game'; Type='float'; Min=0; Default='100.0'; Label='Player Starting Water'; Help='Water amount when a player spawns. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
+    @{ Section=$script:DuneGcSecOnline; Key='m_DefaultReconnectGracePeriodSeconds'; File='game'; Type='int'; Min=0; Unit='sec'; Default='300'; Label='Reconnect Grace Period'; Help="Seconds a player's corpse persists after disconnect. Also needs client-side apply."; ClientApply=$true; Category='Survival' }
+    @{ Section=$script:DuneGcSecDurab; Key='m_ItemDurabilityLossMultiplier'; File='game'; Type='float'; Min=0; Max=10; Default='1.0'; Label='Item Durability Loss Multiplier'; Help='Scales durability loss for all items. 0 = off. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
+    @{ Section=$script:DuneGcSecDurab; Key='UpdateRateInSeconds'; File='game'; Type='float'; Min=0; Max=10; Unit='sec'; Default='1.0'; Label='Item Decay Rate'; Help='Deterioration tick rate. 0 = off, 1-10 typical. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
 
     # --- Resources & Economy (engine ConsoleVariables) ---
     @{ Section=$script:DuneGcSecConsole; Key='Dune.GlobalMiningOutputMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Global Mining Multiplier'; Help='Scales hand-mining resource output.'; Category='Resources & Economy' }
@@ -183,7 +183,9 @@ $script:DuneGameConfigResolvedEngine = $null
 # Funcom's shipped DefaultGame.ini). The remaining flagged keys were confirmed by
 # live in-game testing on a self-hosted server: the change had NO effect until the
 # same value was also set in the client Game.ini. Sections currently flagged
-# ClientApply=$true above: BuildingSettings, InventorySystemSettings,
+# ClientApply=$true above: DuneGameMode (Survival: water + starting water),
+# PlayerOnlineStateSettings (reconnect grace), ItemDeteriorationConstants
+# (durability/decay), BuildingSettings, InventorySystemSettings,
 # CoriolisSubsystem, SpiceHarvestingSystem, SandwormSettings.
 $script:DuneGameConfigClientPath = '%LOCALAPPDATA%\DuneSandbox\Saved\Config\WindowsClient\Game.ini'
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1,4 +1,4 @@
-#Requires -RunAsAdministrator
+﻿#Requires -RunAsAdministrator
 
 [CmdletBinding()]
 param(
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.17"
+$script:ToolVersion = "12.0.18"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Summary

Extends the client-mirror feature to the **Survival** category. Those settings are read by the game client as well as the server, so they now flow through the same client-apply path as Building/Inventory/Spice/Sandworm/Coriolis.

## What changed
Flagged all six Survival schema fields `ClientApply=$true` in `app/server/lib/GameConfig.ps1`:

| Setting | Section | Key |
|---|---|---|
| Water Consumption Rate | `DuneGameMode` | `m_WaterConsumptionRate` |
| Water Consumption in Storm | `DuneGameMode` | `m_WaterConsumptionInStormMultiplier` |
| Player Starting Water | `DuneGameMode` | `m_PlayerStartingWater` |
| Reconnect Grace Period | `PlayerOnlineStateSettings` | `m_DefaultReconnectGracePeriodSeconds` |
| Item Durability Loss Multiplier | `ItemDeteriorationConstants` | `m_ItemDurabilityLossMultiplier` |
| Item Decay Rate | `ItemDeteriorationConstants` | `UpdateRateInSeconds` |

This means DST will now:
- offer to mirror these into the local client `Game.ini` on save (with permission), and
- include them in the client/server mismatch check + "Fix my client config".

Total `ClientApply` keys: 14 → 20. The `Save-DuneGameConfigClient` allow-list is schema-driven, so flagging is all that's needed to permit writing these keys.

## Testing
- Schema loads under PS 5.1; all 6 Survival keys report `ClientApply=$true`
- `Invoke-Pester tests/GameConfig.Tests.ps1` → 10/10 pass

## Version
Bumped all 5 version stamps to `12.0.18`; CHANGELOG + README updated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>