### PR TITLE
Add Journey browser, Unlock Trainers, Unlock Main Quest (v12.3.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.2.3"
+      placeholder: "v12.3.0"
     validations:
       required: true
 
@@ -86,6 +86,8 @@ body:
         - Web portal — Gameplay Admin — Players
         - Web portal — Gameplay Admin — Players — Give Item / Give Package / Give Vehicle Kit (incl. "Allow overflow")
         - Web portal — Gameplay Admin — Players — Cheat Scripts / Dev-Perf Scripts (Live)
+        - Web portal — Gameplay Admin — Players — Journey (node browser / complete / reset / wipe)
+        - Web portal — Gameplay Admin — Players — Unlock Trainers / Unlock Main Quest (Progression)
         - Web portal — Gameplay Admin — Players — Landsraad (contribution editor)
         - Web portal — Gameplay Admin — Bases
         - Web portal — Gameplay Admin — Storage
@@ -114,7 +116,7 @@ body:
     attributes:
       label: Specific page / button / command
       description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug?
-      placeholder: "e.g. Server Health 'Restart battlegroup' button, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
+      placeholder: "e.g. Server Health 'Restart battlegroup' button, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Journey > Complete node, Gameplay Admin > Players > Actions > Unlock Trainers > Swordmaster, Gameplay Admin > Players > Actions > Unlock Main Quest > A New Beginning, Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.3.0] - 2026-06-16
+
+### Added
+
+- **Journey Nodes browser (Players → Journey).** A new player section lists every
+  journey/quest node on the account with filter tabs (All / Done / Revealed /
+  Reward), node-id search, and pagination. Each row can be completed (or re-done)
+  or reset individually, and a Wipe All control restarts the whole journey. Works
+  online or offline — changes take effect on the player's next login.
+- **Unlock Trainers (Players → Actions → Progression).** Completes a skill
+  trainer's starting quest line and grants the full job skill tree, broken out
+  per trainer type — Swordmaster, Trooper, Mentat, Bene Gesserit, Planetologist —
+  each with its own Unlock and Reset Skill Tree buttons.
+- **Unlock Main Quest (Players → Actions → Progression).** Completes an entire
+  main-quest story line in one click, chosen from a dropdown (A New Beginning,
+  Find the Fremen, Assassin's Handbook, The Great Convention, and Pt. 2).
+
+### Changed
+
+- **Player action rows no longer block on online/offline status.** Actions that
+  only take full effect on a live session keep their "LIVE REQ'D" badge for
+  guidance, but the rows are always openable so the options are visible
+  regardless of whether the player is online.
+
 ## [12.2.3] - 2026-06-16
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.2.3'
+$script:DuneToolVersion = '12.3.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.2.3',
+    [string]$Version = '12.3.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.2.3</Version>
+    <Version>12.3.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.2.3"
+#define MyAppVersion "12.3.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersRead.ps1
+++ b/app/server/lib/PlayersRead.ps1
@@ -442,3 +442,95 @@ function Get-DuneProgressionPresetsCatalog {
     $cat = Get-DuneProgressionPresetCatalog
     return @{ ok = $true; presets = @($cat); total = @($cat).Count }
 }
+
+# ----- §1.13 GET /players/trainers ----------------------------------------
+# Skill-trainer quest lines. Each job's starting quest line is a set of
+# DA_CT_Trainer_<Job><tier>_<nn> contracts (transcribed into dune-tags.json).
+# Completing them + granting the job skill tree = "unlock trainer".
+$script:DuneTrainerJobOrder = @('Swordmaster', 'Trooper', 'Mentat', 'BeneGesserit', 'Planetologist')
+$script:DuneTrainerJobLabels = @{
+    Swordmaster   = 'Swordmaster'
+    Trooper       = 'Trooper'
+    Mentat        = 'Mentat'
+    BeneGesserit  = 'Bene Gesserit'
+    Planetologist = 'Planetologist'
+}
+
+function Get-DuneTrainerContractIds {
+    param([string]$Job)
+    $tags = Get-DuneTagsData
+    $esc = [regex]::Escape($Job)
+    $ids = @($tags.contractTags.Keys | Where-Object { $_ -match "^DA_CT_Trainer_$esc\d" } | Sort-Object)
+    return $ids
+}
+
+function Get-DuneTrainerCatalog {
+    $tags = Get-DuneTagsData
+    $list = @()
+    foreach ($job in $script:DuneTrainerJobOrder) {
+        if (-not $tags.jobSkillBlocks.ContainsKey($job)) { continue }
+        $ids = Get-DuneTrainerContractIds -Job $job
+        $list += @{
+            job            = [string]$job
+            name           = [string]$script:DuneTrainerJobLabels[$job]
+            contract_count = @($ids).Count
+            skill_count    = @($tags.jobSkillBlocks[$job]).Count
+        }
+    }
+    return @{ ok = $true; trainers = $list; total = $list.Count }
+}
+
+# ----- §1.14 GET /players/main-quests -------------------------------------
+# Main-quest story lines. Each is a DA_MQ_<Root> subtree in journey_node_tags;
+# completing the root node flips every DA_MQ_<Root>.* journey row complete and
+# applies the union of subtree reward tags.
+$script:DuneMainQuestOrder = @(
+    'DA_MQ_ANewBeginning',
+    'DA_MQ_FindTheFremen',
+    'DA_MQ_AssassinsHandbook',
+    'DA_MQ_TheGreatConvention',
+    'DA_MQ_TheGreatConventionPt2'
+)
+$script:DuneMainQuestLabels = @{
+    DA_MQ_ANewBeginning         = 'A New Beginning'
+    DA_MQ_FindTheFremen         = 'Find the Fremen'
+    DA_MQ_AssassinsHandbook     = "Assassin's Handbook"
+    DA_MQ_TheGreatConvention    = 'The Great Convention'
+    DA_MQ_TheGreatConventionPt2 = 'The Great Convention (Pt. 2)'
+}
+
+function Get-DuneMainQuestRoots {
+    $tags = Get-DuneTagsData
+    $counts = @{}
+    foreach ($k in $tags.journeyNodeTags.Keys) {
+        if ($k -notlike 'DA_MQ_*') { continue }
+        $dot = $k.IndexOf('.')
+        $root = if ($dot -gt 0) { $k.Substring(0, $dot) } else { $k }
+        if ($counts.ContainsKey($root)) { $counts[$root]++ } else { $counts[$root] = 1 }
+    }
+    return $counts
+}
+
+function Get-DuneMainQuestCatalog {
+    $counts = Get-DuneMainQuestRoots
+    $list = @()
+    $seen = @{}
+    foreach ($root in $script:DuneMainQuestOrder) {
+        $seen[$root] = $true
+        $name = if ($script:DuneMainQuestLabels.ContainsKey($root)) { $script:DuneMainQuestLabels[$root] } else { $root }
+        $n = if ($counts.ContainsKey($root)) { [int]$counts[$root] } else { 0 }
+        $list += @{ id = [string]$root; name = [string]$name; node_count = $n }
+    }
+    foreach ($root in ($counts.Keys | Sort-Object)) {
+        if ($seen.ContainsKey($root)) { continue }
+        $name = ($root -replace '^DA_MQ_', '') -creplace '(?<!^)([A-Z])', ' $1'
+        $list += @{ id = [string]$root; name = [string]$name.Trim(); node_count = [int]$counts[$root] }
+    }
+    return @{ ok = $true; main_quests = $list; total = $list.Count }
+}
+
+function Test-DuneMainQuestRoot {
+    param([string]$Root)
+    $counts = Get-DuneMainQuestRoots
+    return $counts.ContainsKey($Root)
+}

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1188,6 +1188,56 @@ WHERE fe.entity_id = (
     return @{ ok = $true; message = "Reset $Job skill tree - scanned $($modules.Count) module slot(s)" }
 }
 
+# Unlock a skill-trainer quest line: completes every DA_CT_Trainer_<Job>* contract
+# (applies their reward tags + skill grants, dismisses active contract items) and
+# grants the full job skill tree. Offline-safe (DB writes; takes effect next login).
+function Invoke-DunePlayerUnlockTrainer {
+    param([string]$Ip, [long]$AccountId, [string]$Job)
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+    if (-not $Job) { return @{ ok = $false; error = 'job is required.' } }
+    _Load-DuneTagsData
+    if (-not $script:DuneTagsData.jobSkillBlocks.ContainsKey($Job)) {
+        return @{ ok = $false; error = "unknown trainer job '$Job'." }
+    }
+
+    $ids = @(Get-DuneTrainerContractIds -Job $Job)
+    $parts = New-Object System.Collections.Generic.List[string]
+    $contractsDone = 0
+
+    if ($ids.Count -gt 0) {
+        $cr = Invoke-DunePlayerCompleteContracts -Ip $Ip -AccountId $AccountId -ContractIds $ids
+        if (-not $cr.ok) { return @{ ok = $false; error = "trainer contracts: $($cr.error)" } }
+        $contractsDone = [int]$cr.contracts
+        [void]$parts.Add("completed $contractsDone contract(s)")
+    }
+
+    $gr = Invoke-DunePlayerGrantJobSkills -Ip $Ip -AccountId $AccountId -Job $Job
+    if (-not $gr.ok) { return @{ ok = $false; error = "grant skill tree: $($gr.error)" } }
+    [void]$parts.Add('granted full skill tree')
+
+    $label = $Job
+    $summary = if ($parts.Count -gt 0) { " - $($parts -join ', ')" } else { '' }
+    return @{
+        ok = $true
+        message = "Unlocked $label trainer$summary - takes effect on next login"
+        contracts = $contractsDone
+    }
+}
+
+# Unlock a main-quest story line: flips every DA_MQ_<Root>.* journey row complete
+# and applies the union of subtree reward tags (reuses the journey-node engine).
+function Invoke-DunePlayerUnlockMainQuest {
+    param([string]$Ip, [long]$AccountId, [string]$Quest)
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+    if (-not $Quest) { return @{ ok = $false; error = 'quest is required.' } }
+    if (-not (Test-DuneMainQuestRoot -Root $Quest)) {
+        return @{ ok = $false; error = "unknown main quest '$Quest'." }
+    }
+    $r = Invoke-DunePlayerCompleteJourneyNode -Ip $Ip -AccountId $AccountId -NodeId $Quest
+    if (-not $r.ok) { return $r }
+    return @{ ok = $true; message = "Unlocked main quest $Quest - $($r.nodes) node(s) completed - takes effect on next login"; nodes = $r.nodes }
+}
+
 function Invoke-DunePlayerSetStarterClass {
     param([string]$Ip, [long]$AccountId, [string]$Job)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }

--- a/app/server/routes/PlayersRead.ps1
+++ b/app/server/routes/PlayersRead.ps1
@@ -155,6 +155,36 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/players/partitions' -Handler
     }
 }
 
