### PR TITLE
fix(bot): resolve valid access_point_id to avoid FK violation (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Market Bot** — fixed `dune_exchange_orders_access_point_id_fkey` foreign-key
+  violation when enabling the bot or clicking **Seed Market** (#194). The bot's
+  access-point resolution defaulted to a hard-coded `access_point_id = 1` and
+  only checked existing orders, so on servers with no bot orders yet (fresh
+  battlegroups, or upgrades from pre-`dune-admin`-removal builds) it handed the
+  order insert a non-existent access point and the FK rejected it. Resolution
+  now cascades through the authoritative `dune_exchange_accesspoints` table
+  (JOIN-/existence-guarded at every tier) and validates the id is a live FK
+  target before inserting, mirroring the existing exchange-id hardening.
+
+
 ## [12.0.19] - 2026-06-13
 
 ### Added

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -447,6 +447,44 @@ function Get-DuneBotScalar {
 }
 
 # ----------------------------------------------------------------------------
+# Resolve a VALID access_point_id for the bot's NPC orders. The bot writes into
+# dune.dune_exchange_orders whose access_point_id FK references
+# dune.dune_exchange_accesspoints(id); handing it a phantom id (the old
+# hard-coded default of 1) trips dune_exchange_orders_access_point_id_fkey on
+# any server that has no bot/player orders for that exchange yet — e.g. fresh
+# battlegroups, or upgrades from pre-dune-admin builds. Cascade mirrors the
+# exchange-id hardening: every tier is JOIN-/existence-guarded so a stale row
+# can never return an id that isn't a live FK target.
+# ----------------------------------------------------------------------------
+function Resolve-DuneBotAccessPointId {
+    param([string]$Ip, [int64]$ExchangeId)
+    $apId = 0L
+    foreach ($q in @(
+        # Tier 1 (authoritative): an access point belonging to this exchange.
+        "SELECT id FROM dune.dune_exchange_accesspoints WHERE exchange_id = $ExchangeId ORDER BY id LIMIT 1",
+        # Tier 2: reuse the access point from an existing order, JOIN-guarded so a
+        # stale order row pointing at a wiped access point can't return a phantom.
+        "SELECT o.access_point_id FROM dune.dune_exchange_orders o JOIN dune.dune_exchange_accesspoints ap ON ap.id = o.access_point_id WHERE o.exchange_id = $ExchangeId LIMIT 1",
+        # Tier 3: any access point on the server (the accesspoints row may carry a
+        # different exchange_id than the one we resolved).
+        'SELECT id FROM dune.dune_exchange_accesspoints ORDER BY id LIMIT 1'
+    )) {
+        $r = Get-DuneBotScalar -Ip $Ip -Sql $q
+        if ($r.ok -and $r.value) { $apId = ConvertTo-DuneInt $r.value; if ($apId -gt 0) { break } }
+    }
+    if ($apId -le 0) {
+        return @{ ok = $false; error = 'no exchange access point found — build/place an Exchange in-world before seeding the market.' }
+    }
+    # Final guard: confirm the resolved id is a live FK target before we hand it
+    # to an INSERT.
+    $v = Get-DuneBotScalar -Ip $Ip -Sql "SELECT id FROM dune.dune_exchange_accesspoints WHERE id = $apId"
+    if (-not ($v.ok -and $v.value)) {
+        return @{ ok = $false; error = "resolved access point id $apId is not a valid FK target." }
+    }
+    return @{ ok = $true; value = $apId }
+}
+
+# ----------------------------------------------------------------------------
 # Bot identity — port of initBotUser + exchange/access-point resolution.
 # Read-only by default; -CreateIfMissing performs the (idempotent) writes that
 # provision the Duke actor + exchange user. Cached per-runspace once resolved.
@@ -513,9 +551,10 @@ function Get-DuneBotIdentity {
                 }
             }
             if ($exId -le 0) { return @{ ok = $false; provisioned = $false; error = 'could not resolve exchange id.' } }
-            $apId = 1L
-            $ap0 = Get-DuneBotScalar -Ip $Ip -Sql "SELECT DISTINCT access_point_id FROM dune.dune_exchange_orders WHERE exchange_id = $exId LIMIT 1"
-            if ($ap0.ok -and $ap0.value) { $apId = ConvertTo-DuneInt $ap0.value }
+            # Read-only/dry path: resolve best-effort. No order insert happens
+            # here, so a missing access point is non-fatal for preview.
+            $apr = Resolve-DuneBotAccessPointId -Ip $Ip -ExchangeId $exId
+            $apId = if ($apr.ok) { $apr.value } else { 0L }
             return @{ ok = $true; provisioned = $false; ownerId = 0L; exchangeId = $exId; accessPointId = $apId }
         }
         # Idempotent create-or-fetch in one statement. Only matches Dukes that
@@ -565,10 +604,11 @@ SELECT id FROM ins UNION ALL SELECT id FROM existing LIMIT 1;
     }
     if ($exchangeId -le 0) { return @{ ok = $false; error = 'could not resolve exchange id.' } }
 
