### PR TITLE
Fix vehicle kit parts + add "Thanks for the Coffee" menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ here cover everything those tags shipped.
 
 - **"Thanks for the Coffee" menu.** A new dropdown sits just to the right of Help
   in the top menu bar, crediting supporters — starting with Decker (@decker177).
+- **Cheat Scripts panel (Players → Live).** Buttons fire the named server cheat
+  scripts for an online player — Playtest Setup, Award Player XP, Unlock All
+  Skills/Abilities, Leave Me Alone — plus a freeform box for any other script
+  name. Developer performance harnesses (Start/Stop Hitch Test) live on a
+  separate **Dev / Perf Scripts** row. Both carry a disclaimer that the scripts
+  originate from the Playtest server and may have no effect on a retail server.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ here cover everything those tags shipped.
   that dropped most members), DST rebuilds it from the full default struct,
   preserves any values already customized in the file, then applies the edit —
   so the ~35 missing members come back instead of staying lost.
+- **Game Config now warns when your client's settings block is incomplete.** The
+  client-vs-server mismatch popup previously only compared settings you'd
+  customized, so a stripped client `LandsraadSettings Data=(...)` stub (missing
+  most members and silently running on game defaults) raised no warning because
+  the missing members sat at default. DST now detects a partial struct box —
+  some members present, some missing — and surfaces "your client is missing part
+  of a settings block" with the missing entries listed; "Fix my client config"
+  rewrites the whole block via the struct-heal path.
 
 ## [12.2.0] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,11 @@ here cover everything those tags shipped.
   struct.** When UserGame.ini had no prior struct, DST seeded a minimal
   `Data=(...)` with only the edited members, dropping board layouts / messages /
   contract settings the game needs. It now seeds the full DefaultGame.ini struct
-  first and edits members in place.
+  first and edits members in place. It also heals legacy stub boxes: if the live
+  file already contains a stripped `Data=(...)` (written by an older DST build
+  that dropped most members), DST rebuilds it from the full default struct,
+  preserves any values already customized in the file, then applies the edit —
+  so the ~35 missing members come back instead of staying lost.
 
 ## [12.2.0] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ here cover everything those tags shipped.
   name. Developer performance harnesses (Start/Stop Hitch Test) live on a
   separate **Dev / Perf Scripts** row. Both carry a disclaimer that the scripts
   originate from the Playtest server and may have no effect on a retail server.
+- **"Allow overflow (drop to ground)" toggle on item/kit gives.** A new checkbox
+  on the Give Item and Give Vehicle Kit forms skips DST's inventory-capacity
+  guard so a full backpack no longer blocks the give — the game's native command
+  drops whatever doesn't fit on the ground next to the player. Online players
+  only (offline SQL gives can't drop to ground, so the flag is ignored there).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **"Thanks for the Coffee" menu.** A new dropdown sits just to the right of Help
+  in the top menu bar, crediting supporters — starting with Decker (@decker177).
+
 ### Fixed
 
 - **Give Vehicle Kit now delivers the correct parts and quantities.** The kit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.2.1] - 2026-06-16
+
 ### Added
 
 - **"Thanks for the Coffee" menu.** A new dropdown sits just to the right of Help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Give Vehicle Kit now delivers the correct parts and quantities.** The kit
+  contents were corrected so each vehicle assembles properly: Sandbike Tread ×3;
+  Buggy Tread ×4 plus the Focused Buggy Cutteray Mk6; Sandcrawler drops the base
+  Tread in favour of Dampened Sandcrawler Treads ×2; Scout Ornithopter swaps its
+  Wing for Albatross Wing Module Mk6 ×4; Assault Ornithopter swaps its Wing for
+  Hummingbird Wing Module Mk6 ×6; Carrier Ornithopter swaps its Wing for Roc
+  Carrier Wing ×8 and now delivers Tail Hull ×2 and Side Hull ×2. The kit action
+  and its preview gained per-part quantity support.
+
 ## [12.2.0] - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ here cover everything those tags shipped.
   Hummingbird Wing Module Mk6 ×6; Carrier Ornithopter swaps its Wing for Roc
   Carrier Wing ×8 and now delivers Tail Hull ×2 and Side Hull ×2. The kit action
   and its preview gained per-part quantity support.
