### PR TITLE
v12.0.19: Players page parity + give-items online/offline fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.19] - 2026-06-13
+
 ### Added
 
 - **Give Package** Player Action (Inventory section) — build and reuse your own

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/coastal-ms/DST-DuneServerTool?sort=semver)](https://github.com/coastal-ms/DST-DuneServerTool/releases/latest)
 
-The current release is **v12.0.18**. The in-app version label and the
+The current release is **v12.0.19**. The in-app version label and the
 website show plain semver tags (e.g. `v12.0.18`) — the previous
 Roman-numeral stylization has been removed.
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.18'
+$script:DuneToolVersion = '12.0.19'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.18',
+    [string]$Version = '12.0.19',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.18</Version>
+    <Version>12.0.19</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.18"
+#define MyAppVersion "12.0.19"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.18"
+$script:ToolVersion = "12.0.19"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Release PR covering the already-merged #190 and #191. Bumps all five version stamps `12.0.18 → 12.0.19`, points the README current-release marker at v12.0.19, and rolls the `[Unreleased]` changelog into a dated `## [12.0.19]` section.

### What ships in 12.0.19
- **Give Item** is volume + slot-aware; online/offline give unified (no more false "not enough slots" on stacks).
- **Spawn Vehicle**, **whole-tier-set gear** giving, **Give Vehicle Kit** (Mk6 parts + unique modules + Large Fuel Cell + Welding Torch Mk5).
- **Give Package** / admin-defined **item packages** (build & reuse named bundles, persisted server-side).
- **Server Health** polling refreshes on tab visibility / window focus regain (no more stale 24/7 window).
- **Game Config** staleness fix, currency/faction action fixes, **Apply Quick Preset** wired, **Stop VM Only** command.
- Bulk give-items no longer crashes on a `List[object]` (`@()` → `.ToArray()`), and now **delivers to online players** via the live server-command path instead of silently writing to SQL the game ignores.

### Build
Full installer build (all five stamps verified matching 12.0.19, `DuneServer.exe` + `DuneShell.exe` rebuilt, SPA rebuilt). `DuneServerSetup.exe` 45.86 MB. The tagged GitHub release will carry that installer as its sole asset.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>