### PR TITLE
v12.0.25 — Fix #209 repair-below-cap + add inline durability editor

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.0.14"
+      placeholder: "v12.0.25"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.0.25] - 2026-06-15
+
+### Fixed
+
+- **Repair Items no longer leaves equipment below its factory-spec cap**
+  ([#209](https://github.com/coastal-ms/DST-DuneServerTool/issues/209)).
+  The per-item / Repair All / Restore Destroyed paths now compute the target
+  as `GREATEST(catalog.max_durability, item.MaxDurability, item.CurrentDurability,
+  item.DecayedMaxDurability)` instead of just `GREATEST` of the item's own
+  three fields. The bundled `gameplay-item-data.json` catalog provides the
+  factory cap (e.g. Stillsuit_T4 → 1000, Maula_Pistol → 400, healthpack →
+  100); the item's own MaxDurability still wins when it's higher because of
+  stat/perk bonuses, so buffed players don't get clamped down. Catalog
+  misses fall back to the v12.0.7 behaviour (GREATEST of the item's three
+  fields). Verified live: 959/1658 enriched templates carry a non-zero
+  durability cap.
+
+### Added
+
+- **Inline durability editor on player inventory items.** Click any item in
+  the Players → Inventory list that has the `FItemStackAndDurabilityStats`
+  nodes (the durability badge is shown, not "N/A") and the row expands
+  underneath to a 3-input editor for `MaxDurability`, `CurrentDurability`,
+  and `DecayedMaxDurability`. Two actions: **Repair (catalog max)** runs
+  the same updated `repair-item` flow; **Save** writes the three typed
+  values verbatim via the new `POST /api/gameplay/players/set-item-durability`
+  endpoint. A disclaimer at the top of the editor explains the repair
+  number is a best-guess from the bundled catalog and to edit + Save
+  manually if it's wrong. Works on online and offline players (the editor
+  shows a soft warning for online players that the change won't appear
+  in-game until relog, because the game server caches inventory in memory).
+  Gated entirely on `it.durability !== 'N/A'`, so if a future game patch
+  adds durability nodes to a new item type the editor picks it up
+  automatically — no per-template allowlist.
+
 ## [12.0.24] - 2026-06-14
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.0.24'
+$script:DuneToolVersion = '12.0.25'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.0.24',
+    [string]$Version = '12.0.25',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.0.24</Version>
+    <Version>12.0.25</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.0.24"
+#define MyAppVersion "12.0.25"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -209,33 +209,123 @@ function Invoke-DunePlayerDeleteItem {
     return @{ ok = $true; message = "Deleted item $ItemId." }
 }
 
+# Catalog max-durability lookup for a template_id. Wraps Get-DuneGameplayItemRule
+# (gameplay-item-data.json) so a missing template returns 0.0 and the repair
+# logic falls back to the item's own three durability fields.
+function Get-DuneItemCatalogMaxDurability {
+    param([string]$TemplateId)
+    if (-not $TemplateId) { return 0.0 }
+    try {
+        $rule = Get-DuneGameplayItemRule -TemplateId $TemplateId
+        if ($null -ne $rule -and $null -ne $rule.max_durability) {
+            return [double]$rule.max_durability
+        }
+    } catch {}
+    return 0.0
+}
+
+# Format a double for inline SQL with invariant decimal separator (a comma from
+# locale-dependent formatting would break PostgreSQL number parsing).
+function Format-DuneFloatForSql {
+    param([double]$Value)
+    return $Value.ToString([System.Globalization.CultureInfo]::InvariantCulture)
+}
+
 # Repair item (repair-item): set MaxDurability/CurrentDurability/DecayedMaxDurability