+- **Landsraad Game Config edits no longer wipe the rest of the LandsraadSettings
+  struct.** When UserGame.ini had no prior struct, DST seeded a minimal
+  `Data=(...)` with only the edited members, dropping board layouts / messages /
+  contract settings the game needs. It now seeds the full DefaultGame.ini struct
+  first and edits members in place.
 
 ## [12.2.0] - 2026-06-15
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.2.0'
+$script:DuneToolVersion = '12.2.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.2.0',
+    [string]$Version = '12.2.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.2.0</Version>
+    <Version>12.2.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.2.0"
+#define MyAppVersion "12.2.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -419,7 +419,7 @@ function Set-DuneIniValuesInPlace {
 # deprecated no-op multiplier keys so the client file stays clean.
 # Returns @{ ok; path; backup; created; applied; items } (backup always '').
 function Save-DuneGameConfigClient {
-    param([object[]]$Updates, [string]$Dir = '')
+    param([object[]]$Updates, [string]$Dir = '', [string]$DefaultsRaw = '')
     if (-not $Updates -or $Updates.Count -eq 0) { throw 'No updates supplied.' }
 
     $allowed = @{}
@@ -457,8 +457,10 @@ function Save-DuneGameConfigClient {
     $quoted = Get-DuneGameConfigQuotedKeys
     # Fold any struct-member updates (e.g. LandsraadSettings Data members) into a
     # single Data write against the CLIENT file's current blob, exactly like the
-    # server path — the client reads the same Data=(...) struct.
-    $folded = Convert-DuneStructUpdates -Raw $existing -Updates $clean.ToArray()
+    # server path -- the client reads the same Data=(...) struct. When the client
+    # Game.ini has no prior struct, seed the full DefaultGame.ini struct so the
+    # other members are preserved (the route supplies $DefaultsRaw).
+    $folded = Convert-DuneStructUpdates -Raw $existing -Updates $clean.ToArray() -DefaultsRaw $DefaultsRaw
     $new    = Set-DuneIniValuesInPlace -Raw $existing -Updates $folded -QuotedKeys $quoted
     $new    = $new -replace "`r?`n", "`r`n"   # local file is Windows CRLF
 
@@ -1060,14 +1062,52 @@ function Get-DuneSchemaStructFieldMap {
     return $map
 }
 
+# True if any of $Updates targets a struct-member schema field (e.g. a
+# LandsraadSettings Data member). Callers use this to decide whether the
+# (relatively expensive) DefaultGame.ini read is worth doing before saving.
+function Test-DuneUpdatesHaveStructMember {
+    param([object[]]$Updates)
+    if (-not $Updates) { return $false }
+    $structMap = Get-DuneSchemaStructFieldMap
+    if ($structMap.Count -eq 0) { return $false }
+    foreach ($u in $Updates) { if ($structMap.ContainsKey("$($u.key)")) { return $true } }
+    return $false
+}
+
+# Find a struct blob "(...)" for ($Section, $StructKey) in a parsed INI doc.
+# Returns the raw value (which may be the empty struct "()" the file explicitly
+# carries) or $null when the section has no such (non-array) line at all.
+function Get-DuneStructBlobFromDoc {
+    param([object]$Doc, [string]$Section, [string]$StructKey)
+    if (-not $Doc) { return $null }
+    foreach ($s in $Doc.sections) {
+        if ($s.name -eq $Section) {
+            foreach ($l in $s.body) {
+                $info = Get-DuneIniLineKey $l
+                if ($info -and -not $info.isArray -and $info.key -eq $StructKey) { return (Get-DuneIniLineValue $l) }
+            }
+        }
+    }
+    return $null
+}
+
 # Fold struct-member updates (e.g. LandsraadSettings Data members) into ONE flat
 # update that sets the parent struct key (Data) to the recomputed blob, leaving
 # every non-struct update as-is. $Raw is the current file content (to read the
 # existing blob). Returns the rewritten update list. A struct field's `remove`
 # (reset to default) writes its Funcom default value into the struct rather than
 # deleting the member, so the Data=() blob always stays well-formed.
+#
+# $DefaultsRaw is OPTIONAL raw DefaultGame.ini text. When the live file has NO
+# struct line for a (section, structKey) -- typical of a fresh UserGame.ini -- we
+# SEED the full default struct (all ~40 members the game ships) from $DefaultsRaw
+# before folding the operator's edits, so the override does not REPLACE the UE
+# struct with a stripped few-member stub. When the file already carries a struct
+# blob (even "()"), we keep editing it in place and never consult defaults. The
+# pure INI engine stays SSH-free: real callers fetch DefaultGame.ini and pass it
+# in; unit tests can omit $DefaultsRaw entirely.
 function Convert-DuneStructUpdates {
-    param([string]$Raw, [object[]]$Updates)
+    param([string]$Raw, [object[]]$Updates, [string]$DefaultsRaw)
     $structMap = Get-DuneSchemaStructFieldMap
     if ($structMap.Count -eq 0) { return $Updates }
     $doc = ConvertFrom-DuneIniDoc -Raw $Raw
@@ -1088,17 +1128,19 @@ function Convert-DuneStructUpdates {
             $flat.Add($u)
         }
     }
+    $defaultsDoc = $null
+    if (-not [string]::IsNullOrWhiteSpace($DefaultsRaw)) { $defaultsDoc = ConvertFrom-DuneIniDoc -Raw $DefaultsRaw }
     foreach ($gid in $structGroups.Keys) {
         $g = $structGroups[$gid]
-        # Current blob for this section's struct key (empty struct if absent).
-        $blob = '()'
-        foreach ($s in $doc.sections) {
-            if ($s.name -eq $g.section) {
-                foreach ($l in $s.body) {
-                    $info = Get-DuneIniLineKey $l
-                    if ($info -and -not $info.isArray -and $info.key -eq $g.structKey) { $blob = (Get-DuneIniLineValue $l) }
-                }
-            }
+        # Current blob for this section's struct key. $null means the live file has
+        # NO struct line at all (distinct from an explicit, possibly-empty "()").
+        $blob = Get-DuneStructBlobFromDoc -Doc $doc -Section $g.section -StructKey $g.structKey
+        if ($null -eq $blob) {
+            # Fresh file: seed the FULL default struct so the ~35 members the game
+            # ships (board layouts, messages, curves, contract timings, ...) survive
+            # the override instead of being wiped by a stripped few-member stub.
+            $seed = Get-DuneStructBlobFromDoc -Doc $defaultsDoc -Section $g.section -StructKey $g.structKey
+            $blob = if ($null -ne $seed) { $seed } else { '()' }
         }
         foreach ($m in $g.members) { $blob = Set-DuneStructScalarMember -Blob $blob -Key $m.key -Value $m.value }
         $flat.Add(@{ file = $g.file; section = $g.section; key = $g.structKey; value = $blob })
@@ -1121,13 +1163,24 @@ function Save-DuneGameConfig {
         if ($byFile.ContainsKey($f)) { $byFile[$f].Add($u) }
     }
 
+    # When any struct-member edit is present, read DefaultGame/Engine.ini ONCE so a
+    # fresh UserGame.ini can seed the FULL default struct before folding edits
+    # (otherwise the override wipes the ~35 nested LandsraadSettings members). A
+    # defaults-read failure (e.g. no running pod) falls back to prior behaviour.
+    $defaults = $null
+    if (Test-DuneUpdatesHaveStructMember -Updates $Updates) {
+        try { $defaults = Get-DuneGameConfigDefaults -Ip $Ip } catch { $defaults = $null }
+    }
+
     foreach ($f in @('game','engine')) {
         if ($byFile[$f].Count -eq 0) { continue }
         $path = if ($f -eq 'game') { $paths.game } else { $paths.engine }
         $raw  = (Invoke-V6Ssh -Ip $Ip -Cmd "sudo cat '$path' 2>/dev/null") -join "`n"
+        $defRaw = if ($defaults) { if ($f -eq 'game') { "$($defaults.game)" } else { "$($defaults.engine)" } } else { '' }
         # Fold any struct-member updates (e.g. LandsraadSettings Data members) into
-        # a single parent-key update against the file's current blob.
-        $fileUpdates = Convert-DuneStructUpdates -Raw $raw -Updates $byFile[$f].ToArray()
+        # a single parent-key update against the file's current blob (seeding from
+        # defaults when the file has no prior struct).
+        $fileUpdates = Convert-DuneStructUpdates -Raw $raw -Updates $byFile[$f].ToArray() -DefaultsRaw $defRaw
         $new  = ConvertTo-DuneIniManaged -Raw $raw -Updates $fileUpdates -QuotedKeys $quoted
         $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($new))
         Invoke-V6Ssh -Ip $Ip -Cmd "base64 -d | sudo tee '$path' > /dev/null" -StdinData $b64 -TimeoutSec 30 | Out-Null

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -1102,10 +1102,17 @@ function Get-DuneStructBlobFromDoc {
 # struct line for a (section, structKey) -- typical of a fresh UserGame.ini -- we
 # SEED the full default struct (all ~40 members the game ships) from $DefaultsRaw
 # before folding the operator's edits, so the override does not REPLACE the UE
-# struct with a stripped few-member stub. When the file already carries a struct
-# blob (even "()"), we keep editing it in place and never consult defaults. The
-# pure INI engine stays SSH-free: real callers fetch DefaultGame.ini and pass it
-# in; unit tests can omit $DefaultsRaw entirely.
+# struct with a stripped few-member stub. Two seeding triggers:
+#   1. File has NO struct line at all (fresh UserGame.ini) -> seed full default.
+#   2. File HAS a struct line but it's a legacy STUB (fewer scalar members than
+#      the default box ships, written by an older DST build) -> rebuild from the
+#      full default box and overlay the file's existing members so real
+#      customizations survive while the ~35 dropped members are healed back.
+# A struct box that is already at least as complete as the defaults is edited in
+# place and NEVER reseeded (don't clobber a genuinely full/custom box). When
+# $DefaultsRaw is empty/unavailable we can't reconstruct, so we keep the
+# edit-in-place behaviour. The pure INI engine stays SSH-free: real callers fetch
+# DefaultGame.ini and pass it in; unit tests can omit $DefaultsRaw entirely.
 function Convert-DuneStructUpdates {
     param([string]$Raw, [object[]]$Updates, [string]$DefaultsRaw)
     $structMap = Get-DuneSchemaStructFieldMap
@@ -1135,12 +1142,25 @@ function Convert-DuneStructUpdates {
         # Current blob for this section's struct key. $null means the live file has
         # NO struct line at all (distinct from an explicit, possibly-empty "()").
         $blob = Get-DuneStructBlobFromDoc -Doc $doc -Section $g.section -StructKey $g.structKey
+        $seed = if ($defaultsDoc) { Get-DuneStructBlobFromDoc -Doc $defaultsDoc -Section $g.section -StructKey $g.structKey } else { $null }
         if ($null -eq $blob) {
             # Fresh file: seed the FULL default struct so the ~35 members the game
             # ships (board layouts, messages, curves, contract timings, ...) survive
             # the override instead of being wiped by a stripped few-member stub.
-            $seed = Get-DuneStructBlobFromDoc -Doc $defaultsDoc -Section $g.section -StructKey $g.structKey
             $blob = if ($null -ne $seed) { $seed } else { '()' }
+        } elseif ($null -ne $seed) {
+            # File HAS a struct line. Heal a legacy STUB: if it carries fewer scalar
+            # members than the default box ships, it's missing members the game needs
+            # (an older DST build wrote a stripped box). Rebuild from the full default
+            # box, then overlay the file's existing members so real customizations are
+            # preserved. A box already at least as complete as defaults is left as-is.
+            $existingMembers = Get-DuneStructScalarMembers -Blob $blob
+            $defaultMembers  = Get-DuneStructScalarMembers -Blob $seed
+            if ($existingMembers.Count -lt $defaultMembers.Count) {
+                $healed = $seed
+                foreach ($mk in $existingMembers.Keys) { $healed = Set-DuneStructScalarMember -Blob $healed -Key $mk -Value $existingMembers[$mk] }
+                $blob = $healed
+            }
         }
         foreach ($m in $g.members) { $blob = Set-DuneStructScalarMember -Blob $blob -Key $m.key -Value $m.value }
         $flat.Add(@{ file = $g.file; section = $g.section; key = $g.structKey; value = $blob })

--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -203,7 +203,8 @@ function Invoke-DunePlayerGiveItemLive {
         [string] $FlsId,
         [Parameter(Mandatory)] [string] $Template,
         [int]    $Quantity = 1,
-        [double] $Durability = 1.0
+        [double] $Durability = 1.0,
+        [bool]   $AllowOverflow = $false
     )
     if ($Quantity -le 0)   { $Quantity = 1 }
     if ($Durability -le 0) { $Durability = 1.0 }
@@ -211,7 +212,10 @@ function Invoke-DunePlayerGiveItemLive {
     $tv = Test-DuneValidGiveTemplate -TemplateId $Template
     if (-not $tv.ok) { return @{ ok = $false; error = $tv.error } }
 
-    if ($ActorId -gt 0) {
+    # When AllowOverflow is set we skip the capacity guard and let the game's
+    # native AddItemToInventory ServerCommand handle the overflow — it drops the
+    # items that don't fit onto the ground next to the online player.
+    if ($ActorId -gt 0 -and -not $AllowOverflow) {
         $cap = Test-DuneInventoryCapacity -Ip $Ip -PawnId $ActorId -Template $Template -Quantity $Quantity
         if (-not $cap.ok) { return $cap }
     }

--- a/app/server/routes/GameConfig.ps1
+++ b/app/server/routes/GameConfig.ps1
@@ -291,7 +291,17 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig/client/apply' -Handler {
         return
     }
     try {
-        $r = Save-DuneGameConfigClient -Updates $updates.ToArray() -Dir $dir
+        # Seed-from-defaults needs DefaultGame.ini (a live pod read); only pay for
+        # it when a Landsraad-style struct member is actually being applied, and
+        # tolerate failure so non-struct client edits still apply offline.
+        $defaultsRaw = ''
+        if (Test-DuneUpdatesHaveStructMember -Updates $updates.ToArray()) {
+            try {
+                $ctx = Get-DuneGameConfigContext
+                if ($ctx.ok) { $defaultsRaw = "$((Get-DuneGameConfigDefaults -Ip $ctx.ip).game)" }
+            } catch { $defaultsRaw = '' }
+        }
+        $r = Save-DuneGameConfigClient -Updates $updates.ToArray() -Dir $dir -DefaultsRaw $defaultsRaw
         $client = Get-DuneGameConfigClient -Dir $dir
         Write-DuneJson -Response $res -Body @{
             ok      = $true

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -127,6 +127,7 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-item' -Handler
         $qty  = Get-DuneBodyInt -Body $body -Name 'qty'
         $qual = Get-DuneBodyInt -Body $body -Name 'quality'
         $fls  = [string](Get-DuneBodyValue -Body $body -Name 'fls_id')
+        $overflow = [bool](Get-DuneBodyValue -Body $body -Name 'allow_overflow')
         if ($null -eq $qual) { $qual = 0L }
         if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
         if (-not $tmpl) { Write-DuneError -Response $res -Status 400 -Message 'template is required.'; return }
@@ -141,7 +142,7 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-item' -Handler
             $isOnline = -not $off.ok
             # Online + default quality → RMQ live (instant, no relog)
             if ($isOnline -and $qual -le 0) {
-                $r = Invoke-DunePlayerGiveItemLive -Ip $ip -ActorId $pawn -FlsId $fls -Template $tmpl -Quantity ([int]$qty) -Durability 1.0
+                $r = Invoke-DunePlayerGiveItemLive -Ip $ip -ActorId $pawn -FlsId $fls -Template $tmpl -Quantity ([int]$qty) -Durability 1.0 -AllowOverflow $overflow
                 if ($r.ok -and -not $r.path) { $r['path'] = 'rmq' }
                 return $r
             }

--- a/app/server/routes/PlayersRmq.ps1
+++ b/app/server/routes/PlayersRmq.ps1
@@ -74,7 +74,7 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/set-skill-module' -
     } catch { Write-DuneError -Response $res -Status 500 -Message "Set skill module failed: $($_.Exception.Message)" }
 }
 
-# POST /api/gameplay/players/give-item-live  { actor_id?, fls_id?, template, qty?, durability? }
+# POST /api/gameplay/players/give-item-live  { actor_id?, fls_id?, template, qty?, durability?, allow_overflow? }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-item-live' -Handler {
     param($req, $res, $routeParams, $body)
     try {
@@ -87,7 +87,8 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-item-live' -Ha
         $dur = 1.0
         if ($null -ne $durRaw) { try { $dur = [double]$durRaw } catch {} }
         if ($dur -le 0) { $dur = 1.0 }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerGiveItemLive -Ip $ip -ActorId $aid -FlsId $fls -Template $tpl -Quantity ([int]$qty) -Durability $dur }
+        $overflow = [bool](Get-DuneBodyValue -Body $body -Name 'allow_overflow')
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerGiveItemLive -Ip $ip -ActorId $aid -FlsId $fls -Template $tpl -Quantity ([int]$qty) -Durability $dur -AllowOverflow $overflow }
     } catch { Write-DuneError -Response $res -Status 500 -Message "Give item live failed: $($_.Exception.Message)" }
 }
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.2.0"
+$script:ToolVersion = "12.2.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -476,4 +476,30 @@ Describe 'GameConfig: Landsraad struct fields integrate with read + save' -Tag '
         $folded[0].value | Should -Match 'm_TermStartedMessage=\(Name="X"\)'
         $folded[0].value | Should -Not -Match 'm_ExtraDefaultOnly'
     }
+
+    It 'heals a legacy STUB box in place, restoring dropped default members and keeping customizations' {
+        # An older DST build wrote a stripped 5-member stub into the live file.
+        $stubRaw = "[/Script/DuneSandbox.LandsraadSettings]`n" +
+            'Data=(m_LandsraadTaskProgressUpdateFrequency=15.0,m_LandsraadTaskDailyRevealFrequency=25.0,m_VotingPeriodStartBeforeCoriolisCycleInSec=118800.0,m_VotingPeriodDurationInSec=118500.0,m_TaskGoalAmount=9999.0)' + "`n"
+        # Full default box ships many more members the stub dropped.
+        $defaultsRaw = "[/Script/DuneSandbox.LandsraadSettings]`n" +
+            'Data=(m_NumberOfDecreesToNominate=5,m_TaskGoalAmount=26000,m_LandsraadTaskProgressUpdateFrequency=10.0,m_LandsraadTaskDailyRevealFrequency=20.0,m_VotingPeriodStartBeforeCoriolisCycleInSec=100000.0,m_VotingPeriodDurationInSec=100000.0,m_ControlPointsPerCycle=10,m_TermStartedMessage=(Name="LandsraadTermStarted"),m_BoardLayouts=((Houses=2)),m_ContributionCurve=(Keys=((Time=0.0,Value=1.0))))' + "`n"
+        $updates = @(
+            @{ file='game'; section='/Script/DuneSandbox.LandsraadSettings'; key='m_TaskGoalAmount'; value='12000' }
+        )
+        $folded = @(Convert-DuneStructUpdates -Raw $stubRaw -Updates $updates -DefaultsRaw $defaultsRaw)
+        $folded.Count   | Should -Be 1
+        $folded[0].key  | Should -Be 'Data'
+        # operator edit applied
+        $folded[0].value | Should -Match 'm_TaskGoalAmount=12000'
+        # dropped default members healed back (nested + scalar)
+        $folded[0].value | Should -Match 'm_TermStartedMessage=\(Name="LandsraadTermStarted"\)'
+        $folded[0].value | Should -Match 'm_BoardLayouts=\(\(Houses=2\)\)'
+        $folded[0].value | Should -Match 'm_ContributionCurve=\(Keys='
+        $folded[0].value | Should -Match 'm_NumberOfDecreesToNominate=5'
+        $folded[0].value | Should -Match 'm_ControlPointsPerCycle=10'
+        # the stub's OWN customized values are preserved (not reset to defaults)
+        $folded[0].value | Should -Match 'm_LandsraadTaskProgressUpdateFrequency=15\.0'
+        $folded[0].value | Should -Match 'm_VotingPeriodDurationInSec=118500\.0'
+    }
 }

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -439,4 +439,41 @@ Describe 'GameConfig: Landsraad struct fields integrate with read + save' -Tag '
         @($folded | Where-Object { $_.key -eq 'Data' }).Count | Should -Be 1
         @($folded | Where-Object { $_.key -eq 'm_WaterConsumptionRate' }).Count | Should -Be 1
     }
+
+    It 'seeds the full default struct when the file has no prior LandsraadSettings section' {
+        # Fresh UserGame.ini: no LandsraadSettings section at all.
+        $freshRaw = "[/Script/DuneSandbox.DuneGameMode]`nm_WaterConsumptionRate=1.0`n"
+        # A representative DefaultGame.ini Data=(...) blob carrying nested members
+        # the operator never touches (message, a board layout struct, a curve).
+        $defaultsRaw = "[/Script/DuneSandbox.LandsraadSettings]`n" +
+            'Data=(m_NumberOfDecreesToNominate=5,m_TaskGoalAmount=26000,m_TermStartedMessage=(Name="LandsraadTermStarted"),m_BoardLayouts=((Houses=2)),m_ContributionCurve=(Keys=((Time=0.0,Value=1.0))),m_bIsPlayerVotingEnabled=True)' + "`n"
+        $updates = @(
+            @{ file='game'; section='/Script/DuneSandbox.LandsraadSettings'; key='m_TaskGoalAmount'; value='12000' }
+        )
+        $folded = @(Convert-DuneStructUpdates -Raw $freshRaw -Updates $updates -DefaultsRaw $defaultsRaw)
+        $folded.Count   | Should -Be 1
+        $folded[0].key  | Should -Be 'Data'
+        # the edited scalar is folded in
+        $folded[0].value | Should -Match 'm_TaskGoalAmount=12000'
+        # and the full default struct survived -- NOT a 1-member stub
+        $folded[0].value | Should -Match 'm_TermStartedMessage=\(Name="LandsraadTermStarted"\)'
+        $folded[0].value | Should -Match 'm_BoardLayouts=\(\(Houses=2\)\)'
+        $folded[0].value | Should -Match 'm_ContributionCurve=\(Keys='
+        $folded[0].value | Should -Match 'm_NumberOfDecreesToNominate=5'
+    }
+
+    It 'does NOT seed from defaults when the file already carries a struct blob' {
+        # File already has the struct -> keep editing it in place; ignore defaults so
+        # we never clobber the user's existing customizations with stock members.
+        $defaultsRaw = "[/Script/DuneSandbox.LandsraadSettings]`n" +
+            'Data=(m_TaskGoalAmount=26000,m_ExtraDefaultOnly=(Name="ShouldNotAppear"))' + "`n"
+        $updates = @(
+            @{ file='game'; section='/Script/DuneSandbox.LandsraadSettings'; key='m_TaskGoalAmount'; value='7777.0' }
+        )
+        $folded = @(Convert-DuneStructUpdates -Raw $script:LsRaw -Updates $updates -DefaultsRaw $defaultsRaw)
+        $folded.Count    | Should -Be 1
+        $folded[0].value | Should -Match 'm_TaskGoalAmount=7777\.0'
+        $folded[0].value | Should -Match 'm_TermStartedMessage=\(Name="X"\)'
+        $folded[0].value | Should -Not -Match 'm_ExtraDefaultOnly'
+    }
 }

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "12.3.0",
+  "version": "12.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -556,9 +556,9 @@ export function giveSolari(controllerId: number, amount: number) {
   })
 }
 
