### PR TITLE
fix(catalog): backfill 552 missing items into the Add-Item picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,13 @@ here cover everything those tags shipped.
   now cascades through the authoritative `dune_exchange_accesspoints` table
   (JOIN-/existence-guarded at every tier) and validates the id is a live FK
   target before inserting, mirroring the existing exchange-id hardening.
-
+- **Add Item search now finds every item the app knows about.** The "Add Item"
+  picker (Player/Storage inventory editors) is backed by `item-catalog.json`,
+  which was scraped from a single source and missing 552 real templates — most
+  visibly raw resources like **Spice Sand**, **Water**, and **Plant Fiber**, plus
+  many garments, vehicle modules, weapons, tools, and components. Backfilled the
+  catalog from the app-bundled `gameplay-item-data.json` so all of these are now
+  searchable and giveable (1294 → 1846 entries).
 
 ## [12.0.19] - 2026-06-13
 

--- a/app/data/README.md
+++ b/app/data/README.md
@@ -4,7 +4,7 @@ Static reference data shipped with the app.
 
 | File | Purpose | Source |
 |------|---------|--------|
-| `item-catalog.json`   | Item template-ID lookup table (~1.3k entries) used by the Character Editor's "Add Item" search box. Gradeable gear/weapons/augments carry a `gradeable` flag + base `tier` so the Give Item form can hand over a whole tier set (Mk1–Mk6). | Adapted from the upstream `dune-awakening-server-manager` reference (MIT); ultimately sourced from [awakening.wiki](https://awakening.wiki). |
+| `item-catalog.json`   | Item template-ID lookup table (~1.85k entries) used by the Character Editor's "Add Item" search box. Gradeable gear/weapons/augments carry a `gradeable` flag + base `tier` so the Give Item form can hand over a whole tier set (Mk1–Mk6). | Base set adapted from the upstream `dune-awakening-server-manager` reference (MIT), sourced from [awakening.wiki](https://awakening.wiki); supplemented with items from the app-bundled `gameplay-item-data.json` so every template the app knows about is searchable (e.g. Spice Sand, Water, Plant Fiber). |
 | `stat-reference.json` | Player stat key reference and inventory container-type map. | Same upstream as above. |
 
 Both files are MIT-licensed; the Character Editor "About" section credits