-# all equal to the HIGHEST of the item's own three values ("highest number wins").
-# No catalog lookup, no hard-coded default — the item's own MaxDurability is the
-# true cap (decay only lowers Current + DecayedMax, never Max).
+# to GREATEST(catalog.max_durability, item.MaxDurability, item.CurrentDurability,
+# item.DecayedMaxDurability). The catalog (gameplay-item-data.json) carries the
+# factory-spec cap; the item's own three fields can be higher because of per-player
+# stat/perk bonuses (decay only lowers Current + DecayedMax, never Max). Taking
+# the GREATEST of all four guarantees repair never lowers an already-buffed cap
+# and never leaves a buggy item below its catalog spec. Catalog miss => fall back
+# to GREATEST of the item's three fields, same behaviour as v12.0.7-12.0.24.
 function Invoke-DunePlayerRepairItem {
     param([string]$Ip, [long]$ItemId)
+    if ($ItemId -le 0) { return @{ ok = $false; error = 'item_id is required.' } }
+
+    $infoSql = @"
+SELECT template_id,
+       COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0)        AS m,
+       COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0)    AS c,
+       COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) AS d
+FROM dune.items
+WHERE id = $ItemId::bigint
+  AND stats ? 'FItemStackAndDurabilityStats';
+"@
+    $info = Invoke-DuneSqlQuery -Ip $Ip -Sql $infoSql -ReadOnly $true -MaxRows 1 -TimeoutSec 30
+    if (-not $info.ok) { return @{ ok = $false; error = "repair item: $($info.error)" } }
+    $rows = @(ConvertTo-DuneRowMaps -Result $info)
+    if ($rows.Count -eq 0) {
+        return @{ ok = $true; message = "Item $ItemId has no durability block — nothing to repair." }
+    }
+    $tmpl    = [string]$rows[0]['template_id']
+    $itemMax = [double]([string]$rows[0]['m'])
+    $itemCur = [double]([string]$rows[0]['c'])
+    $itemDec = [double]([string]$rows[0]['d'])
+    $catMax  = Get-DuneItemCatalogMaxDurability -TemplateId $tmpl
+    $target  = [Math]::Max([Math]::Max([Math]::Max($catMax, $itemMax), $itemCur), $itemDec)
+    if ($target -le 0) {
+        return @{ ok = $true; message = "Item $ItemId has no usable durability value — left untouched." }
+    }
+    $tval = Format-DuneFloatForSql -Value $target
+
     $sql = @"
 UPDATE dune.items i
 SET stats = jsonb_set(jsonb_set(jsonb_set(i.stats,
-        '{FItemStackAndDurabilityStats,1,MaxDurability}',        to_jsonb(t.val), true),
-        '{FItemStackAndDurabilityStats,1,CurrentDurability}',    to_jsonb(t.val), true),
-        '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}', to_jsonb(t.val), true)
-FROM (
-    SELECT GREATEST(
-        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0),
-        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0),
-        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0)
-    ) AS val
-    FROM dune.items
-    WHERE id = $ItemId::bigint
-      AND stats ? 'FItemStackAndDurabilityStats'
-) AS t
-WHERE i.id = $ItemId::bigint AND t.val > 0;
+        '{FItemStackAndDurabilityStats,1,MaxDurability}',        to_jsonb($tval::float8), true),
+        '{FItemStackAndDurabilityStats,1,CurrentDurability}',    to_jsonb($tval::float8), true),
+        '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}', to_jsonb($tval::float8), true)
+WHERE i.id = $ItemId::bigint
+  AND i.stats ? 'FItemStackAndDurabilityStats';
 "@
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
-    return @{ ok = $true; message = "Repaired item $ItemId to full durability." }
+    return @{ ok = $true; message = "Repaired item $ItemId to $tval durability." }
+}
+
+# Set the three FItemStackAndDurabilityStats fields directly. Per-item editor for
+# the UI: lets the operator override Max / Current / DecayedMax manually when the
+# catalog max-guess is wrong or the durability values are otherwise broken. No
+# offline gate (same as the wrench Repair button); rejects negatives, NaN, and
+# infinities. Items without a durability block are left untouched.
+function Invoke-DunePlayerSetItemDurability {
+    param(
+        [string]$Ip, [long]$ItemId,
+        [double]$Max, [double]$Current, [double]$Decayed
+    )
+    if ($ItemId -le 0) { return @{ ok = $false; error = 'item_id is required.' } }
+    foreach ($pair in @(
+            @{ n='Max';     v=$Max },
+            @{ n='Current'; v=$Current },
+            @{ n='Decayed'; v=$Decayed })) {
+        if ([double]::IsNaN($pair.v) -or [double]::IsInfinity($pair.v)) {
+            return @{ ok = $false; error = "$($pair.n) must be a finite number." }
+        }
+        if ($pair.v -lt 0) {
+            return @{ ok = $false; error = "$($pair.n) must be >= 0." }
+        }
+    }
+    $mv = Format-DuneFloatForSql -Value $Max
+    $cv = Format-DuneFloatForSql -Value $Current
+    $dv = Format-DuneFloatForSql -Value $Decayed
+
+    $sql = @"
+UPDATE dune.items i
+SET stats = jsonb_set(jsonb_set(jsonb_set(i.stats,
+        '{FItemStackAndDurabilityStats,1,MaxDurability}',        to_jsonb($mv::float8), true),
+        '{FItemStackAndDurabilityStats,1,CurrentDurability}',    to_jsonb($cv::float8), true),
+        '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}', to_jsonb($dv::float8), true)
+WHERE i.id = $ItemId::bigint
+  AND i.stats ? 'FItemStackAndDurabilityStats'
+RETURNING i.id::text AS item_id;
+"@
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    $affected = @(ConvertTo-DuneRowMaps -Result $res).Count
+    if ($affected -eq 0) {
+        return @{ ok = $true; message = "Item $ItemId has no durability block — nothing changed." }
+    }
+    return @{ ok = $true; message = "Set item $ItemId durability to Max=$mv / Current=$cv / DecayedMax=$dv." }
 }
 
 # Give item (give-item): stack onto a matching backpack stack or insert a new one.

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -421,10 +421,11 @@ function Invoke-DunePlayerGiveItemsBulk {
 }
 
 # Repair equipped gear — OFFLINE only. Sets every durability item in the gear