-export function giveItem(pawnId: number, template: string, qty: number, quality: number) {
+export function giveItem(pawnId: number, template: string, qty: number, quality: number, allowOverflow = false) {
   return api<WriteResult>('/api/gameplay/players/give-item', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, template, qty, quality }),
+    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, template, qty, quality, allow_overflow: allowOverflow }),
   })
 }
 

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -121,6 +121,10 @@ export type GameConfigField = {
   max?: number
   quoted?: boolean
   clientApply?: boolean
+  // When set, this field is a scalar member of a nested struct (e.g. the
+  // LandsraadSettings Data=(...) box) rather than a flat INI key. Members that
+  // share a (file, section, structKey) are written into one struct line.
+  structKey?: string
   options?: GameConfigFieldOption[]
 }
 

--- a/webui/src/data/vehicles.ts
+++ b/webui/src/data/vehicles.ts
@@ -19,6 +19,10 @@ export interface VehicleTemplate {
   // kit so the player also gets the best specialized variants. Empty when the
   // vehicle has no unique modules in the catalog.
   unique: string[]
+  // Optional per-template delivery quantity (template id -> count) for the Give
+  // Vehicle Kit action. Any template not listed defaults to 1. Lets a single part
+  // be handed out in multiples (e.g. a Buggy assembles from 4 treads).
+  qty?: Record<string, number>
 }
 
 // The consumables bundled into every Give Vehicle Kit alongside the parts: one
