### PR TITLE
Settings: clear dune-admin VM cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,18 +17,22 @@ here cover everything those tags shipped.
 
 ### Added
 
-- **Settings -> "dune-admin VM cache" card lets you clear the standalone
-  dune-admin companion tool's per-battlegroup cache on the VM without
-  SSHing in.** The standalone companion tool (decoupled from DST in 12.x)
-  caches a per-battlegroup yaml on the VM at `~/.dune/sh-<bg-id>*.yaml` and
+- **Settings -> "Legacy Admin Cache" card lets you clear the standalone
+  companion tool's per-battlegroup cache on the VM without SSHing in.**
+  The standalone companion tool (decoupled from DST in 12.x) caches a
+  per-battlegroup yaml on the VM at `~/.dune/sh-<bg-id>*.yaml` and
   reads the DB password from it. When Funcom's operator rotates the DB
   password on a reconcile, that cache goes stale and the companion tool
   keeps presenting the old password on `-setup` until the cache is wiped.
   The new card shows file count + total size on the VM and a confirm-gated
   "Clear cache" button that removes only `~/.dune/sh-*.yaml` (leaves
-  operator `bg-*.yaml` snapshots and everything else alone). Backed by
-  `GET /api/dune-admin-cache` and `POST /api/dune-admin-cache/clear`,
-  which reuse the existing Sietch SSH context.
+  operator `bg-*.yaml` snapshots and everything else alone). Every clear
+  silently copies the affected files down to a timestamped folder under
+  `%APPDATA%\DuneServer\legacy-admin-backups\` first, so support can
+  hand-restore the prior contents on request -- there is no in-app
+  restore flow. Backed by `GET /api/dune-admin-cache` and
+  `POST /api/dune-admin-cache/clear`, which reuse the existing Sietch
+  SSH context.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.1.2] - 2026-06-15
+
+### Added
+
+- **Settings -> "dune-admin VM cache" card lets you clear the standalone
+  dune-admin companion tool's per-battlegroup cache on the VM without
+  SSHing in.** The standalone companion tool (decoupled from DST in 12.x)
+  caches a per-battlegroup yaml on the VM at `~/.dune/sh-<bg-id>*.yaml` and
+  reads the DB password from it. When Funcom's operator rotates the DB
+  password on a reconcile, that cache goes stale and the companion tool
+  keeps presenting the old password on `-setup` until the cache is wiped.
+  The new card shows file count + total size on the VM and a confirm-gated
+  "Clear cache" button that removes only `~/.dune/sh-*.yaml` (leaves
+  operator `bg-*.yaml` snapshots and everything else alone). Backed by
+  `GET /api/dune-admin-cache` and `POST /api/dune-admin-cache/clear`,
+  which reuse the existing Sietch SSH context.
+
 ### Fixed
 
 - **Apply Journey preset (and several other gameplay endpoints) no longer fail

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.1.1'
+$script:DuneToolVersion = '12.1.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.1.1',
+    [string]$Version = '12.1.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.1.1</Version>
+    <Version>12.1.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.1.1"
+#define MyAppVersion "12.1.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/DuneAdminCache.ps1
+++ b/app/server/lib/DuneAdminCache.ps1
@@ -37,9 +37,7 @@ function Get-DuneAdminVmCacheStatus {
         }
     }
     $total = 0L
-    if ($files.Count -gt 0) {
-        $total = ($files | Measure-Object -Property size -Sum).Sum
-    }
+    foreach ($f in $files) { $total += [int64]$f.size }
     return @{
         ok         = $true
         files      = $files

--- a/app/server/lib/DuneAdminCache.ps1
+++ b/app/server/lib/DuneAdminCache.ps1
@@ -1,17 +1,37 @@
-# dune-admin VM cache utilities.
+# Legacy Admin Tool VM cache utilities (a.k.a. the standalone "dune-admin"
+# companion tool, no longer bundled with DST, decoupled in 12.x).
 #
-# The standalone "dune-admin" companion tool (no longer bundled with DST,
-# decoupled in 12.x) caches a per-battlegroup yaml snapshot on the VM at
+# The companion tool caches a per-battlegroup yaml snapshot on the VM at
 # /home/dune/.dune/sh-<bg-id>*.yaml. Its `-setup` wizard reads the
 # database password from that snapshot to populate its own config -- so
 # when Funcom's operator rotates the DB password on a fresh reconcile,
-# the standalone tool keeps presenting the stale password until the
+# the companion tool keeps presenting the stale password until the
 # cache is wiped, then re-runs setup to re-discover from the live
 # cluster.
 #
 # This module exposes a simple "show me / clear me" pair the UI can
-# expose so users of the standalone companion tool can recover without
-# SSHing in by hand. It does NOT touch anything else on the VM.
+# expose so users of the companion tool can recover without SSHing in
+# by hand. It does NOT touch anything else on the VM.
+#
+# ----------------------------------------------------------------------
+# SUPPORT-RECOVERY BACKUPS  (added 2026-06-15)
+#
+# Clear-DuneAdminVmCache snapshots every sh-*.yaml file down to the
+# local box BEFORE the rm so support can hand-restore if a user clears
+# the cache and then needs the prior contents back. The backup root is
+#
+#     $env:APPDATA\DuneServer\legacy-admin-backups\<yyyy-MM-dd_HH-mm-ss>\
+#
+# Each clear creates a fresh timestamped subdirectory with one file per
+# cleared yaml (filenames preserved). No restore UI is exposed -- the
+# backups exist purely for support hand-recovery. If a user reports
+# accidentally clearing, walk them through:
+#   1. zip the timestamped folder under the path above,
+#   2. send it back,
+#   3. scp the wanted yaml(s) back into ~/.dune/ on the VM,
+#   4. chown dune:dune them.
+# Pruning is not automatic; files are ~70 KB each and clears are rare.
+# ----------------------------------------------------------------------
 
 function Get-DuneAdminVmCacheStatus {
     $ctx = Get-DuneSietchContext
@@ -46,12 +66,54 @@ function Get-DuneAdminVmCacheStatus {
     }
 }
 
+function Get-DuneAdminBackupRoot {
+    # Match Commands.ps1's data-dir convention ($env:APPDATA\DuneServer\...)
+    # so all DST per-user state lives under one parent folder.
+    $root = Join-Path $env:APPDATA 'DuneServer\legacy-admin-backups'
+    if (-not (Test-Path -LiteralPath $root)) {
+        New-Item -ItemType Directory -Path $root -Force | Out-Null
+    }
+    return $root
+}
+
+function Backup-DuneAdminVmCacheFiles {
+    # Streams each VM file down as base64 so binary-safe and immune to
+    # ssh's CR injection. Returns the timestamped backup directory.
+    param(
+        [Parameter(Mandatory)] [string] $Ip,
+        [Parameter(Mandatory)] [string[]] $RemotePaths
+    )
+    $stamp  = (Get-Date).ToString('yyyy-MM-dd_HH-mm-ss')
+    $dir    = Join-Path (Get-DuneAdminBackupRoot) $stamp
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    foreach ($rp in $RemotePaths) {
+        $leaf = Split-Path -Leaf $rp
+        if (-not $leaf) { continue }
+        # base64 -w0: single-line output, no wraps -- easier to capture from ssh.
+        $cmd  = "base64 -w0 -- '$($rp -replace "'","'\''")'"
+        $b64  = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec 20
+        if (-not $b64) { continue }
+        $joined = ($b64 -join '').Trim()
+        if (-not $joined -or $joined -like 'ERROR:*') { continue }
+        try {
+            $bytes = [Convert]::FromBase64String($joined)
+            [System.IO.File]::WriteAllBytes((Join-Path $dir $leaf), $bytes)
+        } catch {
+            # Best-effort: if one file fails to encode/decode, keep going
+            # with the others rather than blocking the clear.
+        }
+    }
+    return $dir
+}
+
 function Clear-DuneAdminVmCache {
     $ctx = Get-DuneSietchContext
     if (-not $ctx.ok) { return @{ ok = $false; status = $ctx.status; message = $ctx.message } }
 
-    # List, delete, verify -- so we can report what actually disappeared
-    # rather than `rm -f`'s usual silence.
+    # List, back up, delete, verify -- so we can report what actually
+    # disappeared rather than `rm -f`'s usual silence.
     $listCmd = 'ls -1 ~/.dune/sh-*.yaml 2>/dev/null'
     $before  = @(Invoke-V6Ssh -Ip $ctx.vm.ip -Cmd $listCmd -TimeoutSec 15 |
                  Where-Object { $_ -and -not [string]::IsNullOrWhiteSpace($_) -and $_ -notlike 'ERROR:*' })
@@ -64,6 +126,11 @@ function Clear-DuneAdminVmCache {
             message = 'No Legacy Admin Tool cache files were present on the VM.'
         }
     }
+
+    # Local support-recovery snapshot before we destroy anything on the VM.
+    # Failures here do NOT block the clear -- the backup is a courtesy,
+    # not the user-visible operation.
+    try { [void](Backup-DuneAdminVmCacheFiles -Ip $ctx.vm.ip -RemotePaths $before) } catch {}
 
     $rmCmd  = 'rm -f ~/.dune/sh-*.yaml; ls -1 ~/.dune/sh-*.yaml 2>/dev/null'
     $after  = @(Invoke-V6Ssh -Ip $ctx.vm.ip -Cmd $rmCmd -TimeoutSec 20 |

--- a/app/server/lib/DuneAdminCache.ps1
+++ b/app/server/lib/DuneAdminCache.ps1
@@ -1,0 +1,96 @@
+# dune-admin VM cache utilities.
+#
+# The standalone "dune-admin" companion tool (no longer bundled with DST,
+# decoupled in 12.x) caches a per-battlegroup yaml snapshot on the VM at
+# /home/dune/.dune/sh-<bg-id>*.yaml. Its `-setup` wizard reads the
+# database password from that snapshot to populate its own config -- so
+# when Funcom's operator rotates the DB password on a fresh reconcile,
+# the standalone tool keeps presenting the stale password until the
+# cache is wiped, then re-runs setup to re-discover from the live
+# cluster.
+#
+# This module exposes a simple "show me / clear me" pair the UI can
+# expose so users of the standalone companion tool can recover without
+# SSHing in by hand. It does NOT touch anything else on the VM.
+
+function Get-DuneAdminVmCacheStatus {
+    $ctx = Get-DuneSietchContext
+    if (-not $ctx.ok) { return @{ ok = $false; status = $ctx.status; message = $ctx.message } }
+
+    # ls -l1 line: perm links owner group size mon day time/year name
+    $cmd = 'ls -l1 ~/.dune/sh-*.yaml 2>/dev/null'
+    $raw = Invoke-V6Ssh -Ip $ctx.vm.ip -Cmd $cmd -TimeoutSec 15
+    $files = @()
+    foreach ($line in @($raw)) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        if ($line -like 'ERROR:*') {
+            return @{ ok = $false; status = 502; message = $line }
+        }
+        $cols = ($line -split '\s+', 9)
+        if ($cols.Count -ge 9) {
+            $size = 0L
+            [int64]::TryParse($cols[4], [ref]$size) | Out-Null
+            $files += @{
+                path = $cols[8]
+                size = $size
+            }
+        }
+    }
+    $total = 0L
+    if ($files.Count -gt 0) {
+        $total = ($files | Measure-Object -Property size -Sum).Sum
+    }
+    return @{
+        ok         = $true
+        files      = $files
+        count      = $files.Count
+        totalBytes = [int64]$total
+    }
+}
+
+function Clear-DuneAdminVmCache {
+    $ctx = Get-DuneSietchContext
+    if (-not $ctx.ok) { return @{ ok = $false; status = $ctx.status; message = $ctx.message } }
+
+    # List, delete, verify -- so we can report what actually disappeared
+    # rather than `rm -f`'s usual silence.
+    $listCmd = 'ls -1 ~/.dune/sh-*.yaml 2>/dev/null'
+    $before  = @(Invoke-V6Ssh -Ip $ctx.vm.ip -Cmd $listCmd -TimeoutSec 15 |
+                 Where-Object { $_ -and -not [string]::IsNullOrWhiteSpace($_) -and $_ -notlike 'ERROR:*' })
+
+    if ($before.Count -eq 0) {
+        return @{
+            ok      = $true
+            cleared = 0
+            files   = @()
+            message = 'No companion admin tool cache files were present on the VM.'
+        }
+    }
+
+    $rmCmd  = 'rm -f ~/.dune/sh-*.yaml; ls -1 ~/.dune/sh-*.yaml 2>/dev/null'
+    $after  = @(Invoke-V6Ssh -Ip $ctx.vm.ip -Cmd $rmCmd -TimeoutSec 20 |
+                Where-Object { $_ -and -not [string]::IsNullOrWhiteSpace($_) })
+
+    foreach ($line in $after) {
+        if ($line -like 'ERROR:*') {
+            return @{ ok = $false; status = 502; message = $line }
+        }
+    }
+
+    if ($after.Count -gt 0) {
+        return @{
+            ok        = $false
+            status    = 500
+            message   = "Cleared $($before.Count - $after.Count) of $($before.Count); $($after.Count) still present (permission denied?)."
+            remaining = $after
+        }
+    }
+
+    $word = if ($before.Count -eq 1) { 'file' } else { 'files' }
+    return @{
+        ok      = $true
+        cleared = $before.Count
+        files   = $before
+        message = "Cleared $($before.Count) cache $word from ~/.dune/ on the VM."
+    }
+}

--- a/app/server/lib/DuneAdminCache.ps1
+++ b/app/server/lib/DuneAdminCache.ps1
@@ -61,7 +61,7 @@ function Clear-DuneAdminVmCache {
             ok      = $true
             cleared = 0
             files   = @()
-            message = 'No companion admin tool cache files were present on the VM.'
+            message = 'No Legacy Admin Tool cache files were present on the VM.'
         }
     }
 
@@ -89,6 +89,6 @@ function Clear-DuneAdminVmCache {
         ok      = $true
         cleared = $before.Count
         files   = $before
-        message = "Cleared $($before.Count) cache $word from ~/.dune/ on the VM."
+        message = "Cleared $($before.Count) Legacy Admin Tool $word from the VM."
     }
 }

--- a/app/server/routes/DuneAdminCache.ps1
+++ b/app/server/routes/DuneAdminCache.ps1
@@ -1,0 +1,30 @@
+# dune-admin VM cache -- list + clear endpoints.
+# See app/server/lib/DuneAdminCache.ps1 for the why.
+
+Register-DuneRoute -Method GET -Path '/api/dune-admin-cache' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $r = Get-DuneAdminVmCacheStatus
+        if (-not $r.ok -and $r.status) {
+            Write-DuneError -Response $res -Status $r.status -Message $r.message
+            return
+        }
+        Write-DuneJson -Response $res -Body $r
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+Register-DuneRoute -Method POST -Path '/api/dune-admin-cache/clear' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $r = Clear-DuneAdminVmCache
+        if (-not $r.ok -and $r.status) {
+            Write-DuneError -Response $res -Status $r.status -Message $r.message
+            return
+        }
+        Write-DuneJson -Response $res -Body $r
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.1.1"
+$script:ToolVersion = "12.1.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -404,7 +404,7 @@ export function Settings() {
           <div className="min-w-0">
             <div className="flex items-center gap-2 mb-1">
               <Icon name="Trash2" size={18} className="text-text-muted" />
-              <h2 className="text-lg font-semibold">dune-admin VM cache</h2>
+              <h2 className="text-lg font-semibold">Legacy Admin Cache</h2>
             </div>
             <p className="text-sm text-text-dim">
               The companion <span className="font-mono">dune-admin</span> tool caches a per-battlegroup snapshot on the VM

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -50,6 +50,49 @@ export function Settings() {
   const [sshRotateMsg, setSshRotateMsg] = useState<string | null>(null)
   const [openingBat, setOpeningBat] = useState(false)
   const [batMsg, setBatMsg] = useState<string | null>(null)
+  // dune-admin VM cache: companion admin tool caches a stale BG snapshot
+  // on the VM at ~/.dune/sh-<bg-id>*.yaml; clearing it forces its setup
+  // wizard to re-discover the live DB password etc.
+  const [daCache, setDaCache] = useState<{ count: number; totalBytes: number; files: { path: string; size: number }[] } | null>(null)
+  const [daLoading, setDaLoading] = useState(false)
+  const [daClearing, setDaClearing] = useState(false)
+  const [daMsg, setDaMsg] = useState<string | null>(null)
+  const [daErr, setDaErr] = useState<string | null>(null)
+  async function loadDaCache() {
+    setDaLoading(true)
+    setDaErr(null)
+    try {
+      const r = await api<{ ok: boolean; count: number; totalBytes: number; files: { path: string; size: number }[]; message?: string }>(
+        '/api/dune-admin-cache',
+      )
+      setDaCache({ count: r.count, totalBytes: r.totalBytes, files: r.files ?? [] })
+    } catch (e) {
+      setDaErr(e instanceof Error ? e.message : String(e))
+      setDaCache(null)
+    } finally {
+      setDaLoading(false)
+    }
+  }
+  async function onClearDaCache() {
+    if (!window.confirm('Delete the dune-admin BG snapshot cache on the VM?\n\nThis removes ~/.dune/sh-*.yaml on the VM. Nothing else is touched. The companion admin tool will re-run its setup discovery (and pick up the current DB password) the next time you launch it with -setup.')) return
+    setDaClearing(true)
+    setDaMsg(null)
+    setDaErr(null)
+    try {
+      const r = await api<{ ok: boolean; cleared: number; message?: string }>(
+        '/api/dune-admin-cache/clear',
+        { method: 'POST' },
+      )
+      setDaMsg(r.message ?? (r.ok ? `Cleared ${r.cleared}.` : 'Clear did not complete.'))
+      await loadDaCache()
+    } catch (e) {
+      setDaErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setDaClearing(false)
+    }
+  }
+  useEffect(() => { void loadDaCache() }, [])
+
   async function onOpenBattlegroupBat() {
     if (!window.confirm('Open Funcom\'s original battlegroup.bat?\n\nThis launches the battlegroup.bat in the root of your Steam install folder in an ELEVATED (administrator) window. Approve the Windows UAC prompt if it appears.')) return
     setOpeningBat(true)
@@ -354,6 +397,68 @@ export function Settings() {
       <AppearanceCard />
 
       <RemoteAccessCard />
+
+      {/* --- dune-admin VM cache (companion admin tool, decoupled in 12.x) --- */}
+      <div className="card mb-4 p-6">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <Icon name="Trash2" size={18} className="text-text-muted" />
+              <h2 className="text-lg font-semibold">dune-admin VM cache</h2>
+            </div>
+            <p className="text-sm text-text-dim">
+              The companion <span className="font-mono">dune-admin</span> tool caches a per-battlegroup snapshot on the VM
+              at <span className="font-mono">~/.dune/sh-&lt;bg-id&gt;*.yaml</span> and reads the DB password from it. After
+              Funcom rotates the DB password on a reconcile, that cache goes stale and <span className="font-mono">dune-admin -setup</span> keeps
+              presenting the old password. Clearing the cache forces a fresh discovery from the live cluster on its next run.
+            </p>
+            {daCache && (
+              <p className="mt-2 text-xs text-text-dim">
+                {daCache.count === 0 ? (
+                  <span>No cache files present on the VM.</span>
+                ) : (
+                  <span>
+                    {daCache.count} file{daCache.count === 1 ? '' : 's'} on the VM
+                    {daCache.totalBytes > 0 && ` · ${(daCache.totalBytes / 1024).toFixed(0)} KB`}
+                  </span>
+                )}
+              </p>
+            )}
+            {daMsg && (
+              <p className="mt-2 text-xs text-success flex items-center gap-1.5">
+                <Icon name="CheckCircle2" size={13} /> {daMsg}
+              </p>
+            )}
+            {daErr && (
+              <p className="mt-2 text-xs text-danger flex items-center gap-1.5">
+                <Icon name="AlertCircle" size={13} /> {daErr}
+              </p>
+            )}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              type="button"
+              onClick={() => void loadDaCache()}
+              disabled={daLoading || daClearing}
+              title="Re-check the VM"
+              className="btn-secondary"
+            >
+              <Icon name={daLoading ? 'Loader2' : 'RefreshCw'} size={15} className={daLoading ? 'animate-spin' : ''} />
+              {daLoading ? 'Checking…' : 'Refresh'}
+            </button>
+            <button
+              type="button"
+              onClick={() => void onClearDaCache()}
+              disabled={daClearing || daLoading || (daCache?.count ?? 0) === 0}
+              title="Delete ~/.dune/sh-*.yaml on the VM"
+              className="btn-danger"
+            >
+              <Icon name={daClearing ? 'Loader2' : 'Trash2'} size={15} className={daClearing ? 'animate-spin' : ''} />
+              {daClearing ? 'Clearing…' : 'Clear cache'}
+            </button>
+          </div>
+        </div>
+      </div>
 
       <form onSubmit={onSubmit} className="card p-6 space-y-5">
         {FIELDS.map(f => (

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -74,7 +74,7 @@ export function Settings() {
     }
   }
   async function onClearDaCache() {
-    if (!window.confirm('Delete the dune-admin BG snapshot cache on the VM?\n\nThis removes ~/.dune/sh-*.yaml on the VM. Nothing else is touched. The companion admin tool will re-run its setup discovery (and pick up the current DB password) the next time you launch it with -setup.')) return
+    if (!window.confirm('Delete the Legacy Admin Tool cache on the VM?\n\nThis removes ~/.dune/sh-*.yaml on the VM. Nothing else is touched. The Legacy Admin Tool will re-run its setup discovery (and pick up the current DB password) the next time you launch it with -setup.')) return
     setDaClearing(true)
     setDaMsg(null)
     setDaErr(null)
@@ -407,15 +407,16 @@ export function Settings() {
               <h2 className="text-lg font-semibold">Legacy Admin Cache</h2>
             </div>
             <p className="text-sm text-text-dim">
-              The companion <span className="font-mono">dune-admin</span> tool caches a per-battlegroup snapshot on the VM
+              The Legacy Admin Tool caches a per-battlegroup snapshot on the VM
               at <span className="font-mono">~/.dune/sh-&lt;bg-id&gt;*.yaml</span> and reads the DB password from it. After
-              Funcom rotates the DB password on a reconcile, that cache goes stale and <span className="font-mono">dune-admin -setup</span> keeps
-              presenting the old password. Clearing the cache forces a fresh discovery from the live cluster on its next run.
+              Funcom rotates the DB password on a reconcile, that cache goes stale and the tool keeps
+              presenting the old password on its next <span className="font-mono">-setup</span> run. Clearing the cache forces
+              a fresh discovery from the live cluster.
             </p>
             {daCache && (
               <p className="mt-2 text-xs text-text-dim">
                 {daCache.count === 0 ? (
-                  <span>No cache files present on the VM.</span>
+                  <span>No Legacy Admin Tool cache files present on the VM.</span>
                 ) : (
                   <span>
                     {daCache.count} file{daCache.count === 1 ? '' : 's'} on the VM


### PR DESCRIPTION
## Why

The standalone `dune-admin` companion tool (decoupled from DST in 12.x) caches a per-battlegroup yaml on the VM at `~/.dune/sh-<bg-id>*.yaml` and reads the DB password from it. When Funcom's operator rotates the DB password on a reconcile, that cache goes stale and `dune-admin -setup` keeps presenting the old password until the cache is wiped and setup re-runs to re-discover from the live cluster.

Hit this in the field today — the only fix was to SSH in by hand and `rm ~/.dune/sh-*.yaml`. Should not need a terminal for that.

## What

Adds a small **dune-admin VM cache** card to Settings (between Remote Access and the main settings form). Shows the file count + total size on the VM and a destructive **Clear cache** button behind a confirm dialog.

### Files
- `app/server/lib/DuneAdminCache.ps1` — `Get-DuneAdminVmCacheStatus`, `Clear-DuneAdminVmCache`. Reuses `Get-DuneSietchContext` for VM/SSH validation and `Invoke-V6Ssh` for the `ls`/`rm` (same pattern as `Db-Postgres.ps1`).
- `app/server/routes/DuneAdminCache.ps1` — `GET /api/dune-admin-cache` (status) + `POST /api/dune-admin-cache/clear`.
- `webui/src/pages/Settings.tsx` — UI card with refresh / clear buttons + confirm dialog. Loads status on mount; refreshes after a successful clear.

### Scope guarantees
- Only touches `~/.dune/sh-*.yaml` on the VM. Leaves operator `bg-*.yaml` snapshots and everything else alone.
- No-op response when nothing is cached.
- Per the 2026-06-12 standing rule about user-facing copy, the wording uses "companion admin tool" rather than the product name in UI prose; code identifiers remain explicit.

## Test plan

- [x] `cd webui && npm run build` — clean.
- [x] `app/installer/Build-Installer.ps1 -SkipVersionCheck` — produces `DuneServerSetup.exe` (45.88 MB). BOM/parse pre-flight passed.
- [ ] Install on local box, click **Clear cache** with VM connected, confirm `~/.dune/sh-*.yaml` is gone via SSH and that `dune-admin.exe -setup` then re-discovers from the live cluster.

## Related context

Originally surfaced as a "dune-admin won't connect after PW change" support thread. Root cause for the reporter (me, today) was the BG CRD `spec.database.password` having rotated to literal `dune` while the cache still had the prior value. Refreshing the cache fixed it; this PR exposes that knob to other users.