### PR TITLE
v12.1.1 — Restore the 10 m_Global*Multiplier Game Config options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.1.0"
+      placeholder: "v12.1.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.1.1] - 2026-06-15
+
+### Fixed
+
+- **Restored the 10 `m_Global*Multiplier` Game Config options that were pulled
+  in v12.0.14.** XP, Damage to NPCs, Damage to Players, Health, Fame,
+  Progression Speed, Harvest Amount, Harvest Health, Building Damage, and
+  Inventory Weight multipliers are back on the Game Config screen — under new
+  **Progression** and **Harvesting** categories (and within **Survival**,
+  **Building**, **Inventory**). v12.0.14's removal relied on an
+  AMP-orchestrated upstream tool's conclusion that these keys were no-ops, but
+  on self-hosted Funcom k3s (DST's target) `UserGame.ini` is loaded at pod
+  startup and scalar `[/Script/DuneSandbox.DuneGameMode]` values *do* apply;
+  the Hexaspark community ServerConfig reference also documents every one of
+  these keys as a real Float setting under `DuneGameMode` with a default of
+  `1.0`. (Discord report from poultrygeist516.)
+
+- **`m_GlobalBuildingDamageMultiplier` now writes to the correct section.** It
+  was previously placed under `[/Script/DuneSandbox.BuildingSettings]`, which
+  the engine ignores; it now writes under `[/Script/DuneSandbox.DuneGameMode]`
+  alongside the other gameplay multipliers, matching the Hexaspark reference.
+
+- **All ten restored multipliers are flagged `ClientApply`.** They are read by
+  both the server and the game client, so saving them now triggers the existing
+  "Apply on each client" notice and the **Apply to my client** button mirrors
+  the new value into the admin's local `Game.ini` — keeping the local client in
+  sync with the server without manual edits.
+
 ## [12.1.0] - 2026-06-15
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.1.0'
+$script:DuneToolVersion = '12.1.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.1.0',
+    [string]$Version = '12.1.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.1.0</Version>
+    <Version>12.1.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.1.0"
+#define MyAppVersion "12.1.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -54,7 +54,7 @@ $script:DuneGcSecUrl       = 'URL'
 
 # Category display order (UI renders in this order; unknown categories appended).
 $script:DuneGameConfigCategoryOrder = @(
-    'Server Identity','Network','Survival',
+    'Server Identity','Network','Survival','Progression','Harvesting',
     'Resources & Economy','Building','Inventory','Guilds & Economy',
     'Storm Cycle','PvP & Security','Spice','Taxation','Sandworm','Vehicles'
 )
@@ -69,12 +69,24 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecUrl; Key='IGWPort'; File='engine'; Type='int'; Min=1024; Max=65535; Default='7780'; Label='IGW Port (starting)'; Help='Starting inter-server port; must not overlap the game port range.'; Category='Network' }
 
     # --- Survival ---