@@ -35,6 +39,7 @@ export const VEHICLE_CATALOG: VehicleTemplate[] = [
     templates: ['T1_ExtraSeat', 'T2_Inventory', 'T3_Boost', 'T4_Scanner', 'T5', 'T6'],
     kit: ['SandbikeChassis_6', 'SandbikeEngine_6', 'SandbikeGenerator_6', 'SandbikeHull_6', 'SandbikeLocomotion_6', 'SandbikeBoost_6'],
     unique: ['SandbikeEngine_Unique_Speed_6', 'SandbikeBoost_Unique_LessHeat_6'],
+    qty: { SandbikeLocomotion_6: 3 },
   },
   {
     id: 'Buggy',
@@ -42,7 +47,8 @@ export const VEHICLE_CATALOG: VehicleTemplate[] = [
     className: '/Game/Dune/Systems/Vehicles/Blueprints/GroundVehicles/BP_Buggy_CHOAM.BP_Buggy_CHOAM_C',
     templates: ['T3_Inventory', 'T4_Boost', 'T5_Mining', 'T6_Combat'],
     kit: ['BuggyChassis_6', 'BuggyEngine_6', 'BuggyGenerator_6', 'BuggyHullFront_6', 'BuggyHullBack_6', 'BuggyHullBackExtra_6', 'BuggyLocomotion_6', 'BuggyBoost_6', 'BuggyInventory_6'],
-    unique: ['BuggyEngine_Unique_Accelerate_06', 'BuggyBoost_Unique_LessHeat_6', 'BuggyInventory_Unique_Capacity_06'],
+    unique: ['BuggyEngine_Unique_Accelerate_06', 'BuggyBoost_Unique_LessHeat_6', 'BuggyInventory_Unique_Capacity_06', 'BuggyMining_Unique_YieldIncrease_06'],
+    qty: { BuggyLocomotion_6: 4 },
   },
   {
     id: 'Tank',
@@ -57,8 +63,9 @@ export const VEHICLE_CATALOG: VehicleTemplate[] = [
     label: 'Sandcrawler',
     className: '/Game/Dune/Systems/Vehicles/Blueprints/GroundVehicles/BP_SandCrawler_CHOAM.BP_SandCrawler_CHOAM_C',
     templates: ['T6_Harvesting'],
-    kit: ['SandcrawlerChassis_6', 'SandcrawlerEngine_6', 'SandcrawlerGenerator_6', 'SandcrawlerHull_6', 'SandcrawlerLocomotion_6', 'SandcrawlerSpiceContainer_6', 'SandcrawlerSpiceHeader_6'],
+    kit: ['SandcrawlerChassis_6', 'SandcrawlerEngine_6', 'SandcrawlerGenerator_6', 'SandcrawlerHull_6', 'SandcrawlerSpiceContainer_6', 'SandcrawlerSpiceHeader_6'],
     unique: ['SandcrawlerEngine_Unique_Speed_06', 'SandcrawlerLocomotion_Unique_WormThreat_06', 'SandcrawlerSpiceContainer_Unique_Capacity_6'],
+    qty: { SandcrawlerLocomotion_Unique_WormThreat_06: 2 },
   },
   {
     id: 'TreadWheel',
@@ -81,23 +88,26 @@ export const VEHICLE_CATALOG: VehicleTemplate[] = [
     label: 'Ornithopter (Light)',
     className: '/Game/Dune/Systems/Vehicles/Blueprints/FlyingVehicles/BP_LightOrnithopter_Choam.BP_LightOrnithopter_Choam_C',
     templates: ['T4_Inventory', 'T5_Boost', 'T6_Combat'],
-    kit: ['OrnithopterLightChassis_6', 'OrnithopterLightEngine_6', 'OrnithopterLightGenerator_6', 'OrnithopterLightHullFront_6', 'OrnithopterLightHullBack_6', 'OrnithopterLightLocomotion_6', 'OrnithopterLightBoost_6'],
+    kit: ['OrnithopterLightChassis_6', 'OrnithopterLightEngine_6', 'OrnithopterLightGenerator_6', 'OrnithopterLightHullFront_6', 'OrnithopterLightHullBack_6', 'OrnithopterLightBoost_6'],
     unique: ['OrnithopterLightLocomotion_Unique_Speed_6', 'OrnithopterLightBoost_Unique_LessHeat_6', 'OrnithopterLightInventory_4'],
+    qty: { OrnithopterLightLocomotion_Unique_Speed_6: 4 },
   },
   {
     id: 'OrnithopterMedium',
     label: 'Ornithopter (Medium)',
     className: '/Game/Dune/Systems/Vehicles/Blueprints/FlyingVehicles/BP_MediumOrnithopter_CHOAM.BP_MediumOrnithopter_CHOAM_C',
     templates: ['T5_Inventory', 'T6_Combat'],
-    kit: ['OrnithopterMediumChassis_6', 'OrnithopterMediumEngine_6', 'OrnithopterMediumGenerator_6', 'OrnithopterMediumHull_6', 'OrnithopterMediumHullFront_6', 'OrnithopterMediumHullBack_6', 'OrnithopterMediumLocomotion_6', 'OrnithopterMediumBoost_6'],
+    kit: ['OrnithopterMediumChassis_6', 'OrnithopterMediumEngine_6', 'OrnithopterMediumGenerator_6', 'OrnithopterMediumHull_6', 'OrnithopterMediumHullFront_6', 'OrnithopterMediumHullBack_6', 'OrnithopterMediumBoost_6'],
     unique: ['OrnithopterMediumLocomotion_Unique_Strafe_6', 'OrnithopterMediumBoost_Unique_LessHeat_6', 'OrnithopterMediumInventory_5'],
+    qty: { OrnithopterMediumLocomotion_Unique_Strafe_6: 6 },
   },
   {
     id: 'OrnithopterTransport',
     label: 'Ornithopter (Transport)',
     className: '/Game/Dune/Systems/Vehicles/Blueprints/FlyingVehicles/BP_TransportOrnithopter_CHOAM.BP_TransportOrnithopter_CHOAM_C',
     templates: ['T6_Boost'],
-    kit: ['OrnithopterTransportChassis_6', 'OrnithopterTransportEngine_6', 'OrnithopterTransportGenerator_6', 'OrnithopterTransportHull_6', 'OrnithopterTransportHullFront_6', 'OrnithopterTransportHullBack_6', 'OrnithopterTransportLocomotion_6', 'OrnithopterTransportBoost_6'],
+    kit: ['OrnithopterTransportChassis_6', 'OrnithopterTransportEngine_6', 'OrnithopterTransportGenerator_6', 'OrnithopterTransportHull_6', 'OrnithopterTransportHullFront_6', 'OrnithopterTransportHullBack_6', 'OrnithopterTransportBoost_6'],
     unique: ['OrnithopterTransportLocomotion_Unique_Speed_6', 'OrnithopterTransportBoost_Unique_LessHeat_06'],
+    qty: { OrnithopterTransportLocomotion_Unique_Speed_6: 8, OrnithopterTransportHullBack_6: 2, OrnithopterTransportHullFront_6: 2 },
   },
 ]

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -8,7 +8,7 @@ import { getAutostartState, setAutostartEnabled, type AutostartState } from '../
 import { getConsoleState, setConsoleVisible, type ConsoleState } from '../api/console'
 import { isLocalViewer } from '../util/viewer'
 
-type MenuKey = NavGroup | 'help'
+type MenuKey = NavGroup | 'help' | 'coffee'
 
 type Props = {
   sidebarCollapsed: boolean
@@ -336,6 +336,32 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
                 {sidebarCollapsed ? 'Expand Sidebar' : 'Collapse Sidebar'}
               </span>
             </button>
+          </div>
+        )}
+      </div>
+
+      {/* "Thanks for the Coffee" — supporter credits, sits immediately to the
+          right of Help. The entries are plain credit lines, not links. */}
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setOpen(open === 'coffee' ? null : 'coffee')}
+          onMouseEnter={() => { if (open !== null) setOpen('coffee') }}
+          className={`px-3 h-7 inline-flex items-center gap-1.5 rounded-md transition-colors ${
+            open === 'coffee'
+              ? 'bg-surface-3 text-text'
+              : 'text-text-muted hover:text-text hover:bg-surface-2/80'
+          }`}
+        >
+          <Icon name="Coffee" size={14} />
+          <span>Thanks for the Coffee</span>
+        </button>
+        {open === 'coffee' && (
+          <div className="absolute left-0 top-full mt-1 min-w-[220px] bg-surface border border-border rounded-xl p-1 shadow-xl shadow-black/40 z-50">
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">Decker (@decker177)</span>
+            </div>
           </div>
         )}
       </div>

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -43,6 +43,10 @@ type ClientMismatch = {
   section: string
   serverValue: string
   clientValue: string | null
+  // True when this entry belongs to a structurally-incomplete client struct box
+  // (a stripped "stub" — see clientMismatches). Drives the "your client is
+  // missing part of a settings block" notice, distinct from a plain value diff.
+  structural?: boolean
 }
 
 const SANDWORM_ENABLED_KEY = 'sandworm.dune.Enabled'