-# inventory types to the HIGHEST of its own three durability fields
-# (Max/Current/DecayedMax) and makes all three match. The item's own
-# MaxDurability already bakes in that player's stat/perk durability bonuses
-# (which differ per player), so it — not the catalog — is the source of truth.
+# inventory types to GREATEST(catalog.max_durability, item.MaxDurability,
+# item.CurrentDurability, item.DecayedMaxDurability), so a buggy/decayed
+# MaxDurability can never leave repair below the factory-spec cap, but
+# stat/perk-buffed ceilings (the item's own MaxDurability after equip-time
+# bonuses) are preserved. Catalog miss => GREATEST of the item's three fields.
 function Invoke-DunePlayerRepairGear {
     param([string]$Ip, [long]$PawnId)
     if ($PawnId -le 0) { return @{ ok = $false; error = 'pawn_id is required.' } }
@@ -435,27 +436,47 @@ function Invoke-DunePlayerRepairGear {
     $invTypes = $script:DuneProgressionNodesCatalog.repairGearInventoryTypes
     $invTypesArr = '(' + (($invTypes | ForEach-Object { "$_::int" }) -join ',') + ')'
 
+    $listSql = @"
+SELECT i.id, i.template_id,
+       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0)        AS m,
+       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0)    AS c,
+       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) AS d
+FROM dune.items i
+JOIN dune.inventories inv ON inv.id = i.inventory_id
+WHERE inv.actor_id = $PawnId::bigint
+  AND inv.inventory_type IN $invTypesArr
+  AND i.stats ? 'FItemStackAndDurabilityStats';
+"@
+    $listRes = Invoke-DuneSqlQuery -Ip $Ip -Sql $listSql -ReadOnly $true -MaxRows 5000 -TimeoutSec 60
+    if (-not $listRes.ok) { return @{ ok = $false; error = "repair gear (lookup): $($listRes.error)" } }
+
+    $values = New-Object System.Collections.Generic.List[string]
+    foreach ($r in (ConvertTo-DuneRowMaps -Result $listRes)) {
+        $tmpl = [string]$r['template_id']
+        $iMax = [double]([string]$r['m'])
+        $iCur = [double]([string]$r['c'])
+        $iDec = [double]([string]$r['d'])
+        $cMax = Get-DuneItemCatalogMaxDurability -TemplateId $tmpl
+        $target = [Math]::Max([Math]::Max([Math]::Max($cMax, $iMax), $iCur), $iDec)
+        if ($target -gt 0) {
+            $iid  = [long]$r['id']
+            $tval = Format-DuneFloatForSql -Value $target
+            $values.Add("($iid::bigint, $tval::float8)")
+        }
+    }
+    if ($values.Count -eq 0) {
+        return @{ ok = $true; message = 'No gear with durability stats — nothing to repair.'; repaired = 0 }
+    }
+
+    $valuesClause = ($values -join ', ')
     $sql = @"
-WITH tgt AS (
-    SELECT i.id AS item_id,
-           GREATEST(
-               COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0),
-               COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0),
-               COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0)
-           ) AS val
-    FROM dune.items i
-    JOIN dune.inventories inv ON inv.id = i.inventory_id
-    WHERE inv.actor_id = $PawnId::bigint
-      AND inv.inventory_type IN $invTypesArr
-      AND i.stats ? 'FItemStackAndDurabilityStats'
-)
 UPDATE dune.items i
 SET stats = jsonb_set(jsonb_set(jsonb_set(i.stats,
         '{FItemStackAndDurabilityStats,1,MaxDurability}',        to_jsonb(tgt.val), true),
         '{FItemStackAndDurabilityStats,1,CurrentDurability}',    to_jsonb(tgt.val), true),
         '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}', to_jsonb(tgt.val), true)