-    # Access point id.
-    $accessPointId = 1L
-    $ap = Get-DuneBotScalar -Ip $Ip -Sql "SELECT DISTINCT access_point_id FROM dune.dune_exchange_orders WHERE exchange_id = $exchangeId LIMIT 1"
-    if ($ap.ok -and $ap.value) { $accessPointId = ConvertTo-DuneInt $ap.value }
+    # Access point id — must be a live FK target in dune_exchange_accesspoints,
+    # otherwise the order insert trips dune_exchange_orders_access_point_id_fkey.
+    $apMain = Resolve-DuneBotAccessPointId -Ip $Ip -ExchangeId $exchangeId
+    if (-not $apMain.ok) { return @{ ok = $false; error = $apMain.error } }
+    $accessPointId = $apMain.value
 
     $ident = @{ ok = $true; provisioned = $true; ownerId = $ownerId; exchangeId = $exchangeId; accessPointId = $accessPointId }
     $script:DuneBotIdentityCache = $ident

--- a/docs/internal/marketbot-port-spec.md
+++ b/docs/internal/marketbot-port-spec.md
@@ -107,14 +107,26 @@ SELECT id FROM dune.dune_exchanges ORDER BY id LIMIT 1
 SELECT dune.get_dune_exchange_id('Global')
 ```
 
-**Access Point ID** — 2-tier cascade:
+**Access Point ID** — 3-tier cascade, every tier existence-/JOIN-guarded so the
+resolved id is always a live FK target for `dune_exchange_orders_access_point_id_fkey`
+(never the old hard-coded `1`, which trips the FK on servers with no bot orders yet):
 ```sql
--- Tier 1 (from access points table):
+-- Tier 1 (authoritative — access point belonging to this exchange):
 SELECT id FROM dune.dune_exchange_accesspoints WHERE exchange_id = $exchangeId ORDER BY id LIMIT 1
 
--- Tier 2 (from existing player orders):
-SELECT DISTINCT access_point_id FROM dune.dune_exchange_orders WHERE exchange_id = $exchangeId LIMIT 1
--- Falls back to 1 if both fail
+-- Tier 2 (reuse an existing order's access point, JOIN-guarded against the
+-- accesspoints table so a stale order can't return a phantom id):
+SELECT o.access_point_id FROM dune.dune_exchange_orders o
+  JOIN dune.dune_exchange_accesspoints ap ON ap.id = o.access_point_id
+  WHERE o.exchange_id = $exchangeId LIMIT 1
+
+-- Tier 3 (any access point on the server):
+SELECT id FROM dune.dune_exchange_accesspoints ORDER BY id LIMIT 1
+
+-- Final guard: re-validate the resolved id exists in dune_exchange_accesspoints.
+-- If nothing resolves on the write path, fail with an actionable error
+-- (operator must build/place an Exchange in-world) rather than inserting a
+-- phantom access_point_id.
 ```
 
 **Exchange Inventory ID** (for `items.inventory_id`):


### PR DESCRIPTION
## Bug

Closes #194. Enabling the Market Bot or clicking **Seed Market** failed with:

```
Bot error: insert chunk: insert or update on table "dune_exchange_orders"
violates foreign key constraint "dune_exchange_orders_access_point_id_fkey"
```

Reported on v12.0.19 after upgrading from an 11.4.x (pre-`dune-admin`-removal) build.

## Root cause

`Get-DuneBotIdentity`'s access-point resolution defaulted to a hard-coded
`access_point_id = 1` and only consulted `dune_exchange_orders` for an existing
id. On any server with **no bot/player orders for that exchange yet** (fresh
battlegroups, or upgrades like the reporter's), both lookups came up empty, so
the bot handed the order insert a non-existent access point and the FK rejected
it. The exchange-id resolution right above it was already hardened against this
exact phantom-id class; the access-point path was never given the same treatment.

## Fix

New `Resolve-DuneBotAccessPointId` helper — a JOIN-/existence-guarded 3-tier
cascade over the authoritative `dune_exchange_accesspoints` table:

1. Access point belonging to the resolved exchange.
2. Reuse an existing order's access point, JOIN-guarded so a stale order can't return a phantom.
3. Any access point on the server.

Then a final existence guard re-validates the id is a live FK target before it
reaches an INSERT. The write path now fails with an actionable error ("build/place
an Exchange in-world") instead of inserting a phantom id; the read-only/dry-run
path stays lenient since it never inserts.

Also updated `docs/internal/marketbot-port-spec.md` to document the new cascade.

## Testing

- `tests/SeedMarket.Tests.ps1` — 23/23 pass.
- Parser syntax check on `GameplayBot.ps1` — clean.

## Release note

Staged under `## [Unreleased]` in `CHANGELOG.md`. Intended to ship in the next
release alongside the missing-inventory-items fix from the parallel session — no
version stamps bumped here; those happen at release prep when both land.