@@ -222,17 +226,61 @@ export function GameConfig() {
     } catch { /* clipboard may be unavailable; the snippet is still shown */ }
   }, [clientSnippet])
 
+  // Schema struct groups (file||section||structKey) -> member field keys. Used to
+  // detect a structurally-incomplete client struct box, e.g. a stripped
+  // LandsraadSettings Data=(...) stub that's missing members the game ships. A
+  // UE struct override REPLACES the whole box, so a stub silently drops every
+  // member it omits back to a built-in default — without ever differing on a
+  // value the admin customised, so the plain value detector below can't see it.
+  const structMemberGroups = useMemo(() => {
+    const groups = new Map<string, { file: string; section: string; structKey: string; keys: string[] }>()
+    if (!schema) return groups
+    for (const cat of schema) {
+      for (const f of cat?.fields ?? []) {
+        if (!f?.clientApply || !f.key || !f.structKey) continue
+        const id = `${f.file}||${f.section}||${f.structKey}`
+        const g = groups.get(id) ?? { file: f.file, section: f.section, structKey: f.structKey, keys: [] }
+        g.keys.push(f.key)
+        groups.set(id, g)
+      }
+    }
+    return groups
+  }, [schema])
+
   // Client-mirror mismatch detector. For every ClientApply field the admin has
   // CUSTOMISED on the server (value present and != default), compare the server's
   // effective value against the player's local client Game.ini. Any that differ
   // (or are missing client-side) won't take full effect until mirrored locally.
