### PR TITLE
Fix $pid collision with PowerShell $PID auto-var (Apply Journey Preset bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Apply Journey preset (and several other gameplay endpoints) no longer fail
+  with "Cannot overwrite variable PID because it is read-only or constant."**
+  Several route/lib handlers used a local variable named `$pid`, which collides
+  with PowerShell's read-only AllScope automatic `$PID` (current process id) and
+  throws on assignment in any scope. Renamed to `$presetId`, `$partId`,
+  `$playerId`, and `$permPid` in `app/server/routes/PlayersWrites.ps1`,
+  `app/server/routes/CoriolisAdmin.ps1`, `app/server/routes/PlayersRead.ps1`,
+  and `app/server/lib/PlayersWrites.ps1`. The Apply Preset path was the
+  user-reported repro (Discord, 2026-06-15); the others were the same latent
+  bug on Set Partition Seed, Keystones, Dungeons, offline teleport, and
+  permission-player lookup.
+
 ## [12.1.1] - 2026-06-15
 
 ### Fixed

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -707,27 +707,27 @@ FROM dune.actors WHERE id = $TargetPawnId::bigint;
     if (-not $fls.ok) { return @{ ok = $false; error = $fls.error } }
     $safeFls = ConvertTo-DuneSqlString $fls.funcom_id
 
-    # resolve partition
-    $pid = 0L
-    if ($PartitionId -and $PartitionId.HasValue) { $pid = [int64]$PartitionId.Value }
-    if ($pid -le 0) {
+    # resolve partition ($partId, not $pid — $PID is a read-only automatic var)
+    $partId = 0L
+    if ($PartitionId -and $PartitionId.HasValue) { $partId = [int64]$PartitionId.Value }
+    if ($partId -le 0) {
         $pSql = "SELECT id::text AS pid FROM dune.world_partition WHERE COALESCE(is_blocked, false) = false ORDER BY id LIMIT 1;"
         $pr = Invoke-DuneSqlQuery -Ip $Ip -Sql $pSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
         if ($pr.ok) {
             $pmaps = ConvertTo-DuneRowMaps -Result $pr
-            if ($pmaps.Count -ge 1) { $pid = [int64](ConvertTo-DuneInt $pmaps[0]['pid']) }
+            if ($pmaps.Count -ge 1) { $partId = [int64](ConvertTo-DuneInt $pmaps[0]['pid']) }
         }
-        if ($pid -le 0) { return @{ ok = $false; error = 'no unblocked world_partition rows found.' } }
+        if ($partId -le 0) { return @{ ok = $false; error = 'no unblocked world_partition rows found.' } }
     }
 
-    $sql = "SELECT dune.admin_move_offline_player_to_partition('$safeFls'::text, $pid::bigint, ROW($tx::float8, $ty::float8, $tz::float8)::dune.Vector);"
+    $sql = "SELECT dune.admin_move_offline_player_to_partition('$safeFls'::text, $partId::bigint, ROW($tx::float8, $ty::float8, $tz::float8)::dune.Vector);"
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $r.ok) { return @{ ok = $false; error = "admin_move_offline_player_to_partition: $($r.error)" } }
     return @{
         ok = $true
-        message = "Teleported offline pawn $SourcePawnId -> ($tx, $ty, $tz) on partition $pid."
+        message = "Teleported offline pawn $SourcePawnId -> ($tx, $ty, $tz) on partition $partId."
         path = 'offline'
-        partition = $pid; x = $tx; y = $ty; z = $tz
+        partition = $partId; x = $tx; y = $ty; z = $tz
     }
 }
 
