### PR TITLE
v12.0.24 — suppress SSH console flashes + add Help → Show/Hide backend console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.24] - 2026-06-14
+
+### Added
+
+- **Help → Show backend console** / **Hide backend console**. There was
+  previously no UI path that brought the backend PowerShell console window
+  back to a visible foreground window once tray mode hid it. The new menu
+  item (visible only to local viewers, since the new `/api/console` route
+  is loopback-only) calls `ShowWindow(SW_RESTORE)` + `SetForegroundWindow`
+  to un-minimize and pop the console where you're looking; toggling it
+  again hides it via `SW_HIDE`. The label tracks the real window state
+  (refreshes when the Help menu opens) so it correctly says "Show" when
+  hidden / minimized and "Hide" when visible.
+
 ## [12.0.23] - 2026-06-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.23] - 2026-06-14
+
+### Fixed
+
+- **Console window no longer flashes during dashboard polling.** The
+  battlegroup-status probe (`Get-DuneBattlegroupSnapshot`) and the setup
+  preflight SSH-key check both used to shell out via `& ssh ... 2>$errFile`,
+  which silently allocated a fresh conhost window for every spawn when the
+  caller was a background runspace whose parent's hidden console handle
+  wasn't inherited. With multiple dashboard panels polling at 10–15 s, that
+  produced a steady stream of brief console flashes on top of every other
+  window. Both call sites now route through a new `Invoke-DuneSshHidden`
+  helper that uses `ProcessStartInfo` with `CreateNoWindow = $true` (same
+  pattern `Invoke-V6Ssh` has used since v10.1.14) and exposes stdout, stderr
+  and the exit code so the existing error-translation logic still works.
+
 ## [12.0.22] - 2026-06-14
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.23'
+$script:DuneToolVersion = '12.0.24'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.22'
+$script:DuneToolVersion = '12.0.23'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.23',
+    [string]$Version = '12.0.24',
     [switch]$Quiet
 )
 

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.22',
+    [string]$Version = '12.0.23',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.22</Version>
+    <Version>12.0.23</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.23</Version>
+    <Version>12.0.24</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.22"
+#define MyAppVersion "12.0.23"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.23"
+#define MyAppVersion "12.0.24"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/lib/Db-Postgres.ps1
+++ b/app/lib/Db-Postgres.ps1
@@ -131,6 +131,79 @@ function Invoke-V6Ssh {
     }
 }
 
