### PR TITLE
Fix Cheat Scripts "script_name is required." error (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cheat Scripts: "script_name is required." error.** The Players → Live →
+  Cheat Scripts form posted the script under the body key `script`, but the
+  `/api/gameplay/players/cheat-script` route reads `script_name`, so every
+  script (Playtest Setup, Award Player XP, Unlock All Skills/Abilities, Leave Me
+  Alone, custom script name, etc.) failed with a 400. The web UI now sends the
+  documented `script_name` field. (#235)
+
 ## [12.3.0] - 2026-06-16
 
 ### Added

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1602,7 +1602,7 @@ export function giveItemLive(t: PlayerTarget, template: string, qty: number, qua
 
 export function cheatScript(t: PlayerTarget, script: string) {
   return api<WriteResult>('/api/gameplay/players/cheat-script', {
-    method: 'POST', body: targetBody(t, { script }),
+    method: 'POST', body: targetBody(t, { script_name: script }),
   })
 }
 


### PR DESCRIPTION
## Summary

Fixes #235. Every cheat script (Players → Live → Cheat Scripts) failed with a `400` error `"script_name is required."`.

## Root cause

Field-name mismatch between web UI and backend:

- `cheatScript()` in `webui/src/api/gameplay.ts` posted the script under body key **`script`**.
- The `/api/gameplay/players/cheat-script` route (`app/server/routes/PlayersRmq.ps1:101`) reads **`script_name`**.

So the name was always empty and the route rejected the request — breaking Playtest Setup, Playtest Setup (Admin), Award Player XP, Unlock All Skills, Unlock All Abilities, Leave Me Alone, and the custom "Other Script Name" field, as confirmed by the reporter.

## Fix

Web UI now sends the documented `script_name` field, matching the route contract (`# POST ... { fls_id?, actor_id?, script_name }`).

## Verification

- `tsc -b && vite build` — clean.

## Notes

Code-only fix to the web UI source. A full installer build (`Build-Installer.ps1`) is needed to ship the rebuilt `webui/dist` bundle to users.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>