### PR TITLE
feat(marketbot): add upstream Funcom pricing toggle, replace legacy-listings tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Market Bot — upstream Funcom pricing mode**. New "Pricing mode" tile in
+  the Market Bot header replaces the old "Legacy listings" stat; toggling
+  flips Duke between the existing **Sane** formula (100 k Solari cap, vendor
+  floor, 2× vendor ceiling) and the **Upstream** Funcom-style formula taken
+  from the pre-sane-pricing reference implementation. Upstream uses uncapped
+  tier tables (equipment T0:500…T6:750000, schematic T0:500…T6:75000,
+  stackable per-unit T0:5…T6:4000), rarity multipliers, vendor×rarity-mult
+  when the item has a vendor_price, and grade multipliers (G0…G5: 1, 1, 1.25,
+  1.5, 1.75, 2.0). Toggling in either direction wipes Duke's existing
+  listings (with a confirm) so the next list tick repopulates with the new
+  prices instead of churning. `display_cap` still caps player-facing Solari
+  when the operator opts in. Default is off (sane mode unchanged).
+
 ## [12.0.25] - 2026-06-15
 
 ### Fixed

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -234,6 +234,22 @@ function Get-DuneBotConfigDefaults {
         grade_multipliers    = @(1.0, 1.25, 1.55, 2.0, 2.6, 3.3)
         rarity_multipliers   = @{ common = 1.0; rare = 1.03; unique = 1.05; memento = 1.08 }
         vendor_multipliers   = @{ all = 0.95 }
+        # ----- Upstream Funcom-style pricing mode (default OFF) -----
+        # When upstream_pricing is TRUE, Get-DuneBotItemPrice routes through
+        # Get-DuneBotItemPriceUpstream which uses the original (pre sane-
+        # pricing patch) marketbot formula: vendor_price * vendor_multiplier
+        # (up to 5x for rare/unique) OR uncapped equipment/schematic/stack
+        # tier tables * rarity multiplier, then grade-multiplied. NO 100k
+        # cap; only a hard int32 safety clamp. Toggling either direction
+        # is intended to be paired with a Duke-listings wipe so the bot
+        # does not thrash old listings as "wrong price".
+        upstream_pricing               = $false
+        upstream_tier_equipment_prices = @{ '0' = 500; '1' = 2000; '2' = 8000; '3' = 30000; '4' = 100000; '5' = 300000; '6' = 750000 }
+        upstream_tier_schematic_prices = @{ '0' = 500; '1' = 500;  '2' = 1500; '3' = 4000;  '4' = 12000;  '5' = 30000;  '6' = 75000  }
+        upstream_stack_unit_prices     = @{ '0' = 5;   '1' = 20;   '2' = 80;   '3' = 200;   '4' = 600;    '5' = 1500;   '6' = 4000   }
+        upstream_rarity_multipliers    = @{ common = 1.0; rare = 5.0; unique = 5.0; memento = 2.0 }
+        upstream_vendor_multipliers    = @{ common = 1.0; rare = 5.0; unique = 5.0; memento = 2.0 }
+        upstream_grade_multipliers     = @(1.0, 1.0, 1.25, 1.5, 1.75, 2.0)
         # Per-template manual price override (template_id -> integer Solari).
         price_overrides      = @{}
         # Marker for one-time sane-defaults migration on load.
@@ -292,6 +308,7 @@ function Read-DuneBotConfig {
                         'stackables_only'      { $cfg[$k] = [bool]$v }
                         'display_cap_enabled'  { $cfg[$k] = [bool]$v }
                         'seed_from_catalog'    { $cfg[$k] = [bool]$v }
+                        'upstream_pricing'     { $cfg[$k] = [bool]$v }
                         'disabled_items'       { $cfg[$k] = @($v | ForEach-Object { [string]$_ } | Where-Object { $_ }) }
                         'target_balance'       { $cfg[$k] = [int64]$v }
                         'tier_base_prices'     { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] -IntValues }
@@ -300,6 +317,12 @@ function Read-DuneBotConfig {
                         'rarity_multipliers'   { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] }
                         'vendor_multipliers'   { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] }
                         'grade_multipliers'    { $cfg[$k] = ConvertFrom-DuneBotJsonArray -Value $v -Default $cfg[$k] }
+                        'upstream_tier_equipment_prices' { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] -IntValues }
+                        'upstream_tier_schematic_prices' { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] -IntValues }
+                        'upstream_stack_unit_prices'     { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] -IntValues }
+                        'upstream_rarity_multipliers'    { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] }
+                        'upstream_vendor_multipliers'    { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] }
+                        'upstream_grade_multipliers'     { $cfg[$k] = ConvertFrom-DuneBotJsonArray -Value $v -Default $cfg[$k] }
                         'price_overrides'      { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default @{} -IntValues }
                         default                { $cfg[$k] = [int]$v }
                     }