@@ -1343,10 +1343,11 @@ LIMIT 1;
         if ($r4.ok) {
             $m4 = ConvertTo-DuneRowMaps -Result $r4
             if ($m4.Count -ge 1) {
-                $pid = [int64](ConvertTo-DuneInt $m4[0]['pid'])
-                $out['permission_player_id'] = $pid
-                if ($pid -gt 0) {
-                    $sql5 = "SELECT account_id::text AS aid FROM dune.player_state WHERE player_pawn_id = $pid::bigint OR player_controller_id = $pid::bigint LIMIT 1;"
+                # $permPid, not $pid — $PID is a read-only automatic variable.
+                $permPid = [int64](ConvertTo-DuneInt $m4[0]['pid'])
+                $out['permission_player_id'] = $permPid
+                if ($permPid -gt 0) {
+                    $sql5 = "SELECT account_id::text AS aid FROM dune.player_state WHERE player_pawn_id = $permPid::bigint OR player_controller_id = $permPid::bigint LIMIT 1;"
                     $r5 = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql5 -ReadOnly $true -MaxRows 1 -TimeoutSec 10
                     if ($r5.ok) {
                         $m5 = ConvertTo-DuneRowMaps -Result $r5

--- a/app/server/routes/CoriolisAdmin.ps1
+++ b/app/server/routes/CoriolisAdmin.ps1
@@ -67,12 +67,13 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/coriolis/set-map-seed' -Han
 Register-DuneRoute -Method POST -Path '/api/gameplay/coriolis/set-partition-seed' -Handler {
     param($req, $res, $routeParams, $body)
     try {
-        $pid = Get-DuneBodyInt -Body $body -Name 'partition_id'
+        # $partId, not $pid — $PID is a read-only automatic variable.
+        $partId = Get-DuneBodyInt -Body $body -Name 'partition_id'
         $seed = Get-DuneBodyInt -Body $body -Name 'seed'
-        if ($null -eq $pid -or $pid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'partition_id (positive integer) is required.'; return }
+        if ($null -eq $partId -or $partId -le 0) { Write-DuneError -Response $res -Status 400 -Message 'partition_id (positive integer) is required.'; return }
         if ($null -eq $seed -or $seed -lt 0) { Write-DuneError -Response $res -Status 400 -Message 'seed (non-negative integer) is required.'; return }
         Invoke-DunePlayerWriteRoute -Response $res -Action {
-            param($ip) Invoke-DuneCoriolisSetPartitionSeed -Ip $ip -PartitionId ([long]$pid) -Seed ([int]$seed)
+            param($ip) Invoke-DuneCoriolisSetPartitionSeed -Ip $ip -PartitionId ([long]$partId) -Seed ([int]$seed)
         }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Set partition seed failed: $($_.Exception.Message)"

--- a/app/server/routes/PlayersRead.ps1
+++ b/app/server/routes/PlayersRead.ps1
@@ -78,11 +78,12 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/players/export' -Handler {
 Register-DuneRoute -Method GET -Path '/api/gameplay/players/keystones' -Handler {
     param($req, $res, $routeParams, $body)
     try {
-        $pid = 0L
-        [void][Int64]::TryParse((Get-DuneQ $req 'player_id'), [ref]$pid)
-        if ($pid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'player_id is required.'; return }
+        # $playerId, not $pid — $PID is a read-only automatic variable.
+        $playerId = 0L
+        [void][Int64]::TryParse((Get-DuneQ $req 'player_id'), [ref]$playerId)
+        if ($playerId -le 0) { Write-DuneError -Response $res -Status 400 -Message 'player_id is required.'; return }
         Invoke-DunePlayerReadRoute -Response $res -Request $req `
-            -LiveBlock { param($ip) Get-DunePlayerKeystonesLive -Ip $ip -PlayerId $pid } `
+            -LiveBlock { param($ip) Get-DunePlayerKeystonesLive -Ip $ip -PlayerId $playerId } `
             -DemoBlock { @{ ok = $true; keystones = @(); total = 0 } } `
             -PayloadKey 'keystones'
     } catch {
@@ -110,11 +111,12 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/players/vehicles' -Handler {
 Register-DuneRoute -Method GET -Path '/api/gameplay/players/dungeons' -Handler {
     param($req, $res, $routeParams, $body)
     try {
-        $pid = 0L
-        [void][Int64]::TryParse((Get-DuneQ $req 'player_id'), [ref]$pid)
-        if ($pid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'player_id is required.'; return }
+        # $playerId, not $pid — $PID is a read-only automatic variable.
+        $playerId = 0L
+        [void][Int64]::TryParse((Get-DuneQ $req 'player_id'), [ref]$playerId)
+        if ($playerId -le 0) { Write-DuneError -Response $res -Status 400 -Message 'player_id is required.'; return }
         Invoke-DunePlayerReadRoute -Response $res -Request $req `
-            -LiveBlock { param($ip) Get-DunePlayerDungeonsLive -Ip $ip -PlayerId $pid } `
+            -LiveBlock { param($ip) Get-DunePlayerDungeonsLive -Ip $ip -PlayerId $playerId } `
             -DemoBlock { @{ ok = $true; dungeons = @(); total = 0 } } `
             -PayloadKey 'dungeons'
     } catch {

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -137,10 +137,13 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/progression/apply-p
     param($req, $res, $routeParams, $body)
     try {
         $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
-        $pid = [string](Get-DuneBodyValue -Body $body -Name 'preset_id')
+        # NOTE: do NOT name this $pid — $PID is a PowerShell read-only automatic
+        # variable (and AllScope), so $pid = ... throws "Cannot overwrite variable
+        # PID because it is read-only or constant." See issue: Apply preset failed.
+        $presetId = [string](Get-DuneBodyValue -Body $body -Name 'preset_id')
         if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
-        if (-not $pid) { Write-DuneError -Response $res -Status 400 -Message 'preset_id is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerApplyProgressionPreset -Ip $ip -AccountId $acc -PresetId $pid }
+        if (-not $presetId) { Write-DuneError -Response $res -Status 400 -Message 'preset_id is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerApplyProgressionPreset -Ip $ip -AccountId $acc -PresetId $presetId }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Apply preset failed: $($_.Exception.Message)"
     }


### PR DESCRIPTION
## Bug

Discord user `boosterfuel` (2026-06-15) hit:

> Apply preset failed: Cannot overwrite variable PID because it is read-only or constant.

…when attempting to apply a Journey preset.

## Root cause

`POST /api/gameplay/players/progression/apply-preset` did:

```powershell
$pid = [string](Get-DuneBodyValue -Body $body -Name 'preset_id')
```

PowerShell's `$PID` (current process id) is an automatic variable created with **both** `[ReadOnly]` and `[AllScope]`. `AllScope` propagates the variable into all child scopes, which means a local `$pid = ...` does **not** shadow the parent — it tries to overwrite the read-only one and throws. Inside a worker-runspace handler (the path `Invoke-DuneApiHandlerAsync` takes for pooled API requests) the assignment trips immediately and bubbles up as the user-visible 500.

## Fix

Renamed `$pid` to a non-colliding name everywhere it was used as a local. Inner script blocks that closed over the variable were updated to match.

| File | Local renamed to |
| --- | --- |
| `app/server/routes/PlayersWrites.ps1` (apply-preset handler) | `$presetId` |
| `app/server/routes/CoriolisAdmin.ps1` (set-partition-seed) | `$partId` |
| `app/server/routes/PlayersRead.ps1` (keystones, dungeons GETs) | `$playerId` |
| `app/server/lib/PlayersWrites.ps1` (offline teleport partition resolve) | `$partId` |
| `app/server/lib/PlayersWrites.ps1` (permission-player fallback) | `$permPid` |

The Apply Preset path is the reproducer the user reported; the others were the same latent bug waiting to fire on Set Partition Seed, Keystones, Dungeons, offline teleport, and permission-player lookup.

Added a short `# do NOT name this $pid` comment at each call site so this doesn't get reintroduced.

## Verification

- All four files parse cleanly via `[Parser]::ParseFile`.
- All four retain their UTF-8 BOM (required for PS2EXE bundling per repo rules).
- `rg '\$pid\b'` shows only comment references remain.
- No `$PID` usage was intended in any of these sites, so no behavior change beyond the fix.

## CHANGELOG

Entry added under `## [Unreleased]`. No version bump (not a release).