### PR TITLE
docs: remove cut Fill Base Water feature from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,6 @@ browser and keeps the server running in the background.
 
 ### New in v12.0.20–v12.0.24
 
-- **Fill Base Water** Player Action (v12.0.21, Inventory section, next to Fill
-  Water) — tops up all water containers in a player's **own** bases (Water
-  Cisterns, Windtraps) plus their carried fillables in one click. Routes
-  through the per-player `UpdateAllWaterFillables` game command keyed by the
-  player's FLS id, so it only ever affects **that** player's own containers —
-  never other players' bases. Online-only: offline players are rejected with
-  a clear message and the button shows a **LIVE REQ'D** badge while they're
-  offline.
 - **Help → Show / Hide backend console** (v12.0.24) — the first UI path that
   un-minimizes and restores the backend PowerShell console window once tray
   mode has hidden it. Backed by a new loopback-only `/api/console` route that


### PR DESCRIPTION
Removes the **Fill Base Water** Player Action bullet from the README — it was cut from the app in **v12.1.2** (cistern water is owned by the live map pod and overwrites any DB/RMQ write, so the feature could never reliably work), but the README still advertised it as a current feature.

## Audit
Checked README + the full marketing site (\site/src/pages/*.astro\) against the app's cut features:
- **Fill Base Water** (cut v12.1.2) — was still in README ➜ **removed here**. Not present anywhere in the site.
- **8 global \m_Global*Multiplier\ Game Config options** (cut v12.2.0) — README only carries a *removal note* (accurate, kept); not advertised as present anywhere. Site clean.
- Carry-water (**Fill Water**) is unaffected and still in the app — left as-is.

No marketing-site changes were needed; it had no stale cut-feature copy.