+    @{ Section=$script:DuneGcSecGame; Key='m_GlobalHealthMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Global Health Multiplier'; Help='Scales the health pool of all entities (players + NPCs). Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
+    @{ Section=$script:DuneGcSecGame; Key='m_GlobalDamageToNpcsMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Damage to NPCs Multiplier'; Help='Scales damage dealt to AI enemies. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
+    @{ Section=$script:DuneGcSecGame; Key='m_GlobalDamageToPlayersMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Damage to Players Multiplier'; Help='Scales player-vs-player damage. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
     @{ Section=$script:DuneGcSecGame; Key='m_WaterConsumptionRate'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Water Consumption Rate'; Help='How quickly players consume water. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
     @{ Section=$script:DuneGcSecGame; Key='m_WaterConsumptionInStormMultiplier'; File='game'; Type='float'; Min=0; Default='2.0'; Label='Water Consumption in Storm'; Help='Additional water drain during sandstorms. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
     @{ Section=$script:DuneGcSecGame; Key='m_PlayerStartingWater'; File='game'; Type='float'; Min=0; Default='100.0'; Label='Player Starting Water'; Help='Water amount when a player spawns. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
     @{ Section=$script:DuneGcSecOnline; Key='m_DefaultReconnectGracePeriodSeconds'; File='game'; Type='int'; Min=0; Unit='sec'; Default='300'; Label='Reconnect Grace Period'; Help="Seconds a player's corpse persists after disconnect. Also needs client-side apply."; ClientApply=$true; Category='Survival' }
     @{ Section=$script:DuneGcSecDurab; Key='m_ItemDurabilityLossMultiplier'; File='game'; Type='float'; Min=0; Max=10; Default='1.0'; Label='Item Durability Loss Multiplier'; Help='Scales durability loss for all items. 0 = off. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
     @{ Section=$script:DuneGcSecDurab; Key='UpdateRateInSeconds'; File='game'; Type='float'; Min=0; Max=10; Unit='sec'; Default='1.0'; Label='Item Decay Rate'; Help='Deterioration tick rate. 0 = off, 1-10 typical. Also needs client-side apply.'; ClientApply=$true; Category='Survival' }
+
+    # --- Progression ---
+    @{ Section=$script:DuneGcSecGame; Key='m_GlobalXPMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='XP Multiplier'; Help='Scales all XP gains. Also needs client-side apply.'; ClientApply=$true; Category='Progression' }
+    @{ Section=$script:DuneGcSecGame; Key='m_GlobalProgressionSpeedMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Progression Speed Multiplier'; Help='Journey / talent unlock speed scalar. Also needs client-side apply.'; ClientApply=$true; Category='Progression' }
+    @{ Section=$script:DuneGcSecGame; Key='m_GlobalFameMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Fame Multiplier'; Help='Scales Fame gained from all sources. Also needs client-side apply.'; ClientApply=$true; Category='Progression' }
+
+    # --- Harvesting ---
+    @{ Section=$script:DuneGcSecGame; Key='m_GlobalHarvestAmountMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Harvest Amount Multiplier'; Help='Scales resources gained per harvest strike. Also needs client-side apply.'; ClientApply=$true; Category='Harvesting' }
+    @{ Section=$script:DuneGcSecGame; Key='m_GlobalHarvestHealthMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Harvest Health Multiplier'; Help='Scales node health (how long harvestables last). Also needs client-side apply.'; ClientApply=$true; Category='Harvesting' }
 
     # --- Resources & Economy (engine ConsoleVariables) ---
     @{ Section=$script:DuneGcSecConsole; Key='Dune.GlobalMiningOutputMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Global Mining Multiplier'; Help='Scales hand-mining resource output.'; Category='Resources & Economy' }
@@ -86,10 +98,12 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecBuilding; Key='m_BuildingBlueprintMaxExtensions'; File='game'; Type='int'; Min=0; Default='4'; Label='Blueprint Max Extensions'; Help='Maximum blueprint extension slots.'; Category='Building' }
     @{ Section=$script:DuneGcSecBuilding; Key='m_BaseBackupMaxExtensions'; File='game'; Type='int'; Min=0; Default='8'; Label='Base Backup Max Extensions'; Help='Backup (reconstruction) extension slots per base.'; Category='Building' }
     @{ Section=$script:DuneGcSecBuilding; Key='m_bBuildingRestrictionLimitsEnabled'; File='game'; Type='bool'; Default='True'; Label='Building Restriction Limits'; Help='Enforce building restriction limits. Also needs client-side apply.'; ClientApply=$true; Category='Building' }
+    @{ Section=$script:DuneGcSecGame; Key='m_GlobalBuildingDamageMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Building Damage Multiplier'; Help='Scales damage dealt to player buildings (0.5 = stronger bases). Also needs client-side apply.'; ClientApply=$true; Category='Building' }
 
     # --- Inventory ---
     @{ Section=$script:DuneGcSecInventory; Key='PlayerInventoryStartingSize'; File='game'; Type='int'; Min=1; Default='35'; Label='Starting Inventory Slots'; Help='Number of inventory slots at spawn. Also needs client-side apply.'; ClientApply=$true; Category='Inventory' }
     @{ Section=$script:DuneGcSecInventory; Key='PlayerInventoryStartingVolumeCapacity'; File='game'; Type='float'; Min=0; Default='175.0'; Label='Starting Inventory Volume'; Help='Volume capacity of the starting inventory. Also needs client-side apply.'; ClientApply=$true; Category='Inventory' }
+    @{ Section=$script:DuneGcSecGame; Key='m_InventoryWeightMultiplier'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Inventory Weight Multiplier'; Help='Scales item weight across all inventories (carry-capacity scalar). Also needs client-side apply.'; ClientApply=$true; Category='Inventory' }
 
     # --- Guilds & Economy ---
     @{ Section=$script:DuneGcSecGuilds; Key='m_MaxGuildMembersAllowed'; File='game'; Type='int'; Min=1; Default='32'; Label='Max Guild Members'; Help='Maximum players per guild.'; Category='Guilds & Economy' }
@@ -183,7 +197,9 @@ $script:DuneGameConfigTplEnginePath  = '/home/dune/.dune/download/scripts/setup/
 # Funcom's shipped DefaultGame.ini). The remaining flagged keys were confirmed by
 # live in-game testing on a self-hosted server: the change had NO effect until the
 # same value was also set in the client Game.ini. Sections currently flagged
-# ClientApply=$true above: DuneGameMode (Survival: water + starting water),
+# ClientApply=$true above: DuneGameMode (Survival: health + damage to NPCs/players
+# + water + starting water + building damage + inventory weight; Progression: XP +
+# progression speed + fame; Harvesting: harvest amount + harvest health),
 # PlayerOnlineStateSettings (reconnect grace), ItemDeteriorationConstants
 # (durability/decay), BuildingSettings, InventorySystemSettings,
 # CoriolisSubsystem, SpiceHarvestingSystem, SandwormSettings.

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.1.0"
+$script:ToolVersion = "12.1.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -207,15 +207,20 @@ PlayerInventoryStartingSize=145
     }
 }
 
-Describe 'DuneGameConfigSchema: no fictional no-op keys' -Tag 'GameConfig' {
+Describe 'DuneGameConfigSchema: m_Global*Multiplier keys restored under DuneGameMode' -Tag 'GameConfig' {
 
-    # Guards against regressing the m_Global*Multiplier keys that the reference
-    # implementation (Icehunter/dune-admin #122 / #139) proved are no-ops: they are
-    # absent from the real engine DefaultGame.ini, so DST writing them under any
-    # section header does nothing in-game (Discord report: XP / Fame / Progression
-    # multipliers had no effect). DST must not ship these dead, misleading keys.
-    It 'excludes every fictional m_Global*Multiplier key from the schema' {
-        $fictional = @(
+    # v12.1.1 restored the 10 m_Global*Multiplier keys after they were dropped
+    # in v12.0.14 on AMP-derived evidence (Icehunter/dune-admin #122/#139). The
+    # Hexaspark community ServerConfig reference (mirrored in our Chroma
+    # `infrastructure` collection under sources `hexaspark`) documents every one
+    # of these keys as a real Float setting under [/Script/DuneSandbox.DuneGameMode]
+    # with a default of 1.0; persistent notes also confirm that scalar
+    # DuneGameMode values from UserGame.ini are applied at pod startup on
+    # self-hosted Funcom k3s (DST's target). m_GlobalBuildingDamageMultiplier in
+    # particular MUST sit under DuneGameMode (Hexaspark places it there) and not
+    # under BuildingSettings, which is where v12.0.13 had it.
+    It 'includes every m_Global*Multiplier key under [/Script/DuneSandbox.DuneGameMode] and flags ClientApply' {
+        $required = @(
             'm_GlobalHealthMultiplier'
             'm_GlobalDamageToNpcsMultiplier'
             'm_GlobalDamageToPlayersMultiplier'
@@ -227,9 +232,12 @@ Describe 'DuneGameConfigSchema: no fictional no-op keys' -Tag 'GameConfig' {
             'm_GlobalBuildingDamageMultiplier'
             'm_InventoryWeightMultiplier'
         )
-        $keys = $script:DuneGameConfigSchema | ForEach-Object { $_.Key }
-        foreach ($f in $fictional) {
-            $keys | Should -Not -Contain $f -Because "$f is a proven no-op key and must not be written"
+        $byKey = @{}
+        foreach ($f in $script:DuneGameConfigSchema) { $byKey[$f.Key] = $f }
+        foreach ($k in $required) {
+            $byKey.ContainsKey($k) | Should -BeTrue -Because "$k is a real DuneGameMode multiplier and must be exposed"
+            $byKey[$k].Section     | Should -Be '/Script/DuneSandbox.DuneGameMode' -Because "$k belongs in DuneGameMode per Hexaspark"
+            $byKey[$k].ClientApply | Should -BeTrue -Because "$k is read by both server and client; admin's local Game.ini must mirror it"
         }
     }
 }


### PR DESCRIPTION
Closes the regression introduced by PR #180 / v12.0.14 (which removed these 10 Game Config options as "fictional no-ops"). Reported by **poultrygeist516** in Discord (15 Jun 2026): *"the Damage to NPC and XP multiplier options have been removed from the Game Config screen on the recent builds."*

## Why the previous removal was wrong

PR #180 relied on Icehunter/dune-admin's PR #139 conclusion that these keys were no-ops. But dune-admin diagnosed them **on AMP**, where INIs are regenerated from AMP's own config on every container start (dune-admin's own PR body says so) — that was an **AMP-specific clobber**, not engine-side.

DST targets **self-hosted Funcom k3s**, where:

- `Saved/UserSettings/UserGame.ini` is loaded at pod startup (confirmed via the `run.sh` symlink trick and persistent notes — `m_BaseBackupToolTimeRestrictionInSeconds=10` proven live vs the 7-day default).
- The **Hexaspark community ServerConfig reference** (mirrored in Chroma `infrastructure` collection) documents **every one of the 10 keys** as a real Float setting under `[/Script/DuneSandbox.DuneGameMode]` with a default of `1.0`.
- The active Discord user is implicitly telling us they were using these values and noticed they disappeared.

## What's restored

All 10 keys back under `[/Script/DuneSandbox.DuneGameMode]`:

| Category | Keys |
|---|---|
| Survival | `m_GlobalHealthMultiplier`, `m_GlobalDamageToNpcsMultiplier`, `m_GlobalDamageToPlayersMultiplier` |
| Progression *(new)* | `m_GlobalXPMultiplier`, `m_GlobalProgressionSpeedMultiplier`, `m_GlobalFameMultiplier` |
| Harvesting *(new)* | `m_GlobalHarvestAmountMultiplier`, `m_GlobalHarvestHealthMultiplier` |
| Building | `m_GlobalBuildingDamageMultiplier` |
| Inventory | `m_InventoryWeightMultiplier` |

## Bonus fix: BuildingDamage section bug

In v12.0.13 (pre-removal), `m_GlobalBuildingDamageMultiplier` was wrongly placed under `[/Script/DuneSandbox.BuildingSettings]`. Per Hexaspark it belongs in `DuneGameMode`. This PR puts it in the correct section, so it now actually applies.

## ClientApply on all 10

Every restored key is flagged `ClientApply=$true` (they're read by both server and client). Saving them now:

- Triggers the existing **"Apply on each client"** notice modal.
- The **"Apply to my client"** button mirrors the new value into the admin's local `Game.ini` automatically — keeping the local client in sync with the server without manual edits.

## Pester guard inverted

The "must NOT contain" regression test from PR #180 is replaced with **"MUST contain under DuneGameMode AND must be ClientApply"** — so we can't regress in either direction. Comment block in the test documents the Hexaspark + self-hosted evidence so a future agent doesn't pull them again.

## Verification

- Version-stamp check: **5/5 match at 12.1.1**.
- UTF-8 BOM check: **all non-ASCII .ps1 carry a BOM**.
- PS 5.1 parse pre-flight: **72/72 files parse**.
- **Pester: 214/214 passed** (incl. the new restore guard).
- **webui build: clean** (1838 modules, no TS errors).
- Installer built: `DuneServerSetup.exe` (45.87 MB), deployed to the canonical `<LOCAL_REPO_ROOT>\DST-DuneServerTool\app\installer\output\`.

## Process note

PR #180 was opened and merged 2 minutes apart on 2026-06-13 by a prior Copilot session under coastal-ms — *one day after* the 2026-06-12 standing rule requiring `open_pr_session` surfacing + explicit approval before merge. This PR is being surfaced via `open_pr_session` per that rule.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>