### PR TITLE
release: v12.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,35 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.21] - 2026-06-14
+
+### Added
+
+- **Fill Base Water** Player Action (Inventory section, next to Fill Water) —
+  tops up all water containers in a player's **own** bases (Water Cisterns,
+  Windtraps) plus their carried fillables in one click. Cistern/windtrap water
+  lives in live game state with no per-cistern database field, so this routes
+  through the per-player `UpdateAllWaterFillables` game command, which is keyed
+  by the player's FLS id and therefore only ever affects **that** player's own
+  containers — never other players' bases. Online-only: offline players are
+  rejected with a clear message and the button shows a **LIVE REQ'D** badge
+  while they're offline.
+
+### Fixed
+
+- **Market Bot** — Duke now lists every stackable resource in consistent full
+  stacks. The bot let the live NPC-vendor snapshot's per-item `max_stack`
+  (often `1` for raw resources) override the catalog stack size, so some
+  resources (e.g. **Plastone**, **Plastanium Ingot**) were sold as single-item
+  listings while others (e.g. **Plasteel Composite Armor Plating**) correctly
+  showed full 500-stacks. Stackable items now use the larger of the snapshot
+  and catalog stack, so every resource lists in its full catalog stack.
+- **Market Bot** — added an optional **displayed-price (Solari) cap**. In-game
+  Solari prices are `item_price × 10`, so the existing 100,000 `item_price` cap
+  actually permitted up to 1,000,000 Solari in-game. A new opt-in toggle
+  (default **off**, preserving the current higher prices) clamps the displayed
+  Solari price to a configurable ceiling.
+
 ## [12.0.20] - 2026-06-14
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.20'
+$script:DuneToolVersion = '12.0.21'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.20',
+    [string]$Version = '12.0.21',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.20</Version>
+    <Version>12.0.21</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.20"
+#define MyAppVersion "12.0.21"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.20"
+$script:ToolVersion = "12.0.21"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Cuts **v12.0.21**, bundling the two features merged since v12.0.20.

## Version bump
Bumps all 5 version stamps `12.0.20` → `12.0.21`:
- `app/DuneServer.ps1`
- `app/build/Build-Exe.ps1`
- `app/desktop/DuneShell/DuneShell.csproj`
- `app/installer/DuneServer.iss`
- `dune-server.ps1`

## CHANGELOG
Rolls a new `## [12.0.21] - 2026-06-14` entry:

### Added
- **Fill Base Water** player action (Inventory, next to Fill Water) — tops up all water containers in a player's **own** bases (Water Cisterns, Windtraps) plus carried fillables, via the per-player `UpdateAllWaterFillables` game command (FLS-keyed, so it only ever affects that player's own containers). Online-only. (#200)

### Fixed
- **Market Bot** — Duke now lists every stackable resource in full catalog stacks (snapshot `max_stack` of `1` for raw resources no longer collapses listings to single items). (#199)
- **Market Bot** — optional displayed-price (Solari) cap, default **off** (the 100,000 `item_price` cap was ×10 in-game, allowing up to 1,000,000 Solari). (#199)

## Release steps after merge
- [ ] FF canonical main
- [ ] Build `DuneServerSetup.exe`
- [ ] Tag `v12.0.21` from the merge commit
- [ ] Create GitHub release with `DuneServerSetup.exe` as the sole asset