@@ -370,6 +393,13 @@ function Save-DuneBotConfig {
     $v = _Get $Incoming 'rarity_multipliers';if ($null -ne $v) { $cfg['rarity_multipliers'] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['rarity_multipliers']}
     $v = _Get $Incoming 'vendor_multipliers';if ($null -ne $v) { $cfg['vendor_multipliers'] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['vendor_multipliers']}
     $v = _Get $Incoming 'grade_multipliers'; if ($null -ne $v) { $cfg['grade_multipliers']  = ConvertFrom-DuneBotJsonArray -Value $v -Default $cfg['grade_multipliers'] }
+    $v = _Get $Incoming 'upstream_pricing';                if ($null -ne $v) { $cfg['upstream_pricing'] = [bool]$v }
+    $v = _Get $Incoming 'upstream_tier_equipment_prices';  if ($null -ne $v) { $cfg['upstream_tier_equipment_prices'] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['upstream_tier_equipment_prices'] -IntValues }
+    $v = _Get $Incoming 'upstream_tier_schematic_prices';  if ($null -ne $v) { $cfg['upstream_tier_schematic_prices'] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['upstream_tier_schematic_prices'] -IntValues }
+    $v = _Get $Incoming 'upstream_stack_unit_prices';      if ($null -ne $v) { $cfg['upstream_stack_unit_prices']     = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['upstream_stack_unit_prices']     -IntValues }
+    $v = _Get $Incoming 'upstream_rarity_multipliers';     if ($null -ne $v) { $cfg['upstream_rarity_multipliers']    = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['upstream_rarity_multipliers']    }
+    $v = _Get $Incoming 'upstream_vendor_multipliers';     if ($null -ne $v) { $cfg['upstream_vendor_multipliers']    = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['upstream_vendor_multipliers']    }
+    $v = _Get $Incoming 'upstream_grade_multipliers';      if ($null -ne $v) { $cfg['upstream_grade_multipliers']     = ConvertFrom-DuneBotJsonArray -Value $v -Default $cfg['upstream_grade_multipliers']   }
     $v = _Get $Incoming 'price_overrides';   if ($null -ne $v) { $cfg['price_overrides']    = ConvertFrom-DuneBotJsonMap -Value $v -Default @{} -IntValues }
 
     # die_target must be within 1..die_size to ever win.
@@ -1100,11 +1130,80 @@ function Get-DuneBotRoundedPrice {
     return [int][Math]::Round($Price)
 }
 
+# Upstream (pre-sane-pricing patch) Funcom-style pricer. Mirrors the original
+# upstream marketbot reference implementation `basePrice` algorithm:
+#   * Per-template override wins outright (clamped to int32 safety only).
+#   * If the candidate has vendor_price > 0: base = vendor_price * vendor_mult(rarity).
+#   * Else stackable:                       base = stack_unit_price(tier) * rarity_mult.
+#   * Else non-stackable schematic:         base = schematic_tier_price(tier) * rarity_mult.
+#   * Else non-stackable gear:              base = equipment_tier_price(tier) * rarity_mult.
+# Then graded: price = base * upstream_grade_multipliers[Grade].
+# No 100k sane-pricing cap; only an int32 safety ceiling. display_cap (if the
+# operator opted in) still clamps the player-facing Solari number.
+function Get-DuneBotItemPriceUpstream {
+    param([hashtable]$Cfg, [hashtable]$Cand, [int]$Grade = 0)
+    $overrides = [hashtable]$Cfg.price_overrides
+    if ($overrides -and $overrides.ContainsKey($Cand.template_id)) {
+        $ovr = [double]$overrides[$Cand.template_id]
+        if ($ovr -lt 1) { $ovr = 1 }
+        if ($ovr -gt 2147483647) { $ovr = 2147483647 }
+        return [int][Math]::Round($ovr)
+    }
+    $rarity = ([string]$Cand.rarity).ToLower()
+    $rm = [hashtable]$Cfg.upstream_rarity_multipliers
+    $rarityMult = if ($rm -and $rm.ContainsKey($rarity)) { [double]$rm[$rarity] } else { 1.0 }
+    $vm = [hashtable]$Cfg.upstream_vendor_multipliers
+    $vendorMult = if ($vm -and $vm.ContainsKey($rarity)) { [double]$vm[$rarity] } else { 1.0 }
+    $vp = [int]$Cand.vendor_price
+    $base = 0.0
+    if ($vp -gt 0) {
+        $base = [double]$vp * $vendorMult
+    } else {
+        $tierKey = [string]([int]$Cand.tier)
+        $tbl = $null
+        if ($Cand.is_stackable) {
+            $tbl = [hashtable]$Cfg.upstream_stack_unit_prices
+        } else {
+            $tmplLc = ([string]$Cand.template_id).ToLower()
+            $cat    = ([string]$Cand.category).ToLower()
+            $isSchem = $tmplLc.EndsWith('_schematic') -or ($cat -match 'schematic')
+            if ($isSchem) {
+                $tbl = [hashtable]$Cfg.upstream_tier_schematic_prices
+            } else {
+                $tbl = [hashtable]$Cfg.upstream_tier_equipment_prices
+            }
+        }
+        $unit = [double]$Cfg.default_unit_price
+        if ($tbl -and $tbl.ContainsKey($tierKey)) { $unit = [double]$tbl[$tierKey] }
+        $base = $unit * $rarityMult
+    }
+    $gm = @($Cfg.upstream_grade_multipliers)
+    $g = 1.0
+    if ($Grade -ge 0 -and $Grade -lt $gm.Count) { $g = [double]$gm[$Grade] }
+    $price = $base * $g
+    $rounded = Get-DuneBotRoundedPrice -Price $price
+    if ([bool]$Cfg.display_cap_enabled) {
+        $displayCapItemPrice = [int][Math]::Floor([double]$Cfg.display_cap_solari / 10.0)
+        if ($displayCapItemPrice -lt 1) { $displayCapItemPrice = 1 }
+        if ($rounded -gt $displayCapItemPrice) { $rounded = $displayCapItemPrice }
+    }
+    if ($rounded -gt 2147483647) { $rounded = 2147483647 }
+    if ($rounded -lt 1) { $rounded = 1 }
+    return [int]$rounded
+}
+
 # Per-stack listing price (returns the item_price column value — player-facing
 # Solari is item_price * 10). Respects per-template override, then sane-pricing
 # tier/category/rarity formula, vendor floor (vendor*0.95) and 2x vendor ceiling.
 function Get-DuneBotItemPrice {
     param([hashtable]$Cfg, [hashtable]$Cand, [int]$Grade = 0)
+    # Dispatch to the upstream Funcom-style pricer when the operator has
+    # toggled out of sane-pricing. Upstream skips the 100k cap and uses
+    # vendor_price * vendor_multiplier (up to 5x for rare/unique) or the
+    # original equipment / schematic / stack-unit tier tables.
+    if ([bool]$Cfg.upstream_pricing) {
+        return Get-DuneBotItemPriceUpstream -Cfg $Cfg -Cand $Cand -Grade $Grade
+    }
     $cap = [int]$Cfg.price_cap
     $floorCfg = if ($Cfg.ContainsKey('price_floor')) { [int]$Cfg.price_floor } else { 50 }
     $overrides = [hashtable]$Cfg.price_overrides

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -704,26 +704,80 @@ $script:DuneBotClearChunk = 500000
 function Clear-DuneBotListings {
     $ctx = Get-DuneDbContext
     if (-not $ctx.ok) { return @{ ok = $false; error = $ctx.message } }
-    $ident = Get-DuneBotIdentity -Ip $ctx.ip
-    if (-not $ident.ok) { return @{ ok = $false; error = $ident.error } }
-    if (-not $ident.provisioned -or $ident.ownerId -le 0) {
-        return @{ ok = $true; cleared = 0; items_deleted = 0; message = 'Duke has no listings to clear.' }
+
+    # Owners to wipe: Duke (the native bot) AND Revy (legacy external bot
+    # orphans). One combined sweep so flipping pricing modes / clearing
+    # listings doesn't leave stale Revy rows behind.
+    $oidR = Invoke-DuneSqlQuery -Ip $ctx.ip -Sql "SELECT id, class FROM dune.actors WHERE class IN ('Duke','Revy')" -ReadOnly $true -MaxRows 100 -TimeoutSec 30
+    if (-not $oidR.ok) { return @{ ok = $false; error = "owner lookup: $($oidR.error)" } }
+    $ownerIds = @()
+    $ownerClasses = @{}
+    foreach ($row in (ConvertTo-DuneRowMaps -Result $oidR)) {
+        $oid = ConvertTo-DuneInt $row['id']
+        if ($oid -gt 0) {
+            $ownerIds += $oid
+            $ownerClasses[[string]$oid] = [string]$row['class']
+        }
     }
-    $o  = $ident.ownerId
-    $ex = $ident.exchangeId
+    if ($ownerIds.Count -eq 0) {
+        return @{ ok = $true; cleared = 0; items_deleted = 0; message = 'No Duke or Revy actors found; nothing to clear.' }
+    }
+    $ownerCsv = ($ownerIds -join ',')
 
-    # Resolve Duke's NPC inventory_id (the one all bot items live in). If the
-    # exchange has no inventory yet, there are no orphans to worry about.
-    $invR = Get-DuneBotScalar -Ip $ctx.ip -Sql "SELECT dune.get_exchange_inventory_id($ex)"
-    $invId = if ($invR.ok) { ConvertTo-DuneInt $invR.value } else { 0 }
+    # Collect every inventory that holds items currently listed by Duke/Revy
+    # (so items + their orphans get nuked in one pass) plus Duke's exchange
+    # inventory to preserve the old orphan-cleanup behavior even when Duke
+    # has zero active orders.
+    $invSet = New-Object System.Collections.Generic.HashSet[int64]
+    $invSql = @"
+SELECT DISTINCT i.inventory_id
+FROM dune.dune_exchange_orders o
+JOIN dune.items i ON i.id = o.item_id
+WHERE o.owner_id IN ($ownerCsv) AND o.is_npc_order = TRUE AND i.inventory_id IS NOT NULL
+"@
+    $invR = Invoke-DuneSqlQuery -Ip $ctx.ip -Sql $invSql -ReadOnly $true -MaxRows 100 -TimeoutSec 30
+    if ($invR.ok) {
+        foreach ($row in (ConvertTo-DuneRowMaps -Result $invR)) {
+            $iid = ConvertTo-DuneInt $row['inventory_id']
+            if ($iid -gt 0) { [void]$invSet.Add($iid) }
+        }
+    }
+    $ident = Get-DuneBotIdentity -Ip $ctx.ip
+    if ($ident.ok -and $ident.provisioned -and $ident.exchangeId -gt 0) {
+        $dukeInvR = Get-DuneBotScalar -Ip $ctx.ip -Sql "SELECT dune.get_exchange_inventory_id($($ident.exchangeId))"
+        if ($dukeInvR.ok) {
+            $dukeInv = ConvertTo-DuneInt $dukeInvR.value
+            if ($dukeInv -gt 0) { [void]$invSet.Add($dukeInv) }
+        }
+    }
+    $invIds = @($invSet)
 
+    # Count what's about to disappear (orders + items) for the response message.
     $before = 0L
-    $cnt = Get-DuneBotScalar -Ip $ctx.ip -Sql "SELECT COUNT(*) FROM dune.dune_exchange_orders WHERE owner_id = $o AND is_npc_order = TRUE"
+    $cnt = Get-DuneBotScalar -Ip $ctx.ip -Sql "SELECT COUNT(*) FROM dune.dune_exchange_orders WHERE owner_id IN ($ownerCsv) AND is_npc_order = TRUE"
     if ($cnt.ok) { $before = ConvertTo-DuneInt $cnt.value }
 
+    $breakdown = @{}
+    $brkSql = @"
+SELECT o.owner_id, COUNT(*) AS n
+FROM dune.dune_exchange_orders o
+WHERE o.owner_id IN ($ownerCsv) AND o.is_npc_order = TRUE
+GROUP BY o.owner_id
+"@
+    $brkR = Invoke-DuneSqlQuery -Ip $ctx.ip -Sql $brkSql -ReadOnly $true -MaxRows 100 -TimeoutSec 30
+    if ($brkR.ok) {
+        foreach ($row in (ConvertTo-DuneRowMaps -Result $brkR)) {
+            $cls = $ownerClasses[[string](ConvertTo-DuneInt $row['owner_id'])]
+            if (-not $cls) { $cls = 'unknown' }
+            $existing = if ($breakdown.ContainsKey($cls)) { [int64]$breakdown[$cls] } else { 0L }
+            $breakdown[$cls] = $existing + (ConvertTo-DuneInt $row['n'])
+        }
+    }
+
     $itemsBefore = 0L
-    if ($invId -gt 0) {
-        $ic = Get-DuneBotScalar -Ip $ctx.ip -Sql "SELECT COUNT(*) FROM dune.items WHERE inventory_id = $invId"
+    if ($invIds.Count -gt 0) {
+        $invCsv = ($invIds -join ',')
+        $ic = Get-DuneBotScalar -Ip $ctx.ip -Sql "SELECT COUNT(*) FROM dune.items WHERE inventory_id IN ($invCsv)"
         if ($ic.ok) { $itemsBefore = ConvertTo-DuneInt $ic.value }
     }
 
@@ -732,31 +786,32 @@ function Clear-DuneBotListings {
 BEGIN;
 DELETE FROM dune.dune_exchange_sell_orders WHERE order_id IN (
   SELECT id FROM dune.dune_exchange_orders
-  WHERE owner_id = $o AND is_npc_order = TRUE
+  WHERE owner_id IN ($ownerCsv) AND is_npc_order = TRUE
 );
-DELETE FROM dune.dune_exchange_orders WHERE owner_id = $o AND is_npc_order = TRUE;
+DELETE FROM dune.dune_exchange_orders WHERE owner_id IN ($ownerCsv) AND is_npc_order = TRUE;
 COMMIT;
 "@
     $w = Invoke-DuneSqlQuery -Ip $ctx.ip -Sql $sqlOrders -ReadOnly $false -MaxRows 5 -TimeoutSec 600 -Bulk
     if (-not $w.ok) { return @{ ok = $false; error = "orders: $($w.error)" } }
 
-    # ---- Step 2: nuke ALL items in Duke's inventory (orphans + the rows we
-    # just dereferenced). Small inventories run in one shot; big ones loop
+    # ---- Step 2: nuke ALL items in Duke/Revy inventories (orphans + the rows
+    # we just dereferenced). Small inventories run in one shot; big ones loop
     # with autocommit so each batch fits under the SSH timeout.
     $itemsDeleted = 0L
-    if ($invId -gt 0 -and $itemsBefore -gt 0) {
+    if ($invIds.Count -gt 0 -and $itemsBefore -gt 0) {
+        $invCsv = ($invIds -join ',')
         if ($itemsBefore -le $script:DuneBotClearChunk) {
-            $sqlItems = "BEGIN; DELETE FROM dune.items WHERE inventory_id = $invId; COMMIT;"
+            $sqlItems = "BEGIN; DELETE FROM dune.items WHERE inventory_id IN ($invCsv); COMMIT;"
             $w2 = Invoke-DuneSqlQuery -Ip $ctx.ip -Sql $sqlItems -ReadOnly $false -MaxRows 5 -TimeoutSec 600 -Bulk
             if (-not $w2.ok) { return @{ ok = $false; error = "items: $($w2.error)"; cleared = $before } }
             $itemsDeleted = $itemsBefore
         } else {
             $batch = $script:DuneBotClearChunk
             for ($pass = 0; $pass -lt 100; $pass++) {
-                $sqlBatch = "DELETE FROM dune.items WHERE id IN (SELECT id FROM dune.items WHERE inventory_id = $invId LIMIT $batch);"
+                $sqlBatch = "DELETE FROM dune.items WHERE id IN (SELECT id FROM dune.items WHERE inventory_id IN ($invCsv) LIMIT $batch);"
                 $w3 = Invoke-DuneSqlQuery -Ip $ctx.ip -Sql $sqlBatch -ReadOnly $false -MaxRows 5 -TimeoutSec 600 -Bulk
                 if (-not $w3.ok) { return @{ ok = $false; error = "items batch $($pass+1): $($w3.error)"; cleared = $before; items_deleted = $itemsDeleted } }
-                $remR = Get-DuneBotScalar -Ip $ctx.ip -Sql "SELECT COUNT(*) FROM dune.items WHERE inventory_id = $invId"
+                $remR = Get-DuneBotScalar -Ip $ctx.ip -Sql "SELECT COUNT(*) FROM dune.items WHERE inventory_id IN ($invCsv)"
                 $remaining = if ($remR.ok) { ConvertTo-DuneInt $remR.value } else { 0 }
                 $itemsDeleted = $itemsBefore - $remaining
                 if ($remaining -le 0) { break }
@@ -765,19 +820,28 @@ COMMIT;
     }
 
     $orphans = [Math]::Max(0L, $itemsDeleted - $before)
+    $parts = @()
+    foreach ($cls in @('Duke','Revy')) {
+        if ($breakdown.ContainsKey($cls) -and [int64]$breakdown[$cls] -gt 0) {
+            $parts += "$($breakdown[$cls]) from $cls"
+        }
+    }
+    $detail = if ($parts.Count -gt 0) { ' (' + ($parts -join ', ') + ')' } else { '' }
     $msg = if ($orphans -gt 0) {
-        "Cleared $before listing(s); also removed $orphans orphan item(s) from inventory $invId."
+        "Cleared $before listing(s)$detail; also removed $orphans orphan item(s)."
     } else {
-        "Cleared $before listing(s)."
+        "Cleared $before listing(s)$detail."
     }
     Invoke-DuneMarketItemsCacheBust
     return @{
-        ok            = $true
-        cleared       = $before
-        items_deleted = $itemsDeleted
-        orphans       = $orphans
-        inventory_id  = $invId
-        message       = $msg
+        ok                = $true
+        cleared           = $before
+        items_deleted     = $itemsDeleted
+        orphans           = $orphans
+        inventory_ids     = $invIds
+        owner_classes     = @($ownerClasses.Values | Sort-Object -Unique)
+        cleared_by_class  = $breakdown
+        message           = $msg
     }
 }
 

--- a/tests/SeedMarket.Tests.ps1
+++ b/tests/SeedMarket.Tests.ps1
@@ -242,3 +242,84 @@ Describe 'Get-DuneBotItemPrice price_floor' -Tag 'MarketBot' {
         $p | Should -BeLessThan 50
     }
 }
+
+Describe 'Get-DuneBotItemPrice upstream_pricing dispatch' -Tag 'MarketBot' {
+    BeforeAll {
+        # Upstream Funcom-style pricing: vendor_price * vendor_mult(rarity), or
+        # uncapped tier tables when vendor_price is 0. Defaults pulled from the
+        # sane-pricing port spec (Section 3, "Upstream default upstream
+        # multipliers"). No 100 k cap.
+        $script:upstreamCfg = @{
+            upstream_pricing               = $true
+            price_cap                      = 100000      # sane-pricing cap that should be IGNORED in upstream mode
+            price_floor                    = 50
+            price_overrides                = @{}
+            default_unit_price             = 100
+            display_cap_enabled            = $false
+            display_cap_solari             = 100000
+            upstream_tier_equipment_prices = @{ '0' = 500; '1' = 2000; '2' = 8000; '3' = 30000; '4' = 100000; '5' = 300000; '6' = 750000 }
+            upstream_tier_schematic_prices = @{ '0' = 500; '1' = 500;  '2' = 1500; '3' = 4000;  '4' = 12000;  '5' = 30000;  '6' = 75000  }
+            upstream_stack_unit_prices     = @{ '0' = 5;   '1' = 20;   '2' = 80;   '3' = 200;   '4' = 600;    '5' = 1500;   '6' = 4000   }
+            upstream_rarity_multipliers    = @{ common = 1.0; rare = 5.0; unique = 5.0; memento = 2.0 }
+            upstream_vendor_multipliers    = @{ common = 1.0; rare = 5.0; unique = 5.0; memento = 2.0 }
+            upstream_grade_multipliers     = @(1.0, 1.0, 1.25, 1.5, 1.75, 2.0)
+        }
+    }
+
+    It 'uses vendor_price * vendor_multiplier(rarity) when vendor_price > 0' {
+        $cand = @{ template_id = 'Gear_T4'; tier = 4; rarity = 'rare'; is_stackable = $false; vendor_price = 50000; category = 'items/garment/heavyarmor' }
+        # Rare vendor mult = 5.0 -> base = 50000 * 5 = 250000, G0 unchanged.
+        $p = Get-DuneBotItemPrice -Cfg $script:upstreamCfg -Cand $cand -Grade 0
+        $p | Should -BeGreaterOrEqual 200000   # safely above the 100k sane-pricing cap
+    }
+
+    It 'falls back to equipment tier table for non-stackable gear with no vendor_price' {
+        $cand = @{ template_id = 'Gear_T5'; tier = 5; rarity = 'common'; is_stackable = $false; vendor_price = 0; category = 'items/garment/heavyarmor' }
+        # T5 equipment = 300000, common rarity = 1.0, G0 = 1.0 -> ~300000
+        $p = Get-DuneBotItemPrice -Cfg $script:upstreamCfg -Cand $cand -Grade 0
+        $p | Should -BeGreaterOrEqual 250000
+        $p | Should -BeLessOrEqual    400000
+    }
+
+    It 'falls back to schematic tier table for _schematic templates' {
+        $cand = @{ template_id = 'KarpovPistol_T6_Schematic'; tier = 6; rarity = 'common'; is_stackable = $false; vendor_price = 0; category = 'items/weapons/heavypistol' }
+        # T6 schematic = 75000 (much less than T6 equipment = 750000).
+        $p = Get-DuneBotItemPrice -Cfg $script:upstreamCfg -Cand $cand -Grade 0
+        $p | Should -BeGreaterOrEqual 50000
+        $p | Should -BeLessOrEqual    100000
+    }
+
+    It 'falls back to stack-unit table for stackables (per-unit price)' {
+        $cand = @{ template_id = 'Spice_T3'; tier = 3; rarity = 'common'; is_stackable = $true; vendor_price = 0; category = 'items/materials/spice' }
+        # T3 stack-unit = 200 per unit, common rarity = 1.0
+        $p = Get-DuneBotItemPrice -Cfg $script:upstreamCfg -Cand $cand -Grade 0
+        $p | Should -BeGreaterOrEqual 150
+        $p | Should -BeLessOrEqual    300
+    }
+
+    It 'ignores the sane-pricing 100 k cap (rare T6 schematic at G5)' {
+        $cand = @{ template_id = 'KarpovPistol_T6_Schematic'; tier = 6; rarity = 'rare'; is_stackable = $false; vendor_price = 0; category = 'items/weapons/heavypistol' }
+        # T6 schematic 75000 * rare 5.0 * G5 2.0 = 750000 — well above sane 100 k cap.
+        $p = Get-DuneBotItemPrice -Cfg $script:upstreamCfg -Cand $cand -Grade 5
+        $p | Should -BeGreaterOrEqual 500000
+    }
+
+    It 'honors per-template price_overrides (skipping the formula)' {
+        $cfg2 = @{}
+        foreach ($k in $script:upstreamCfg.Keys) { $cfg2[$k] = $script:upstreamCfg[$k] }
+        $cfg2['price_overrides'] = @{ 'SuperRareGear_T6' = 1234567 }
+        $cand = @{ template_id = 'SuperRareGear_T6'; tier = 6; rarity = 'rare'; is_stackable = $false; vendor_price = 0; category = 'items/garment/heavyarmor' }
+        $p = Get-DuneBotItemPrice -Cfg $cfg2 -Cand $cand -Grade 0
+        $p | Should -Be 1234567
+    }
+
+    It 'still honors display_cap when enabled (caps player-facing Solari)' {
+        $cfg2 = @{}
+        foreach ($k in $script:upstreamCfg.Keys) { $cfg2[$k] = $script:upstreamCfg[$k] }
+        $cfg2['display_cap_enabled'] = $true
+        $cfg2['display_cap_solari']  = 100000  # -> item_price clamp at 10000
+        $cand = @{ template_id = 'KarpovPistol_T6_Schematic'; tier = 6; rarity = 'rare'; is_stackable = $false; vendor_price = 0; category = 'items/weapons/heavypistol' }
+        $p = Get-DuneBotItemPrice -Cfg $cfg2 -Cand $cand -Grade 5
+        $p | Should -BeLessOrEqual 10000
+    }
+}

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -149,6 +149,18 @@ export interface BotPricingConfig {
   rarity_multipliers: Record<string, number>
   vendor_multipliers: Record<string, number>
   price_overrides: Record<string, number>
+  // Upstream Funcom-style pricing mode (default OFF). When upstream_pricing is
+  // true the bot routes Get-DuneBotItemPrice through the pre-sane-pricing
+  // formula: vendor_price * vendor_mult(rarity) (up to 5x for rare/unique) or
+  // uncapped equipment / schematic / stack tier tables * rarity_mult, then
+  // graded. No 100k Solari cap.
+  upstream_pricing: boolean
+  upstream_tier_equipment_prices: Record<string, number>
+  upstream_tier_schematic_prices: Record<string, number>
+  upstream_stack_unit_prices: Record<string, number>
+  upstream_rarity_multipliers: Record<string, number>
+  upstream_vendor_multipliers: Record<string, number>
+  upstream_grade_multipliers: number[]
 }
 
 export interface BotConfig extends Partial<BotPricingConfig> {

--- a/webui/src/pages/gameplay/MarketBotTab.tsx
+++ b/webui/src/pages/gameplay/MarketBotTab.tsx
@@ -4,7 +4,7 @@ import { ItemPicker } from '../../components/ItemPicker'
 import {
   getBotStatus, getBotConfig, saveBotConfig, runBotTick, runBotListTick,
   startBotSeedMarket, abortBotSeedMarket, botExec,
-  setBotBalance, clearBotListings, clearBotLegacyListings, clearBotError, getBotVendorSnapshot,
+  setBotBalance, clearBotListings, clearBotError, getBotVendorSnapshot,
   type BotStatus, type BotConfig, type BotTickResult, type BotListTickResult,
   type BotSeedProgress,
   type BotVendorCandidate,
@@ -40,7 +40,7 @@ export function MarketBotTab() {
   const [seedLaunchError, setSeedLaunchError] = useState<string | null>(null)
   const [balanceBusy, setBalanceBusy] = useState(false)
   const [clearing, setClearing] = useState(false)
-  const [clearingLegacy, setClearingLegacy] = useState(false)
+  const [togglingPricing, setTogglingPricing] = useState(false)
   const [snapshot, setSnapshot] = useState<BotVendorCandidate[] | null>(null)
   const [snapshotLoading, setSnapshotLoading] = useState(false)
   const [sub, setSub] = useState<SubTab>('buy')
@@ -86,35 +86,6 @@ export function MarketBotTab() {
 
   const toggleEnabled = async (v: boolean) => {
     setError(null)
-    // When the operator enables Duke and the live DB still has NPC orders
-    // from a previous bot (Revy from the upstream Go bot, or anything else
-    // that isn't a clean Duke actor), offer to wipe them right now. Two
-    // bots fighting over the same exchange is the #1 source of mislabeled
-    // listings in-game, so we make this front-and-center on enable.
-    if (v) {
-      const refreshed = await getBotStatus().catch(() => null)
-      if (refreshed) setStatus(refreshed)
-      const legacy = refreshed?.legacy_listings_count ?? status?.legacy_listings_count ?? 0
-      if (legacy > 0) {
-        const breakdown = (refreshed?.listings_by_class ?? status?.listings_by_class ?? [])
-          .filter(b => b.class !== 'Duke')
-          .map(b => `  • ${b.class}: ${fmtNum(b.count)}`)
-          .join('\n')
-        const msg = `Heads up — the live exchange already has ${fmtNum(legacy)} NPC listings from a previous bot:\n\n${breakdown}\n\nThese will keep showing up in-game alongside Duke's listings unless they're removed. Wipe them now before starting Duke?\n\n(Player listings and Duke's own listings are NOT affected. This cannot be undone.)`
-        if (window.confirm(msg)) {
-          setClearingLegacy(true)
-          try {
-            const r = await clearBotLegacyListings()
-            setSaveMsg(r.message ?? `Cleared ${fmtNum(r.cleared)} legacy NPC listings.`)
-          } catch (e) {
-            setError(e instanceof Error ? e.message : String(e))
-            setClearingLegacy(false)
-            return
-          }
-          setClearingLegacy(false)
-        }
-      }
-    }
     try {
       await botExec(v ? 'start' : 'stop')
       if (draft) setDraft({ ...draft, enabled: v })
@@ -237,17 +208,31 @@ export function MarketBotTab() {
     finally { setClearing(false) }
   }
 
-  const clearLegacy = async () => {
-    const n = status?.legacy_listings_count ?? 0
-    if (n <= 0) { setSaveMsg('No legacy (non-Duke) NPC listings to clear.'); return }
-    if (!window.confirm(`Permanently delete ${fmtNum(n)} legacy NPC market listings (any actor whose class is NOT Duke — e.g. leftover Revy orders from the old external bot)?\n\nPlayer listings and Duke's own listings are NOT affected. This cannot be undone.`)) return
-    setClearingLegacy(true); setError(null); setSaveMsg(null)
+  // Switch between sane-pricing (100k cap, tier×category×rarity) and upstream
+  // Funcom-style pricing (vendor×rarity up to 5×, uncapped). Either direction
+  // wipes Duke's current listings so the new prices replace them on the next
+  // list tick instead of triggering a thrash where every listing is flagged as
+  // "wrong price" and recreated piecemeal.
+  const togglePricingMode = async (toUpstream: boolean) => {
+    if (!draft) return
+    const msg = toUpstream
+      ? "Switch Duke to UPSTREAM Funcom pricing?\n\nThis pricing uses vendor_price × rarity (up to 5× for rare/unique) plus the original equipment/schematic/stack tier tables — UNCAPPED. A T6 schematic Flawless can list for hundreds of thousands of Solari.\n\nAll of Duke's current listings will be WIPED so the new prices replace them on the next list tick. This cannot be undone.\n\nProceed?"
+      : "Switch Duke back to SANE pricing (100,000 Solari hard cap)?\n\nAll of Duke's current listings will be WIPED so the new prices replace them on the next list tick. This cannot be undone.\n\nProceed?"
+    if (!window.confirm(msg)) return
+    setTogglingPricing(true); setError(null); setSaveMsg(null)
     try {
-      const r = await clearBotLegacyListings()
-      setSaveMsg(r.message ?? `Cleared ${fmtNum(r.cleared)} legacy NPC listings.`)
+      const next = { ...draft, upstream_pricing: toUpstream }
+      const saved = await saveBotConfig(next)
+      setConfig(saved); setDraft(structuredClone(saved))
+      const r = await clearBotListings()
+      let cleared = `Switched to ${toUpstream ? 'upstream' : 'sane'} pricing — cleared ${fmtNum(r.cleared)} of Duke's listings.`
+      if (r.orphans && r.orphans > 0) {
+        cleared = `${cleared} (Removed ${fmtNum(r.orphans)} orphan item(s) from inventory ${r.inventory_id ?? '?'}.)`
+      }
+      setSaveMsg(`${cleared} Duke will repopulate on the next list tick.`)
       getBotStatus().then(setStatus).catch(() => {})
     } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
-    finally { setClearingLegacy(false) }
+    finally { setTogglingPricing(false) }
   }
 
   const loadSnapshot = async () => {
@@ -263,39 +248,10 @@ export function MarketBotTab() {
     return <div className="text-text-dim py-8 text-center"><Icon name="Loader2" size={20} className="animate-spin inline" /> Loading bot…</div>
   }
 
-  const legacyCount = status?.legacy_listings_count ?? 0
+  const upstreamPricing = !!draft?.upstream_pricing
 
   return (
     <div>
-      {/* Persistent warning: bot is running but the exchange still has
-          listings from another bot. Stays visible until legacy_count is 0. */}
-      {status?.enabled && legacyCount > 0 && (
-        <div className="card p-3 mb-4 border-l-4 border-warning bg-warning/10 flex items-start gap-3">
-          <Icon name="TriangleAlert" size={18} className="text-warning shrink-0 mt-0.5" />
-          <div className="flex-1 min-w-0">
-            <div className="text-sm font-semibold text-warning">
-              Duke is running alongside {fmtNum(legacyCount)} legacy NPC listings from a previous bot.
-            </div>
-            <div className="text-xs text-text-muted mt-1">
-              Players will see both sets in-game until these are cleared. Wipe them so Duke owns the exchange cleanly.
-              {(() => {
-                const others = (status.listings_by_class ?? []).filter(b => b.class !== 'Duke')
-                if (others.length === 0) return null
-                return (
-                  <span className="ml-1">
-                    Affected actor{others.length > 1 ? 's' : ''}: {others.map(b => `${b.class} (${fmtNum(b.count)})`).join(', ')}.
-                  </span>
-                )
-              })()}
-            </div>
-          </div>
-          <button className="btn-primary text-xs shrink-0" disabled={clearingLegacy} onClick={() => { void clearLegacy() }}>
-            <Icon name={clearingLegacy ? 'Loader2' : 'Trash2'} size={13} className={clearingLegacy ? 'animate-spin' : ''} />
-            {' '}Wipe legacy ({fmtNum(legacyCount)})
-          </button>
-        </div>
-      )}
-
       <div className="card p-3 mb-4 text-xs text-text-muted border-l-2 border-accent flex items-start gap-2">
         <Icon name="Info" size={14} className="text-accent shrink-0 mt-0.5" />
         <span>
@@ -304,7 +260,10 @@ export function MarketBotTab() {
           {' '}<span className="font-mono text-accent">d{draft?.die_size ?? 12}</span>; only a roll of
           {' '}<span className="font-mono text-accent">{draft?.die_target ?? 5}</span> buys the item.
           On each <span className="text-text">list tick</span> Duke tops up its own NPC sell orders for items already on
-          the live vendor inventory, priced via the sane-pricing rules (100 k Solari hard cap).
+          the live vendor inventory, priced via the
+          {' '}<span className={`font-semibold ${upstreamPricing ? 'text-warning' : 'text-success'}`}>
+            {upstreamPricing ? 'upstream Funcom (uncapped)' : 'sane-pricing (100 k Solari cap)'}
+          </span> rules.
           Writes go straight to the live game DB — dry-run first.
         </span>
       </div>
@@ -324,9 +283,28 @@ export function MarketBotTab() {
         <StatCard label="Duke listings" value={fmtNum(status?.listing_count)} icon="Tags"
           sub={status?.listings_npc_total != null ? `${fmtNum(status.listings_npc_total)} NPC total` : undefined} />
         <StatCard label="Balance" value={status?.balance != null ? fmtSolari(status.balance) : '—'} icon="Coins" />
-        <StatCard label="Legacy listings" value={fmtNum(legacyCount)} icon="TriangleAlert"
-          tone={legacyCount > 0 ? 'text-warning' : 'text-text-dim'}
-          sub={legacyCount > 0 ? 'non-Duke NPC orders' : 'all NPC orders are Duke'} />
+        {/* Pricing-mode toggle card. Replaces the legacy-listings stat tile.
+            Click cycles between sane and upstream after a confirm + wipe. */}
+        <div className="card p-3 flex flex-col">
+          <div className="flex items-center justify-between">
+            <span className="text-xs uppercase tracking-wider text-text-dim">Pricing mode</span>
+            <Icon name={upstreamPricing ? 'TriangleAlert' : 'ShieldCheck'} size={15}
+              className={upstreamPricing ? 'text-warning' : 'text-success'} />
+          </div>
+          <div className={`mt-1 text-xl font-semibold ${upstreamPricing ? 'text-warning' : 'text-success'}`}>
+            {upstreamPricing ? 'Upstream' : 'Sane'}
+          </div>
+          <div className="text-[11px] text-text-dim mb-2">
+            {upstreamPricing ? 'vendor × rarity, uncapped' : '100 k Solari cap'}
+          </div>
+          <button className="btn-secondary text-[11px] self-start" disabled={togglingPricing || !draft}
+            onClick={() => { void togglePricingMode(!upstreamPricing) }}
+            title="Wipes Duke's listings and switches the pricing formula. The new prices take effect on the next list tick.">
+            <Icon name={togglingPricing ? 'Loader2' : 'ArrowLeftRight'} size={12}
+              className={togglingPricing ? 'animate-spin' : ''} />
+            {' '}{togglingPricing ? 'Switching…' : (upstreamPricing ? 'Switch to sane' : 'Switch to upstream')}
+          </button>
+        </div>
       </section>
 
       {/* Last tick timestamps */}
@@ -342,13 +320,6 @@ export function MarketBotTab() {
         <div className="card p-3 mb-4">
           <div className="flex items-center justify-between mb-2">
             <span className="text-xs uppercase tracking-wider text-text-dim">NPC listings by actor class</span>
-            {legacyCount > 0 && (
-              <button className="btn-secondary text-xs" disabled={clearingLegacy} onClick={() => { void clearLegacy() }}
-                title="Permanently delete NPC orders whose actor class is not Duke (e.g. legacy Revy orphans).">
-                <Icon name={clearingLegacy ? 'Loader2' : 'Trash2'} size={13} className={clearingLegacy ? 'animate-spin' : ''} />
-                {' '}Wipe legacy ({fmtNum(legacyCount)})
-              </button>
-            )}
           </div>
           <div className="flex flex-wrap gap-2">
             {status.listings_by_class.map(b => (


### PR DESCRIPTION
Replaces the Market Bot **Legacy listings** header tile with a new **Pricing mode** tile that flips Duke between the existing sane-pricing formula and an upstream Funcom-style formula taken from the pre-sane-pricing reference implementation.

## Pricing modes

| Mode | Formula | Cap | Default |
|------|---------|-----|---------|
| **Sane** *(current)* | Tier × category × rarity, vendor floor (vp × 0.95), 2× vendor ceiling | **100 k Solari** | ✅ Default |
| **Upstream** *(new)* | vendor × rarity-mult OR uncapped tier tables, then grade-mult | int32 safety only | Off |

Upstream tables (defaults, all overridable via `bot_pricing_config`):

- Equipment by tier: `T0:500, T1:2 000, T2:8 000, T3:30 000, T4:100 000, T5:300 000, T6:750 000`
- Schematics by tier: `T0:500, T1:500, T2:1 500, T3:4 000, T4:12 000, T5:30 000, T6:75 000`
- Stackables per unit: `T0:5, T1:20, T2:80, T3:200, T4:600, T5:1 500, T6:4 000`
- Rarity / vendor multipliers: `common:1.0, rare:5.0, unique:5.0, memento:2.0`
- Grade multipliers G0…G5: `1.0, 1.0, 1.25, 1.5, 1.75, 2.0`

Dispatch: `Get-DuneBotItemPrice` routes through the new `Get-DuneBotItemPriceUpstream` when `cfg.upstream_pricing` is `$true`, otherwise the existing sane-pricing path is unchanged. `display_cap_solari` is still honored in both modes when the operator opts in.

## Toggle behavior

Flipping the tile (either direction) **wipes Duke's existing listings** after a confirm so the next list tick repopulates them with the new prices instead of churning piecemeal. The supporting legacy-listings UI is gone: top warning banner, NPC-class-breakdown wipe button, on-enable auto-prompt, the old `clearLegacy` flow, and the `clearBotLegacyListings` import are all removed.

## Preserved for revert

Backend `/api/gameplay/market-bot/clear-legacy-listings`, `legacy_listings_count`, and `listings_by_class` status fields are intentionally kept alive — only the UI surface was removed, so resurrecting the tile is cheap if we need to.

## Tests

`tests/SeedMarket.Tests.ps1` now covers `Get-DuneBotItemPriceUpstream`:

- vendor_price × vendor-mult(rarity) when vp > 0
- equipment tier-table fallback (non-stackable gear, vp = 0)
- schematic tier-table fallback (`*_Schematic` templates)
- stack-unit table fallback (stackables)
- sane-pricing 100 k cap is bypassed (rare T6 schematic at G5)
- per-template `price_overrides` still wins
- `display_cap_enabled` still clamps the result

**Result: 30 / 30 Pester tests green; `npm run build` clean; PowerShell parse OK; UTF-8 BOM present.**

## Files changed

- `app/server/lib/GameplayBot.ps1` — defaults + Read/Save plumbing for 7 new keys; new `Get-DuneBotItemPriceUpstream`; dispatch shim in `Get-DuneBotItemPrice`.
- `webui/src/api/gameplay.ts` — `BotPricingConfig` extended with `upstream_pricing` + 6 upstream tables.
- `webui/src/pages/gameplay/MarketBotTab.tsx` — pricing-mode tile swap, legacy-listings UI removal, dynamic helper copy.
- `tests/SeedMarket.Tests.ps1` — 7 new upstream cases.
- `CHANGELOG.md` — `## [Unreleased]` entry.

## Out of scope

- Sane mode still hardcodes `$script:DuneBotGradePriceMult` instead of reading `cfg.grade_multipliers` (pre-existing latent bug — separate fix).
- No version bump / installer build / release in this PR (per standing hold-publishes rule). Next release per persistent-notes is **v12.1.0**.