### PR TITLE
Clarify Find the Fremen preset does not unlock ability slots (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ here cover everything those tags shipped.
   is generated — the currently-running term keeps its existing seeded values
   until it rolls over. The tool already writes both values correctly; the delay
   is server-side behavior, not a write bug (#234).
+- Clarified the "Complete: Find the Fremen (Trials of Aql)" progression preset
+  description to note it does not unlock active-ability slots — those come from
+  the separate Spice Agony progression, which this preset does not grant (#236).
 
 ## [12.3.0] - 2026-06-16
 

--- a/app/data/dune-progression-presets.json
+++ b/app/data/dune-progression-presets.json
@@ -24,7 +24,7 @@
     "nodes": [
       "DA_MQ_FindTheFremen"
     ],
-    "description": "All 7 trials, the Sietch, and Epilogue. Unlocks the Fremkit (Stillsuit, Thumper, Cryss Knife, etc.) and completes Act 1."
+    "description": "All 7 trials, the Sietch, and Epilogue. Unlocks the Fremkit (Stillsuit, Thumper, Cryss Knife, etc.) and completes Act 1. Does not unlock active-ability slots - those come from the separate Spice Agony progression, which this preset does not grant."
   },
   {
     "id": "act1_complete",


### PR DESCRIPTION
## Summary

Description-only clarification for the **"Complete: Find the Fremen (Trials of Aql)"** progression preset.

Issue #236 reported that this preset leaves the 3rd active-ability slot locked. Investigation confirmed this is expected: the preset marks the `DA_MQ_FindTheFremen` journey nodes complete and applies the Fremkit item tags + `Journey.Act1.Completed` + Sietch progression. The 3rd ability slot is **not** gated by any journey tag — active-ability slots come from the separate **Spice Agony / spice-vision** progression subsystem, which the tool does not model. There is no ability-slot unlock tag anywhere in the repo data, so the preset cannot grant it.

No logic fix is possible. #236 has been reclassified as an enhancement.

## Changes

- `app/data/dune-progression-presets.json` — appended a clarifying sentence to the `find_the_fremen` preset description noting it does not unlock active-ability slots (those come from the separate Spice Agony progression). ASCII-safe `-` used to match the file's existing convention (no BOM, no non-ASCII bytes; JSON validated).
- `CHANGELOG.md` — added a `### Changed` entry under `## [Unreleased]` referencing #236.

Only the one description string changed; `node_count`, `nodes`, and all other presets untouched.