-FROM tgt
-WHERE i.id = tgt.item_id AND tgt.val > 0
+FROM (VALUES $valuesClause) AS tgt(item_id, val)
+WHERE i.id = tgt.item_id
 RETURNING i.id::text AS item_id;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 5000 -TimeoutSec 60
@@ -474,9 +495,10 @@ RETURNING i.id::text AS item_id;
 # Restore destroyed gear — OFFLINE only. Targets ONLY items that already have an
 # FItemStackAndDurabilityStats block and whose CurrentDurability is 0 or NULL
 # (Chopper's "completely dead" case the standard Repair didn't obviously cover).
-# Same inventory_type scope as RepairGear. Each match is re-seeded to the highest
-# of its own three durability fields. It deliberately does NOT graft a durability
-# block onto items that lack one — resources, consumables, and contract items
+# Same inventory_type scope as RepairGear. Each match is re-seeded to
+# GREATEST(catalog.max_durability, item.MaxDurability, item.CurrentDurability,
+# item.DecayedMaxDurability). It deliberately does NOT graft a durability block
+# onto items that lack one — resources, consumables, and contract items
 # legitimately have no durability and must be left alone.
 function Invoke-DunePlayerRestoreDestroyedGear {
     param([string]$Ip, [long]$PawnId)
@@ -488,35 +510,48 @@ function Invoke-DunePlayerRestoreDestroyedGear {
     $invTypes = $script:DuneProgressionNodesCatalog.repairGearInventoryTypes
     $invTypesArr = '(' + (($invTypes | ForEach-Object { "$_::int" }) -join ',') + ')'
 
-    # Only touch items that ALREADY carry an FItemStackAndDurabilityStats block
-    # AND are dead (CurrentDurability <= 0). We never graft a durability block
-    # onto an item that doesn't have one — resources, consumables, welding wire,
-    # staking units, contract items, etc. legitimately have no durability and
-    # must be left untouched. Each dead item is re-seeded to the HIGHEST of its
-    # own three durability fields (the item's own MaxDurability already bakes in
-    # this player's stat/perk bonuses, so it is the source of truth).
+    $listSql = @"
+SELECT i.id, i.template_id,
+       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0)        AS m,
+       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0)    AS c,
+       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) AS d
+FROM dune.items i
+JOIN dune.inventories inv ON inv.id = i.inventory_id
+WHERE inv.actor_id = $PawnId::bigint
+  AND inv.inventory_type IN $invTypesArr
+  AND i.stats ? 'FItemStackAndDurabilityStats'
+  AND COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0) <= 0;
+"@
+    $listRes = Invoke-DuneSqlQuery -Ip $Ip -Sql $listSql -ReadOnly $true -MaxRows 5000 -TimeoutSec 60
+    if (-not $listRes.ok) { return @{ ok = $false; error = "restore destroyed (lookup): $($listRes.error)" } }
+
+    $values = New-Object System.Collections.Generic.List[string]
+    foreach ($r in (ConvertTo-DuneRowMaps -Result $listRes)) {
+        $tmpl = [string]$r['template_id']
+        $iMax = [double]([string]$r['m'])
+        $iCur = [double]([string]$r['c'])
+        $iDec = [double]([string]$r['d'])
+        $cMax = Get-DuneItemCatalogMaxDurability -TemplateId $tmpl
+        $target = [Math]::Max([Math]::Max([Math]::Max($cMax, $iMax), $iCur), $iDec)
+        if ($target -gt 0) {
+            $iid  = [long]$r['id']
+            $tval = Format-DuneFloatForSql -Value $target
+            $values.Add("($iid::bigint, $tval::float8)")
+        }
+    }
+    if ($values.Count -eq 0) {
+        return @{ ok = $true; message = 'No destroyed items with a durability block — nothing to restore.'; restored = 0 }
+    }
+
+    $valuesClause = ($values -join ', ')
     $sql = @"
-WITH tgt AS (
-    SELECT i.id AS item_id,
-           GREATEST(
-               COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0),
-               COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0),
-               COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0)
-           ) AS val
-    FROM dune.items i
-    JOIN dune.inventories inv ON inv.id = i.inventory_id
-    WHERE inv.actor_id = $PawnId::bigint
-      AND inv.inventory_type IN $invTypesArr
-      AND i.stats ? 'FItemStackAndDurabilityStats'
-      AND COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0) <= 0
-)
 UPDATE dune.items i
 SET stats = jsonb_set(jsonb_set(jsonb_set(i.stats,
         '{FItemStackAndDurabilityStats,1,MaxDurability}',        to_jsonb(tgt.val), true),
         '{FItemStackAndDurabilityStats,1,CurrentDurability}',    to_jsonb(tgt.val), true),
         '{FItemStackAndDurabilityStats,1,DecayedMaxDurability}', to_jsonb(tgt.val), true)
