### PR TITLE
docs(README): bump current release to v12.0.24 + roll up v12.0.20–24 highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 **🌐 Website & feature tour: [coastal-ms.github.io/DST-DuneServerTool](https://coastal-ms.github.io/DST-DuneServerTool/)** — screenshots, install guide, and the full changelog.
 
-The current release is **v12.0.19**. The in-app version label and the
-website show plain semver tags (e.g. `v12.0.18`) — the previous
+The current release is **v12.0.24**. The in-app version label and the
+website show plain semver tags (e.g. `v12.0.24`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.5.0**
@@ -30,6 +30,54 @@ the sidebar's **Web Portal** button hands the portal off to your default
 browser and keeps the server running in the background.
 
 ![Server Health](docs/img/server-health.png)
+
+### New in v12.0.20–v12.0.24
+
+- **Fill Base Water** Player Action (v12.0.21, Inventory section, next to Fill
+  Water) — tops up all water containers in a player's **own** bases (Water
+  Cisterns, Windtraps) plus their carried fillables in one click. Routes
+  through the per-player `UpdateAllWaterFillables` game command keyed by the
+  player's FLS id, so it only ever affects **that** player's own containers —
+  never other players' bases. Online-only: offline players are rejected with
+  a clear message and the button shows a **LIVE REQ'D** badge while they're
+  offline.
+- **Help → Show / Hide backend console** (v12.0.24) — the first UI path that
+  un-minimizes and restores the backend PowerShell console window once tray
+  mode has hidden it. Backed by a new loopback-only `/api/console` route that
+  calls `ShowWindow(SW_RESTORE)` + `SetForegroundWindow`. The menu label
+  tracks the real window state (refreshed when the Help menu opens), so it
+  correctly reads "Show backend console" whenever the window is hidden *or*
+  minimized to the taskbar.
+- **Add Item search** (v12.0.20) — the picker's results popup now scrolls
+  correctly to the last match (was clipped behind the next section before, so
+  later catalog rows were unreachable) and the catalog gained **552 missing
+  templates** (1294 → 1846 entries). Raw resources like **Spice Sand**,
+  **Water**, and **Plant Fiber**, plus many garments, vehicle modules,
+  weapons, and components, are now searchable and giveable.
+- **Website link** in the menu bar (v12.0.22) — a right-aligned "Website"
+  item opens the project's marketing site in your default browser.
+
+#### Fixes
+
+- **Console window no longer flashes during dashboard polling** (v12.0.23).
+  The battlegroup-status probe (`Get-DuneBattlegroupSnapshot`) and the setup
+  preflight SSH-key check both used to shell out via `& ssh ... 2>$errFile`,
+  which silently allocated a fresh conhost window for every spawn when the
+  caller was a background runspace whose parent's hidden console handle
+  wasn't inherited. With multiple dashboard panels polling at 10–15 s, that
+  produced a steady stream of brief console flashes on top of every other
+  window. Both call sites now route through a new `Invoke-DuneSshHidden`
+  helper (sibling of `Invoke-V6Ssh`) using `ProcessStartInfo` with
+  `CreateNoWindow = $true`.
+- **Market Bot** (v12.0.20–v12.0.21) — fixed `dune_exchange_orders_access_point_id_fkey`
+  foreign-key violation when enabling the bot or clicking **Seed Market** on
+  servers with no bot orders yet (fresh battlegroups, or upgrades from
+  pre-`dune-admin`-removal builds). Access-point resolution now cascades
+  through the authoritative `dune_exchange_accesspoints` table at every
+  tier. Stackable raw resources (e.g. **Plastone**, **Plastanium Ingot**)
+  now list in their full catalog stack instead of single-item listings, and
+  a new opt-in **displayed-Solari-price cap** lets you clamp listing prices
+  below the implicit `item_price × 10` ceiling.
 
 ### New in v12.0.19
 


### PR DESCRIPTION
The README was still showing **v12.0.19** as current and only carried "New in v12.0.19" / "New in v12.0.0" sections, missing the four releases that landed since.

## What this PR does

Bumps the "current release" line to **v12.0.24** and adds a single consolidated **New in v12.0.20–v12.0.24** section above the existing v12.0.19 history. The section is grouped into additions then fixes, following the rollup convention `CHANGELOG.md` already uses for patch releases.

Highlights covered:

- **Fill Base Water** Player Action (v12.0.21)
- **Help → Show / Hide backend console** (v12.0.24)
- **Add Item search** scroll fix + 552-template catalog backfill (v12.0.20)
- **Website link** in the menu bar (v12.0.22)
- **Console-flash fix** during dashboard polling — `Invoke-DuneSshHidden` (v12.0.23)
- **Market Bot** access-point FK fix + stack/price polish (v12.0.20–v12.0.21)

## Marketing site

No changes needed in `site/`. The Astro source already pulls the latest version dynamically through `site/src/lib/release.ts` (GitHub API `releases/latest`) and renders the changelog from `CHANGELOG.md` via `site/src/lib/changelog.ts`. The `deploy-site.yml` workflow ran on the v12.0.24 merge (#207) and is already live at <https://coastal-ms.github.io/DST-DuneServerTool/>.

`deploy-site.yml`'s path filter (`site/**`, `CHANGELOG.md`, `docs/img/**`, the workflow itself) does not include `README.md`, so this PR will not trigger a redundant site rebuild.

## Verification

- Plain Markdown edit; no build/lint impact.
- `git diff` reviewed (50 insertions / 2 deletions, all on README.md).