### PR TITLE
fix(players): restore UTF-8 BOM on Fill Base Water .ps1 files

### DIFF
--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -1,4 +1,4 @@
-# PlayersRmq.ps1
+﻿# PlayersRmq.ps1
 # High-level handlers that publish RMQ ServerCommand messages for live
 # (online-player) operations. Ports the reference implementation handlers_rmq.go logic:
 # parameter validation, optional FLS id resolution from actor_id, lightweight

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -1,4 +1,4 @@
-# Gameplay API — Players. Read views (list + detail) follow the live/demo +
+﻿# Gameplay API — Players. Read views (list + detail) follow the live/demo +
 # `source` convention; write actions require a live DB (no demo writes) and
 # mirror the reference implementation's stored procedures. Shared helpers Get-DuneQ /
 # Test-DuneDemoRequested come from routes/Gameplay.ps1 (loaded first).


### PR DESCRIPTION
## Problem
The installer build (`Build-Installer.ps1`) fails its UTF-8 BOM pre-flight on `main`:

```
BOM missing on these files (PS 5.1 would mojibake them at runtime):
  app/server/lib/PlayersRmq.ps1
  app/server/routes/GameplayPlayers.ps1
```

Both files contain non-ASCII bytes (em-dashes, arrows, box-drawing) in comments **and** user-facing messages. PS2EXE compiles `DuneServer.exe` against the Windows PowerShell 5.1 host, which decodes BOM-less files as Windows-1252 — corrupting those bytes and (per the build script's own notes, cf. v11.4.0) potentially breaking startup.

## Cause
Confirmed via git blobs: both files **had** a BOM before the Fill Base Water feature merged (`438494c`→`f960287`). The merge's LF-normalization step stripped it:

| file | before #200 | after #200 |
|------|------------|-----------|
| `PlayersRmq.ps1` | BOM=True | BOM=False |
| `GameplayPlayers.ps1` | BOM=True | BOM=False |

## Fix
Re-add the UTF-8 BOM to both files (line-1-only change; LF endings preserved). Unblocks the v12.0.21 installer build.