-FROM tgt
-WHERE i.id = tgt.item_id AND tgt.val > 0
+FROM (VALUES $valuesClause) AS tgt(item_id, val)
+WHERE i.id = tgt.item_id
 RETURNING i.id::text AS item_id;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 5000 -TimeoutSec 60

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -214,6 +214,40 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/repair-item' -Handl
     }
 }
 
+# POST /api/gameplay/players/set-item-durability  { item_id, max, current, decayed }
+# Per-item durability editor: writes the three FItemStackAndDurabilityStats
+# fields verbatim. Lets the operator override the GREATEST/catalog guess when
+# it's wrong. Items without the durability block are left untouched (no-op).
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/set-item-durability' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $iid = Get-DuneBodyInt -Body $body -Name 'item_id'
+        if ($null -eq $iid -or $iid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'item_id is required.'; return }
+        $mv = Get-DuneBodyValue -Body $body -Name 'max'
+        $cv = Get-DuneBodyValue -Body $body -Name 'current'
+        $dv = Get-DuneBodyValue -Body $body -Name 'decayed'
+        if ($null -eq $mv -or $null -eq $cv -or $null -eq $dv) {
+            Write-DuneError -Response $res -Status 400 -Message 'max, current, and decayed are required.'; return
+        }
+        $mxd = 0.0; $crd = 0.0; $dcd = 0.0
+        $ci = [System.Globalization.CultureInfo]::InvariantCulture
+        if (-not [double]::TryParse([string]$mv, [System.Globalization.NumberStyles]::Float, $ci, [ref]$mxd)) {
+            Write-DuneError -Response $res -Status 400 -Message 'max must be a number.'; return
+        }
+        if (-not [double]::TryParse([string]$cv, [System.Globalization.NumberStyles]::Float, $ci, [ref]$crd)) {
+            Write-DuneError -Response $res -Status 400 -Message 'current must be a number.'; return
+        }
+        if (-not [double]::TryParse([string]$dv, [System.Globalization.NumberStyles]::Float, $ci, [ref]$dcd)) {
+            Write-DuneError -Response $res -Status 400 -Message 'decayed must be a number.'; return
+        }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip)
+            Invoke-DunePlayerSetItemDurability -Ip $ip -ItemId $iid -Max $mxd -Current $crd -Decayed $dcd
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Set item durability failed: $($_.Exception.Message)"
+    }
+}
+
 # ===========================================================================
 # v11.5.6 — extended player surface routes.
 # ===========================================================================

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.0.24"
+$script:ToolVersion = "12.0.25"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -572,6 +572,13 @@ export function repairInventoryItem(itemId: number) {
   })
 }
 