+  //
+  // Plus a STRUCTURAL pass: when a client struct box is a partial stub (some
+  // members present, some missing), surface every member that's missing or
+  // differs — even ones at server default — so clicking Fix rewrites the box
+  // whole (the server-side apply reseeds the full struct). This catches a
+  // stripped LandsraadSettings box that the value-only pass would miss because
+  // the missing members sit at default and so never register as customised.
   const clientMismatches = useMemo<ClientMismatch[]>(() => {
     if (!schema || !cfg || !clientInfo || !clientInfo.exists) return []
+    // Struct groups that are a PARTIAL stub client-side: at least one member
+    // present AND at least one missing. A complete box (all present) is healthy;
+    // an entirely-absent box is "not applied yet" (handled by the value path
+    // for any customised members), not a stub — only the partial case is drift.
+    const stubGroups = new Set<string>()
+    for (const [id, g] of structMemberGroups) {
+      let present = 0
+      let missing = 0
+      for (const mk of g.keys) {
+        const v = clientInfo.effectiveByKey?.[mk]
+        if (v === undefined || v === null) missing++
+        else present++
+      }
+      if (present > 0 && missing > 0) stubGroups.add(id)
+    }
     const out: ClientMismatch[] = []
     for (const cat of schema) {
       for (const f of cat?.fields ?? []) {
         if (!f?.clientApply || !f.key) continue
-        if (!isCustomized(cfg, f)) continue
+        const groupId = f.structKey ? `${f.file}||${f.section}||${f.structKey}` : null
+        const inStub = groupId ? stubGroups.has(groupId) : false
         const serverValue = currentValue(cfg, f)
         // Client value: prefer the flat section||key, but fall back to the by-key
         // map so struct members (e.g. LandsraadSettings Data=(...) scalars) — which
@@ -243,12 +291,22 @@ export function GameConfig() {
           ? clientInfo.effectiveByKey?.[f.key]
           : flat
         const clientValue = raw === undefined || raw === null ? null : String(raw)
+        if (inStub) {
+          if (clientValue !== null && valuesEqual(clientValue, serverValue)) continue
+          out.push({ key: f.key, label: f.label, section: f.section, serverValue, clientValue, structural: true })
+          continue
+        }
+        if (!isCustomized(cfg, f)) continue
         if (clientValue !== null && valuesEqual(clientValue, serverValue)) continue
         out.push({ key: f.key, label: f.label, section: f.section, serverValue, clientValue })
       }
     }
     return out
-  }, [schema, cfg, clientInfo])
+  }, [schema, cfg, clientInfo, structMemberGroups])
+
+  // True when any mismatch comes from a stripped/incomplete client struct box —
+  // drives the stronger "your client is missing part of a settings block" copy.
+  const hasStructuralDrift = useMemo(() => clientMismatches.some(m => m.structural), [clientMismatches])
 
   // INI snippet of the SERVER values for the mismatched keys (manual-merge / share).
   const mismatchSnippet = useMemo(() => {
@@ -913,7 +971,9 @@ export function GameConfig() {
           className="card p-3 mb-4 w-full text-left border-warning/40 bg-warning/10 text-warning text-sm flex items-center gap-2 hover:bg-warning/15"
         >
           <Icon name="MonitorSmartphone" size={14} />
-          {clientMismatches.length} client setting{clientMismatches.length === 1 ? '' : 's'} {clientMismatches.length === 1 ? "doesn't" : "don't"} match the server — review &amp; fix
+          {hasStructuralDrift
+            ? <>Your client is missing part of a settings block — review &amp; fix</>
+            : <>{clientMismatches.length} client setting{clientMismatches.length === 1 ? '' : 's'} {clientMismatches.length === 1 ? "doesn't" : "don't"} match the server — review &amp; fix</>}
         </button>
       )}
       {mismatchOpen && clientMismatches.length > 0 && (
@@ -929,14 +989,30 @@ export function GameConfig() {
               <Icon name="MonitorSmartphone" size={18} className="text-warning mt-0.5 shrink-0" />
               <div className="flex-1 min-w-0">
                 <div className="font-semibold text-text mb-1">
-                  Your client config doesn&apos;t match the server
+                  {hasStructuralDrift
+                    ? 'Your client is missing part of a settings block'
+                    : 'Your client config doesn\u2019t match the server'}
                 </div>
+                {hasStructuralDrift && (
+                  <p className="text-warning mb-2 flex items-start gap-1.5">
+                    <Icon name="AlertTriangle" size={14} className="mt-0.5 shrink-0" />
+                    <span>
+                      Your local client{' '}
+                      <span className="font-mono break-all">{clientInfo?.path ?? 'Game.ini'}</span>{' '}
+                      has an <strong>incomplete</strong> settings block — it carries only some of the
+                      entries the game expects, so the rest silently fall back to built-in defaults
+                      in-game (a stripped struct from an older write). Fixing rewrites the whole block.
+                    </span>
+                  </p>
+                )}
                 <p className="text-text-muted mb-3">
                   {clientMismatches.length === 1 ? 'This setting is' : 'These settings are'} read by both the
                   server and the game client. Your server uses {clientMismatches.length === 1 ? 'this value' : 'these values'},
                   but your local client{' '}
                   <span className="font-mono break-all">{clientInfo?.path ?? 'Game.ini'}</span>{' '}
-                  {clientMismatches.length === 1 ? 'has a different one' : 'has different ones'}. Until they match,
+                  {hasStructuralDrift
+                    ? 'is missing or differs on them'
+                    : (clientMismatches.length === 1 ? 'has a different one' : 'has different ones')}. Until they match,
                   the change won&apos;t take full effect for you in-game.
                 </p>
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -742,7 +742,7 @@ function ActionRow({ def, player, busy, hasLiveSession, open, danger, onToggle, 
             <VehicleKitForm busy={busy}
               onSubmit={veh => runAction(def, async () => {
                 const parts = [...veh.kit, ...veh.unique, VEHICLE_KIT_FUEL_TEMPLATE, VEHICLE_KIT_TORCH_TEMPLATE]
-                for (const tpl of parts) await giveItem(player.id, tpl, 1, 0)
+                for (const tpl of parts) await giveItem(player.id, tpl, veh.qty?.[tpl] ?? 1, 0)
                 const count = veh.kit.length + veh.unique.length
                 return { message: `Gave ${veh.label} kit — ${count} part${count === 1 ? '' : 's'} + Large Fuel Cell + Welding Torch Mk5 to ${player.name}.` }
               })} />
@@ -1045,6 +1045,8 @@ function VehicleKitForm({ busy, onSubmit }: {
   if (!veh) return <div className="text-sm text-text-muted">No vehicles with part kits available.</div>
 
   const label = (tpl: string) => names[tpl] || tpl
+  const qtyOf = (tpl: string) => veh.qty?.[tpl] ?? 1
+  const qtySuffix = (tpl: string) => qtyOf(tpl) > 1 ? ` ×${qtyOf(tpl)}` : ''
 
   return (
     <div className="space-y-3">
@@ -1062,12 +1064,12 @@ function VehicleKitForm({ busy, onSubmit }: {
         <ul className="space-y-0.5 text-text-muted">
           {veh.kit.map(tpl => (
             <li key={tpl} className="flex items-center gap-1.5">
-              <Icon name="Cog" size={12} className="shrink-0 text-text-dim" /> {label(tpl)}
+              <Icon name="Cog" size={12} className="shrink-0 text-text-dim" /> {label(tpl)}{qtySuffix(tpl)}
             </li>
           ))}
           {veh.unique.map(tpl => (
             <li key={tpl} className="flex items-center gap-1.5 text-ibad">
-              <Icon name="Sparkles" size={12} className="shrink-0" /> {label(tpl)}
+              <Icon name="Sparkles" size={12} className="shrink-0" /> {label(tpl)}{qtySuffix(tpl)}
             </li>
           ))}
           <li className="flex items-center gap-1.5 text-amber-200/90">

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -733,9 +733,9 @@ function ActionRow({ def, player, busy, hasLiveSession, open, danger, onToggle, 
         <div className="border-t border-border p-3">
           {def.custom === 'give-item' ? (
             <GiveItemForm busy={busy} submitLabel={def.label}
-              onSubmit={(tpl, qty, qual) => runAction(def, () => giveItem(player.id, tpl, qty, qual))}
-              onSubmitTierSet={(tpl, qty) => runAction(def, async () => {
-                for (let q = 0; q <= 5; q++) await giveItem(player.id, tpl, qty, q)
+              onSubmit={(tpl, qty, qual, overflow) => runAction(def, () => giveItem(player.id, tpl, qty, qual, overflow))}
+              onSubmitTierSet={(tpl, qty, overflow) => runAction(def, async () => {
+                for (let q = 0; q <= 5; q++) await giveItem(player.id, tpl, qty, q, overflow)
                 return { message: `Gave ${tpl} Mk1–Mk6 (x${qty} each) to ${player.name}.` }
               })} />
           ) : def.custom === 'whisper' ? (
@@ -743,9 +743,9 @@ function ActionRow({ def, player, busy, hasLiveSession, open, danger, onToggle, 
               onSubmit={msg => runAction(def, () => chatWhisper(String(player.id), msg))} />
           ) : def.custom === 'spawn-vehicle' || def.custom === 'vehicle-kit' ? (
             <VehicleKitForm busy={busy}
-              onSubmit={veh => runAction(def, async () => {
+              onSubmit={(veh, overflow) => runAction(def, async () => {
                 const parts = [...veh.kit, ...veh.unique, VEHICLE_KIT_FUEL_TEMPLATE, VEHICLE_KIT_TORCH_TEMPLATE]
-                for (const tpl of parts) await giveItem(player.id, tpl, veh.qty?.[tpl] ?? 1, 0)
+                for (const tpl of parts) await giveItem(player.id, tpl, veh.qty?.[tpl] ?? 1, 0, overflow)
                 const count = veh.kit.length + veh.unique.length
                 return { message: `Gave ${veh.label} kit — ${count} part${count === 1 ? '' : 's'} + Large Fuel Cell + Welding Torch Mk5 to ${player.name}.` }
               })} />
@@ -786,14 +786,15 @@ function ActionRow({ def, player, busy, hasLiveSession, open, danger, onToggle, 
 // wrapper — ActionRow provides the container.
 function GiveItemForm({ busy, submitLabel, onSubmit, onSubmitTierSet }: {
   busy: boolean; submitLabel: string
-  onSubmit: (tpl: string, qty: number, qual: number) => void
-  onSubmitTierSet: (tpl: string, qty: number) => void
+  onSubmit: (tpl: string, qty: number, qual: number, allowOverflow: boolean) => void
+  onSubmitTierSet: (tpl: string, qty: number, allowOverflow: boolean) => void
 }) {
   const [giveTpl, setGiveTpl]   = useState('')
   const [giveName, setGiveName] = useState('')
   const [giveQty, setGiveQty]   = useState('1')
   const [giveQual, setGiveQual] = useState('0')
   const [gradeable, setGradeable] = useState(false)
+  const [overflow, setOverflow] = useState(false)
   return (
     <div className="space-y-3">
       <ItemPicker label="Item — type to search by name or template id"
@@ -814,18 +815,41 @@ function GiveItemForm({ busy, submitLabel, onSubmit, onSubmitTierSet }: {
             className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
         </div>
       </div>
+      <OverflowToggle checked={overflow} disabled={busy} onChange={setOverflow} />
       <button className="btn-primary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
-        onClick={() => onSubmit(giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0)}>
+        onClick={() => onSubmit(giveTpl.trim(), Number(giveQty) || 1, Number(giveQual) || 0, overflow)}>
         {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} {submitLabel}
       </button>
       {gradeable && (
         <button className="btn-secondary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
           title="Gives one of this item at every grade, Mk1 through Mk6"
-          onClick={() => onSubmitTierSet(giveTpl.trim(), Number(giveQty) || 1)}>
+          onClick={() => onSubmitTierSet(giveTpl.trim(), Number(giveQty) || 1, overflow)}>
           {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Layers" size={13} />} Give whole tier set (Mk1-Mk6)
         </button>
       )}
     </div>
+  )
+}
+
+// Shared "drop overflow to the ground" toggle. When checked, the give skips
+// DST's inventory-capacity guard so the game's native AddItemToInventory command
+// handles a full backpack by dropping the excess on the ground. Online players
+// only — offline (SQL) gives can't drop to ground, so the flag is ignored there.
+function OverflowToggle({ checked, disabled, onChange }: {
+  checked: boolean; disabled: boolean; onChange: (v: boolean) => void
+}) {
+  return (
+    <label className="flex items-start gap-2 text-xs text-text-muted cursor-pointer select-none">
+      <input type="checkbox" checked={checked} disabled={disabled}
+        onChange={e => onChange(e.target.checked)}
+        className="mt-0.5 accent-ibad" />
+      <span>
+        <span className="text-text">Allow overflow (drop to ground)</span>
+        <span className="block text-[11px] text-text-dim">
+          If the inventory is full, drop the items that don't fit on the ground next to the player. Online players only.
+        </span>
+      </span>
+    </label>
   )
 }
 
@@ -1034,11 +1058,12 @@ function GivePackageForm({ busy, playerName, onGive }: {
 // chassis/modules. Shared by both the "Spawn Vehicle" and "Give Vehicle Kit"
 // actions, which call the same handler.
 function VehicleKitForm({ busy, onSubmit }: {
-  busy: boolean; onSubmit: (veh: VehicleTemplate) => void
+  busy: boolean; onSubmit: (veh: VehicleTemplate, allowOverflow: boolean) => void
 }) {
   const kitVehicles = useMemo(() => VEHICLE_CATALOG.filter(v => v.kit.length > 0), [])
   const [vid, setVid] = useState(kitVehicles[0]?.id ?? '')
   const [names, setNames] = useState<Record<string, string>>({})
+  const [overflow, setOverflow] = useState(false)
   const veh = kitVehicles.find(v => v.id === vid) || kitVehicles[0]
   const selectCls = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50'
 
@@ -1095,8 +1120,9 @@ function VehicleKitForm({ busy, onSubmit }: {
           </li>
         </ul>
       </div>
+      <OverflowToggle checked={overflow} disabled={busy} onChange={setOverflow} />
       <button className="btn-primary w-full" disabled={busy}
-        onClick={() => onSubmit(veh)}>
+        onClick={() => onSubmit(veh, overflow)}>
         {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Truck" size={13} />} Give Vehicle Kit
       </button>
     </div>

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -418,7 +418,7 @@ interface ActionDef {
   liveOnly?: boolean      // requires player to be online (RMQ path)
   offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   fields?: ActionField[]
-  custom?: 'give-item' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package'
+  custom?: 'give-item' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts'
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
   rowNote?: string        // short italic note shown inline on the row heading
@@ -520,9 +520,12 @@ const ACTIONS: ActionDef[] = [
     run: (p, v) => teleportToPlayer(p.id, Number(v.target) || 0) },
   { id: 'whisper', group: 'Live', label: 'Whisper', icon: 'MessageCircle', liveOnly: true, custom: 'whisper',
     run: () => Promise.resolve({ message: '' }) },
-  { id: 'cheat-script', group: 'Live', label: 'Cheat Script', icon: 'Terminal', liveOnly: true,
-    fields: [{ key: 'script', label: 'Cheat command', type: 'text', placeholder: 'ce God' }],
-    run: (p, v) => cheatScript({ actor_id: p.id }, String(v.script || '').trim()) },
+  { id: 'cheat-script', group: 'Live', label: 'Cheat Scripts', icon: 'Terminal', liveOnly: true, custom: 'cheat-scripts',
+    rowNote: 'Fire a server cheat script — loadouts, XP, unlock skills/abilities. Online only',
+    run: () => Promise.resolve({ message: '' }) },
+  { id: 'dev-scripts', group: 'Live', label: 'Dev / Perf Scripts', icon: 'FlaskConical', liveOnly: true, custom: 'dev-scripts',
+    rowNote: 'Developer performance-test harnesses (hitch tests). Playtest-only, online only',
+    run: () => Promise.resolve({ message: '' }) },
 
   // ----- Identity -----
   { id: 'rename', group: 'Identity', label: 'Rename Character', icon: 'PenLine',
@@ -745,6 +748,18 @@ function ActionRow({ def, player, busy, hasLiveSession, open, danger, onToggle, 
                 for (const tpl of parts) await giveItem(player.id, tpl, veh.qty?.[tpl] ?? 1, 0)
                 const count = veh.kit.length + veh.unique.length
                 return { message: `Gave ${veh.label} kit — ${count} part${count === 1 ? '' : 's'} + Large Fuel Cell + Welding Torch Mk5 to ${player.name}.` }
+              })} />
+          ) : def.custom === 'cheat-scripts' ? (
+            <CheatScriptForm busy={busy}
+              onSubmit={name => runAction(def, async () => {
+                await cheatScript({ actor_id: player.id }, name)
+                return { message: `Sent cheat script "${name}" to ${player.name}.` }
+              })} />
+          ) : def.custom === 'dev-scripts' ? (
+            <DevScriptForm busy={busy}
+              onSubmit={name => runAction(def, async () => {
+                await cheatScript({ actor_id: player.id }, name)
+                return { message: `Sent dev script "${name}" to ${player.name}.` }
               })} />
           ) : def.custom === 'quick-presets' ? (
             <QuickPresetsForm busy={busy}
@@ -1084,6 +1099,99 @@ function VehicleKitForm({ busy, onSubmit }: {
         onClick={() => onSubmit(veh)}>
         {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Truck" size={13} />} Give Vehicle Kit
       </button>
+    </div>
+  )
+}
+
+// Cheat-script panel. Buttons fire named server cheat scripts (CheatScript
+// ServerCommand) for the online player — loadouts, XP, skill/ability unlocks.
+// The named scripts are defined server-side in the game's [CheatScript.*] INI;
+// DST can only invoke ones the server ships. These are transcribed from the
+// Dune: Awakening PLAYTEST server, so they may be absent / no-ops on a retail
+// dedicated server (see the disclaimer). A freeform box sends any other name.
+const CHEAT_SCRIPTS: { name: string; label: string; desc: string; icon: string; group: string }[] = [
+  { name: 'PlaytestSetup',      label: 'Playtest Setup',         desc: 'Full loadout — resets progression, refills, grants a large weapon/armor/consumable kit, awards XP, unlocks skills (items by display name).', icon: 'PackagePlus', group: 'Loadout & Progression' },
+  { name: 'PlaytestSetupAdmin', label: 'Playtest Setup (Admin)', desc: 'Same as Playtest Setup but items are referenced by class string only.', icon: 'PackagePlus', group: 'Loadout & Progression' },
+  { name: 'AwardPlayerXP',      label: 'Award Player XP',        desc: 'Grants 10,000 XP in each of the three categories.', icon: 'Star', group: 'Loadout & Progression' },
+  { name: 'UnlockAllSkills',    label: 'Unlock All Skills',      desc: 'Sets every key skill module and capstone to level 1.', icon: 'Sparkles', group: 'Loadout & Progression' },
+  { name: 'UnlockAllAbilities', label: 'Unlock All Abilities',   desc: 'Sets every ability module to level 1.', icon: 'Sparkles', group: 'Loadout & Progression' },
+  { name: 'LeaveMeAlone',       label: 'Leave Me Alone',         desc: 'Clears nearby threats and disables environmental hazards (NPCs, sandstorms, worms).', icon: 'ShieldOff', group: 'Utility' },
+]
+
+// Dev/perf-test harnesses, kept on a separate action row.
+const DEV_SCRIPTS: { name: string; label: string; desc: string; icon: string }[] = [
+  { name: 'StartHitchVehicleTest', label: 'Start Hitch Test', desc: 'Dev/perf harness — forces frame hitches and unsteady FPS.', icon: 'Activity' },
+  { name: 'StopHitchVehicleTest',  label: 'Stop Hitch Test',  desc: 'Reverts the hitch/FPS performance test.', icon: 'Activity' },
+]
+
+function PlaytestDisclaimer() {
+  return (
+    <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning flex items-start gap-2">
+      <Icon name="TriangleAlert" size={14} className="shrink-0 mt-0.5" />
+      <span>
+        These scripts come from the Dune: Awakening <strong>Playtest</strong> server and are defined server-side. On a
+        retail dedicated server they may be absent and have <strong>no effect</strong>. Online players only.
+      </span>
+    </div>
+  )
+}
+
+function ScriptButton({ s, busy, onSubmit }: {
+  s: { name: string; label: string; desc: string; icon: string }; busy: boolean; onSubmit: (name: string) => void
+}) {
+  return (
+    <button type="button" disabled={busy} onClick={() => onSubmit(s.name)} title={s.desc}
+      className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded border border-border bg-surface-2 hover:bg-surface-3 text-left text-sm text-text-muted hover:text-text transition-colors disabled:opacity-60 disabled:cursor-wait">
+      <Icon name={s.icon} size={14} className="mt-0.5 shrink-0 text-text-dim" />
+      <span className="flex-1 min-w-0">
+        <span className="block text-text">{s.label}</span>
+        <span className="block text-[11px] text-text-dim">{s.desc}</span>
+      </span>
+    </button>
+  )
+}
+
+function CheatScriptForm({ busy, onSubmit }: { busy: boolean; onSubmit: (name: string) => void }) {
+  const [freeform, setFreeform] = useState('')
+  const groups = ['Loadout & Progression', 'Utility']
+  const inputCls = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50'
+  return (
+    <div className="space-y-3">
+      <PlaytestDisclaimer />
+      {groups.map(g => (
+        <div key={g}>
+          <div className="text-[11px] uppercase tracking-wider text-text-dim mb-1.5">{g}</div>
+          <div className="space-y-1.5">
+            {CHEAT_SCRIPTS.filter(s => s.group === g).map(s => (
+              <ScriptButton key={s.name} s={s} busy={busy} onSubmit={onSubmit} />
+            ))}
+          </div>
+        </div>
+      ))}
+      <div>
+        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Other script name</label>
+        <div className="flex gap-2">
+          <input type="text" value={freeform} disabled={busy} placeholder="e.g. PlaytestSetup"
+            className={inputCls} onChange={e => setFreeform(e.target.value)} />
+          <button type="button" className="btn-primary shrink-0" disabled={busy || !freeform.trim()}
+            onClick={() => onSubmit(freeform.trim())}>
+            {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Send" size={13} />} Send
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DevScriptForm({ busy, onSubmit }: { busy: boolean; onSubmit: (name: string) => void }) {
+  return (
+    <div className="space-y-3">
+      <PlaytestDisclaimer />
+      <div className="space-y-1.5">
+        {DEV_SCRIPTS.map(s => (
+          <ScriptButton key={s.name} s={s} busy={busy} onSubmit={onSubmit} />
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Vehicle kit corrections

The **Give Vehicle Kit** action delivered the wrong loadouts. Adds optional per-part quantity support to the vehicle catalog and corrects each kit:

| Vehicle | Change |
|---|---|
| Sandbike | Tread Mk6 → ×3 |
| Buggy | Tread Mk6 → ×4; **add** Focused Buggy Cutteray Mk6 |
| Sandcrawler | **delete** Tread Mk6; Dampened Sandcrawler Treads → ×2 |
| Ornithopter (Light) | **delete** Scout Wing Mk6; Albatross Wing Module Mk6 → ×4 |
| Ornithopter (Medium) | **delete** Assault Wing Mk6; Hummingbird Wing Module Mk6 → ×6 |
| Ornithopter (Transport) | **delete** Carrier Wing Mk6; Roc Carrier Wing → ×8; Tail Hull → ×2; Side Hull → ×2 |

Tank / Treadwheel / Container unchanged (spawn-only — no part items).

The kit give-loop and preview now read a `qty` map (template → count), defaulting to 1.

## "Thanks for the Coffee" menu

New supporter-credits dropdown to the right of **Help** in the top menu bar. First entry: Decker (@decker177), rendered as a plain credit line.

---

Build clean (tsc + vite); 50/50 webui tests pass.