+# GET /api/gameplay/players/trainers  (skill-trainer quest line catalog)
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/trainers' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $payload = Get-DuneTrainerCatalog
+        Write-DuneJson -Response $res -Body @{
+            trainers = $payload.trainers
+            total    = $payload.total
+            source   = 'catalog'
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Trainers failed: $($_.Exception.Message)"
+    }
+}
+
+# GET /api/gameplay/players/main-quests  (main-quest story line catalog)
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/main-quests' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $payload = Get-DuneMainQuestCatalog
+        Write-DuneJson -Response $res -Body @{
+            main_quests = $payload.main_quests
+            total       = $payload.total
+            source      = 'catalog'
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Main quests failed: $($_.Exception.Message)"
+    }
+}
+
 # GET /api/gameplay/contracts  (contract tag catalog)
 Register-DuneRoute -Method GET -Path '/api/gameplay/contracts' -Handler {
     param($req, $res, $routeParams, $body)

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -233,6 +233,34 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/contracts/reverse' 
     }
 }
 
+# POST /api/gameplay/players/unlock-trainer  { account_id, job }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/unlock-trainer' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
+        $job = [string](Get-DuneBodyValue -Body $body -Name 'job')
+        if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
+        if (-not $job) { Write-DuneError -Response $res -Status 400 -Message 'job is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerUnlockTrainer -Ip $ip -AccountId $acc -Job $job }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Unlock trainer failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/unlock-main-quest  { account_id, quest }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/unlock-main-quest' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
+        $quest = [string](Get-DuneBodyValue -Body $body -Name 'quest')
+        if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
+        if (-not $quest) { Write-DuneError -Response $res -Status 400 -Message 'quest is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerUnlockMainQuest -Ip $ip -AccountId $acc -Quest $quest }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Unlock main quest failed: $($_.Exception.Message)"
+    }
+}
+
 # POST /api/gameplay/players/grant-job-skills  { account_id, job }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/grant-job-skills' -Handler {
     param($req, $res, $routeParams, $body)

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.2.3"
+$script:ToolVersion = "12.3.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1460,6 +1460,57 @@ export function wipeJourney(accountId: number) {
   })
 }
 
