### PR TITLE
feat(sidebar): add Buy Me a Coffee donation link (v12.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.1.3] - 2026-06-15
+
+Sidebar tweak: adds a **Buy Me a Coffee** donation link between the
+**Web Portal** button and the version row at the bottom of the left
+sidebar. Opens `https://buymeacoffee.com/coastal_dst` in the OS default
+browser (routed via the same WebView2 `NewWindowRequested` ->
+`OpenExternal` path the portal-detach button uses, so it lands in a
+non-elevated Chrome/Edge instance instead of inside the shell). Amber
+tint distinguishes it from the accent-colored Web Portal button; in
+collapsed-rail mode it shows just the Coffee icon.
+
+### Added
+
+- **Sidebar "Buy Me a Coffee" donation link** at
+  `https://buymeacoffee.com/coastal_dst`, between the Web Portal button
+  and the version footer.
+
 ## [12.1.2] - 2026-06-15
 
 This release ships fixes for four user-reported issues from Discord on

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.1.2'
+$script:DuneToolVersion = '12.1.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.1.2',
+    [string]$Version = '12.1.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.1.2</Version>
+    <Version>12.1.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.1.2"
+#define MyAppVersion "12.1.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.1.2"
+$script:ToolVersion = "12.1.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -175,6 +175,20 @@ export function Sidebar({ collapsed }: Props) {
             {!collapsed && <span>Web Portal</span>}
           </button>
         )}
+        <a
+          href="https://buymeacoffee.com/coastal_dst"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Support development — Buy Me a Coffee"
+          className={
+            collapsed
+              ? 'w-full flex items-center justify-center h-8 rounded-md border border-amber-400/30 text-amber-300/90 hover:text-amber-200 hover:bg-amber-400/10 hover:border-amber-400/50 transition-colors'
+              : 'w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-amber-400/30 text-amber-300/90 hover:text-amber-200 hover:bg-amber-400/10 hover:border-amber-400/50 transition-colors uppercase tracking-widest'
+          }
+        >
+          <Icon name="Coffee" size={collapsed ? 14 : 11} />
+          {!collapsed && <span>Buy Me a Coffee</span>}
+        </a>
         {!collapsed && (
           <div className="flex items-center justify-between">
             <span>{version ? fmtToolVersion(version) : '—'}</span>


### PR DESCRIPTION
Adds an amber-tinted **Buy Me a Coffee** button between the **Web Portal** button and the version row at the bottom of the left sidebar, linking to https://buymeacoffee.com/coastal_dst.

### Behavior

- **Native shell (WebView2):** `<a target="_blank">` → `OnNewWindowRequested` → non-loopback → `OpenExternal` → OS default browser (non-elevated Chrome/Edge), same path the portal-detach button uses.
- **Browser fallback:** opens in a new tab.
- **Collapsed rail:** shows just the Coffee icon.
- **Expanded:** "BUY ME A COFFEE" with amber tint to distinguish from the accent-colored Web Portal button.

### Version

Bumps all 5 stamps **12.1.2 → 12.1.3** (`app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/installer/DuneServer.iss`, `dune-server.ps1`) and adds a CHANGELOG entry.

### Build

`pwsh app/installer/Build-Installer.ps1` → `app/installer/output/DuneServerSetup.exe` (45.88 MB). Copied to the primary checkout for install/test.