### PR TITLE
Add Ogmosis and boosterfuel to coffee supporters (v12.2.3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.2.1"
+      placeholder: "v12.2.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.2.3] - 2026-06-16
+
+### Changed
+
+- **"Thanks for the Coffee" menu.** Added Ogmosis (@ogmosis) and boosterfuel
+  (@boosterfuel) to the supporter credits.
+
 ## [12.2.2] - 2026-06-16
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.2.2'
+$script:DuneToolVersion = '12.2.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.2.2',
+    [string]$Version = '12.2.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.2.2</Version>
+    <Version>12.2.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.2.2"
+#define MyAppVersion "12.2.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.2.2"
+$script:ToolVersion = "12.2.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -362,6 +362,14 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <Icon name="Heart" size={14} className="text-ibad shrink-0" />
               <span className="flex-1">Decker (@decker177)</span>
             </div>
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">Ogmosis (@ogmosis)</span>
+            </div>
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">boosterfuel (@boosterfuel)</span>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Adds **Ogmosis (@ogmosis)** and **boosterfuel (@boosterfuel)** to the "Thanks for the Coffee" supporter dropdown in the top menu bar.
- Bumps version to **12.2.3** across all five stamped files.
- Rolls CHANGELOG `[Unreleased]` into a dated `[12.2.3]` entry.
- Bumps bug-report template `tool_version` placeholder to v12.2.3.

## Release

Framework Maintenance.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>