+# Run an arbitrary ssh command with a HIDDEN window (no conhost flash) and
+# return BOTH stdout and stderr separately, plus the process exit code.
+#
+# Why this exists alongside Invoke-V6Ssh:
+#   Invoke-V6Ssh is tuned for the kubectl/psql call path -- it discards
+#   stderr (mirrors the old `2>$null` semantics) and only returns stdout.
+#   The preflight / status code paths need stderr (to surface "Permission
+#   denied" / "Host key verification failed" etc. as actionable hints) AND
+#   the exit code. They used to call `& ssh ... 2>$errFile`, which
+#   silently allocates a fresh conhost window for every spawn when run
+#   from a background runspace whose parent's hidden console isn't
+#   inherited -- producing the "console keeps popping up and disappearing"
+#   flash users see while the dashboard polls (every 10-15 s per panel).
+function Invoke-DuneSshHidden {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]   $Ip,
+        [Parameter(Mandatory)] [string]   $KeyPath,
+        [string[]]                       $SshOptions = @(),
+        [string]                         $RemoteCommand,
+        [string]                         $User       = 'dune',
+        [int]                            $TimeoutSec = 30
+    )
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName               = 'ssh'
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute        = $false
+    $psi.CreateNoWindow         = $true
+
+    # Build argv. Same quoting strategy as Invoke-V6Ssh: only quote args
+    # that contain whitespace or quotes, and escape any embedded ".
+    $sshArgs = @('-n') + $SshOptions
+    if ($KeyPath) { $sshArgs += @('-i', $KeyPath) }
+    $sshArgs += @("$User@$Ip")
+    if ($RemoteCommand) { $sshArgs += @($RemoteCommand) }
+    $psi.Arguments = (@($sshArgs) | ForEach-Object {
+        if ($_ -match '[\s"]') { '"' + ($_ -replace '"','\"') + '"' } else { $_ }
+    }) -join ' '
+
+    $proc = [System.Diagnostics.Process]::new()
+    $proc.StartInfo = $psi
+    try {
+        [void]$proc.Start()
+        $outTask  = $proc.StandardOutput.ReadToEndAsync()
+        $errTask  = $proc.StandardError.ReadToEndAsync()
+        $timeoutMs = [int]$TimeoutSec * 1000
+        if (-not $proc.WaitForExit($timeoutMs)) {
+            try { $proc.Kill() } catch {}
+            try { [void]$proc.WaitForExit(2000) } catch {}
+            if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                Write-DuneLog "Invoke-DuneSshHidden: ssh to $Ip exceeded ${TimeoutSec}s, killed" 'WARN'
+            }
+            return @{
+                Stdout = @()
+                Stderr = "ssh timed out after ${TimeoutSec}s"
+                Exit   = -1
+            }
+        }
+        [void]$proc.WaitForExit()
+        $stdoutText = $outTask.GetAwaiter().GetResult()
+        $stderrText = $errTask.GetAwaiter().GetResult()
+        return @{
+            Stdout = if ([string]::IsNullOrEmpty($stdoutText)) { @() } else { @($stdoutText -split "`r?`n") }
+            Stderr = $stderrText
+            Exit   = $proc.ExitCode
+        }
+    } finally {
+        try { $proc.Dispose() } catch {}
+    }
+}
+
 function Find-V6DbPod {
     param([string]$Ip, [switch]$Force)
     if (-not $Force -and $script:V6DbPodCache -and ((Get-Date) - $script:V6DbPodCacheTime).TotalSeconds -lt 120) {

--- a/app/server/lib/Setup.ps1
+++ b/app/server/lib/Setup.ps1
@@ -112,15 +112,24 @@ function Get-DuneSetupPreflight {
             }
             else {
                 $ip = $vm.ip
-                $errFile = [System.IO.Path]::GetTempFileName()
-                $probe = ''
+                $probe  = ''
+                $sshErr = ''
                 try {
-                    $probe = (& ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=ERROR `
-                                -o ConnectTimeout=6 -o PreferredAuthentications=publickey `
-                                -i $keyPath "dune@$ip" 'echo dune-ok' 2>$errFile) -join "`n"
+                    # Same hidden-window routing as the battlegroup status probe
+                    # (Get-DuneBattlegroupSnapshot). The Settings/Setup wizard
+                    # re-runs this check on each panel open + every preflight
+                    # poll, so spawning a visible conhost per call is the most
+                    # frequent flash source on the dashboard.
+                    $r = Invoke-DuneSshHidden -Ip $ip -KeyPath $keyPath -TimeoutSec 10 -SshOptions @(
+                        '-o','BatchMode=yes'
+                        '-o','StrictHostKeyChecking=no'
+                        '-o','LogLevel=ERROR'
+                        '-o','ConnectTimeout=6'
+                        '-o','PreferredAuthentications=publickey'
+                    ) -RemoteCommand 'echo dune-ok'
+                    $probe  = ($r.Stdout -join "`n")
+                    $sshErr = $r.Stderr
                 } catch { }
-                $sshErr = if (Test-Path $errFile) { (Get-Content -Raw -ErrorAction SilentlyContinue $errFile) } else { '' }
-                Remove-Item $errFile -ErrorAction SilentlyContinue
 
                 if ($probe -match 'dune-ok') {
                     $checks.Add(@{

--- a/app/server/lib/Status.ps1
+++ b/app/server/lib/Status.ps1
@@ -92,17 +92,23 @@ function Get-DuneBattlegroupSnapshot {
         # Capture stderr separately so a real SSH failure (auth / connection)
         # can be surfaced as a clear reason instead of collapsing into a blank
         # "Unknown" state. LogLevel=ERROR (not QUIET) lets ssh's own diagnostics
-        # through to the error file.
-        $errFile = [System.IO.Path]::GetTempFileName()
-        try {
-            $raw = & ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR `
-                         -o ConnectTimeout=10 -o BatchMode=yes `
-                         -i $sshKey "dune@$($vm.ip)" '/home/dune/.dune/bin/battlegroup status' 2>$errFile
-            $exit   = $LASTEXITCODE
-            $sshErr = if (Test-Path $errFile) { Get-Content -Raw -ErrorAction SilentlyContinue $errFile } else { '' }
-        } finally {
-            Remove-Item $errFile -ErrorAction SilentlyContinue
-        }
+        # through to the error stream.
+        #
+        # Routed through Invoke-DuneSshHidden (ProcessStartInfo + CreateNoWindow=$true)
+        # so background-runspace polling — server-health refresh runs every ~60 s,
+        # and the dashboard fires this path indirectly through several panels —
+        # doesn't pop a transient conhost window for each spawn (the original
+        # `& ssh ... 2>$errFile` allocates a fresh console when the runspace
+        # parent's hidden console handle isn't inherited).
+        $r = Invoke-DuneSshHidden -Ip $vm.ip -KeyPath $sshKey -TimeoutSec 15 -SshOptions @(
+            '-o','StrictHostKeyChecking=no'
+            '-o','LogLevel=ERROR'
+            '-o','ConnectTimeout=10'
+            '-o','BatchMode=yes'
+        ) -RemoteCommand '/home/dune/.dune/bin/battlegroup status'
+        $raw    = $r.Stdout
+        $exit   = $r.Exit
+        $sshErr = $r.Stderr
 
         # `battlegroup status` (a kubectl wrapper) can write status-shaped text —
         # notably the empty-namespace "No resources found" stopped signal — to

--- a/app/server/routes/Console.ps1
+++ b/app/server/routes/Console.ps1
@@ -1,0 +1,149 @@
+﻿# Console window control — backs Help → Show / Hide backend console.
+#
+# Loopback-only: a remote viewer (Tailscale / LAN) with a valid token must NOT
+# be able to twiddle the host machine's backend console window. Both endpoints
+# reject non-loopback callers with 403.
+#
+# Compiled-exe-only: dev pwsh has no console of its own to show/hide. The GET
+# handler returns available=false in that case so the menu item can be hidden.
+#
+# Why this exists: until 12.0.24, once tray mode came up the backend console
+# was permanently locked at SW_HIDE (see ConsoleHost.ps1) and there was no
+# user-facing path to reveal it. Users who wanted to watch the server work
+# in real time had no way to bring the console back to a visible window.
+
+function Test-DuneConsoleLoopbackRequest {
+    param($req)
+    try {
+        $remote = $req.RemoteEndPoint.Address
+        if ($remote) { return [System.Net.IPAddress]::IsLoopback($remote) }
+    } catch {}
+    return $false
+}
+
+# Reach into the same console hwnd ConsoleHost.ps1 already manages. The native
+# type was added by Get-DuneConsoleNativeType either at startup or on first use
+# in tray mode; we call the same factory so we share its cached P/Invoke
+# instead of redefining a parallel one.
+function Get-DuneConsoleHwnd {
+    try {
+        $native = Get-DuneConsoleNativeType
+        return @{ native = $native; hwnd = $native::GetConsoleWindow() }
+    } catch {
+        return $null
+    }
+}
+
+# Lazily P/Invoke IsWindowVisible + IsIconic + SetForegroundWindow alongside
+# the existing GetConsoleWindow/ShowWindow pair. Same namespace, distinct type
+# name so we don't clash with the startup-path or ConsoleHost-path natives.
+function Get-DuneConsoleExtraNativeType {
+    if (-not ('DuneServer.DuneConsoleExtraNative' -as [type])) {
+        Add-Type -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("user32.dll")]
+public static extern bool IsWindowVisible(System.IntPtr hWnd);
+[System.Runtime.InteropServices.DllImport("user32.dll")]
+public static extern bool IsIconic(System.IntPtr hWnd);
+[System.Runtime.InteropServices.DllImport("user32.dll")]
+public static extern bool SetForegroundWindow(System.IntPtr hWnd);
+'@ -Name 'DuneConsoleExtraNative' -Namespace 'DuneServer' -ErrorAction Stop
+    }
+    return [DuneServer.DuneConsoleExtraNative]
+}
+
+function Get-DuneConsoleState {
+    $isCompiled = $false
+    try { if ($script:DuneIsCompiledExe) { $isCompiled = $true } } catch {}
+
+    $state = @{
+        available = $isCompiled
+        visible   = $false
+        minimized = $false
+    }
+    if (-not $isCompiled) { return $state }
+
+    $info = Get-DuneConsoleHwnd
+    if (-not $info -or $info.hwnd -eq [System.IntPtr]::Zero) { return $state }
+    try {
+        $extra = Get-DuneConsoleExtraNativeType
+        $state.visible   = [bool]$extra::IsWindowVisible($info.hwnd)
+        $state.minimized = [bool]$extra::IsIconic($info.hwnd)
+    } catch {}
+    return $state
+}
+
+# SW_HIDE = 0, SW_SHOWNORMAL = 1, SW_SHOW = 5, SW_RESTORE = 9.
+# When asked to show: SW_RESTORE un-minimizes AND brings to normal size, then
+# we SetForegroundWindow so it actually pops up where the user is looking
+# instead of flashing in the taskbar.
+function Set-DuneConsoleVisible {
+    param([bool]$Visible)
+
+    $info = Get-DuneConsoleHwnd
+    if (-not $info -or $info.hwnd -eq [System.IntPtr]::Zero) {
+        return @{ ok = $false; error = 'No console window handle available (running headless or as dev pwsh).' }
+    }
+    try {
+        if ($Visible) {
+            [void]$info.native::ShowWindow($info.hwnd, 9)  # SW_RESTORE
+            try { [void](Get-DuneConsoleExtraNativeType)::SetForegroundWindow($info.hwnd) } catch {}
+        } else {
+            [void]$info.native::ShowWindow($info.hwnd, 0)  # SW_HIDE
+        }
+        return @{ ok = $true }
+    } catch {
+        return @{ ok = $false; error = $_.Exception.Message }
+    }
+}
+
+# GET /api/console — current state.
+Register-DuneRoute -Method GET -Path '/api/console' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        if (-not (Test-DuneConsoleLoopbackRequest $req)) {
+            Write-DuneError -Response $res -Status 403 -Message 'Backend console can only be managed from the host machine.'
+            return
+        }
+        Write-DuneJson -Response $res -Body (Get-DuneConsoleState)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+# POST /api/console  body: { visible: bool }
+Register-DuneRoute -Method POST -Path '/api/console' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        if (-not (Test-DuneConsoleLoopbackRequest $req)) {
+            Write-DuneError -Response $res -Status 403 -Message 'Backend console can only be managed from the host machine.'
+            return
+        }
+
+        $visible = $null
+        if ($body -is [hashtable]) {
+            if ($body.ContainsKey('visible')) { $visible = [bool]$body.visible }
+        } elseif ($body -and $body.PSObject.Properties.Name -contains 'visible') {
+            $visible = [bool]$body.visible
+        }
+        if ($null -eq $visible) {
+            Write-DuneError -Response $res -Status 400 -Message "Missing required field 'visible' (bool)."
+            return
+        }
+
+        $state = Get-DuneConsoleState
+        if (-not $state.available) {
+            Write-DuneError -Response $res -Status 400 -Message 'Backend console control is only available from the installed DuneServer.exe (not a dev pwsh build).'
+            return
+        }
+
+        $result = Set-DuneConsoleVisible -Visible $visible
+        if (-not $result.ok) {
+            Write-DuneError -Response $res -Status 500 -Message $result.error
+            return
+        }
+
+        Write-DuneJson -Response $res -Body (Get-DuneConsoleState)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.23"
+$script:ToolVersion = "12.0.24"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.22"
+$script:ToolVersion = "12.0.23"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/console.ts
+++ b/webui/src/api/console.ts
@@ -1,0 +1,26 @@
+// Backend-console window control — backs Help → Show / Hide backend console.
+//
+// Loopback-only on the backend: a remote viewer (Tailscale / LAN) cannot toggle
+// the host machine's console window, and the UI hides the menu entry entirely
+// in that case via isLocalViewer().
+import { api } from './client'
+
+export interface ConsoleState {
+  /** False when running as a dev pwsh shell (no DuneServer.exe console to control). UI hides the menu item. */
+  available: boolean
+  /** True when the console window is currently visible (shown or minimized — not SW_HIDE'd). */
+  visible: boolean
+  /** True when the console window is minimized to the taskbar. */
+  minimized: boolean
+}
+
+export function getConsoleState() {
+  return api<ConsoleState>('/api/console')
+}
+
+export function setConsoleVisible(visible: boolean) {
+  return api<ConsoleState>('/api/console', {
+    method: 'POST',
+    body: JSON.stringify({ visible }),
+  })
+}

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -5,6 +5,7 @@ import { NAV_ITEMS, GROUP_LABELS, GROUP_ORDER, type NavGroup } from '../nav'
 import { useUpdateCheck } from '../hooks/useUpdateCheck'
 import { buildDiagnosticBundle, type DiagnosticBundle } from '../api/diagnostics'
 import { getAutostartState, setAutostartEnabled, type AutostartState } from '../api/autostart'
+import { getConsoleState, setConsoleVisible, type ConsoleState } from '../api/console'
 import { isLocalViewer } from '../util/viewer'
 
 type MenuKey = NavGroup | 'help'
@@ -36,6 +37,12 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
   const [autostartConfirm, setAutostartConfirm] = useState<null | { nextEnabled: boolean }>(null)
   const [autostartError, setAutostartError] = useState<string | null>(null)
 
+  // Backend-console state. Loopback-only (the backend route 403s remote
+  // callers anyway, and the menu item is hidden for them via `local`).
+  // null = not loaded yet / route unavailable on older backends.
+  const [consoleState, setConsoleState] = useState<ConsoleState | null>(null)
+  const [consoleBusy, setConsoleBusy] = useState(false)
+
   // Diagnostics-bundle result, surfaced so the user always learns where the
   // ZIP landed (Desktop vs. %APPDATA% fallback) or why it couldn't be built —
   // instead of the old fire-and-forget that silently swallowed both.
@@ -56,6 +63,39 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
   }, [local])
 
   useEffect(() => { void refreshAutostart() }, [refreshAutostart])
+
+  // Console state — refresh when the Help menu opens so the Show / Hide label
+  // tracks the real window state even if the user minimized / restored it
+  // outside the app (e.g. via the taskbar).
+  const refreshConsole = useCallback(async () => {
+    if (!local) return
+    try {
+      const s = await getConsoleState()
+      setConsoleState(s)
+    } catch {
+      setConsoleState(null)
+    }
+  }, [local])
+
+  useEffect(() => { void refreshConsole() }, [refreshConsole])
+  useEffect(() => { if (open === 'help') void refreshConsole() }, [open, refreshConsole])
+
+  const onConsoleToggleClick = async () => {
+    if (!consoleState || !consoleState.available || consoleBusy) return
+    // If currently visible AND not minimized, hide it. Otherwise show it
+    // (this also un-minimizes via SW_RESTORE in the backend).
+    const nextVisible = !(consoleState.visible && !consoleState.minimized)
+    setConsoleBusy(true)
+    try {
+      const s = await setConsoleVisible(nextVisible)
+      setConsoleState(s)
+      setOpen(null)
+    } catch {
+      // Best-effort: leave state as it was, user can retry.
+    } finally {
+      setConsoleBusy(false)
+    }
+  }
 
   const onAutostartToggleClick = () => {
     if (!autostart || !autostart.available || autostartBusy) return
@@ -255,6 +295,35 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
                 {autostart.enabled && (
                   <Icon name="Check" size={13} className="text-success mt-1" />
                 )}
+              </button>
+            )}
+            {local && consoleState && consoleState.available && (
+              <button
+                type="button"
+                onClick={onConsoleToggleClick}
+                disabled={consoleBusy}
+                className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors text-left disabled:opacity-60 disabled:cursor-wait"
+                title={
+                  consoleState.visible && !consoleState.minimized
+                    ? 'Hide the backend PowerShell console window. The server keeps running — log output still goes to dune-server.log.'
+                    : 'Bring the backend PowerShell console window to the foreground so you can watch the server work in real time.'
+                }
+              >
+                <Icon name="Terminal" size={14} className="mt-0.5" />
+                <span className="flex-1">
+                  <span className="block">
+                    {consoleState.visible && !consoleState.minimized
+                      ? 'Hide backend console'
+                      : 'Show backend console'}
+                  </span>
+                  <span className="block text-[11px] text-text-dim">
+                    {consoleState.visible
+                      ? (consoleState.minimized
+                          ? 'Currently minimized — click to restore to a visible window'
+                          : 'Currently visible — click to hide')
+                      : 'Currently hidden — click to reveal the live server output'}
+                  </span>
+                </span>
               </button>
             )}
             <button


### PR DESCRIPTION
Two small DST UX/quality fixes that go together because they're both about the backend console window.

## v12.0.23 — Suppress conhost flashes from background SSH polling

`Get-DuneBattlegroupSnapshot` (`Status.ps1`) and the Setup wizard's
SSH-key preflight (`Setup.ps1`) both shelled out via
`& ssh ... 2>$errFile`. When the caller is a background runspace whose
parent's hidden console handle isn't inherited cleanly, Windows
allocates a fresh `conhost` window per spawn — producing brief
"console keeps popping up and disappearing" flashes on the desktop
while DST polls. With `/api/status` polling every 10 s, that's
roughly 360 flashes per hour for any user whose runspace hierarchy
doesn't propagate the hidden-console handle.

The flash had been latent in the code since commit `9346f47` (2026-06-03,
v10.1.x) which added the bare-`ssh` call so it could capture stderr for
the actionable failure-reason hint.

Both call sites now route through a new `Invoke-DuneSshHidden` helper
in `app/lib/Db-Postgres.ps1`. The helper is a sibling of the existing
`Invoke-V6Ssh` (added in v10.1.14 for the same hidden-window reason
on the kubectl/psql path) but additionally exposes `Stdout` / `Stderr` /
`Exit` separately so the existing `Get-DuneSshFailureReason`
translation logic (passphrase-protected key, unauthorized key,
unreachable VM) keeps working unchanged.

Implementation pattern is unchanged from `Invoke-V6Ssh`:
`ProcessStartInfo` + `UseShellExecute=$false` + `CreateNoWindow=$true`,
with a hard deadline kill via `WaitForExit($TimeoutSec * 1000)`.

## v12.0.24 — Help → Show / Hide backend console

Until now there was **no UI path anywhere in DST** that brought the
backend PowerShell console window back to a visible foreground window
once tray mode had hidden it. `ConsoleHost.ps1` locks the console at
`SW_HIDE` whenever the tray icon comes up successfully, and the only
console-related Help item was "Run at Windows startup", which is about
*future* logins, not the running process.

This adds a `Show backend console` / `Hide backend console` item in the
Help menu (between the autostart toggle and Collapse Sidebar) backed
by a new loopback-only `/api/console` route pair in
`app/server/routes/Console.ps1`. Showing it calls
`ShowWindow(SW_RESTORE)` + `SetForegroundWindow` so it un-minimizes and
pops where you're looking; hiding it calls `SW_HIDE`. The label tracks
real window state (refreshed when the menu opens), so it correctly
reads "Show backend console" whenever the window is hidden *or*
minimized to the taskbar — including the case where the user thought
disabling autostart from this same menu should have revealed it.

## Verification

- All `.ps1` files (incl. new `Console.ps1`) parse-clean.
- `tsc -b` passes for the webui.
- Version stamps bumped 12.0.22 → 12.0.24 in all 5 required files.
- Routes are auto-discovered by `HttpServer.ps1:247`
  (`Get-ChildItem $routesDir -Filter '*.ps1'`), so `Console.ps1` is
  picked up without additional wiring.