--- a/app/data/item-catalog.json
+++ b/app/data/item-catalog.json
@@ -1,9 +1,10 @@
 {
   "_meta": {
-    "total": 1294,
+    "total": 1846,
     "source": "awakening.wiki",
     "scraped": "2026-05-20",
-    "gradeable": 378
+    "gradeable": 378,
+    "supplemented": "gameplay-item-data.json (DST app-bundled item metadata)"
   },
   "items": {
     "SMG_Unique_LargeMag_06": {
@@ -5937,6 +5938,2214 @@
       "category": "Schematics",
       "gradeable": true,
       "tier": 6
+    },
+    "Social_Atre_Casual03_Unique_Story_TheBloodline_Bottom": {
+      "name": "Arrakeen Palace Servant’s Trousers",
+      "category": "Garments - Legs"
+    },
+    "Social_Atre_Casual03_Unique_Story_TheBloodline_Shoes": {
+      "name": "Arrakeen Palace Servant’s Shoes",
+      "category": "Garments - Feet"
+    },
+    "Social_Neut_Unique_Story_ProcesVerbal_NobleMask": {
+      "name": "Phaedra's Mask",
+      "category": "Garments - Head"
+    },
+    "Stillsuit_Choam_Unique_Dashed02_Top": {
+      "name": "Desert Dasher Garment",
+      "category": "Garments - Chest"
+    },
+    "Stillsuit_Choam_Unique_Dashed03_Top": {
+      "name": "Sprinter's Stillsuit Garment",
+      "category": "Garments - Chest"
+    },
+    "Stillsuit_Choam_Unique_Dashed04_Top": {
+      "name": "Sand Strider Stillsuit Garment",
+      "category": "Garments - Chest"
+    },
+    "MTX_Stillsuit_Smuggler_Boots": {
+      "name": "Smuggler’s Stillsuit Boots",
+      "category": "Garments - Feet"
+    },
+    "MTX_Stillsuit_Smuggler_Gloves": {
+      "name": "Smuggler's Stillsuit Gloves",
+      "category": "Garments - Hands"
+    },
+    "MTX_Stillsuit_Smuggler_Helmet": {
+      "name": "Smuggler’s Stillsuit Mask",
+      "category": "Garments - Head"
+    },
+    "MTX_Stillsuit_Smuggler_Top": {
+      "name": "Smuggler’s Stillsuit Vesture",
+      "category": "Garments - Chest"
+    },
+    "Combat_Light_Unique_BeneGeserit_Boots": {
+      "name": "Boots of the Sisterhood",
+      "category": "Garments - Feet"
+    },
+    "Combat_Light_Unique_BeneGeserit_Gloves": {
+      "name": "Gloves of the Sisterhood",
+      "category": "Garments - Hands"
+    },
+    "Combat_Light_Unique_BeneGeserit_Helmet": {
+      "name": "Veil of the Sisterhood",
+      "category": "Garments - Head"
+    },
+    "Combat_Light_Unique_BeneGeserit_Bottom": {
+      "name": "Leggings of the Sisterhood",
+      "category": "Garments - Legs"
+    },
+    "Combat_Light_Unique_BeneGeserit_Top": {
+      "name": "Robe of the Sisterhood",
+      "category": "Garments - Chest"
+    },
+    "Combat_Light_Unique_Mentat_Boots": {
+      "name": "Reinforced Boots of the Mentat",
+      "category": "Garments - Feet"
+    },
+    "MTX_D_Combat_Light_Smuggler_Boots": {
+      "name": "Smuggler’s Agile Assault Boots",
+      "category": "Garments - Feet"
+    },
+    "Combat_Light_Unique_Mentat_Gloves": {
+      "name": "Gauntlets of the Mentat",
+      "category": "Garments - Hands"
+    },
+    "MTX_D_Combat_Light_Smuggler_Gloves": {
+      "name": "Smuggler’s Nimble-Fingered Gloves",
+      "category": "Garments - Hands"
+    },
+    "Combat_Light_Unique_Mentat_Helmet": {
+      "name": "Helm of the Mentat",
+      "category": "Garments - Head"
+    },
+    "MTX_D_Combat_Light_Smuggler_Helmet": {
+      "name": "Smuggler’s Sly Helm",
+      "category": "Garments - Head"
+    },
+    "Combat_Light_Unique_Mentat_Bottom": {
+      "name": "Leggings of the Mentat",
+      "category": "Garments - Legs"
+    },
+    "MTX_D_Combat_Light_Smuggler_Bottom": {
+      "name": "Smuggler’s Chausses",
+      "category": "Garments - Legs"
+    },
+    "Combat_Light_Unique_Mentat_Top": {
+      "name": "Tactical Coat of the Mentat",
+      "category": "Garments - Chest"
+    },
+    "MTX_D_Combat_Light_Smuggler_Top": {
+      "name": "Smuggler’s Gambeson",
+      "category": "Garments - Chest"
+    },
+    "Stillsuit_Unique_Planetologist_Boots": {
+      "name": "Planetologist Light Armor Boots",
+      "category": "Garments - Feet"
+    },
+    "Stillsuit_Unique_Planetologist_Gloves": {
+      "name": "Planetologist Light Armor Gloves",
+      "category": "Garments - Hands"
+    },
+    "Stillsuit_Unique_Planetologist_Helmet": {
+      "name": "Planetologist Light Armor Headpiece",
+      "category": "Garments - Head"
+    },
+    "Stillsuit_Unique_Planetologist_Bottom": {
+      "name": "Planetologist Light Armor Leggings",
+      "category": "Garments - Legs"
+    },
+    "Stillsuit_Unique_Planetologist_Top": {
+      "name": "Planetologist Light Armor Coat",
+      "category": "Garments - Chest"
+    },
+    "Combat_Heavy_Unique_Swordmaster_Boots": {
+      "name": "Boots of Ginaz",
+      "category": "Garments - Feet"
+    },
+    "MTX_D_Combat_Heavy_Smuggler_Boots": {
+      "name": "Smuggler’s Heavy Reinforced Boots",
+      "category": "Garments - Feet"
+    },
+    "Combat_Heavy_Unique_Swordmaster_Gloves": {
+      "name": "Gauntlets of Ginaz",
+      "category": "Garments - Hands"
+    },
+    "MTX_D_Combat_Heavy_Smuggler_Gloves": {
+      "name": "Smuggler’s Heavy Gauntlets",
+      "category": "Garments - Hands"
+    },
+    "Combat_Heavy_Unique_Swordmaster_Helmet": {
+      "name": "Helm of Ginaz",
+      "category": "Garments - Head"
+    },
+    "MTX_D_Combat_Heavy_Smuggler_Helmet": {
+      "name": "Smuggler’s Heavy Casque",
+      "category": "Garments - Head"
+    },
+    "Combat_Heavy_Unique_Swordmaster_Bottom": {
+      "name": "Leggings of Ginaz",
+      "category": "Garments - Legs"
+    },
+    "MTX_D_Combat_Heavy_Smuggler_Bottom": {
+      "name": "Smuggler’s Heavy Chausses",
+      "category": "Garments - Legs"
+    },
+    "Combat_Heavy_Unique_Swordmaster_Top": {
+      "name": "Tunic of Ginaz",
+      "category": "Garments - Chest"
+    },
+    "MTX_D_Combat_Heavy_Smuggler_Top": {
+      "name": "Smuggler’s Heavy Armored Coat",
+      "category": "Garments - Chest"
+    },
+    "Combat_Heavy_Unique_Trooper_Boots": {
+      "name": "Trooper Heavy Armor Tactical Boots",
+      "category": "Garments - Feet"
+    },
+    "Combat_Heavy_Unique_Trooper_Gloves": {
+      "name": "Trooper Heavy Armor Tactical Gauntlets",
+      "category": "Garments - Hands"
+    },
+    "Combat_Heavy_Unique_Trooper_Helmet": {
+      "name": "Trooper Heavy Armor Tactical Helmet",
+      "category": "Garments - Head"
+    },
+    "Combat_Heavy_Unique_Trooper_Bottom": {
+      "name": "Trooper Heavy Armor Tactical Pants",
+      "category": "Garments - Legs"
+    },
+    "Combat_Heavy_Unique_Trooper_Top": {
+      "name": "Trooper Heavy Armor Tactical Coat",
+      "category": "Garments - Chest"
+    },
+    "Stillsuit_Choam_Unique_Dashed05_Top": {
+      "name": "Dune Dancer Stillsuit Garment",
+      "category": "Garments - Chest"
+    },
+    "Social_Atre_Casual03_Unique_Story_TheBloodline_Top": {
+      "name": "Arrakeen Palace Servant’s Tunic",
+      "category": "Garments - Chest"
+    },
+    "ExplorationSuit_Choam_06_Boots": {
+      "name": "Cold Survival Exploration Suit, Boots",
+      "category": "Garments - Feet"
+    },
+    "ExplorationSuit_Choam_06_Gloves": {
+      "name": "Cold Survival Exploration Suit, Gloves",
+      "category": "Garments - Hands"
+    },
+    "ExplorationSuit_Choam_06_Mask": {
+      "name": "Cold Survival Exploration Suit, Mask",
+      "category": "Garments - Head"
+    },
+    "ExplorationSuit_Choam_06_Top": {
+      "name": "Cold Survival Exploration Suit, Top",
+      "category": "Garments - Chest"
+    },
+    "Insulated_Combat_Choam_Heavy06_Shoes": {
+      "name": "PH_Cold Survival Heavy Combat set, Shoes",
+      "category": "Garments - Feet"
+    },
+    "Insulated_Combat_Choam_Heavy06_Gloves": {
+      "name": "PH_Cold Survival Heavy Combat set, Gloves",
+      "category": "Garments - Hands"
+    },
+    "Insulated_Combat_Choam_Heavy06_Helmet": {
+      "name": "PH_Cold Survival Heavy Combat set, Helmet",
+      "category": "Garments - Head"
+    },
+    "Insulated_Combat_Choam_Heavy06_Bottom": {
+      "name": "PH_Cold Survival Heavy Combat set, Bottom",
+      "category": "Garments - Legs"
+    },
+    "Insulated_Combat_Choam_Heavy06_Top": {
+      "name": "PH_Cold Survival Heavy Combat set, Top",
+      "category": "Garments - Chest"
+    },
+    "Insulated_Combat_Choam_Light06_Boots": {
+      "name": "PH_Cold Survival Light Combat set, Shoes",
+      "category": "Garments - Feet"
+    },
+    "Insulated_Combat_Choam_Light06_Gloves": {
+      "name": "PH_Cold Survival Light Combat set, Gloves",
+      "category": "Garments - Hands"
+    },
+    "Insulated_Combat_Choam_Light06_Helmet": {
+      "name": "PH_Cold Survival Light Combat set, Helmet",
+      "category": "Garments - Head"
+    },
+    "Insulated_Combat_Choam_Light06_Bottom": {
+      "name": "PH_Cold Survival Light Combat set, Bottom",
+      "category": "Garments - Legs"
+    },
+    "Insulated_Combat_Choam_Light06_Top": {
+      "name": "PH_Cold Survival Light Combat set, Top",
+      "category": "Garments - Chest"
+    },
+    "Insulated_Combat_Choam_Heavy06_Unique_Boots": {
+      "name": "PH_Cold Survival Heavy Combat set, Shoes (Unique)",
+      "category": "Garments - Feet"
+    },
+    "Insulated_Combat_Choam_Heavy06_Unique_Gloves": {
+      "name": "PH_Cold Survival Heavy Combat set, Gloves (Unique)",
+      "category": "Garments - Hands"
+    },
+    "Insulated_Combat_Choam_Heavy06_Unique_Helmet": {
+      "name": "PH_Cold Survival Heavy Combat set, Helmet (Unique)",
+      "category": "Garments - Head"
+    },
+    "Insulated_Combat_Choam_Heavy06_Unique_Bottom": {
+      "name": "PH_Cold Survival Heavy Combat set, Bottom (Unique)",
+      "category": "Garments - Legs"
+    },
+    "Insulated_Combat_Choam_Heavy06_Unique_Top": {
+      "name": "PH_Cold Survival Heavy Combat set, Top (Unique)",
+      "category": "Garments - Chest"
+    },
+    "Insulated_Combat_Choam_Light06_Unique_Boots": {
+      "name": "PH_Cold Survival Light Combat set, Shoes (Unique)",
+      "category": "Garments - Feet"
+    },
+    "Insulated_Combat_Choam_Light06_Unique_Gloves": {
+      "name": "PH_Cold Survival Light Combat set, Gloves (Unique)",
+      "category": "Garments - Hands"
+    },
+    "Insulated_Combat_Choam_Light06_Unique_Helmet": {
+      "name": "PH_Cold Survival Light Combat set, Helmet (Unique)",
+      "category": "Garments - Head"
+    },
+    "Insulated_Combat_Choam_Light06_Unique_Bottom": {
+      "name": "PH_Cold Survival Light Combat set, Bottom (Unique)",
+      "category": "Garments - Legs"
+    },
+    "Insulated_Combat_Choam_Light06_Unique_Top": {
+      "name": "PH_Cold Survival Light Combat set, Top (Unique)",
+      "category": "Garments - Chest"
+    },
+    "ExplorationSuit_Choam_06_Unique_Boots": {
+      "name": "Cold Survival Exploration Suit, Boots (Unique)",
+      "category": "Garments - Feet"
+    },
+    "ExplorationSuit_Choam_06_Unique_Gloves": {
+      "name": "Cold Survival Exploration Suit, Gloves (Unique)",
+      "category": "Garments - Hands"
+    },
+    "ExplorationSuit_Choam_06_Unique_Mask": {
+      "name": "Cold Survival Exploration Suit, Mask (Unique)",
+      "category": "Garments - Head"
+    },
+    "ExplorationSuit_Choam_06_Unique_Top": {
+      "name": "Cold Survival Exploration Suit, Top (Unique)",
+      "category": "Garments - Chest"
+    },
+    "Combat_Heavy_B1C4_Unique_Top1": {
+      "name": "XX_Cut",
+      "category": "Garments - Chest"
+    },
+    "Combat_Light_B1C4_Unique_Top1": {
+      "name": "XX_Cut",
+      "category": "Garments - Chest"
+    },
+    "Combat_Light_B1C4_Unique_Helmet1": {
+      "name": "XX_Cut",
+      "category": "Garments - Head"
+    },
+    "InsulatedCryo_Combat_Heavy06_Unique_Boots": {
+      "name": "PH_Cold AND Cryo defense armor Heavy06_Unique_Boots NAME",
+      "category": "Garments - Feet"
+    },
+    "InsulatedCryo_Combat_Heavy06_Unique_Gloves": {
+      "name": "PH_Cold AND Cryo defense armor Heavy06_Unique_Gloves NAME",
+      "category": "Garments - Hands"
+    },
+    "InsulatedCryo_Combat_Heavy06_Unique_Helmet": {
+      "name": "PH_Cold AND Cryo defense armor Heavy06_Unique_Helmet NAME",
+      "category": "Garments - Head"
+    },
+    "InsulatedCryo_Combat_Heavy06_Unique_Bottom": {
+      "name": "PH_Cold AND Cryo defense armor Heavy06_Unique_Bottom NAME",
+      "category": "Garments - Legs"
+    },
+    "InsulatedCryo_Combat_Heavy06_Unique_Top": {
+      "name": "PH_Cold AND Cryo defense armor Heavy06_Unique_Top NAME",
+      "category": "Garments - Chest"
+    },
+    "InsulatedCryo_Combat_Light06_Unique_Boots": {
+      "name": "PH_Cold AND Cryo defense armor Light06_Unique_Boots NAME",
+      "category": "Garments - Feet"
+    },
+    "InsulatedCryo_Combat_Light06_Unique_Gloves": {
+      "name": "PH_Cold AND Cryo defense armor Light06_Unique_Gloves NAME",
+      "category": "Garments - Hands"
+    },
+    "InsulatedCryo_Combat_Light06_Unique_Helmet": {
+      "name": "PH_Cold AND Cryo defense armor Light06_Unique_Helmet NAME",
+      "category": "Garments - Head"
+    },
+    "InsulatedCryo_Combat_Light06_Unique_Bottom": {
+      "name": "PH_Cold AND Cryo defense armor Light06_Unique_Bottom NAME",
+      "category": "Garments - Legs"
+    },
+    "InsulatedCryo_Combat_Light06_Unique_Top": {
+      "name": "PH_Cold AND Cryo defense armor Light06_Unique_Top NAME",
+      "category": "Garments - Chest"
+    },
+    "Stillsuit_Unique_ThermalSuit_06_Boots": {
+      "name": "PH_Stillsuit_Unique_ThermalSuit_06_Boots NAME",
+      "category": "Garments - Feet"
+    },
+    "Stillsuit_Unique_ThermalSuit_06_Gloves": {
+      "name": "PH_Stillsuit_Unique_ThermalSuit_06_Gloves NAME",
+      "category": "Garments - Hands"
+    },
+    "Stillsuit_Unique_ThermalSuit_06_Mask": {
+      "name": "PH_Stillsuit_Unique_ThermalSuit_06_Mask NAME",
+      "category": "Garments - Head"
+    },
+    "Stillsuit_Unique_ThermalSuit_06_Top": {
+      "name": "PH_Stillsuit_Unique_ThermalSuit_06_Top NAME",
+      "category": "Garments - Chest"
+    },
+    "MTX_Combat_Heavy_Watershippers_Boots": {
+      "name": "Tharnox Operations Boots",
+      "category": "Garments - Feet"
+    },
+    "MTX_Combat_Heavy_Watershippers_Gloves": {
+      "name": "Tharnox Operations Gauntlets",
+      "category": "Garments - Hands"
+    },
+    "MTX_Combat_Heavy_Watershippers_Helmet": {
+      "name": "Tharnox Operations Helmet",
+      "category": "Garments - Head"
+    },
+    "MTX_Combat_Heavy_Watershippers_Bottom": {
+      "name": "Tharnox Operations Greaves",
+      "category": "Garments - Legs"
+    },
+    "MTX_Combat_Heavy_Watershippers_Top": {
+      "name": "Tharnox Operations Cuirass",
+      "category": "Garments - Chest"
+    },
+    "MTX_Stillsuit_Watershippers_Boots": {
+      "name": "Polar Operations Stillsuit Boots",
+      "category": "Garments - Feet"
+    },
+    "MTX_Stillsuit_Watershippers_Gloves": {
+      "name": "Polar Operations Stillsuit Gloves",
+      "category": "Garments - Hands"
+    },
+    "MTX_Stillsuit_Watershippers_Helmet": {
+      "name": "Polar Operations Stillsuit Helmet",
+      "category": "Garments - Head"
+    },
+    "MTX_Stillsuit_Watershippers_Top": {
+      "name": "Polar Operations Stillsuit Top",
+      "category": "Garments - Chest"
+    },
+    "MTX_Combat_Assault_Watershippers_Boots": {
+      "name": "Ranger Operations Boots",
+      "category": "Garments - Feet"
+    },
+    "MTX_Combat_Assault_Watershippers_Gloves": {
+      "name": "Ranger Operations Gloves",
+      "category": "Garments - Hands"
+    },
+    "MTX_Combat_Assault_Watershippers_Helmet": {
+      "name": "Ranger Operations Helmet",
+      "category": "Garments - Head"
+    },
+    "MTX_Combat_Assault_Watershippers_Bottom": {
+      "name": "Ranger Operations Trousers",
+      "category": "Garments - Legs"
+    },
+    "MTX_Combat_Assault_Watershippers_Top": {
+      "name": "Ranger Operations Jacket",
+      "category": "Garments - Chest"
+    },
+    "Thumper": {
+      "name": "Thumper",
+      "category": "Tools"
+    },
+    "PlantFiber": {
+      "name": "Plant Fiber",
+      "category": "Resources"
+    },
+    "SpiceSand": {
+      "name": "Spice Sand",
+      "category": "Resources"
+    },
+    "T6IndustrialPump": {
+      "name": "Fluid Efficient Industrial Pump",
+      "category": "Resources"
+    },
+    "LandsraadComponent": {
+      "name": "Offworld Regis Compound",
+      "category": "Resources"
+    },
+    "T6LandsraadCraftedComponent": {
+      "name": "Regis Component",
+      "category": "Resources"
+    },
+    "T6SchematicFragmentQL1": {
+      "name": "Schematic Pattern Grade 1",
+      "category": "Resources"
+    },
+    "T6SchematicFragmentQL2": {
+      "name": "Schematic Pattern Grade 2",
+      "category": "Resources"
+    },
+    "T6SchematicFragmentQL3": {
+      "name": "Schematic Pattern Grade 3",
+      "category": "Resources"
+    },
+    "T6SchematicFragmentQL4": {
+      "name": "Schematic Pattern Grade 4",
+      "category": "Resources"
+    },
+    "T6SchematicFragmentQL5": {
+      "name": "Schematic Pattern Grade 5",
+      "category": "Resources"
+    },
+    "WaterItem": {
+      "name": "Water",
+      "category": "Resources"
+    },
+    "BuggyBoost_0": {
+      "name": "Scrap Buggy Booster",
+      "category": "Vehicle Modules"
+    },
+    "BuggyBoost_7": {
+      "name": "PH_Chromium Buggy Booster",
+      "category": "Vehicle Modules"
+    },
+    "BuggyChassis_7": {
+      "name": "PH_Chromium Buggy Chassis",
+      "category": "Vehicle Modules"
+    },
+    "BuggyEngine_7": {
+      "name": "PH_Chroium Buggy Engine",
+      "category": "Vehicle Modules"
+    },
+    "BuggyGenerator_PolarCap_6": {
+      "name": "PH_Buggy Generator Polar Cap 6",
+      "category": "Vehicle Modules"
+    },
+    "BuggyHullBack_7": {
+      "name": "PH_Chromium Buggy Rear Hull",
+      "category": "Vehicle Modules"
+    },
+    "BuggyHullBackExtra_0": {
+      "name": "Scrap Buggy Utility Rear",
+      "category": "Vehicle Modules"
+    },
+    "BuggyHullBackExtra_7": {
+      "name": "PH_Chromium Buggy Utility Rear Hull",
+      "category": "Vehicle Modules"
+    },
+    "BuggyHullFront_7": {
+      "name": "PH_Chromium Buggy Front hull",
+      "category": "Vehicle Modules"
+    },
+    "BuggyInventory_0": {
+      "name": "Scrap Buggy Inventory",
+      "category": "Vehicle Modules"
+    },
+    "BuggyInventory_7": {
+      "name": "PH_Chromium Buggy Storage",
+      "category": "Vehicle Modules"
+    },
+    "BuggyLauncher_0": {
+      "name": "Scrap Buggy Rocket Launcher",
+      "category": "Vehicle Modules"
+    },
+    "BuggyLocomotion_7": {
+      "name": "PH_Chromium Buggy Tread",
+      "category": "Vehicle Modules"
+    },
+    "BuggyMining_0": {
+      "name": "Scrap Buggy Mining Laser",
+      "category": "Vehicle Modules"
+    },
+    "BuggyMining_Polarcap_6": {
+      "name": "PH_Polarcap Buggy Mining Laser NAME",
+      "category": "Vehicle Modules"
+    },
+    "ContainerVehicle": {
+      "name": "Carrier Ornithopter Cargo Container",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightChassis_0": {
+      "name": "Scrap Scout Ornithopter Chassis",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightEngine_0": {
+      "name": "Scrap Scout Ornithopter Engine",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightGenerator_0": {
+      "name": "Scrap Scout Ornithopter Generator",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightGenerator_PolarCap_6": {
+      "name": "PH_Ornithopter Light Generator Polar Cap 6",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightHullFront_0": {
+      "name": "Scrap Scout Ornithopter Cockpit",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightLocomotion_0": {
+      "name": "Scrap Scout Ornithopter Wing",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterMediumGenerator_PolarCap_6": {
+      "name": "PH_Ornithopter MediumGenerator Polar Cap 6",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterTransportGenerator_PolarCap_6": {
+      "name": "PH_Ornithopter Transport Generator Polar Cap 6",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeBoost_0": {
+      "name": "Scrap Sandbike Booster",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeBoost_7": {
+      "name": "PH_Chromium Sandbike Booster",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeChassis_7": {
+      "name": "PH_Chromium Sandbike Chassis",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeEngine_7": {
+      "name": "PH_Chromium Sandbike Engine",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeGenerator_PolarCap_6": {
+      "name": "PH_Sandbike Generator Polar Cap 6",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeHull_7": {
+      "name": "PH_Chromoium Sandbike Hull",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeInventory_0": {
+      "name": "Scrap Sandbike Inventory",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeInventory_7": {
+      "name": "PH_Chromium Sandbike Inventory",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeLocomotion_7": {
+      "name": "PH_Chromium Sandbike Tread",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeScanner_7": {
+      "name": "PH_Chromium Sandbike Scanner",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_0": {
+      "name": "Scrap Treadwheel Boost",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_1": {
+      "name": "Treadwheel Boost Mk1",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_2": {
+      "name": "Treadwheel Boost Mk2",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_3": {
+      "name": "Treadwheel Boost Mk3",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_4": {
+      "name": "Treadwheel Boost Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_5": {
+      "name": "Treadwheel Boost Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_6": {
+      "name": "Treadwheel Boost Mk6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_Unique_LessHeat_4": {
+      "name": "Steady Treadwheel Boost Module Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_Unique_LessHeat_5": {
+      "name": "Steady Treadwheel Boost Module Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_Unique_LessHeat_6": {
+      "name": "Steady Treadwheel Boost Module Mk6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelChassis_0": {
+      "name": "Scrap Treadwheel Chassis",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelChassis_1": {
+      "name": "Treadwheel Chassis Mk1",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelChassis_2": {
+      "name": "Treadwheel Chassis Mk2",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelChassis_3": {
+      "name": "Treadwheel Chassis Mk3",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelChassis_4": {
+      "name": "Treadwheel Chassis Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelChassis_5": {
+      "name": "Treadwheel Chassis Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelChassis_6": {
+      "name": "Treadwheel Chassis Mk6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_0": {
+      "name": "Scrap Treadwheel Engine",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_1": {
+      "name": "Treadwheel Engine Mk1",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_2": {
+      "name": "Treadwheel Engine Mk2",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_3": {
+      "name": "Treadwheel Engine Mk3",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_4": {
+      "name": "Treadwheel Engine Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_5": {
+      "name": "Treadwheel Engine Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_6": {
+      "name": "Treadwheel Engine Mk6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_Unique_Speed_4": {
+      "name": "Swift Treadwheel Engine Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_Unique_Speed_5": {
+      "name": "Swift Treadwheel Engine Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_Unique_Speed_6": {
+      "name": "Swift Treadwheel Engine Mk6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelGenerator_0": {
+      "name": "Scrap Treadwheel PSU",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelGenerator_1": {
+      "name": "Treadwheel PSU Mk1",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelGenerator_2": {
+      "name": "Treadwheel PSU Mk2",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelGenerator_3": {
+      "name": "Treadwheel PSU Mk3",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelGenerator_4": {
+      "name": "Treadwheel PSU Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelGenerator_5": {
+      "name": "Treadwheel PSU Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelGenerator_6": {
+      "name": "Treadwheel PSU Mk6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelGenerator_PolarCap_6": {
+      "name": "PH_treadwheel Generator Polar Cap 6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelInventory_0": {
+      "name": "Scrap Treadwheel Inventory",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelInventory_1": {
+      "name": "Treadwheel Inventory Mk1",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelInventory_2": {
+      "name": "Treadwheel Inventory Mk2",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelInventory_3": {
+      "name": "Treadwheel Inventory Mk3",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelInventory_4": {
+      "name": "Treadwheel Inventory Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelInventory_5": {
+      "name": "Treadwheel Inventory Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelInventory_6": {
+      "name": "Treadwheel Inventory Mk6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelLocomotion_0": {
+      "name": "Scrap Treadwheel Tread",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelLocomotion_1": {
+      "name": "Treadwheel Tread Mk1",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelLocomotion_2": {
+      "name": "Treadwheel Tread Mk2",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelLocomotion_3": {
+      "name": "Treadwheel Tread Mk3",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelLocomotion_4": {
+      "name": "Treadwheel Tread Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelLocomotion_5": {
+      "name": "Treadwheel Tread Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelLocomotion_6": {
+      "name": "Treadwheel Tread Mk6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelPassenger_0": {
+      "name": "Scrap Treadwheel Passenger",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelPassenger_1": {
+      "name": "Treadwheel Passenger Mk1",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelPassenger_2": {
+      "name": "Treadwheel Passenger Mk2",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelPassenger_3": {
+      "name": "Treadwheel Passenger Mk3",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelPassenger_4": {
+      "name": "Treadwheel Passenger Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelPassenger_5": {
+      "name": "Treadwheel Passenger Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelPassenger_6": {
+      "name": "Treadwheel Passenger Mk6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelScanner_0": {
+      "name": "Scrap Treadwheel Scanner",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelScanner_1": {
+      "name": "Treadwheel Scanner Mk1",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelScanner_2": {
+      "name": "Treadwheel Scanner Mk2",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelScanner_3": {
+      "name": "Treadwheel Scanner Mk3",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelScanner_4": {
+      "name": "Treadwheel Scanner Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelScanner_5": {
+      "name": "Treadwheel Scanner Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelScanner_6": {
+      "name": "Treadwheel Scanner Mk6",
+      "category": "Vehicle Modules"
+    },
+    "ScrapMetalKnife_NPENPC": {
+      "name": "Scrap Metal Knife",
+      "category": "Weapons - Melee"
+    },
+    "StaticCompactor_CR": {
+      "name": "Static Compactor",
+      "category": "Tools"
+    },
+    "ChoamFlameThrower_T4": {
+      "name": "WEAPON_UNIQUE_FLAMETHROWER_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "Hark_AR_T4_Poison": {
+      "name": "WEAPON_KARPOV38_MK_III_BATTLE_RIFLE_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "Crysknife_CR": {
+      "name": "Crysknife",
+      "category": "Weapons - Melee"
+    },
+    "Sardaukar_Dagger_CR": {
+      "name": "Sardaukar Dagger",
+      "category": "Weapons - Melee"
+    },
+    "Ghola_NPC_Knife_01": {
+      "name": "Ghola Scrap Knife 1",
+      "category": "Weapons - Melee"
+    },
+    "Ghola_NPC_Knife_02": {
+      "name": "Ghola Scrap Knife 2",
+      "category": "Weapons - Melee"
+    },
+    "Ghola_NPC_Knife_03": {
+      "name": "Ghola Scrap Knife 3",
+      "category": "Weapons - Melee"
+    },
+    "NPE_ScrapMetalKnife": {
+      "name": "Scrap Metal Knife",
+      "category": "Weapons - Melee"
+    },
+    "Unique_Sword_BleedyBlocky_4": {
+      "name": "Sword of Seven Sorrows",
+      "category": "Weapons - Melee"
+    },
+    "Unique_Sword_BleedyBlocky_5": {
+      "name": "Bite Back Blade",
+      "category": "Weapons - Melee"
+    },
+    "Fireballer_2": {
+      "name": "Duraluminum Pyrocket",
+      "category": "Weapons - Ranged"
+    },
+    "RocketLauncher_3": {
+      "name": "Adept Missile Launcher",
+      "category": "Weapons - Ranged"
+    },
+    "RocketLauncher_1": {
+      "name": "RocketLauncher_1",
+      "category": "Weapons - Ranged"
+    },
+    "DualBlades_1": {
+      "name": "Adept Dual Blades",
+      "category": "Weapons - Melee"
+    },
+    "DualBlades_2": {
+      "name": "Regis Dual Blades",
+      "category": "Weapons - Melee"
+    },
+    "Cine_Minotaur_Sword": {
+      "name": "Cinematic Minotaur Sword",
+      "category": "Weapons - Melee"
+    },
+    "Minotaur_Sword": {
+      "name": "Minotaur Sword",
+      "category": "Weapons - Melee"
+    },
+    "Fireballer_NPC": {
+      "name": "XX_WEAPON_FIREBALLER_3_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "AtreLMGRadiationNPC": {
+      "name": "WEAPON_ATREIDES_LMG_MK_III_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "Minotaur_Memento": {
+      "name": "Asterion’s End",
+      "category": "Weapons - Melee"
+    },
+    "DualBlades_Memento": {
+      "name": "Feyd’s Spare Blades",
+      "category": "Weapons - Melee"
+    },
+    "CHOAMSword_2_Poison_NPC": {
+      "name": "NPC Poison Sword",
+      "category": "Weapons - Melee"
+    },
+    "Scattergun_Prototype_RadiationNPC": {
+      "name": "NA_WEAPON_GRDA_44_SCATTERGUN_RADIATION_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueAr_Burst_RadiationNPC": {
+      "name": "NA_WEAPON_RADIATION_BURST_FIRE_RIFLE_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "HarkHeavyPistolNPC": {
+      "name": "WEAPON_RAFIQ_SNUBNOSE_NPC_PISTOL_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "SmugDmrParaNPC": {
+      "name": "SmugDmrParaNPC",
+      "category": "Weapons - Ranged"
+    },
+    "ScattergunEliteNPC": {
+      "name": "ScattergunEliteNPC",
+      "category": "Weapons - Ranged"
+    },
+    "SmugShotEliteNPC": {
+      "name": "SmugShotEliteNPC",
+      "category": "Weapons - Ranged"
+    },
+    "Crysknife_SleeperNPC": {
+      "name": "Sleepers Crysknife",
+      "category": "Weapons - Melee"
+    },
+    "HarkArEliteNPC": {
+      "name": "HarkArEliteNPC",
+      "category": "Weapons - Ranged"
+    },
+    "B1C4_NPCweapon_Cryo_Karpov": {
+      "name": "XX_WEAPON_B1C4_UNIQUE_HARKAR1_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "B1C4_NPCweapon_Cryo_Spitdart": {
+      "name": "XX_WEAPON_B1C4_UNIQUE_SMUGDMR1_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "B1C4_NPCweapon_Cryo_MaulaPistol": {
+      "name": "XX_WEAPON_B1C4_UNIQUE_SDA1_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "B1C4_NPCweapon_Cryo_HeavyPistol": {
+      "name": "XX_WEAPON_PLASTANIUM_DEADSHOT_PISTOL_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "B1C4_NPCweapon_Cryo_SMG": {
+      "name": "XX_WEAPON_B1C4_UNIQUE_SMG1_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "B1C4_NPCweapon_Cryo_LMG": {
+      "name": "XX_WEAPON_B1C4_UNIQUE_LMG1_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "B1C4_NPCweapon_Cryo_Shotgun": {
+      "name": "XX_WEAPON_B1C4_UNIQUE_SHOTGUN1_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "B1C4_NPCweapon_Cryo_Scattergun": {
+      "name": "XX_WEAPON_B1C4_UNIQUE_SCATTERGUN1_NAME",
+      "category": "Weapons - Ranged"
+    },
+    "SardaukarSword_1": {
+      "name": "XX_Sardaukar Blade",
+      "category": "Weapons - Melee"
+    },
+    "B1C4_TaligariPistol": {
+      "name": "PH_TaligariHeavyPistol NAME",
+      "category": "Weapons - Ranged"
+    },
+    "PowerPack_Unique_Capacity_06": {
+      "name": "Accelerator Power Pack",
+      "category": "Tools"
+    },
+    "PowerPack_Unique_PoisRadMitigation_06": {
+      "name": "Purifier Power Pack",
+      "category": "Tools"
+    },
+    "HoltzmanShieldActiveDrainNPC": {
+      "name": "HoltzmanShieldActiveDrainNPC",
+      "category": "Tools"
+    },
+    "FullSuspensorBelt_Unique_Durability": {
+      "name": "Elohim-Class Suspensor Belt",
+      "category": "Tools"
+    },
+    "HoltzmanShieldActiveDrain_Unique_B1C4_1": {
+      "name": "XX_CUT",
+      "category": "Tools"
+    },
+    "T6_Augment_Damage2": {
+      "name": "House Heavy Caliber Upgrade",
+      "category": "Augments"
+    },
+    "ChoamHeavyLasgunSchematic": {
+      "name": "Arhun K-28 Lasgun",
+      "category": "Weapons - Ranged"
+    },
+    "Flamethrower1Schematic": {
+      "name": "Scorchbolt",
+      "category": "Weapons - Ranged"
+    },
+    "Schematic_UniqueBattleRifle": {
+      "name": "The Tapper",
+      "category": "Weapons - Ranged"
+    },
+    "Schematic_UniqueBikeBoost": {
+      "name": "Night Rider Sandbike Boost Mk2",
+      "category": "Vehicle Modules"
+    },
+    "Schematic_UniqueBuggyBoost": {
+      "name": "Rattler Boost Module Mk3",
+      "category": "Vehicle Modules"
+    },
+    "Schematic_UniqueChoamSword": {
+      "name": "Pseudo-Pulse-Sword",
+      "category": "Weapons - Melee"
+    },
+    "Schematic_UniqueCutteray2": {
+      "name": "Sim's Cutter",
+      "category": "Tools"
+    },
+    "Schematic_UniqueCutteray3": {
+      "name": "Olef's Quickcutter",
+      "category": "Tools"
+    },
+    "Schematic_UniqueCutteray4": {
+      "name": "Callie's Breaker",
+      "category": "Tools"
+    },
+    "Schematic_UniqueCutteray5": {
+      "name": "Tarl Cutteray",
+      "category": "Tools"
+    },
+    "Schematic_UniqueCutteray6": {
+      "name": "Sandflies Carver",
+      "category": "Tools"
+    },
+    "Schematic_UniqueDewReaper": {
+      "name": "Buoyant Reaper Mk2",
+      "category": "Tools"
+    },
+    "Schematic_UniqueDirk": {
+      "name": "Searing Shiv",
+      "category": "Weapons - Melee"
+    },
+    "Schematic_UniqueFlamethrower": {
+      "name": "Shaitan's Tongue",
+      "category": "Weapons - Ranged"
+    },
+    "Schematic_UniqueForgeChest": {
+      "name": "Syndicate Chestplate",
+      "category": "Garments"
+    },
+    "Schematic_UniqueForgeFeet": {
+      "name": "Syndicate Boots",
+      "category": "Garments"
+    },
+    "Schematic_UniqueForgeHands": {
+      "name": "Syndicate Gauntlets",
+      "category": "Garments"
+    },
+    "Schematic_UniqueForgeHead": {
+      "name": "Syndicate Helmet",
+      "category": "Garments"
+    },
+    "Schematic_UniqueForgeLegs": {
+      "name": "Syndicate Pants",
+      "category": "Garments"
+    },
+    "Schematic_UniqueLiterjon": {
+      "name": "Hajra Literjon Mk1",
+      "category": "Tools"
+    },
+    "Schematic_UniqueMaulaPistol": {
+      "name": "Way of the Fallen",
+      "category": "Weapons - Ranged"
+    },
+    "Schematic_UniqueOathbreakerChest": {
+      "name": "Oathbreaker Chestpiece",
+      "category": "Garments"
+    },
+    "Schematic_UniqueOathbreakerFeet": {
+      "name": "Oathbreaker Boots",
+      "category": "Garments"
+    },
+    "Schematic_UniqueOathbreakerHands": {
+      "name": "Oathbreaker Gauntlets",
+      "category": "Garments"
+    },
+    "Schematic_UniqueOathbreakerHead": {
+      "name": "Oathbreaker Headwrap",
+      "category": "Garments"
+    },
+    "Schematic_UniqueOathbreakerLegs": {
+      "name": "Oathbreaker Pants",
+      "category": "Garments"
+    },
+    "Schematic_UniquePincushionChest": {
+      "name": "Aren's Chestpiece",
+      "category": "Garments"
+    },
+    "Schematic_UniquePincushionFeet": {
+      "name": "Aren's Boots",
+      "category": "Garments"
+    },
+    "Schematic_UniquePincushionHands": {
+      "name": "Aren's Gloves",
+      "category": "Garments"
+    },
+    "Schematic_UniquePincushionHead": {
+      "name": "Aren's Mask",
+      "category": "Garments"
+    },
+    "Schematic_UniquePincushionLegs": {
+      "name": "Aren's Pants",
+      "category": "Garments"
+    },
+    "Schematic_UniqueRapier": {
+      "name": "Poison Mist",
+      "category": "Weapons - Melee"
+    },
+    "Schematic_UniqueScattergun": {
+      "name": "Shredder",
+      "category": "Weapons - Ranged"
+    },
+    "Schematic_UniqueSMG": {
+      "name": "Abulurd's Rapture",
+      "category": "Weapons - Ranged"
+    },
+    "Schematic_UniqueSuspensor": {
+      "name": "The Emperor's Wings Mk1",
+      "category": "Tools"
+    },
+    "Schematic_UniqueThopterBoost": {
+      "name": "Stormrider Boost Module Mk4",
+      "category": "Vehicle Modules"
+    },
+    "Schematic_UniqueThumper": {
+      "name": "Clapper Mk4",
+      "category": "Tools"
+    },
+    "T3_Tool_ScannerEfficient_Schematic": {
+      "name": "Long Range Scanner",
+      "category": "Tools"
+    },
+    "HoltzmanShieldActiveDrain_Unique_01_Schematic": {
+      "name": "Adaptive Holtzman Shield",
+      "category": "Tools"
+    },
+    "SandbikeEngine_Unique_Speed_1_Schematic": {
+      "name": "Mohandis Sandbike Engine Mk1",
+      "category": "Vehicle Modules"
+    },
+    "PowerPack_Unique_Regen_01_Schematic": {
+      "name": "Old Sparky Mk1",
+      "category": "Tools"
+    },
+    "Stillsuit_Unique_Armored_01_Mask_Schematic": {
+      "name": "Hollower Stillsuit Mask",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_01_Boots_Schematic": {
+      "name": "Hollower Stillsuit Boots",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_01_Gloves_Schematic": {
+      "name": "Hollower Stillsuit Gloves",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_01_Top_Schematic": {
+      "name": "Hollower Stillsuit Garment",
+      "category": "Garments"
+    },
+    "Kindjal_Unique_Blood_01_Schematic": {
+      "name": "Kaleff's Drinker",
+      "category": "Weapons - Melee"
+    },
+    "UniqueAr_Burst_01_Schematic": {
+      "name": "Aren's Vengeance",
+      "category": "Weapons - Ranged"
+    },
+    "SandbikeEngine_Unique_Speed_2_Schematic": {
+      "name": "Mohandis Sandbike Engine Mk2",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeScanner_Unique_LongRange_02_Schematic": {
+      "name": "Duneman Sandbike Scanner Mk2",
+      "category": "Vehicle Modules"
+    },
+    "HighCapacityLiterjon_02_Schematic": {
+      "name": "Hajra Literjon Mk2",
+      "category": "Tools"
+    },
+    "GlidePartialStabilizationBelt_02_Schematic": {
+      "name": "The Emperor's Wings Mk2",
+      "category": "Tools"
+    },
+    "PowerPack_Unique_Regen_02_Schematic": {
+      "name": "Old Sparky Mk2",
+      "category": "Tools"
+    },
+    "Bloodsack_Unique_Durable_02_Schematic": {
+      "name": "Scipio's Bloodbag",
+      "category": "Tools"
+    },
+    "Combat_Neut_SmugglerDeserterUnique02_Helmet_Schematic": {
+      "name": "Mendia's Wrap",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique02_Top_Schematic": {
+      "name": "Mendia's Jacket",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique02_Bottom_Schematic": {
+      "name": "Mendia's Pants",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique02_Gloves_Schematic": {
+      "name": "Mendia's Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique02_Boots_Schematic": {
+      "name": "Mendia's Boots",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_02_Mask_Schematic": {
+      "name": "Menol's Stillsuit Mask",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_02_Boots_Schematic": {
+      "name": "Menol's Stillsuit Boots",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_02_Gloves_Schematic": {
+      "name": "Menol's Stillsuit Gloves",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_02_Top_Schematic": {
+      "name": "Menol's Stillsuit Garment",
+      "category": "Garments"
+    },
+    "Combat_Heavy_Unique_PowerEfficient_Gloves_02_Schematic": {
+      "name": "Iri's Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_WormThreat_Boots_02_Schematic": {
+      "name": "Softstep Boots",
+      "category": "Garments"
+    },
+    "UniqueSda2_Schematic": {
+      "name": "Way of the Wanderer",
+      "category": "Weapons - Ranged"
+    },
+    "SMG_Unique_LargeMag_02_Schematic": {
+      "name": "Legion Tattoo",
+      "category": "Weapons - Ranged"
+    },
+    "Kindjal_Unique_Blood_02_Schematic": {
+      "name": "Scipio's Drinker",
+      "category": "Weapons - Melee"
+    },
+    "UniqueAr_Burst_02_Schematic": {
+      "name": "Fila's Regret",
+      "category": "Weapons - Ranged"
+    },
+    "SandbikeChoamBoostHeatEfficient2_Schematic": {
+      "name": "Night Rider Sandbike Boost Mk3",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeEngine_Unique_Speed_3_Schematic": {
+      "name": "Mohandis Sandbike Engine Mk3",
+      "category": "Vehicle Modules"
+    },
+    "BuggyEngine_Unique_Accelerate_03_Schematic": {
+      "name": "Bluddshot Buggy Engine Mk3",
+      "category": "Vehicle Modules"
+    },
+    "BuggyMining_Unique_YieldIncrease_03_Schematic": {
+      "name": "Focused Buggy Cutteray Mk3",
+      "category": "Vehicle Modules"
+    },
+    "BuggyInventory_Unique_Capacity_03_Schematic": {
+      "name": "Bigger Buggy Boot Mk3",
+      "category": "Vehicle Modules"
+    },
+    "HighCapacityLiterjon_03_Schematic": {
+      "name": "Hajra Literjon Mk3",
+      "category": "Tools"
+    },
+    "DewReaper_Unique_02_Schematic": {
+      "name": "Buoyant Reaper Mk3",
+      "category": "Tools"
+    },
+    "GlidePartialStabilizationBelt_03_Schematic": {
+      "name": "The Emperor's Wings Mk3",
+      "category": "Tools"
+    },
+    "StaticCompactor_Unique_Compact_03_Schematic": {
+      "name": "Compact Compactor Mk3",
+      "category": "Tools"
+    },
+    "BodyFluidExtractor_Unique_Water_03_Schematic": {
+      "name": "Filter Extractor Mk3",
+      "category": "Tools"
+    },
+    "PowerPack_Unique_Regen_03_Schematic": {
+      "name": "Old Sparky Mk3",
+      "category": "Tools"
+    },
+    "Bloodsack_Unique_Durable_03_Schematic": {
+      "name": "Glutton's Bloodbag",
+      "category": "Tools"
+    },
+    "Scanner_Unique_Body_03_Schematic": {
+      "name": "Handheld Life Scanner Mk3",
+      "category": "Tools"
+    },
+    "Combat_Neut_SmugglerDeserterUnique03_Helmet_Schematic": {
+      "name": "Inkvine Mask",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique03_Top_Schematic": {
+      "name": "Inkvine Jacket",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique03_Bottom_Schematic": {
+      "name": "Inkvine Pants",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique03_Gloves_Schematic": {
+      "name": "Inkvine Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique03_Boots_Schematic": {
+      "name": "Inkvine Boots",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique02_Helmet_Schematic": {
+      "name": "Karak's Helmet",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique02_Top_Schematic": {
+      "name": "Karak's Jacket",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique02_Bottom_Schematic": {
+      "name": "Karak's Pants",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique02_Gloves_Schematic": {
+      "name": "Karak's Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique02_Boots_Schematic": {
+      "name": "Karak's Boots",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_03_Mask_Schematic": {
+      "name": "Kel's Stillsuit Mask",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_03_Boots_Schematic": {
+      "name": "Kel's Stillsuit Boots",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_03_Gloves_Schematic": {
+      "name": "Kel's Stillsuit Gloves",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_03_Top_Schematic": {
+      "name": "Kel's Stillsuit Garment",
+      "category": "Garments"
+    },
+    "Combat_Heavy_Unique_PowerEfficient_Gloves_03_Schematic": {
+      "name": "Shock Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_WormThreat_Boots_03_Schematic": {
+      "name": "Ta'lab Softstep Boots",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_DewReap_Gloves_03_Schematic": {
+      "name": "Reaper Gloves",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_ReduceSuspensor_Top_03_Schematic": {
+      "name": "Rigged Suspensor Jacket",
+      "category": "Garments"
+    },
+    "UniqueSda3_Schematic": {
+      "name": "Way of the Lost",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueSword_02_Schematic": {
+      "name": "Shock-sword ",
+      "category": "Weapons - Melee"
+    },
+    "UniqueScattergun2_Schematic": {
+      "name": "Ripper",
+      "category": "Weapons - Ranged"
+    },
+    "SMG_Unique_LargeMag_03_Schematic": {
+      "name": "Seb's Kisser",
+      "category": "Weapons - Ranged"
+    },
+    "Kindjal_Unique_Blood_03_Schematic": {
+      "name": "Glutton's Drinker",
+      "category": "Weapons - Melee"
+    },
+    "LongRifle_Unique_Poison_03_Schematic": {
+      "name": "Assassin's Rifle",
+      "category": "Weapons - Ranged"
+    },
+    "HeavyPistol_Unique_Bleed_03_Schematic": {
+      "name": "Artisan Disruptor Pistol",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueAr_Burst_03_Schematic": {
+      "name": "Zaal's Companion",
+      "category": "Weapons - Ranged"
+    },
+    "Kindjal_Unique_Stamina_03_Schematic": {
+      "name": "Shock-Knife",
+      "category": "Weapons - Melee"
+    },
+    "Combat_Light_Unique_BiomeHeat_Top_03_Schematic": {
+      "name": "Skin-lined Jacket",
+      "category": "Garments"
+    },
+    "SandbikeChoamBoostHeatEfficient3_Schematic": {
+      "name": "Night Rider Sandbike Boost Mk4",
+      "category": "Vehicle Modules"
+    },
+    "BuggyChoamBoostHeatEfficient2_Schematic": {
+      "name": "Rattler Boost Module Mk4",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeEngine_Unique_Speed_4_Schematic": {
+      "name": "Mohandis Sandbike Engine Mk4",
+      "category": "Vehicle Modules"
+    },
+    "BuggyEngine_Unique_Accelerate_04_Schematic": {
+      "name": "Bluddshot Buggy Engine Mk4",
+      "category": "Vehicle Modules"
+    },
+    "BuggyMining_Unique_YieldIncrease_04_Schematic": {
+      "name": "Focused Buggy Cutteray Mk4",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightEngine_Unique_Speed_04_Schematic": {
+      "name": "Dyvetz Ornithopter Engine Mk4",
+      "category": "Vehicle Modules"
+    },
+    "BuggyInventory_Unique_Capacity_04_Schematic": {
+      "name": "Bigger Buggy Boot Mk4",
+      "category": "Vehicle Modules"
+    },
+    "HighCapacityLiterjon_04_Schematic": {
+      "name": "Hajra Literjon Mk4",
+      "category": "Tools"
+    },
+    "DewReaper_Unique_03_Schematic": {
+      "name": "Buoyant Reaper Mk4",
+      "category": "Tools"
+    },
+    "GlidePartialStabilizationBelt_04_Schematic": {
+      "name": "The Emperor's Wings Mk4",
+      "category": "Tools"
+    },
+    "StaticCompactor_Unique_Compact_04_Schematic": {
+      "name": "Compact Compactor Mk4",
+      "category": "Tools"
+    },
+    "BodyFluidExtractor_Unique_Water_04_Schematic": {
+      "name": "Filter Extractor Mk4",
+      "category": "Tools"
+    },
+    "PowerPack_Unique_Regen_04_Schematic": {
+      "name": "Old Sparky Mk4",
+      "category": "Tools"
+    },
+    "DewReaper_1h_Unique_Compact_04_Schematic": {
+      "name": "Collapsible Dew Reaper Mk4",
+      "category": "Tools"
+    },
+    "Bloodsack_Unique_Durable_04_Schematic": {
+      "name": "Sinner's Bloodbag",
+      "category": "Tools"
+    },
+    "Combat_Neut_SmugglerDeserterUnique04_Helmet_Schematic": {
+      "name": "Quirth's Helmet",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique04_Top_Schematic": {
+      "name": "Quirth's Jacket",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique04_Bottom_Schematic": {
+      "name": "Quirth's Pants",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique04_Gloves_Schematic": {
+      "name": "Quirth's Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique04_Boots_Schematic": {
+      "name": "Quirth's Boots",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique03_Helmet_Schematic": {
+      "name": "Sentinel Helmet",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique03_Top_Schematic": {
+      "name": "Sentinel Jacket",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique03_Bottom_Schematic": {
+      "name": "Sentinel Pants",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique03_Gloves_Schematic": {
+      "name": "Sentinel Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique03_Boots_Schematic": {
+      "name": "Sentinel Boots",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_04_Mask_Schematic": {
+      "name": "Shadrath's Stillsuit Mask",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_04_Boots_Schematic": {
+      "name": "Shadrath's Stillsuit Boots",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_04_Gloves_Schematic": {
+      "name": "Shadrath's Stillsuit Gloves",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_04_Top_Schematic": {
+      "name": "Shadrath's Stillsuit Garment",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Efficient_04_Boots_Schematic": {
+      "name": "Maraqeb Stillsuit Boots",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Efficient_04_Gloves_Schematic": {
+      "name": "Maraqeb Stillsuit Gloves",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Efficient_04_Mask_Schematic": {
+      "name": "Maraqeb Stillsuit Mask",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Efficient_04_Top_Schematic": {
+      "name": "Maraqeb Stillsuit Garment",
+      "category": "Garments"
+    },
+    "Combat_Heavy_Unique_PowerEfficient_Gloves_04_Schematic": {
+      "name": "Power Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_WormThreat_Boots_04_Schematic": {
+      "name": "Idaho Softstep Boots",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_Stamina_Bottom_04_Schematic": {
+      "name": "Compression-Stim Leggings",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_HeatMitigation_04_Mask_Schematic": {
+      "name": "Shadow Hood",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_DewReap_Gloves_04_Schematic": {
+      "name": "Improved Reaper Gloves",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_ReduceSuspensor_Top_04_Schematic": {
+      "name": "Improved Suspensor Jacket",
+      "category": "Garments"
+    },
+    "UniqueSda4_Schematic": {
+      "name": "Way of the Fighter",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueSword_03_Schematic": {
+      "name": "Spark-sword",
+      "category": "Weapons - Melee"
+    },
+    "UniqueScattergun3_Schematic": {
+      "name": "Eviscerator",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueDirk_02_Schematic": {
+      "name": "Denira's Gift",
+      "category": "Weapons - Melee"
+    },
+    "UniqueAr2_Schematic": {
+      "name": "Pipecleaner",
+      "category": "Weapons - Ranged"
+    },
+    "SMG_Unique_LargeMag_04_Schematic": {
+      "name": "Ironwatch Special",
+      "category": "Weapons - Ranged"
+    },
+    "Kindjal_Unique_Blood_04_Schematic": {
+      "name": "Shadrath's Drinker",
+      "category": "Weapons - Melee"
+    },
+    "LongRifle_Unique_Poison_04_Schematic": {
+      "name": "Long Shot",
+      "category": "Weapons - Ranged"
+    },
+    "HeavyPistol_Unique_Bleed_04_Schematic": {
+      "name": "House Disruptor Pistol",
+      "category": "Weapons - Ranged"
+    },
+    "LMG_Unique_RapidFire_04_Schematic": {
+      "name": "Experimental Vulcan GAU-94",
+      "category": "Weapons - Ranged"
+    },
+    "Shotgun_Unique_Explosive_04_Schematic": {
+      "name": "House Burst Drillshot",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueSda_Doubleshot_04_Schematic": {
+      "name": "Shadrath's Edge",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueScattergun_Fire_04_Schematic": {
+      "name": "Firestorm",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueAr_Burst_04_Schematic": {
+      "name": "Stammershot",
+      "category": "Weapons - Ranged"
+    },
+    "Kindjal_Unique_Stamina_04_Schematic": {
+      "name": "Spark-Knife",
+      "category": "Weapons - Melee"
+    },
+    "Combat_Light_Unique_BiomeHeat_Top_04_Schematic": {
+      "name": "Miner's Blessing",
+      "category": "Garments"
+    },
+    "SandbikeChoamBoostHeatEfficient4_Schematic": {
+      "name": "Night Rider Sandbike Boost Mk5",
+      "category": "Vehicle Modules"
+    },
+    "BuggyChoamBoostHeatEfficient3_Schematic": {
+      "name": "Rattler Boost Module Mk5",
+      "category": "Vehicle Modules"
+    },
+    "LightOrnithopterChoamBoostHeatEfficient2_Schematic": {
+      "name": "Stormrider Boost Module Mk5",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeEngine_Unique_Speed_5_Schematic": {
+      "name": "Mohandis Sandbike Engine Mk5",
+      "category": "Vehicle Modules"
+    },
+    "BuggyEngine_Unique_Accelerate_05_Schematic": {
+      "name": "Bluddshot Buggy Engine Mk5",
+      "category": "Vehicle Modules"
+    },
+    "BuggyMining_Unique_YieldIncrease_05_Schematic": {
+      "name": "Focused Buggy Cutteray Mk5",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightEngine_Unique_Speed_05_Schematic": {
+      "name": "Dyvetz Ornithopter Engine Mk5",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterMediumLauncher_Unique_LargeExplosion_05_Schematic": {
+      "name": "Adept High-payload Rocket Module",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterMediumEngine_Unique_Speed_05_Schematic": {
+      "name": "Dyvetz Ornithopter Engine Mk5",
+      "category": "Vehicle Modules"
+    },
+    "BuggyInventory_Unique_Capacity_05_Schematic": {
+      "name": "Bigger Buggy Boot Mk5",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightScanner_Unique_LongRange_05_Schematic": {
+      "name": "Hawkeye Scanner Module Mk5",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightLauncher_Unique_RapidFire_05_Schematic": {
+      "name": "Heaven's Wrath Rocket Module Mk5",
+      "category": "Vehicle Modules"
+    },
+    "HighCapacityLiterjon_05_Schematic": {
+      "name": "Hajra Literjon Mk5",
+      "category": "Tools"
+    },
+    "DewReaper_Unique_04_Schematic": {
+      "name": "Buoyant Reaper Mk5",
+      "category": "Tools"
+    },
+    "GlidePartialStabilizationBelt_05_Schematic": {
+      "name": "The Emperor's Wings Mk5",
+      "category": "Tools"
+    },
+    "DewReaper_2h_Unique_YieldIncrease_05_Schematic": {
+      "name": "Focused Reaper Mk5",
+      "category": "Tools"
+    },
+    "StaticCompactor_Unique_Compact_05_Schematic": {
+      "name": "Compact Compactor Mk5",
+      "category": "Tools"
+    },
+    "BodyFluidExtractor_Unique_Water_05_Schematic": {
+      "name": "Filter Extractor Mk5",
+      "category": "Tools"
+    },
+    "BodyFluidExtractor_Unique_Poison_05_Schematic": {
+      "name": "Impure Extractor Mk5",
+      "category": "Tools"
+    },
+    "PowerPack_Unique_Regen_05_Schematic": {
+      "name": "Young Sparky Mk5",
+      "category": "Tools"
+    },
+    "DewReaper_1h_Unique_Compact_05_Schematic": {
+      "name": "Collapsible Dew Reaper Mk5",
+      "category": "Tools"
+    },
+    "Bloodsack_Unique_Durable_05_Schematic": {
+      "name": "Maas Kharet Bloodbag",
+      "category": "Tools"
+    },
+    "Combat_Neut_SmugglerDeserterUnique05_Helmet_Schematic": {
+      "name": "Chosen Helmet",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique05_Top_Schematic": {
+      "name": "Chosen Chestplate",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique05_Bottom_Schematic": {
+      "name": "Chosen Pants",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique05_Gloves_Schematic": {
+      "name": "Chosen Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Neut_SmugglerDeserterUnique05_Boots_Schematic": {
+      "name": "Chosen Boots",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique04_Helmet_Schematic": {
+      "name": "Acheronian Helmet",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique04_Top_Schematic": {
+      "name": "Acheronian Chestplate",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique04_Bottom_Schematic": {
+      "name": "Acheronian Pants",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique04_Gloves_Schematic": {
+      "name": "Acheronian Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Neut_AtreidesDeserterUnique04_Boots_Schematic": {
+      "name": "Acheronian Boots",
+      "category": "Garments"
+    },
+    "Combat_Heavy_Unique_Reinforced_Bottom_05_Schematic": {
+      "name": "Mendek's Pants",
+      "category": "Garments"
+    },
+    "Combat_Heavy_Unique_Reinforced_Gloves_05_Schematic": {
+      "name": "Mendek's Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Heavy_Unique_Reinforced_Helmet_05_Schematic": {
+      "name": "Mendek's Helmet",
+      "category": "Garments"
+    },
+    "Combat_Heavy_Unique_Reinforced_Boots_05_Schematic": {
+      "name": "Mendek's Boots",
+      "category": "Garments"
+    },
+    "Combat_Heavy_Unique_Reinforced_Top_05_Schematic": {
+      "name": "Mendek's Chestplate",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_05_Mask_Schematic": {
+      "name": "Saturnine Stillsuit Mask",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_05_Boots_Schematic": {
+      "name": "Saturnine Stillsuit Boots",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_05_Gloves_Schematic": {
+      "name": "Saturnine Stillsuit Gloves",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Armored_05_Top_Schematic": {
+      "name": "Saturnine Stillsuit Garment",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Efficient_05_Boots_Schematic": {
+      "name": "Batigh Stillsuit Boots",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Efficient_05_Gloves_Schematic": {
+      "name": "Batigh Stillsuit Gloves",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Efficient_05_Mask_Schematic": {
+      "name": "Batigh Stillsuit Mask",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_Efficient_05_Top_Schematic": {
+      "name": "Batigh Stillsuit Garment",
+      "category": "Garments"
+    },
+    "Combat_Heavy_Unique_PowerEfficient_Gloves_05_Schematic": {
+      "name": "Station Gauntlets",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_Scanning_Helmet_05_Schematic": {
+      "name": "Wayfinder Helm",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_WormThreat_Boots_05_Schematic": {
+      "name": "Tarl Softstep Boots",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_Stamina_Bottom_05_Schematic": {
+      "name": "Stim-Leggings ",
+      "category": "Garments"
+    },
+    "Stillsuit_Unique_HeatMitigation_05_Mask_Schematic": {
+      "name": "Shaded Hood",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_DewReap_Gloves_05_Schematic": {
+      "name": "Advanced Reaper Gloves",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_ReduceSuspensor_Top_05_Schematic": {
+      "name": "Advanced Suspensor Jacket",
+      "category": "Garments"
+    },
+    "UniqueSda5_Schematic": {
+      "name": "Way of the Desert",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueSword_04_Schematic": {
+      "name": "Jolt-sword",
+      "category": "Weapons - Melee"
+    },
+    "UniqueScattergun4_Schematic": {
+      "name": "Syndicate Impaler",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueDirk_03_Schematic": {
+      "name": "Moisture Sealer",
+      "category": "Weapons - Melee"
+    },
+    "UniqueAr3_Schematic": {
+      "name": "Scrubber",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueRapier_02_Schematic": {
+      "name": "Kharet Viper",
+      "category": "Weapons - Melee"
+    },
+    "UniqueSmg2_Schematic": {
+      "name": "Piter's Disruptor",
+      "category": "Weapons - Ranged"
+    },
+    "SMG_Unique_LargeMag_05_Schematic": {
+      "name": "Relentless",
+      "category": "Weapons - Ranged"
+    },
+    "Kindjal_Unique_Blood_05_Schematic": {
+      "name": "Pardot's Drinker",
+      "category": "Weapons - Melee"
+    },
+    "LongRifle_Unique_Poison_05_Schematic": {
+      "name": "Thufir's Best",
+      "category": "Weapons - Ranged"
+    },
+    "HeavyPistol_Unique_Bleed_05_Schematic": {
+      "name": "Adept Disruptor Pistol",
+      "category": "Weapons - Ranged"
+    },
+    "LMG_Unique_RapidFire_05_Schematic": {
+      "name": "Extravagant Message",
+      "category": "Weapons - Ranged"
+    },
+    "Shotgun_Unique_Explosive_05_Schematic": {
+      "name": "Adept Burst Drillshot",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueSda_Doubleshot_05_Schematic": {
+      "name": "Taqwa's Double",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueScattergun_Fire_05_Schematic": {
+      "name": "Starburst",
+      "category": "Weapons - Ranged"
+    },
+    "HeavyPistol_Unique_Headshot_05_Schematic": {
+      "name": "Cope",
+      "category": "Weapons - Ranged"
+    },
+    "LongRifle_Unique_LargeMag_05_Schematic": {
+      "name": "Fivefinger's Tripleshot Rifle",
+      "category": "Weapons - Ranged"
+    },
+    "UniqueAr_Burst_05_Schematic": {
+      "name": "Mendek's Rattle",
+      "category": "Weapons - Ranged"
+    },
+    "Kindjal_Unique_Stamina_05_Schematic": {
+      "name": "Jolt-knife",
+      "category": "Weapons - Melee"
+    },
+    "Combat_Light_Unique_BiomeHeat_Top_05_Schematic": {
+      "name": "Station Garb",
+      "category": "Garments"
+    },
+    "SandbikeChoamBoostHeatEfficient5_Schematic": {
+      "name": "Night Rider Sandbike Boost Mk6",
+      "category": "Vehicle Modules"
+    },
+    "BuggyChoamBoostHeatEfficient4_Schematic": {
+      "name": "Rattler Boost Module Mk6",
+      "category": "Vehicle Modules"
+    },
+    "LightOrnithopterChoamBoostHeatEfficient3_Schematic": {
+      "name": "Stormrider Boost Module Mk6",
+      "category": "Vehicle Modules"
+    },
+    "SandbikeEngine_Unique_Speed_6_Schematic": {
+      "name": "Mohandis Sandbike Engine Mk6",
+      "category": "Vehicle Modules"
+    },
+    "BuggyEngine_Unique_Accelerate_06_Schematic": {
+      "name": "Bluddshot Buggy Engine Mk6",
+      "category": "Vehicle Modules"
+    },
+    "BuggyMining_Unique_YieldIncrease_06_Schematic": {
+      "name": "Focused Buggy Cutteray Mk6",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightEngine_Unique_Speed_06_Schematic": {
+      "name": "Dyvetz Ornithopter Engine Mk6",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterTransportEngine_Unique_Speed_06_Schematic": {
+      "name": "Dragon Carrier Engine",
+      "category": "Vehicle Modules"
+    },
+    "SandcrawlerEngine_Unique_Speed_06_Schematic": {
+      "name": "Walker Sandcrawler Engine Mk6",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterMediumLauncher_Unique_LargeExplosion_06_Schematic": {
+      "name": "Regis High-payload Rocket Module",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterMediumEngine_Unique_Speed_06_Schematic": {
+      "name": "Dyvetz Ornithopter Engine Mk6",
+      "category": "Vehicle Modules"
+    },
+    "BuggyInventory_Unique_Capacity_06_Schematic": {
+      "name": "Bigger Buggy Boot Mk6",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightLauncher_Unique_RapidFire_06_Schematic": {
+      "name": "Heaven's Wrath Rocket Module Mk6",
+      "category": "Vehicle Modules"
+    },
+    "SandcrawlerLocomotion_Unique_WormThreat_06_Schematic": {
+      "name": "Dampened Sandcrawler Treads",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterTransportBoost_Unique_LessHeat_06_Schematic": {
+      "name": "Steady Carrier Boost Module Mk6",
+      "category": "Vehicle Modules"
+    },
+    "HighCapacityLiterjon_06_Schematic": {
+      "name": "Hajra Literjon Mk6",
+      "category": "Tools"
+    },
+    "DewReaper_Unique_05_Schematic": {
+      "name": "Buoyant Reaper Mk6",
+      "category": "Tools"
+    },
+    "MiningTool_2h_Unique_04_Schematic": {
+      "name": "Kynes's Cutteray",
+      "category": "Tools"
+    },
+    "GlidePartialStabilizationBelt_06_Schematic": {
+      "name": "The Emperor's Wings Mk6",
+      "category": "Tools"
+    },
+    "DewReaper_2h_Unique_YieldIncrease_06_Schematic": {
+      "name": "Omni Focused Dew Scythe",
+      "category": "Tools"
+    },
+    "StaticCompactor_Unique_Compact_06_Schematic": {
+      "name": "Compact Compactor Mk6",
+      "category": "Tools"
+    },
+    "BodyFluidExtractor_Unique_Water_06_Schematic": {
+      "name": "Filter Extractor Mk6",
+      "category": "Tools"
+    },
+    "BodyFluidExtractor_Unique_Poison_06_Schematic": {
+      "name": "Impure Extractor Mk6",
+      "category": "Tools"
+    },
+    "PowerPack_Unique_Regen_06_Schematic": {
+      "name": "Young Sparky Mk6",
+      "category": "Tools"
+    },
+    "DewReaper_1h_Unique_Compact_06_Schematic": {
+      "name": "Collapsible Dew Reaper Mk6",
+      "category": "Tools"
+    },
+    "Bloodsack_Unique_Durable_06_Schematic": {
+      "name": "The Baron's Bloodbag",
+      "category": "Tools"
+    },
+    "OrnithopterLightLocomotion_Unique_Speed_4_Schematic": {
+      "name": "Albatross Wing Module Mk4",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightLocomotion_Unique_Speed_5_Schematic": {
+      "name": "Albatross Wing Module Mk5",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterLightLocomotion_Unique_Speed_6_Schematic": {
+      "name": "Albatross Wing Module Mk6",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterMediumBoost_Unique_LessHeat_5_Schematic": {
+      "name": "Steady Assault Boost Module Mk5",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterMediumBoost_Unique_LessHeat_6_Schematic": {
+      "name": "Steady Assault Boost Module Mk6",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterMediumLocomotion_Unique_Strafe_5_Schematic": {
+      "name": "Hummingbird Wing Module Mk5",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterMediumLocomotion_Unique_Strafe_6_Schematic": {
+      "name": "Hummingbird Wing Module Mk6",
+      "category": "Vehicle Modules"
+    },
+    "OrnithopterTransportLocomotion_Unique_Speed_6_Schematic": {
+      "name": "Roc Carrier Wing",
+      "category": "Vehicle Modules"
+    },
+    "Combat_Light_Unique_MovingDmgReduction_Boots_06_Schematic": {
+      "name": "Adrenal Boots",
+      "category": "Garments"
+    },
+    "Combat_Heavy_Unique_StandStillDmgReduction_Top_06_Schematic": {
+      "name": "Fortress Chestpiece",
+      "category": "Garments"
+    },
+    "Combat_Light_Unique_StaminaDmgIncrease_Helmet_06_Schematic": {
+      "name": "Seeker Helmet",
+      "category": "Garments"
+    },
+    "PowerPack_Unique_PoisRadMitigation_06_Schematic": {
+      "name": "Purifier Power Pack",
+      "category": "Tools"
+    },
+    "FullStabilizationBelt_Unique_DmgReduction_Schematic": {
+      "name": "Sentinel Belt",
+      "category": "Tools"
+    },
+    "SandcrawlerSpiceContainer_Unique_Capacity_6_Schematic": {
+      "name": "Upgraded Regis Spice Container",
+      "category": "Vehicle Modules"
+    },
+    "Unique_Sword_BleedyBlocky_4_Schematic": {
+      "name": "Sword of Seven Sorrows",
+      "category": "Weapons - Melee"
+    },
+    "Unique_Sword_BleedyBlocky_5_Schematic": {
+      "name": "Bite Back Blade",
+      "category": "Weapons - Melee"
+    },
+    "TreadwheelBoost_Unique_LessHeat_4_Schematic": {
+      "name": "Steady Treadwheel Boost Module Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_Unique_Speed_4_Schematic": {
+      "name": "Swift Treadwheel Engine Mk4",
+      "category": "Vehicle Modules"
+    },
+    "Stillsuit_Choam_Unique_Dashed02_Top_Schematic": {
+      "name": "Desert Dasher Garment",
+      "category": "Garments"
+    },
+    "Stillsuit_Choam_Unique_Dashed03_Top_Schematic": {
+      "name": "Sprinter's Stillsuit Garment",
+      "category": "Garments"
+    },
+    "Stillsuit_Choam_Unique_Dashed04_Top_Schematic": {
+      "name": "Sand Strider Stillsuit Garment",
+      "category": "Garments"
+    },
+    "Stillsuit_Choam_Unique_Dashed05_Top_Schematic": {
+      "name": "Dune Dancer Stillsuit Garment",
+      "category": "Garments"
+    },
+    "TreadwheelBoost_Unique_LessHeat_5_Schematic": {
+      "name": "Steady Treadwheel Boost Module Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_Unique_Speed_5_Schematic": {
+      "name": "Swift Treadwheel Engine Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelBoost_Unique_LessHeat_6_Schematic": {
+      "name": "Steady Treadwheel Boost Module Mk6",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelEngine_Unique_Speed_6_Schematic": {
+      "name": "Swift Treadwheel Engine Mk6",
+      "category": "Vehicle Modules"
+    },
+    "Fireballer_2_Schematic": {
+      "name": "Duraluminum Pyrocket",
+      "category": "Weapons - Ranged"
     }
   }
 }


### PR DESCRIPTION
## Problem

Players reported items missing from the **Add Item** search when adding to an inventory — e.g. **Spice Sand** isn't there.

## Root cause

The Add-Item picker (`/api/catalog/items` → `app\data\item-catalog.json`) is backed by a catalog scraped from awakening.wiki (1294 items). The app *also* ships a richer `gameplay-item-data.json` (1658 fully-described items) used for inventory display. **552 real templates** the app already knows about were absent from the picker catalog, so they couldn't be searched or given.

Missing items, by bucket:

| Count | Bucket |
|------:|--------|
| 218 | Garments |
| 157 | Vehicle Modules |
| 66 | Weapons - Ranged |
| 62 | Tools |
| 37 | Weapons - Melee |
| 11 | Resources / Components |
| 1 | Augments |

Headline resources missing: **Spice Sand, Water, Plant Fiber**, plus components (Offworld Regis Compound, Regis Component, Schematic Pattern Grade 1–5, …).

## Fix

Backfilled `item-catalog.json` from the app-bundled `gameplay-item-data.json` (**1294 → 1846 entries**), mapping internal category paths (`items/misc/rawresources`, `items/garment/lightarmor/chest`, …) to the picker's friendly categories (`Resources`, `Garments - Chest`, `Vehicle Modules`, `Tools`, `Augments`, …) and carrying `gradeable`/`tier` flags where present. Existing entries untouched — pure append + `_meta` bump.

Verified the live `Get-DuneItemCatalog` loader reads the merged file (1846 items) and Spice Sand now resolves as `Resources`.

- Updated `app/data/README.md` and `CHANGELOG.md`.

No logic changes; data-only. Existing fixture-based catalog tests are unaffected.