### PR TITLE
release: v12.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.20] - 2026-06-14
+
 ### Fixed
 
 - **Add Item search list now scrolls to the last result.** The picker's results

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.19'
+$script:DuneToolVersion = '12.0.20'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.19',
+    [string]$Version = '12.0.20',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.19</Version>
+    <Version>12.0.20</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.19"
+#define MyAppVersion "12.0.20"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.19"
+$script:ToolVersion = "12.0.20"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Bumps all 5 version stamps `12.0.19 → 12.0.20` and rolls the `[Unreleased]` CHANGELOG section into a dated `[12.0.20]` entry.

### Ships
- #195 — Market Bot `access_point_id` FK violation fix
- #196 — Add-Item catalog backfill (552 missing items, incl. Spice Sand / Water / Plant Fiber; 1294 → 1846)
- #197 — Add-Item results popup scrolls to the last match (portal fix)

### Version stamps bumped
- `dune-server.ps1` → `$script:ToolVersion`
- `app/DuneServer.ps1` → `$script:DuneToolVersion`
- `app/build/Build-Exe.ps1` → default `$Version`
- `app/installer/DuneServer.iss` → `MyAppVersion`
- `app/desktop/DuneShell/DuneShell.csproj` → `<Version>`

Tag + GitHub release (with `DuneServerSetup.exe` asset) follow once this merges.