### PR TITLE
fix(sidebar): make Buy Me a Coffee link readable on Sietch Tabr (v12.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.1.4] - 2026-06-15
+
+Hotfix for the donation button shipped in v12.1.3: the hardcoded
+Tailwind `amber-300` text was unreadable on the **Sietch Tabr** light
+theme (tan-on-tan). Swapped to the theme-adaptive `warning` token,
+which renders as bright amber on the dark themes (Eyes of Ibad,
+Caladan, Giedi Prime, House Harkonnen, Atreides) and deep amber
+`#854d0e` on Sietch Tabr's parchment background — readable everywhere.
+Border and hover state follow the same token. Also bumped the label to
+`font-semibold` so it stands out more in expanded-rail mode.
+
+### Fixed
+
+- **Buy Me a Coffee sidebar link is now readable on every theme**, not
+  just dark ones. Now uses `text-warning` / `border-warning/50` instead
+  of a fixed light-amber color.
+
 ## [12.1.3] - 2026-06-15
 
 Sidebar tweak: adds a **Buy Me a Coffee** donation link between the

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.1.3'
+$script:DuneToolVersion = '12.1.4'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.1.3',
+    [string]$Version = '12.1.4',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.1.3</Version>
+    <Version>12.1.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.1.3"
+#define MyAppVersion "12.1.4"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.1.3"
+$script:ToolVersion = "12.1.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -182,8 +182,8 @@ export function Sidebar({ collapsed }: Props) {
           title="Support development — Buy Me a Coffee"
           className={
             collapsed
-              ? 'w-full flex items-center justify-center h-8 rounded-md border border-amber-400/30 text-amber-300/90 hover:text-amber-200 hover:bg-amber-400/10 hover:border-amber-400/50 transition-colors'
-              : 'w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-amber-400/30 text-amber-300/90 hover:text-amber-200 hover:bg-amber-400/10 hover:border-amber-400/50 transition-colors uppercase tracking-widest'
+              ? 'w-full flex items-center justify-center h-8 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors'
+              : 'w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors uppercase tracking-widest font-semibold'
           }
         >
           <Icon name="Coffee" size={collapsed ? 14 : 11} />


### PR DESCRIPTION
Hotfix for the donation button shipped in v12.1.3: the hardcoded Tailwind `amber-300` text was unreadable on the **Sietch Tabr** light theme (tan-on-tan).

### Fix

Switched to the theme-adaptive `warning` token:

| Theme         | `--color-warning` | Result |
|---------------|-------------------|--------|
| Eyes of Ibad  | `#fbbf24`         | Bright amber on dark — readable |
| Sietch Tabr   | `#854d0e`         | **Deep amber on tan parchment — readable** |
| Caladan       | `#fcd34d`         | Bright amber on slate — readable |
| Giedi Prime   | `#eab308`         | Amber on dark slate — readable |
| House Harkonnen | `#facc15`       | Amber on crimson/black — readable |
| Atreides      | `#fbbf24`         | Bright amber on midnight — readable |

Border and hover use the same token. Label also bumped to `font-semibold` for stronger presence.

### Version

Bumps all 5 stamps **12.1.3 → 12.1.4**. CHANGELOG updated.

### Build

`pwsh app/installer/Build-Installer.ps1` → `app/installer/output/DuneServerSetup.exe` (45.88 MB). Copied to primary checkout.