+// Journey Nodes browser — reads every journey_story_node row for the account.
+export interface JourneyNode {
+  node_id: string
+  is_complete: boolean
+  is_revealed: boolean
+  has_pending_reward: boolean
+}
+export function getPlayerJourneyNodes(accountId: number, demo?: boolean) {
+  return api<{ ok: boolean; nodes: JourneyNode[]; total: number; source: DataSource }>(
+    `/api/gameplay/players/journey${qs({ account_id: accountId, demo: demo ? 1 : undefined })}`)
+}
+export function completeJourneyNode(accountId: number, nodeId: string) {
+  return api<WriteResult>('/api/gameplay/players/journey/complete', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId, node_id: nodeId }),
+  })
+}
+export function resetJourneyNode(accountId: number, nodeId: string) {
+  return api<WriteResult>('/api/gameplay/players/journey/reset', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId, node_id: nodeId }),
+  })
+}
+
+// Unlock Trainers — skill-trainer starting quest lines.
+export interface TrainerInfo { job: string; name: string; contract_count: number; skill_count: number }
+export function getTrainerCatalog() {
+  return api<{ ok: boolean; trainers: TrainerInfo[]; total: number; source: DataSource }>(
+    '/api/gameplay/players/trainers')
+}
+export function unlockTrainer(accountId: number, job: string) {
+  return api<WriteResult>('/api/gameplay/players/unlock-trainer', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId, job }),
+  })
+}
+export function resetTrainerSkills(accountId: number, job: string) {
+  return api<WriteResult>('/api/gameplay/players/reset-job-skills', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId, job }),
+  })
+}
+
+// Unlock Main Quest — main-quest story lines.
+export interface MainQuestInfo { id: string; name: string; node_count: number }
+export function getMainQuestCatalog() {
+  return api<{ ok: boolean; main_quests: MainQuestInfo[]; total: number; source: DataSource }>(
+    '/api/gameplay/players/main-quests')
+}
+export function unlockMainQuest(accountId: number, quest: string) {
+  return api<WriteResult>('/api/gameplay/players/unlock-main-quest', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId, quest }),
+  })
+}
+
 export function completeContract(accountId: number, contractId: string) {
   return api<WriteResult>('/api/gameplay/players/contract/complete', {
     method: 'POST', body: JSON.stringify({ account_id: accountId, contract_id: contractId }),

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -26,9 +26,13 @@ import {
   chatWhisper, isValidTemplateId, getItemCatalog,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
   getLandsraadOverview, getLandsraadPlayerContributions, setLandsraadContribution,
+  getPlayerJourneyNodes, completeJourneyNode, resetJourneyNode,
+  getTrainerCatalog, unlockTrainer, resetTrainerSkills,
+  getMainQuestCatalog, unlockMainQuest,
   type Player, type PlayerEvent, type PlayerStats, type ProgressionPreset, type SpecTrackFull,
   type CatalogItem, type ItemPackage, type GiveItemEntry,
   type LandsraadHouse, type LandsraadIniSetting,
+  type JourneyNode, type TrainerInfo, type MainQuestInfo,
 } from '../../../api/gameplay'
 import { VEHICLE_CATALOG, VEHICLE_KIT_FUEL_TEMPLATE, VEHICLE_KIT_TORCH_TEMPLATE, type VehicleTemplate } from '../../../data/vehicles'
 import { fmtNum, fmtSolari } from '../shared'
@@ -418,7 +422,7 @@ interface ActionDef {
   liveOnly?: boolean      // requires player to be online (RMQ path)
   offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   fields?: ActionField[]
-  custom?: 'give-item' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts'
+  custom?: 'give-item' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest'
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
   rowNote?: string        // short italic note shown inline on the row heading
@@ -464,6 +468,12 @@ const ACTIONS: ActionDef[] = [
     run: (p, v) => setFactionTier(p.controller_id, String(v.faction || '').trim(), Number(v.tier) || 0) },
   { id: 'apply-progression-preset', group: 'Progression', label: 'Apply Quick Preset', icon: 'Zap', custom: 'quick-presets',
     rowNote: 'Completes a story/journey chapter instantly',
+    run: () => Promise.resolve({ message: '' }) },
+  { id: 'unlock-trainers', group: 'Progression', label: 'Unlock Trainers', icon: 'GraduationCap', custom: 'unlock-trainers',
+    rowNote: 'Complete a skill-trainer quest line + grant its skill tree — separated by trainer',
+    run: () => Promise.resolve({ message: '' }) },
+  { id: 'unlock-main-quest', group: 'Progression', label: 'Unlock Main Quest', icon: 'Flag', custom: 'unlock-mainquest',
+    rowNote: 'Complete an entire main-quest story line',
     run: () => Promise.resolve({ message: '' }) },
   { id: 'reset-progression', group: 'Progression', label: 'Reset Progression (live)', icon: 'RotateCcw', liveOnly: true,
     rowNote: 'Single confirmation required',
@@ -662,7 +672,7 @@ export function ActionsSection({ player, canWrite, flash, onChanged }: SectionPr
     <div className="space-y-4">
       {!hasLiveSession && (
         <div className="card p-2.5 text-xs text-text-muted border-l-2 border-warning flex items-center gap-2">
-          <Icon name="WifiOff" size={12} /> Player is offline — buttons marked "(live)" are disabled (require RMQ + an online or mid-logout player).
+          <Icon name="WifiOff" size={12} /> Player is offline — actions marked "LIVE REQ'D" need the player online (RMQ + an online or mid-logout player) to take effect.
         </div>
       )}
 
@@ -677,7 +687,7 @@ export function ActionsSection({ player, canWrite, flash, onChanged }: SectionPr
             </div>
             <div className="space-y-1.5">
               {acts.map(a => (
-                <ActionRow key={a.id} def={a} player={player} busy={busy} hasLiveSession={hasLiveSession}
+                <ActionRow key={a.id} def={a} player={player} busy={busy}
                   open={openId === a.id} danger={group === 'Danger'}
                   onToggle={() => openAction(a.id)} runAction={runAction} />
               ))}
@@ -695,17 +705,16 @@ export function ActionsSection({ player, canWrite, flash, onChanged }: SectionPr
 // directly beneath it. Replaces the older wrap-of-buttons layout so the panel
 // reads as a vertical list rather than a wall of buttons.
 // ---------------------------------------------------------------------------
-function ActionRow({ def, player, busy, hasLiveSession, open, danger, onToggle, runAction }: {
+function ActionRow({ def, player, busy, open, danger, onToggle, runAction }: {
   def: ActionDef
   player: Player
   busy: boolean
-  hasLiveSession: boolean
   open: boolean
   danger?: boolean
   onToggle: () => void
   runAction: (def: ActionDef, exec: () => Promise<{ message: string }>) => void
 }) {
-  const disabled = busy || (!!def.liveOnly && !hasLiveSession) || (!!def.offlineOnly && hasLiveSession)
+  const disabled = busy
   return (
     <div className="card overflow-hidden">
       <button type="button"
@@ -764,6 +773,22 @@ function ActionRow({ def, player, busy, hasLiveSession, open, danger, onToggle, 
           ) : def.custom === 'quick-presets' ? (
             <QuickPresetsForm busy={busy}
               onSubmit={presetId => runAction(def, () => applyProgressionPreset(player.account_id, presetId))} />
+          ) : def.custom === 'unlock-trainers' ? (
+            <UnlockTrainersForm busy={busy}
+              onUnlock={(job, name) => runAction(def, async () => {
+                const r = await unlockTrainer(player.account_id, job)
+                return { message: r.message || `Unlocked ${name} trainer for ${player.name}.` }
+              })}
+              onReset={(job, name) => runAction(def, async () => {
+                const r = await resetTrainerSkills(player.account_id, job)
+                return { message: r.message || `Reset ${name} skill tree for ${player.name}.` }
+              })} />
+          ) : def.custom === 'unlock-mainquest' ? (
+            <UnlockMainQuestForm busy={busy}
+              onSubmit={(quest, name) => runAction(def, async () => {
+                const r = await unlockMainQuest(player.account_id, quest)
+                return { message: r.message || `Unlocked main quest "${name}" for ${player.name}.` }
+              })} />
           ) : def.custom === 'give-package' ? (
             <GivePackageForm busy={busy} playerName={player.name}
               onGive={(items, pkgName) => runAction(def, async () => {
@@ -1294,6 +1319,116 @@ function QuickPresetsForm({ busy, onSubmit }: { busy: boolean; onSubmit: (preset
   )
 }
 
+// Self-contained Unlock-Trainers form. Fetches the skill-trainer catalog on
+// mount and renders one card per trainer type (separated by trainer), each with
+// an "Unlock" button (completes the trainer's quest line + grants the full job
+// skill tree) and a "Reset Skill Tree" button. Renders without a card wrapper.
+function UnlockTrainersForm({ busy, onUnlock, onReset }: {
+  busy: boolean
+  onUnlock: (job: string, name: string) => void
+  onReset: (job: string, name: string) => void
+}) {
+  const [trainers, setTrainers] = useState<TrainerInfo[]>([])
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState('')
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true)
+    getTrainerCatalog()
+      .then(r => { if (alive) setTrainers(r.trainers || []) })
+      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [])
+
+  if (loading) return <div className="text-sm text-text-dim flex items-center gap-2"><Icon name="Loader2" size={13} className="animate-spin" /> Loading trainers…</div>
+  if (err) return <div className="text-sm text-danger">{err}</div>
+  if (trainers.length === 0) return <div className="text-sm text-text-dim">No trainers available.</div>
+
+  return (
+    <div className="space-y-3">
+      <div className="text-[11px] text-text-muted">
+        Completes the trainer's starting quest line and grants the full job skill tree. Works online or offline — takes effect on next login.
+      </div>
+      <div className="space-y-2">
+        {trainers.map(t => (
+          <div key={t.job} className="rounded-lg border border-border bg-surface-2 px-3 py-2">
+            <div className="flex items-center gap-2 mb-1.5">
+              <Icon name="GraduationCap" size={14} className="shrink-0 text-text-dim" />
+              <span className="flex-1 min-w-0 text-sm text-text font-medium">{t.name}</span>
+              <span className="text-[11px] text-text-dim">{t.contract_count} quest{t.contract_count === 1 ? '' : 's'} · {t.skill_count} skill block{t.skill_count === 1 ? '' : 's'}</span>
+            </div>
+            <div className="flex gap-2">
+              <button type="button" className="btn-primary flex-1 text-xs" disabled={busy}
+                onClick={() => onUnlock(t.job, t.name)}>
+                {busy ? <Icon name="Loader2" size={12} className="animate-spin" /> : <Icon name="Unlock" size={12} />} Unlock
+              </button>
+              <button type="button" className="btn-secondary shrink-0 text-xs" disabled={busy}
+                onClick={() => onReset(t.job, t.name)} title="Reset this job's skill tree">
+                <Icon name="RotateCcw" size={12} /> Reset Skill Tree
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// Self-contained Unlock-Main-Quest form. Fetches the main-quest catalog and
+// completes the chosen story line (flips every node in the subtree complete).
+function UnlockMainQuestForm({ busy, onSubmit }: { busy: boolean; onSubmit: (quest: string, name: string) => void }) {
+  const [quests, setQuests] = useState<MainQuestInfo[]>([])
+  const [sel, setSel] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState('')
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true)
+    getMainQuestCatalog()
+      .then(r => {
+        if (!alive) return
+        const list = r.main_quests || []
+        setQuests(list)
+        setSel(list[0]?.id || '')
+      })
+      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [])
+
+  const chosen = quests.find(q => q.id === sel)
+  const selectCls = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50'
+
+  if (loading) return <div className="text-sm text-text-dim flex items-center gap-2"><Icon name="Loader2" size={13} className="animate-spin" /> Loading main quests…</div>
+  if (err) return <div className="text-sm text-danger">{err}</div>
+  if (quests.length === 0) return <div className="text-sm text-text-dim">No main quests available.</div>
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Main quest</label>
+        <select value={sel} disabled={busy} className={selectCls} onChange={e => setSel(e.target.value)}>
+          {quests.map(q => (
+            <option key={q.id} value={q.id}>
+              {q.name}{q.node_count > 0 ? ` (${q.node_count} nodes)` : ''}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="text-[11px] text-text-muted">
+        Flips every node in this story line complete and applies its reward tags. Takes effect on next login.
+      </div>
+      <button className="btn-primary w-full" disabled={busy || !sel}
+        onClick={() => onSubmit(sel, chosen?.name || sel)}>
+        {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Flag" size={13} />} Unlock Main Quest
+      </button>
+    </div>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Items action block — the 'Items' group of ACTIONS, rendered inside the
 // Inventory section (between the inventory title and the items list).
@@ -1305,8 +1440,6 @@ function ItemsActionBlock({ player, canWrite, flash, onChanged }: {
 }) {
   const [openId, setOpenId] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
-
-  const hasLiveSession = ['online', 'loggingout'].includes((player.online_status || '').toLowerCase())
 
   const acts = useMemo(() => ACTIONS.filter(a => a.group === ITEMS_GROUP), [])
 
@@ -1335,7 +1468,7 @@ function ItemsActionBlock({ player, canWrite, flash, onChanged }: {
   return (
     <div className="space-y-1.5 mb-2">
       {acts.map(a => (
-        <ActionRow key={a.id} def={a} player={player} busy={busy} hasLiveSession={hasLiveSession}
+        <ActionRow key={a.id} def={a} player={player} busy={busy}
           open={openId === a.id} onToggle={() => openAction(a.id)} runAction={runAction} />
       ))}
     </div>
@@ -1942,8 +2075,171 @@ function LandsraadSection({ player, canWrite, demo, refreshKey, flash, onChanged
   )
 }
 
+// ---------------------------------------------------------------------------
+// Journey — full browser over every journey_story_node row for the account.
+// Filter tabs (All / Done / Revealed / Reward), node-id search, client-side
+// pagination, per-row Complete/Reset, and a Wipe-All control. All writes work
+// online or offline (DB writes); they take effect on the player's next login.
+// ---------------------------------------------------------------------------
+const JOURNEY_PAGE_SIZE = 50
+type JourneyFilter = 'all' | 'done' | 'revealed' | 'reward'
+
+export function JourneySection({ player, canWrite, demo, refreshKey, flash, onChanged }: SectionProps) {
+  const [nodes, setNodes] = useState<JourneyNode[]>([])
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [filter, setFilter] = useState<JourneyFilter>('all')
+  const [search, setSearch] = useState('')
+  const [page, setPage] = useState(0)
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true); setErr(null)
+    getPlayerJourneyNodes(player.account_id, demo)
+      .then(r => { if (alive) setNodes(r.nodes || []) })
+      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [player.account_id, demo, refreshKey, tick])
+
+  const counts = useMemo(() => ({
+    all: nodes.length,
+    done: nodes.filter(n => n.is_complete).length,
+    revealed: nodes.filter(n => n.is_revealed).length,
+    reward: nodes.filter(n => n.has_pending_reward).length,
+  }), [nodes])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return nodes.filter(n => {
+      if (filter === 'done' && !n.is_complete) return false
+      if (filter === 'revealed' && !n.is_revealed) return false
+      if (filter === 'reward' && !n.has_pending_reward) return false
+      if (q && !n.node_id.toLowerCase().includes(q)) return false
+      return true
+    })
+  }, [nodes, filter, search])
+
+  useEffect(() => { setPage(0) }, [filter, search])
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / JOURNEY_PAGE_SIZE))
+  const pageClamped = Math.min(page, pageCount - 1)
+  const pageRows = filtered.slice(pageClamped * JOURNEY_PAGE_SIZE, (pageClamped + 1) * JOURNEY_PAGE_SIZE)
+
+  const run = async (fn: () => Promise<{ message: string }>) => {
+    setBusy(true); setErr(null)
+    try {
+      const r = await fn()
+      flash(r.message, 'ok')
+      onChanged()
+      setTick(t => t + 1)
+    } catch (e) {
+      flash(e instanceof Error ? e.message : String(e), 'err')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const wipeAll = () => {
+    if (!window.confirm(
+      `WIPE ${player.name}'s entire journey and restart it from the beginning? All journey/quest progress is lost. This cannot be undone.`
+    )) return
+    void run(() => wipeJourney(player.account_id))
+  }
+
+  if (loading) return <Loading label="Loading journey…" />
+
+  const tabs: Array<{ id: JourneyFilter; label: string; n: number }> = [
+    { id: 'all', label: 'All', n: counts.all },
+    { id: 'done', label: 'Done', n: counts.done },
+    { id: 'revealed', label: 'Revealed', n: counts.revealed },
+    { id: 'reward', label: 'Reward', n: counts.reward },
+  ]
+
+  return (
+    <div className="space-y-3">
+      {err && <ErrorBox msg={err} />}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap gap-1">
+          {tabs.map(t => (
+            <button key={t.id} type="button" onClick={() => setFilter(t.id)}
+              className={`px-2.5 py-1 rounded-md text-xs border transition-colors ${filter === t.id ? 'bg-ibad/20 border-ibad/50 text-text' : 'bg-surface-2 border-border text-text-muted hover:text-text'}`}>
+              {t.label} <span className="text-text-dim">({fmtNum(t.n)})</span>
+            </button>
+          ))}
+        </div>
+        <div className="flex-1 min-w-[160px]">
+          <input type="text" value={search} onChange={e => setSearch(e.target.value)}
+            placeholder="Search node id…"
+            className="w-full px-3 py-1.5 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+        </div>
+        {canWrite && (
+          <button type="button" className="btn-secondary shrink-0 text-xs text-error" disabled={busy} onClick={wipeAll}
+            title="Delete every journey node for this account">
+            <Icon name="RefreshCw" size={12} /> Wipe All
+          </button>
+        )}
+      </div>
+
+      {nodes.length === 0 ? (
+        <EmptyBox msg={demo ? 'Journey browsing is unavailable in demo mode.' : 'No journey nodes recorded for this player yet.'} />
+      ) : filtered.length === 0 ? (
+        <EmptyBox msg="No nodes match the current filter." />
+      ) : (
+        <>
+          <div className="space-y-1">
+            {pageRows.map(n => (
+              <div key={n.node_id} className="card px-3 py-2 flex items-center gap-2">
+                <span className="flex-1 min-w-0 font-mono text-xs text-text truncate" title={n.node_id}>{n.node_id}</span>
+                <div className="flex items-center gap-1 shrink-0">
+                  {n.is_complete && <span className="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-success/20 text-success border border-success/40">Done</span>}
+                  {n.is_revealed && <span className="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-info/20 text-info border border-info/40">Rev</span>}
+                  {n.has_pending_reward && <span className="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-warning/20 text-warning border border-warning/40">Reward</span>}
+                </div>
+                {canWrite && (
+                  <div className="flex items-center gap-1 shrink-0">
+                    <button type="button" className="btn-secondary text-[11px] px-2 py-1" disabled={busy}
+                      onClick={() => void run(() => completeJourneyNode(player.account_id, n.node_id))}
+                      title={n.is_complete ? 'Re-apply completion + reward tags' : 'Complete this node + subtree'}>
+                      <Icon name="Check" size={11} /> {n.is_complete ? 'Re-do' : 'Complete'}
+                    </button>
+                    <button type="button" className="btn-secondary text-[11px] px-2 py-1" disabled={busy}
+                      onClick={() => void run(() => resetJourneyNode(player.account_id, n.node_id))}
+                      title="Reset this node + subtree">
+                      <Icon name="RotateCcw" size={11} /> Reset
+                    </button>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {pageCount > 1 && (
+            <div className="flex items-center justify-between text-xs text-text-dim">
+              <span>{fmtNum(filtered.length)} node(s) · page {pageClamped + 1} of {pageCount}</span>
+              <div className="flex gap-1">
+                <button type="button" className="btn-secondary px-2 py-1" disabled={pageClamped <= 0}
+                  onClick={() => setPage(p => Math.max(0, p - 1))}>
+                  <Icon name="ChevronLeft" size={13} />
+                </button>
+                <button type="button" className="btn-secondary px-2 py-1" disabled={pageClamped >= pageCount - 1}
+                  onClick={() => setPage(p => Math.min(pageCount - 1, p + 1))}>
+                  <Icon name="ChevronRight" size={13} />
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
 // Re-export the section component type for the tab shell.
-export type SectionId = 'stats' | 'specs' | 'tags' | 'history' | 'inventory' | 'landsraad' | 'actions'
+export type SectionId = 'stats' | 'specs' | 'tags' | 'history' | 'inventory' | 'landsraad' | 'journey' | 'actions'
 
 export const SECTIONS: Array<{ id: SectionId; label: string; icon: string }> = [
   { id: 'stats',     label: 'Stats',     icon: 'User' },
@@ -1952,6 +2248,7 @@ export const SECTIONS: Array<{ id: SectionId; label: string; icon: string }> = [
   { id: 'landsraad', label: 'Landsraad', icon: 'Landmark' },
   { id: 'tags',      label: 'Tags',      icon: 'Tag' },
   { id: 'history',   label: 'History',   icon: 'History' },
+  { id: 'journey',   label: 'Journey',   icon: 'Map' },
   { id: 'actions',   label: 'Actions',   icon: 'Wand2' },
 ]
 
@@ -1962,5 +2259,6 @@ export const SECTION_COMPONENTS: Record<SectionId, (p: SectionProps) => ReactEle
   history:   HistorySection,
   inventory: InventorySection,
   landsraad: LandsraadSection,
+  journey:   JourneySection,
   actions:   ActionsSection,
 }


### PR DESCRIPTION
## Summary

Ports three player/progression features and ships the player-menu online-gating change, bundled as **v12.3.0**.

### Added
- **Journey Nodes browser** (Players → Journey) — lists every journey/quest node on the account with filter tabs (All / Done / Revealed / Reward), node-id search, and pagination. Per-row Complete (or Re-do) / Reset, plus a Wipe All control. Works online or offline.
- **Unlock Trainers** (Players → Actions → Progression) — completes a skill trainer's starting quest line and grants the full job skill tree, broken out per trainer type: Swordmaster, Trooper, Mentat, Bene Gesserit, Planetologist. Each has Unlock + Reset Skill Tree.
- **Unlock Main Quest** (Players → Actions → Progression) — completes an entire main-quest story line from a dropdown (A New Beginning, Find the Fremen, Assassin's Handbook, The Great Convention, Pt. 2).

### Changed
- Player action rows no longer block on online/offline status — the "LIVE REQ'D" badge stays as guidance, but rows are always openable so options are visible regardless of online state.

## Implementation notes
The backend engine already existed (trainer contracts in `dune-tags.json`, contract-complete, grant-job-skills, journey-node complete). This change wires data-driven catalogs (`Get-DuneTrainerCatalog`, `Get-DuneMainQuestCatalog`) + thin write fns (`Invoke-DunePlayerUnlockTrainer`, `Invoke-DunePlayerUnlockMainQuest`) and the React UI. Trainer contract ids are resolved server-side — no hardcoded lists.

## Verification
- webui `npm run build` green; backend PowerShell parse-clean; catalog derivations validated against `dune-tags.json`.
- Installer built clean (BOM + PS5.1 preflights passed).
- 5 version stamps bumped 12.2.3 → 12.3.0; CHANGELOG + bug_report.yml updated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>