### PR TITLE
Linux port scaffold (untested handoff)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,11 @@
 # Remote VM scripts pushed by Sync-DunePartitionAutomation must be LF —
 # Alpine /bin/sh sees $'\r' on CRLF and fails with cryptic errors.
 app/resources/remote-scripts/* text eol=lf
+
+# Linux port scaffold — POSIX launcher, systemd unit, debian metadata. These
+# are consumed by bash / dpkg on Linux and break if checked out as CRLF.
+bin/dune-server                          text eol=lf
+packaging/linux/systemd/*.service        text eol=lf
+packaging/linux/debian/control           text eol=lf
+packaging/linux/debian/postinst          text eol=lf
+packaging/linux/debian/prerm             text eol=lf

--- a/LINUX-PORT-STATUS.md
+++ b/LINUX-PORT-STATUS.md
@@ -1,0 +1,179 @@
+# Linux port — handoff status
+
+> **This is an untested scaffold, not a working Linux port.** It exists so
+> someone other than the current Windows maintainer can pick the Linux build
+> up without starting from a blank repo. Expect bugs on first run; some
+> features will return graceful "not supported on Linux" responses and a few
+> will straight up throw.
+
+## Scope of this scaffold
+
+What was asked for: enough Linux scaffolding to hand the project to a Linux
+maintainer who wants to keep DST going on Ubuntu / Debian. Specifically:
+
+- A Linux entrypoint that boots the existing PowerShell backend under `pwsh`.
+- A POSIX launcher (`bin/dune-server`) and a systemd user unit so the backend
+  can be started by hand or at login.
+- A `.deb` packaging script (`packaging/linux/build-deb.sh`) that produces a
+  single installable artifact for Debian / Ubuntu.
+
+What is explicitly **out of scope** for the scaffold:
+
+- No native shell (no Linux replacement for the WinForms + WebView2
+  `DuneShell.exe`). The Linux entrypoint opens the user's default browser via
+  `xdg-open`, full stop. A Tauri / WebKitGTK replacement is the obvious next
+  step but is not done here.
+- No CI matrix entry for Linux. The Windows-only `Build-Installer.ps1` and
+  `Build-Exe.ps1` are untouched.
+- No actual run on a Linux box. Nothing in this branch has been started.
+
+## How the backend boots on Linux
+
+Entry point: `app/DuneServer-Linux.ps1` (run by `bin/dune-server`).
+
+The big simplification vs. `app/DuneServer.ps1`:
+
+| Windows entry                         | Linux entry                       |
+|---------------------------------------|-----------------------------------|
+| Self-elevates for Hyper-V             | Skipped                           |
+| Minimizes own console via Win32       | Skipped                           |
+| Launches `DuneShell.exe` (WebView2)   | Opens browser via `xdg-open`      |
+| Reads `%LOCALAPPDATA%\DuneServer\…`   | XDG shim — see "compat shim" below |
+| Writes scheduled task for autostart   | systemd user unit                 |
+
+### XDG compatibility shim
+
+The PowerShell backend has dozens of references like
+`Join-Path $env:APPDATA 'DuneServer'` and
+`Join-Path $env:LOCALAPPDATA 'DuneServer'`. Refactoring every one of them
+would touch most of `app/server/lib/` and `app/server/routes/` and risks
+breaking the Windows build.
+
+Instead, `DuneServer-Linux.ps1` rewrites the two env vars at startup so the
+existing paths still resolve to sensible Linux locations:
+
+```
+$env:APPDATA       -> $XDG_CONFIG_HOME or ~/.config       (config, JSON state)
+$env:LOCALAPPDATA  -> $XDG_STATE_HOME  or ~/.local/state  (logs, last-url)
+```
+
+That makes the on-disk layout end up as:
+
+```
+~/.config/DuneServer/dune-server.config
+~/.config/DuneServer/item-packages.json
+~/.config/DuneServer/gameplay-bot.json
+~/.local/state/DuneServer/dune-server.log
+~/.local/state/DuneServer/last-url.txt
+```
+
+A clean follow-up is to introduce `Get-DuneConfigDir` / `Get-DuneStateDir`
+helpers and migrate callers off the env vars.
+
+## What we expect to work
+
+These are the parts that read as cross-platform-safe but **have not been run
+on Linux**:
+
+- `app/server/HttpServer.ps1` — `System.Net.HttpListener` works on
+  PowerShell 7 / Linux. Bound to `127.0.0.1` only, so no Windows-only URL
+  ACL setup is needed.
+- Route handlers that do nothing more than read / write JSON files under the
+  XDG dirs (item packages, gameplay bot config, broadcasts, links, catalog).
+- Anything that shells out to `ssh` / `ssh-keygen` (the lib code calls
+  `ssh-keygen` and `ssh` without an `.exe` suffix — Linux has both).
+- `app/lib/Db-Postgres.ps1` — uses `psql` via `Invoke-Expression`, no
+  Windows-specific path assumptions in the SQL paths themselves.
+- The webui (Vite build) — no Windows ties.
+
+## What we expect to fail or degrade
+
+- **Hyper-V routes** (`Status.ps1` → `Get-VM`, `Sietch.ps1` → `Get-VM` /
+  `Win32_ComputerSystem`, `Setup.ps1` preflight, etc.): on Linux the `Get-VM`
+  cmdlet does not exist, the try/catch catches the missing-command error,
+  and the routes return a "VM status unavailable" payload. The dashboard
+  will show empty / unknown VM state. The right long-term fix is libvirt
+  bindings or treating DST as a pure remote-SSH-only manager on Linux.
+- **Autostart route** (`app/server/lib/Autostart.ps1`): the existing code
+  already gates on `Test-DuneAutostartAvailable`, which returns `$false`
+  whenever the process isn't the compiled `.exe`. On Linux that's always
+  the case, so the Help → "Run at startup" toggle is reported as
+  unavailable. Use the systemd user unit instead.
+- **Backend-console show/hide** (`app/server/routes/Console.ps1`): same
+  story — `$script:DuneIsCompiledExe` is never set on Linux, so the route
+  reports `available: false`. Fine; there's no console window to manage.
+- **In-app updater** (`app/server/routes/Update.ps1`): hard-coded to download
+  and run `DuneServerSetup.exe`. On Linux it should be replaced with an
+  `apt install --reinstall dune-server` call (or just disabled). Currently
+  it will try to run the Inno installer and fail.
+- **`app/server/lib/MapSpinUp.ps1`** — there's a comment about ssh.exe arg
+  quoting; verify the same code path works when `ssh` is OpenSSH on Linux.
+  Looks correct on inspection, but unverified.
+- **`app/server/lib/Commands.ps1`** — invokes `pwsh.exe` by name in one
+  error path. Replace with `pwsh`.
+- **Diagnostics route** — the WebView2 registry probe in
+  `app/server/routes/Diagnostics.ps1` reads `HKLM:`/`HKCU:` which will fail
+  inside a `try`/`catch`. The diagnostic line will just be blank.
+
+## How to install / run
+
+### From source (quickest)
+
+```bash
+sudo apt install powershell openssh-client xdg-utils nodejs npm
+cd webui && npm ci && npm run build && cd ..
+./bin/dune-server
+```
+
+The first run will:
+
+1. Create `~/.config/DuneServer/` and `~/.local/state/DuneServer/`.
+2. Bind `http://127.0.0.1:8765/` (next free port if 8765 is taken).
+3. Write the per-launch tokened URL to
+   `~/.local/state/DuneServer/last-url.txt`.
+4. `xdg-open` that URL.
+
+### From a .deb
+
+On a Debian / Ubuntu host (NOT Windows — `dpkg-deb` only):
+
+```bash
+./packaging/linux/build-deb.sh
+sudo apt install ./packaging/linux/output/dune-server_12.0.24_all.deb
+dune-server
+```
+
+### Run at login
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp /opt/dune-server/packaging/linux/systemd/dune-server.service \
+   ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now dune-server.service
+journalctl --user -u dune-server.service -f
+```
+
+## What I'd hand to the next maintainer
+
+In rough priority order:
+
+1. **Actually run it.** The scaffold has not been booted once. Expect at
+   least one path / module-load surprise.
+2. **Decide on the native shell story.** The Linux build is "open in default
+   browser" today. Either accept that forever, or scaffold a Tauri shell so
+   DST feels like an app on Linux too.
+3. **Refactor the XDG shim out.** Replace
+   `Join-Path $env:APPDATA 'DuneServer'` with a `Get-DuneConfigDir` helper
+   that does the right thing on both OSes, and remove the env-var rewrite
+   from `DuneServer-Linux.ps1`.
+4. **Decide what to do about Hyper-V.** Either gate the routes behind
+   `$IsWindows` and return a clean 501 with a "use a remote SSH-only
+   deployment on Linux" message, or write a libvirt equivalent of the
+   handful of `Get-VM` calls in `Status.ps1` / `Sietch.ps1`.
+5. **Wire `DuneServer-Linux.ps1` into the version-sync check** in
+   `app/installer/Build-Installer.ps1`. There are now six files that need to
+   agree on the release version; the script only checks five.
+6. **CI**: add an Ubuntu runner that at minimum dot-sources every `lib/*.ps1`
+   and `routes/*.ps1` under pwsh — the cheapest possible smoke test that
+   guards against future Windows-only top-level code creeping in.

--- a/app/DuneServer-Linux.ps1
+++ b/app/DuneServer-Linux.ps1
@@ -1,0 +1,255 @@
+#!/usr/bin/env pwsh
+# Dune Server — Linux entry point (untested handoff scaffold).
+#
+# This is the Linux equivalent of app/DuneServer.ps1. It deliberately avoids
+# the Windows-only bits the EXE entry needs:
+#
+#   * No Hyper-V self-elevation (no Hyper-V on Linux)
+#   * No DuneShell / WebView2 launch (no native shell yet)
+#   * No console minimize / tray P-Invoke (no Win32 API)
+#   * No Task Scheduler autostart (use the systemd user unit instead)
+#
+# Status: UNTESTED. See LINUX-PORT-STATUS.md at the repo root for what works,
+# what's stubbed, and what the recipient needs to wire up. The intent of this
+# file is to give a Linux maintainer a believable starting point — not a
+# fully-validated daemon.
+
+$ErrorActionPreference = 'Stop'
+
+# ---------- Sanity: pwsh on Linux ---------------------------------------------
+if (-not $IsLinux -and -not $IsMacOS) {
+    Write-Host 'DuneServer-Linux.ps1 is for Linux / macOS hosts. Use DuneServer.ps1 on Windows.' -ForegroundColor Yellow
+    exit 1
+}
+
+# ---------- XDG compatibility shim --------------------------------------------
+# The PowerShell codebase has dozens of  `Join-Path $env:APPDATA 'DuneServer'`
+# and `Join-Path $env:LOCALAPPDATA 'DuneServer'` references that were written
+# when the only target was Windows. Rather than refactor every one of them
+# (high-risk for the Windows build), we map both env vars to XDG-equivalent
+# locations under $HOME so the existing paths resolve to:
+#
+#   $env:APPDATA       -> $XDG_CONFIG_HOME or ~/.config       (writeable config)
+#   $env:LOCALAPPDATA  -> $XDG_STATE_HOME  or ~/.local/state  (logs, last-url)
+#
+# The end result is:
+#   ~/.config/DuneServer/dune-server.config
+#   ~/.config/DuneServer/item-packages.json
+#   ~/.local/state/DuneServer/dune-server.log
+#   ~/.local/state/DuneServer/last-url.txt
+#
+# A clean handoff candidate would replace the env vars with proper helpers
+# (Get-DuneConfigDir / Get-DuneStateDir) — left as future work.
+
+function Initialize-DuneLinuxEnv {
+    $home = $env:HOME
+    if (-not $home) { $home = [System.Environment]::GetFolderPath('UserProfile') }
+    if (-not $home) {
+        Write-Host 'Cannot determine $HOME on this host.' -ForegroundColor Red
+        exit 1
+    }
+
+    $configHome = if ($env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else { Join-Path $home '.config' }
+    $stateHome  = if ($env:XDG_STATE_HOME)  { $env:XDG_STATE_HOME }  else { Join-Path $home '.local/state' }
+    $cacheHome  = if ($env:XDG_CACHE_HOME)  { $env:XDG_CACHE_HOME }  else { Join-Path $home '.cache' }
+
+    foreach ($d in @($configHome, $stateHome, $cacheHome,
+                     (Join-Path $configHome 'DuneServer'),
+                     (Join-Path $stateHome  'DuneServer'))) {
+        if (-not (Test-Path -LiteralPath $d)) {
+            New-Item -ItemType Directory -Path $d -Force | Out-Null
+        }
+    }
+
+    $env:APPDATA      = $configHome
+    $env:LOCALAPPDATA = $stateHome
+    # USERPROFILE is referenced in a few places (mostly diagnostics).
+    if (-not $env:USERPROFILE) { $env:USERPROFILE = $home }
+}
+
+Initialize-DuneLinuxEnv
+
+# ---------- Emergency crash log -----------------------------------------------
+$script:DuneStartupLog = $null
+try {
+    $stateDir = Join-Path $env:LOCALAPPDATA 'DuneServer'
+    $script:DuneStartupLog = Join-Path $stateDir 'dune-startup.log'
+    $hdr = "==== $(Get-Date -Format 's')  DuneServer-Linux startup, pid=$PID, host=$($PSVersionTable.PSVersion) ===="
+    Add-Content -LiteralPath $script:DuneStartupLog -Value $hdr -Encoding UTF8
+} catch { }
+
+function Write-DuneStartupLog {
+    param([string]$Message)
+    if (-not $script:DuneStartupLog) { return }
+    try { Add-Content -LiteralPath $script:DuneStartupLog -Value "[$(Get-Date -Format 'HH:mm:ss')] $Message" -Encoding UTF8 } catch { }
+}
+
+trap {
+    $err = $_
+    Write-DuneStartupLog "BOOTSTRAP CRASH: $($err.Exception.Message)"
+    Write-DuneStartupLog ($err | Out-String)
+    Write-Host "Dune Server bootstrap failed: $($err.Exception.Message)" -ForegroundColor Red
+    Write-Host "Details: $script:DuneStartupLog" -ForegroundColor Red
+    exit 1
+}
+
+Write-DuneStartupLog 'Bootstrap entered (Linux)'
+
+# ---------- CLI args ----------------------------------------------------------
+# --headless     : never try to open a browser
+# --open-browser : explicitly request xdg-open on startup (default when stdout is a tty)
+# --port <N>     : preferred starting port (default 8765)
+$script:DuneHeadlessMode = $false
+$script:DuneOpenBrowser  = $null   # null = auto-decide
+$script:DunePreferredPort = 8765
+
+for ($i = 0; $i -lt $args.Count; $i++) {
+    switch -Regex ($args[$i]) {
+        '^--?headless$'      { $script:DuneHeadlessMode = $true }
+        '^--?open-browser$'  { $script:DuneOpenBrowser  = $true }
+        '^--?no-browser$'    { $script:DuneOpenBrowser  = $false }
+        '^--?port$'          { if ($i + 1 -lt $args.Count) { $script:DunePreferredPort = [int]$args[++$i] } }
+    }
+}
+if ($null -eq $script:DuneOpenBrowser) {
+    $script:DuneOpenBrowser = -not $script:DuneHeadlessMode
+}
+
+# ---------- Path resolution ---------------------------------------------------
+if ($PSScriptRoot) {
+    $script:AppDir = $PSScriptRoot
+} elseif ($PSCommandPath) {
+    $script:AppDir = Split-Path -Parent $PSCommandPath
+} else {
+    $script:AppDir = (Get-Location).Path
+}
+$script:RepoRoot = Split-Path -Parent $script:AppDir
+
+function Find-DuneSubpath {
+    param([string]$Sub, [int]$MaxLevels = 6)
+    $probe = $script:AppDir
+    for ($i = 0; $i -lt $MaxLevels -and $probe; $i++) {
+        $candidate = Join-Path $probe $Sub
+        if (Test-Path -LiteralPath $candidate) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+        $parent = Split-Path -Parent $probe
+        if ($parent -eq $probe) { break }
+        $probe = $parent
+    }
+    return $null
+}
+
+$script:DistRoot = Find-DuneSubpath 'webui/dist'
+if (-not $script:DistRoot) {
+    Write-Host "Could not locate webui/dist (searched upward from '$script:AppDir')." -ForegroundColor Red
+    Write-Host 'Build it first: cd webui && npm ci && npm run build' -ForegroundColor Yellow
+    exit 1
+}
+
+$serverDir = Find-DuneSubpath 'server'
+if (-not $serverDir) {
+    Write-Host "Could not locate server/ near '$script:AppDir'." -ForegroundColor Red
+    exit 1
+}
+$script:DuneServerDir = $serverDir
+
+# pwsh — on Linux it's just `pwsh` on PATH.
+$script:PwshExe = (Get-Command pwsh -ErrorAction SilentlyContinue).Source
+if (-not $script:PwshExe) {
+    Write-Host 'pwsh (PowerShell 7) not found on PATH. Install from https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-linux' -ForegroundColor Red
+    exit 1
+}
+
+$script:MainScript = Find-DuneSubpath 'dune-server.ps1'
+if (-not $script:MainScript) {
+    Write-Host "WARNING: dune-server.ps1 not found near '$script:AppDir'. Command execution will fail." -ForegroundColor Yellow
+}
+
+# ---------- Tool version (kept in sync with DuneServer.ps1) -------------------
+# Mirrored manually for the scaffold. Build-Installer's version-sync check
+# does NOT currently know about this file — see LINUX-PORT-STATUS.md.
+$script:DuneToolVersion = '12.0.24'
+
+# ---------- Load server + routes ----------------------------------------------
+$duneLogFile = Join-Path $serverDir 'lib/DuneLog.ps1'
+if (Test-Path -LiteralPath $duneLogFile) { . $duneLogFile }
+
+$script:DuneLogFilePath = Join-Path $env:LOCALAPPDATA 'DuneServer/dune-server.log'
+Initialize-DuneLog -Path $script:DuneLogFilePath
+
+. (Join-Path $serverDir 'HttpServer.ps1')
+
+$libDir = Join-Path $serverDir 'lib'
+if (Test-Path $libDir) {
+    Get-ChildItem -Path $libDir -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+}
+
+$routesDir = Join-Path $serverDir 'routes'
+if (Test-Path $routesDir) {
+    Get-ChildItem -Path $routesDir -Filter '*.ps1' | ForEach-Object { . $_.FullName }
+}
+
+if (Get-Command Start-DuneGameplayBotScheduler -ErrorAction SilentlyContinue) {
+    try { [void](Start-DuneGameplayBotScheduler -ServerDir $serverDir) } catch {}
+}
+
+# ---------- Token -------------------------------------------------------------
+$script:LaunchToken = [Guid]::NewGuid().ToString('N')
+
+# ---------- Clear stale last-url ----------------------------------------------
+$urlFilePath = Join-Path $env:LOCALAPPDATA 'DuneServer/last-url.txt'
+try {
+    if (Test-Path -LiteralPath $urlFilePath) { Remove-Item -LiteralPath $urlFilePath -Force -ErrorAction Stop }
+} catch {
+    Write-DuneLog "Could not remove stale last-url.txt: $($_.Exception.Message)" 'WARN'
+}
+
+# ---------- Browser opener (async, after listener binds) ----------------------
+# On Linux we use xdg-open. We poll last-url.txt (written by HttpServer.ps1
+# once the listener binds) and hand the URL to xdg-open. No DuneShell, no
+# WebView2 — the user's default browser is the UI surface.
+$browserJob = $null
+if ($script:DuneOpenBrowser) {
+    $browserJob = Start-Job -ScriptBlock {
+        param($urlFile)
+        $deadline = (Get-Date).AddSeconds(30)
+        while ((Get-Date) -lt $deadline) {
+            if (Test-Path -LiteralPath $urlFile) {
+                try {
+                    $url = (Get-Content -LiteralPath $urlFile -Raw).Trim()
+                    if ($url) {
+                        $opener = $null
+                        foreach ($cmd in @('xdg-open', 'gio', 'wslview', 'open')) {
+                            $resolved = Get-Command $cmd -ErrorAction SilentlyContinue
+                            if ($resolved) { $opener = $resolved.Source; break }
+                        }
+                        if ($opener) {
+                            Start-Process -FilePath $opener -ArgumentList $url -ErrorAction SilentlyContinue
+                        } else {
+                            Write-Host "No browser opener found. Visit: $url" -ForegroundColor Yellow
+                        }
+                    }
+                } catch {}
+                return
+            }
+            Start-Sleep -Milliseconds 250
+        }
+    } -ArgumentList $urlFilePath
+}
+
+# ---------- Start the listener (blocking) -------------------------------------
+Write-DuneStartupLog 'Handing off to Start-DuneHttpServer'
+Write-DuneLog "Dune Server (Linux) v$script:DuneToolVersion starting"
+Write-DuneLog "Serving from: $script:DistRoot"
+Write-DuneLog "Headless: $script:DuneHeadlessMode  OpenBrowser: $script:DuneOpenBrowser  PreferredPort: $script:DunePreferredPort"
+
+try {
+    Start-DuneHttpServer -DistRoot $script:DistRoot -PreferredPort $script:DunePreferredPort -Token $script:LaunchToken
+} finally {
+    if ($browserJob) {
+        try { Stop-Job -Job $browserJob -ErrorAction SilentlyContinue } catch {}
+        try { Remove-Job -Job $browserJob -ErrorAction SilentlyContinue } catch {}
+    }
+    Write-DuneLog 'Dune Server (Linux) exited'
+}

--- a/bin/dune-server
+++ b/bin/dune-server
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Dune Server launcher (Linux). Locates the bundled DuneServer-Linux.ps1 and
+# runs it under pwsh. Installed by the .deb package at /usr/bin/dune-server,
+# pointing at /opt/dune-server. Also usable from a source checkout: copy or
+# symlink this file somewhere on $PATH.
+#
+# Status: UNTESTED handoff scaffold. See LINUX-PORT-STATUS.md.
+
+set -euo pipefail
+
+# Resolve real script path (handles symlinks).
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+BIN_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+
+# Layout candidates:
+#   1. Installed:    /opt/dune-server/app/DuneServer-Linux.ps1   (BIN_DIR is /usr/bin)
+#   2. Source repo:  <repo>/app/DuneServer-Linux.ps1             (BIN_DIR is <repo>/bin)
+ENTRY=""
+for candidate in \
+    "/opt/dune-server/app/DuneServer-Linux.ps1" \
+    "$BIN_DIR/../app/DuneServer-Linux.ps1" \
+    "$BIN_DIR/../../app/DuneServer-Linux.ps1"
+do
+    if [ -f "$candidate" ]; then
+        ENTRY="$(readlink -f "$candidate")"
+        break
+    fi
+done
+
+if [ -z "$ENTRY" ]; then
+    echo "dune-server: could not locate DuneServer-Linux.ps1" >&2
+    echo "  searched: /opt/dune-server/app/  and  $BIN_DIR/../app/" >&2
+    exit 1
+fi
+
+if ! command -v pwsh >/dev/null 2>&1; then
+    echo "dune-server: pwsh (PowerShell 7) is not installed." >&2
+    echo "  Install via: https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-linux" >&2
+    exit 1
+fi
+
+exec pwsh -NoProfile -ExecutionPolicy Bypass -File "$ENTRY" "$@"

--- a/packaging/linux/build-deb.sh
+++ b/packaging/linux/build-deb.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Build a .deb for Dune Server (Linux). Run on a Debian/Ubuntu host with
+# `dpkg-deb` and `npm` installed:
+#
+#     ./packaging/linux/build-deb.sh
+#
+# Output: ./packaging/linux/output/dune-server_<version>_all.deb
+#
+# Layout produced inside the .deb:
+#   /opt/dune-server/
+#       app/                       (PowerShell backend + entry)
+#       webui/dist/                (built React SPA)
+#       bin/dune-server            (launcher)
+#       packaging/linux/systemd/   (the user unit template, copied for refs)
+#       LINUX-PORT-STATUS.md
+#       README.md
+#       LICENSE
+#       CHANGELOG.md
+#   /usr/bin/dune-server -> /opt/dune-server/bin/dune-server   (symlink)
+#
+# This script does NOT build the Windows installer or DuneShell — those stay
+# in app/build and app/installer for the Windows release path.
+#
+# Status: UNTESTED handoff scaffold. See LINUX-PORT-STATUS.md.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PACKAGING_DIR="$REPO_ROOT/packaging/linux"
+OUTPUT_DIR="$PACKAGING_DIR/output"
+DEBIAN_TEMPLATE="$PACKAGING_DIR/debian"
+
+# ---------- Version from debian/control ---------------------------------------
+VERSION="$(awk -F': ' '/^Version:/ { print $2; exit }' "$DEBIAN_TEMPLATE/control")"
+if [ -z "$VERSION" ]; then
+    echo "build-deb: could not read Version from $DEBIAN_TEMPLATE/control" >&2
+    exit 1
+fi
+echo "build-deb: building dune-server v$VERSION"
+
+# ---------- Build the web UI --------------------------------------------------
+if [ ! -d "$REPO_ROOT/webui/dist" ] || [ "${REBUILD_WEBUI:-1}" = "1" ]; then
+    echo "build-deb: building webui/ (set REBUILD_WEBUI=0 to skip)"
+    pushd "$REPO_ROOT/webui" >/dev/null
+    if [ ! -d node_modules ]; then npm ci; fi
+    npm run build
+    popd >/dev/null
+fi
+if [ ! -f "$REPO_ROOT/webui/dist/index.html" ]; then
+    echo "build-deb: webui/dist/index.html missing after build" >&2
+    exit 1
+fi
+
+# ---------- Stage payload -----------------------------------------------------
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+INSTALL_PREFIX="$STAGE/opt/dune-server"
+mkdir -p "$INSTALL_PREFIX/app" \
+         "$INSTALL_PREFIX/webui" \
+         "$INSTALL_PREFIX/bin" \
+         "$INSTALL_PREFIX/packaging/linux/systemd" \
+         "$STAGE/usr/bin" \
+         "$STAGE/DEBIAN"
+
+# Backend (PowerShell + assets). Exclude the Windows-only build/ and
+# installer/ directories, the WinForms shell, and any stray bin/obj output.
+cp -r "$REPO_ROOT/app/server"   "$INSTALL_PREFIX/app/"
+cp -r "$REPO_ROOT/app/lib"      "$INSTALL_PREFIX/app/" 2>/dev/null || true
+cp -r "$REPO_ROOT/app/assets"   "$INSTALL_PREFIX/app/" 2>/dev/null || true
+cp    "$REPO_ROOT/app/DuneServer-Linux.ps1" "$INSTALL_PREFIX/app/"
+cp    "$REPO_ROOT/dune-server.ps1"          "$INSTALL_PREFIX/"
+
+# Web UI
+cp -r "$REPO_ROOT/webui/dist"  "$INSTALL_PREFIX/webui/"
+
+# Launcher + systemd unit (reference copy)
+cp    "$REPO_ROOT/bin/dune-server"                              "$INSTALL_PREFIX/bin/"
+cp    "$PACKAGING_DIR/systemd/dune-server.service"              "$INSTALL_PREFIX/packaging/linux/systemd/"
+
+# Top-level docs
+for f in LINUX-PORT-STATUS.md README.md LICENSE CHANGELOG.md; do
+    if [ -f "$REPO_ROOT/$f" ]; then cp "$REPO_ROOT/$f" "$INSTALL_PREFIX/"; fi
+done
+
+# Symlink in /usr/bin
+ln -s /opt/dune-server/bin/dune-server "$STAGE/usr/bin/dune-server"
+
+# Permissions
+chmod 0755 "$INSTALL_PREFIX/bin/dune-server"
+find "$INSTALL_PREFIX/app" -name '*.ps1' -exec chmod 0644 {} \;
+chmod 0755 "$INSTALL_PREFIX/app/DuneServer-Linux.ps1"
+
+# ---------- DEBIAN/ metadata --------------------------------------------------
+cp "$DEBIAN_TEMPLATE/control"  "$STAGE/DEBIAN/control"
+cp "$DEBIAN_TEMPLATE/postinst" "$STAGE/DEBIAN/postinst"
+cp "$DEBIAN_TEMPLATE/prerm"    "$STAGE/DEBIAN/prerm"
+chmod 0755 "$STAGE/DEBIAN/postinst" "$STAGE/DEBIAN/prerm"
+
+# ---------- Build the .deb ----------------------------------------------------
+mkdir -p "$OUTPUT_DIR"
+DEB_FILE="$OUTPUT_DIR/dune-server_${VERSION}_all.deb"
+rm -f "$DEB_FILE"
+dpkg-deb --root-owner-group --build "$STAGE" "$DEB_FILE"
+
+echo ""
+echo "build-deb: wrote $DEB_FILE"
+echo "build-deb: install with:  sudo apt install $DEB_FILE"

--- a/packaging/linux/debian/control
+++ b/packaging/linux/debian/control
@@ -1,0 +1,22 @@
+Package: dune-server
+Version: 12.0.24
+Section: games
+Priority: optional
+Architecture: all
+Depends: powershell (>= 7.4), openssh-client, xdg-utils
+Recommends: postgresql-client, jq
+Suggests: rabbitmq-server
+Maintainer: Coastal <coastal-ms@users.noreply.github.com>
+Homepage: https://github.com/coastal-ms/DST-DuneServerTool
+Description: Self-hosted Dune: Awakening server management portal (Linux scaffold)
+ Dune Server Tool (DST) is a self-hosted management portal for the Dune:
+ Awakening dedicated server. It runs a local PowerShell + Vite web UI on
+ 127.0.0.1 with a per-launch tokenized URL.
+ .
+ This .deb is an UNTESTED handoff scaffold of the Linux port. The PowerShell
+ backend, web UI, and SSH paths come over from the Windows build largely
+ unchanged; Hyper-V-dependent routes (local VM dashboard, sietch resize)
+ will return graceful "not supported on Linux" responses at runtime.
+ .
+ See /opt/dune-server/LINUX-PORT-STATUS.md for what works, what's stubbed,
+ and where to start fixing things up.

--- a/packaging/linux/debian/postinst
+++ b/packaging/linux/debian/postinst
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Dune Server — post-install hook.
+set -e
+
+case "$1" in
+    configure)
+        # Make sure the launcher and POSIX script bits are executable.
+        chmod 0755 /usr/bin/dune-server || true
+        chmod 0755 /opt/dune-server/bin/dune-server || true
+
+        cat <<'EOF'
+
+Dune Server Tool installed to /opt/dune-server.
+
+Quick start (per-user, runs in your current session):
+    dune-server                  # opens http://127.0.0.1:8765 in your browser
+
+Run at login (systemd user unit):
+    mkdir -p ~/.config/systemd/user
+    cp /opt/dune-server/packaging/linux/systemd/dune-server.service \
+       ~/.config/systemd/user/
+    systemctl --user daemon-reload
+    systemctl --user enable --now dune-server.service
+
+The per-launch URL (with auth token) is written to:
+    ~/.local/state/DuneServer/last-url.txt
+
+This is an UNTESTED port scaffold. See:
+    /opt/dune-server/LINUX-PORT-STATUS.md
+EOF
+        ;;
+esac
+
+exit 0

--- a/packaging/linux/debian/prerm
+++ b/packaging/linux/debian/prerm
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Dune Server — pre-removal hook.
+set -e
+
+case "$1" in
+    remove|upgrade|deconfigure)
+        # If a user has the systemd unit enabled, the unit lives under their
+        # $HOME/.config/systemd/user/ — we never created it, we can't remove
+        # it. Tell them how.
+        cat <<'EOF'
+
+Dune Server is being removed.
+
+User config / logs / state are preserved at:
+    ~/.config/DuneServer/
+    ~/.local/state/DuneServer/
+
+If you previously enabled the systemd user unit, stop it manually:
+    systemctl --user disable --now dune-server.service
+    rm ~/.config/systemd/user/dune-server.service
+EOF
+        ;;
+esac
+
+exit 0

--- a/packaging/linux/systemd/dune-server.service
+++ b/packaging/linux/systemd/dune-server.service
@@ -1,0 +1,41 @@
+# Dune Server — systemd user unit (Linux).
+#
+# Install:    cp dune-server.service ~/.config/systemd/user/
+# Enable:     systemctl --user daemon-reload
+#             systemctl --user enable --now dune-server.service
+# Status:     systemctl --user status dune-server.service
+# Logs:       journalctl --user -u dune-server.service -f
+#             (the app also writes ~/.local/state/DuneServer/dune-server.log)
+# Disable:    systemctl --user disable --now dune-server.service
+#
+# This is the Linux replacement for the Windows Task Scheduler "Run at Windows
+# startup" toggle. It runs the backend headless (no browser auto-open) so the
+# user isn't surprised by a tab opening at login. Visit the portal manually at
+# http://127.0.0.1:8765 — the per-launch token is written to
+# ~/.local/state/DuneServer/last-url.txt.
+#
+# To run as a system service instead of per-user, drop this in
+# /etc/systemd/system/ and add an explicit User=, Group=, and Environment=HOME=.
+#
+# Status: UNTESTED handoff scaffold. See LINUX-PORT-STATUS.md.
+
+[Unit]
+Description=Dune Server Tool (DST) backend
+Documentation=https://github.com/coastal-ms/DST-DuneServerTool
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/dune-server --headless --no-browser
+Restart=on-failure
+RestartSec=5s
+
+# Light hardening — relax if the recipient needs additional fs writes.
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=read-only
+ReadWritePaths=%h/.config/DuneServer %h/.local/state/DuneServer %h/.cache/DuneServer
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## ⚠️ This PR is an untested handoff scaffold

**Nothing in this branch has been booted on Linux.** The goal isn't a working
Linux build — it's enough scaffolding that a Linux maintainer can pick the
project up without starting from a blank repo. Expect bugs on first run.

See [`LINUX-PORT-STATUS.md`](../blob/coastal-ms/linux-port-wip/LINUX-PORT-STATUS.md)
in this branch for the full breakdown of what works, what's stubbed, and where
to look first.

## What's in here

| Path                                              | Purpose                                                     |
|---------------------------------------------------|-------------------------------------------------------------|
| `app/DuneServer-Linux.ps1`                        | Linux entrypoint, sibling of the Windows `DuneServer.ps1`   |
| `bin/dune-server`                                 | POSIX launcher (resolves entry + execs `pwsh`)              |
| `packaging/linux/systemd/dune-server.service`     | systemd **user** unit (replaces Task Scheduler autostart)   |
| `packaging/linux/build-deb.sh`                    | `.deb` builder for Debian / Ubuntu                          |
| `packaging/linux/debian/{control,postinst,prerm}` | `dpkg-deb` metadata + install hooks                         |
| `LINUX-PORT-STATUS.md`                            | Recipient-facing status doc                                 |
| `.gitattributes`                                  | Locks the new POSIX files to LF on checkout                 |

## The one slightly clever thing

Rather than refactor every `Join-Path $env:APPDATA 'DuneServer'` reference in
the backend (dozens of them, high regression risk for the Windows build),
`DuneServer-Linux.ps1` rewrites the two env vars at startup so they point at
XDG locations:

```
$env:APPDATA       -> $XDG_CONFIG_HOME or ~/.config       (config, JSON state)
$env:LOCALAPPDATA  -> $XDG_STATE_HOME  or ~/.local/state  (logs, last-url)
```

That makes the on-disk layout `~/.config/DuneServer/...` and
`~/.local/state/DuneServer/...` without touching any of the existing route or
lib code. A proper `Get-DuneConfigDir` / `Get-DuneStateDir` refactor is
listed as follow-up work for the recipient.

## What is *expected* to fail at runtime on Linux

These already exist as `try`/`catch`-wrapped or `available=false`-gated paths
in the backend, so they degrade rather than crash:

- Hyper-V routes (`Status.ps1`, `Sietch.ps1`, `Setup.ps1` preflight) — `Get-VM`
  isn't a Linux cmdlet, the catch fires, the UI shows "VM unavailable".
- Help → "Run at startup" toggle — gated on the compiled-EXE check, never
  available on Linux. Use the systemd user unit instead.
- Backend console show/hide — same gate, reports `available: false`.

These will throw and need to be replaced before they're usable:

- In-app updater (`Update.ps1`) — hard-coded to `DuneServerSetup.exe`.
  Needs an `apt`-equivalent path on Linux.
- One `pwsh.exe` string literal in `Commands.ps1` — should be `pwsh`.

Full list with file references is in `LINUX-PORT-STATUS.md`.

## What is *not* in here

- No Linux native shell. `xdg-open` opens the user's default browser, full
  stop. A Tauri / WebKitGTK replacement for `DuneShell.exe` is the obvious
  next step but is out of scope for this scaffold.
- No CI matrix entry. The Windows-only `Build-Installer.ps1` and
  `Build-Exe.ps1` are untouched.
- No version-sync coverage. `Build-Installer.ps1` still checks the five
  Windows files for version agreement; `DuneServer-Linux.ps1` is the sixth
  but isn't yet wired into that check. Documented as follow-up.
- No actual run on a Linux box. **None.**

## Verifying it doesn't break Windows

The only file shared with the Windows build is `.gitattributes`, where I
only *added* entries for the new POSIX paths. `app/DuneServer.ps1`,
`app/build/`, `app/installer/`, and `app/desktop/DuneShell/` are untouched.
A Windows installer build from this branch should still produce a working
`DuneServerSetup.exe`.

`pwsh` parse-check of `app/DuneServer-Linux.ps1` on Windows passes.

---

Hand this to whoever's taking the Linux build on. Leaving it as a **draft**
PR on purpose so it doesn't accidentally land on `main` before someone has
actually tried to run it.