+export function setItemDurability(itemId: number, max: number, current: number, decayed: number) {
+  return api<WriteResult>('/api/gameplay/players/set-item-durability', {
+    method: 'POST',
+    body: JSON.stringify({ item_id: itemId, max, current, decayed }),
+  })
+}
+
 // ---------------------------------------------------------------------------
 // v11.5.6 — extended player surface (port of the reference implementation's player tooling).
 // ---------------------------------------------------------------------------

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -18,6 +18,7 @@ import {
   getPlayerStats, getPlayerTags, giveFactionRep, giveItem,
   giveScrip, giveSolari, grantAllKeystones, grantLive, grantMaxSpec,
   kickPlayer, refuelVehicle, renamePlayer, repairGear, repairInventoryItem,
+  setItemDurability,
   resetAllKeystones, resetAllSpecs, resetJourney, resetProgressionLive, resetSpec,
   restoreDestroyed,
   returningPlayerAward, setFactionTier, setPlayerTags, setSkillPoints,
@@ -1257,6 +1258,7 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
   const [err, setErr] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [tick, setTick] = useState(0)
+  const isOnline = (player.online_status || '').toLowerCase() === 'online'
 
   useEffect(() => {
     let alive = true
@@ -1302,23 +1304,25 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
         </button>
       </div>
       <ItemList title={`Inventory (${fmtNum(groups.gear.length)})`} icon="Backpack" items={groups.gear}
-        canWrite={canWrite} busy={busy} run={run}
+        canWrite={canWrite} busy={busy} run={run} isOnline={isOnline}
         extra={<ItemsActionBlock player={player} canWrite={canWrite} flash={flash} onChanged={() => { onChanged(); setTick(t => t + 1) }} />} />
       <ItemList title={`Emotes (${fmtNum(groups.emotes.length)})`} icon="Smile" items={groups.emotes} collapsed
-        canWrite={canWrite} busy={busy} run={run} />
+        canWrite={canWrite} busy={busy} run={run} isOnline={isOnline} />
       <ItemList title={`Contract items (${fmtNum(groups.contracts.length)})`} icon="FileText" items={groups.contracts} collapsed
-        canWrite={canWrite} busy={busy} run={run} />
+        canWrite={canWrite} busy={busy} run={run} isOnline={isOnline} />
     </div>
   )
 }
 
-function ItemList({ title, icon, items, canWrite, busy, run, collapsed, extra }: {
+function ItemList({ title, icon, items, canWrite, busy, run, collapsed, extra, isOnline }: {
   title: string; icon: string; items: InventoryItem[]; canWrite: boolean; busy: boolean
   run: (fn: () => Promise<{ message: string }>, label: string) => void | Promise<void>
   collapsed?: boolean
   extra?: React.ReactNode
+  isOnline: boolean
 }) {
   const [open, setOpen] = useState(!collapsed)
+  const [editingId, setEditingId] = useState<number | null>(null)
   if (collapsed && items.length === 0) return null
   return (
     <div>
@@ -1341,35 +1345,56 @@ function ItemList({ title, icon, items, canWrite, busy, run, collapsed, extra }:
               const ratio = hasDur ? curN / maxN : 1
               const durCls =
                 !hasDur          ? 'text-text-dim' :
-                ratio <= 0.0001  ? 'text-danger font-semibold' :  // fully dead
+                ratio <= 0.0001  ? 'text-danger font-semibold' :
                 ratio < 0.25     ? 'text-danger' :
                 ratio < 0.5      ? 'text-warning' :
                                    'text-text-dim'
+              const canEdit = canWrite && it.durability !== 'N/A'
+              const isEditing = canEdit && editingId === it.id
+              const toggleEdit = () => {
+                if (!canEdit) return
+                setEditingId(prev => (prev === it.id ? null : it.id))
+              }
               return (
-                <div key={it.id} className="flex items-center justify-between text-sm bg-surface-2 rounded-lg px-3 py-2 border border-border/50">
-                  <span className="truncate max-w-[320px]">
-                    <span className="text-text">{it.name || it.template_id}</span>
-                    {it.quality > 0 && <span className={`ml-1.5 text-[11px] ${qualityClass(it.quality)}`}>Q{it.quality}</span>}
-                    {hasDur && (
-                      <span className={`ml-1.5 font-mono text-[11px] ${durCls}`} title={`Durability ${curN.toFixed(0)} / ${maxN.toFixed(0)} (${Math.round(ratio * 100)}%)`}>
-                        {curN.toFixed(0)}/{maxN.toFixed(0)}
+                <div key={it.id} className="bg-surface-2 rounded-lg border border-border/50">
+                  <div
+                    className={`flex items-center justify-between text-sm px-3 py-2 ${canEdit ? 'cursor-pointer hover:bg-surface-3/40' : ''}`}
+                    onClick={canEdit ? toggleEdit : undefined}
+                    role={canEdit ? 'button' : undefined}
+                    tabIndex={canEdit ? 0 : undefined}
+                    onKeyDown={canEdit ? (e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleEdit() } }) : undefined}
+                    title={canEdit ? (isEditing ? 'Hide durability editor' : 'Click to edit durability') : undefined}
+                  >
+                    <span className="truncate max-w-[320px]">
+                      {canEdit && (
+                        <Icon name={isEditing ? 'ChevronDown' : 'ChevronRight'} size={11} className="inline-block mr-1 text-text-dim" />
+                      )}
+                      <span className="text-text">{it.name || it.template_id}</span>
+                      {it.quality > 0 && <span className={`ml-1.5 text-[11px] ${qualityClass(it.quality)}`}>Q{it.quality}</span>}
+                      {hasDur && (
+                        <span className={`ml-1.5 font-mono text-[11px] ${durCls}`} title={`Durability ${curN.toFixed(0)} / ${maxN.toFixed(0)} (${Math.round(ratio * 100)}%)`}>
+                          {curN.toFixed(0)}/{maxN.toFixed(0)}
+                        </span>
+                      )}
+                      <span className="ml-1.5 font-mono text-text-dim text-xs">×{fmtNum(it.stack_size)}</span>
+                    </span>
+                    {canWrite && (
+                      <span className="flex items-center gap-2 shrink-0" onClick={e => e.stopPropagation()}>
+                        {it.durability !== 'N/A' && (
+                          <button className="text-info hover:text-accent-bright" title="Repair to full (best-guess from catalog)" disabled={busy}
+                            onClick={() => run(() => repairInventoryItem(it.id), 'Repair')}>
+                            <Icon name="Wrench" size={13} />
+                          </button>
+                        )}
+                        <button className="text-danger/80 hover:text-danger" title="Delete item" disabled={busy}
+                          onClick={() => void run(() => deleteInventoryItem(it.id), 'Delete')}>
+                          <Icon name="Trash2" size={13} />
+                        </button>
                       </span>
                     )}
-                    <span className="ml-1.5 font-mono text-text-dim text-xs">×{fmtNum(it.stack_size)}</span>
-                  </span>
-                  {canWrite && (
-                    <span className="flex items-center gap-2 shrink-0">
-                      {it.durability !== 'N/A' && (
-                        <button className="text-info hover:text-accent-bright" title="Repair to full" disabled={busy}
-                          onClick={() => run(() => repairInventoryItem(it.id), 'Repair')}>
-                          <Icon name="Wrench" size={13} />
-                        </button>
-                      )}
-                      <button className="text-danger/80 hover:text-danger" title="Delete item" disabled={busy}
-                        onClick={() => void run(() => deleteInventoryItem(it.id), 'Delete')}>
-                        <Icon name="Trash2" size={13} />
-                      </button>
-                    </span>
+                  </div>
+                  {isEditing && (
+                    <DurabilityEditor item={it} busy={busy} run={run} isOnline={isOnline} onClose={() => setEditingId(null)} />
                   )}
                 </div>
               )
@@ -1377,6 +1402,109 @@ function ItemList({ title, icon, items, canWrite, busy, run, collapsed, extra }:
           </div>
         )
       )}
+    </div>
+  )
+}
+
+// Inline durability editor — appears underneath an inventory row when the user
+// clicks it. Only rendered when the item already has the
+// FItemStackAndDurabilityStats nodes (it.durability !== 'N/A'), so if a future
+// game patch adds the block to a new item type it picks up the editor
+// automatically — no per-template allowlist.
+function DurabilityEditor({ item, busy, run, isOnline, onClose }: {
+  item: InventoryItem
+  busy: boolean
+  run: (fn: () => Promise<{ message: string }>, label: string) => void | Promise<void>
+  isOnline: boolean
+  onClose: () => void
+}) {
+  const cur0 = parseFloat(item.durability)
+  const max0 = parseFloat(item.max_durability)
+  const [maxStr, setMaxStr] = useState(Number.isFinite(max0) ? String(max0) : '0')
+  const [curStr, setCurStr] = useState(Number.isFinite(cur0) ? String(cur0) : '0')
+  const [decStr, setDecStr] = useState(Number.isFinite(max0) ? String(max0) : '0')
+
+  const parse = (s: string) => {
+    const n = parseFloat(s)
+    return Number.isFinite(n) && n >= 0 ? n : null
+  }
+  const mN = parse(maxStr), cN = parse(curStr), dN = parse(decStr)
+  const valid = mN !== null && cN !== null && dN !== null
+
+  return (
+    <div className="border-t border-border/50 px-3 py-3 bg-surface-1/60 rounded-b-lg space-y-3">
+      <div className="text-[11px] text-text-dim italic flex items-start gap-1.5">
+        <Icon name="Info" size={11} className="mt-0.5 shrink-0" />
+        <span>
+          Repair uses a best-guess maximum from the bundled game-item catalog. The catalog
+          can be out of date or missing values for newer items — if Repair gives the wrong
+          numbers, edit the fields below and Save instead.
+        </span>
+      </div>
+      {isOnline && (
+        <div className="text-[11px] text-warning flex items-start gap-1.5">
+          <Icon name="Wifi" size={11} className="mt-0.5 shrink-0" />
+          <span>
+            Player is online — the game server caches inventory in memory, so the new
+            values write to the database immediately but won't appear in-game until the
+            player relogs.
+          </span>
+        </div>
+      )}
+      <div className="grid grid-cols-3 gap-2">
+        <label className="text-xs">
+          <div className="text-text-dim mb-1">MaxDurability</div>
+          <input
+            type="number" inputMode="decimal" step="any" min="0"
+            value={maxStr}
+            onChange={e => setMaxStr(e.target.value)}
+            disabled={busy}
+            className="w-full font-mono text-sm bg-surface-2 border border-border rounded px-2 py-1"
+          />
+        </label>
+        <label className="text-xs">
+          <div className="text-text-dim mb-1">CurrentDurability</div>
+          <input
+            type="number" inputMode="decimal" step="any" min="0"
+            value={curStr}
+            onChange={e => setCurStr(e.target.value)}
+            disabled={busy}
+            className="w-full font-mono text-sm bg-surface-2 border border-border rounded px-2 py-1"
+          />
+        </label>
+        <label className="text-xs">
+          <div className="text-text-dim mb-1">DecayedMaxDurability</div>
+          <input
+            type="number" inputMode="decimal" step="any" min="0"
+            value={decStr}
+            onChange={e => setDecStr(e.target.value)}
+            disabled={busy}
+            className="w-full font-mono text-sm bg-surface-2 border border-border rounded px-2 py-1"
+          />
+        </label>
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <button
+          type="button"
+          className="btn-secondary text-xs"
+          disabled={busy}
+          onClick={() => run(() => repairInventoryItem(item.id), 'Repair')}
+        >
+          <Icon name="Wrench" size={12} /> Repair (catalog max)
+        </button>
+        <button
+          type="button"
+          className="btn-primary text-xs"
+          disabled={busy || !valid}
+          onClick={() => {
+            if (!valid) return
+            void run(() => setItemDurability(item.id, mN!, cN!, dN!), 'Save')
+            onClose()
+          }}
+        >
+          <Icon name="Save" size={12} /> Save
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #209.

## What changed

### Repair never falls below factory cap (the #209 fix)

`Invoke-DunePlayerRepairItem`, `Invoke-DunePlayerRepairGear` (Repair All), and `Invoke-DunePlayerRestoreDestroyedGear` now compute the target as:

```
GREATEST(catalog.max_durability,
         item.MaxDurability,
         item.CurrentDurability,
         item.DecayedMaxDurability)
```

Catalog comes from the bundled `app/data/gameplay-item-data.json` (959 of 1658 enriched templates carry a non-zero `max_durability`). The item's own `MaxDurability` still wins when it's higher (stat/perk buffs), so we don't clamp buffed players down. Catalog misses fall back to the v12.0.7+ behaviour (GREATEST of the item's own three fields).

Bulk paths use a 2-step pattern (discovery SELECT → VALUES-clause UPDATE) so we can compute per-row targets against catalog without round-tripping each item.

### New per-item durability editor

Click any inventory row on Players → Inventory whose item has `FItemStackAndDurabilityStats` (durability badge shown, not `N/A`) and it expands underneath to a 3-input editor for `MaxDurability` / `CurrentDurability` / `DecayedMaxDurability`. Two actions:

- **Repair (catalog max)** — runs the same updated repair flow.
- **Save** — writes the three typed values verbatim via the new `POST /api/gameplay/players/set-item-durability` endpoint.

UI includes:
- Disclaimer at the top that catalog-max is a best guess from bundled templates; manual edit + Save if it's wrong.
- Soft warning when the player is online that direct DB writes won't appear in-game until relog (game-server caches inventory in memory — same caveat as Fill Water before v11.5.9).

Gating is purely on node presence (`it.durability !== 'N/A'`), so any future item that gains durability nodes auto-shows the editor with no per-template allowlist needed.

### Online support

Per-item endpoints have no offline gate — works on online and offline players. Bulk repair stays offline-only as before.

## Files touched

- `app/server/lib/GameplayPlayers.ps1` — `Get-DuneItemCatalogMaxDurability`, `Format-DuneFloatForSql` (InvariantCulture-safe), rewrote `Invoke-DunePlayerRepairItem`, added `Invoke-DunePlayerSetItemDurability`
- `app/server/lib/PlayersWrites.ps1` — rewrote `Invoke-DunePlayerRepairGear` + `Invoke-DunePlayerRestoreDestroyedGear` as 2-step catalog-aware
- `app/server/routes/GameplayPlayers.ps1` — new `POST /api/gameplay/players/set-item-durability` (InvariantCulture `TryParse`)
- `webui/src/api/gameplay.ts` — `setItemDurability()`
- `webui/src/pages/gameplay/players/sections.tsx` — clickable rows, `DurabilityEditor` component, `isOnline` plumbing
- 5 version stamps bumped 12.0.24 → 12.0.25 + bug_report.yml placeholder + CHANGELOG entry

## Verification

- ✅ PowerShell parse all 3 edited `.ps1` files
- ✅ BOM + non-ASCII confirmed on all 3 (PS2EXE safe)
- ✅ `webui` build PASS
- ✅ `webui` tests — same 4 pre-existing failures as `main` (verified via `git stash`), no regressions
- ✅ Installer built (45.87 MB) and copied to canonical `<LOCAL_REPO_ROOT>\DST-DuneServerTool\app\installer\output\DuneServerSetup.exe`
- Manual in-game test of the editor + repair-online warning is pending.