### PR TITLE
Release 12.3.2 — #239 SQL fix + #236 Find the Fremen tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ here cover everything those tags shipped.
 
 ### Fixed
 
+- **Returning-Player Award / character export: `trailing junk after numeric
+  literal` error.** Grant / Dismiss Returning-Player Award, Delete Account, and
+  character export resolved a player's Funcom `"user"` id (a hex string such as
+  `7A1728E90111EDDB`) and injected it into SQL **unquoted**, so PostgreSQL 15+
+  parsed it as a malformed numeric literal and the write failed. The id is now
+  wrapped in single quotes in all four queries. (#239)
 - **Cheat Scripts: "script_name is required." error.** The Players → Live →
   Cheat Scripts form posted the script under the body key `script`, but the
   `/api/gameplay/players/cheat-script` route reads `script_name`, so every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.3.2] - 2026-06-16
+
 ### Changed
 
 - **Find the Fremen (Trials of Aql) preset now grants the full Sietch journey-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
-## [12.3.1] - 2026-06-16
-
 ### Fixed
 
 - **Returning-Player Award / character export: `trailing junk after numeric
@@ -23,6 +21,11 @@ here cover everything those tags shipped.
   `7A1728E90111EDDB`) and injected it into SQL **unquoted**, so PostgreSQL 15+
   parsed it as a malformed numeric literal and the write failed. The id is now
   wrapped in single quotes in all four queries. (#239)
+
+## [12.3.1] - 2026-06-16
+
+### Fixed
+
 - **Cheat Scripts: "script_name is required." error.** The Players → Live →
   Cheat Scripts form posted the script under the body key `script`, but the
   `/api/gameplay/players/cheat-script` route reads `script_name`, so every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- **Find the Fremen (Trials of Aql) preset now grants the full Sietch journey-tag
+  set.** Verified against a completed live character, the preset was missing five
+  in-Sietch interaction flags. Added `Journey.TheSietch.Interactions.Lesson1Completed`,
+  `Lesson2Completed`, `Lesson3Completed`, `DeathStillInteracted`, and
+  `SafeInteracted` so the preset reproduces every Find-the-Fremen journey tag a
+  real completed character holds. (#236)
+
 ### Fixed
 
 - **Returning-Player Award / character export: `trailing junk after numeric

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.3.1'
+$script:DuneToolVersion = '12.3.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.3.1',
+    [string]$Version = '12.3.2',
     [switch]$Quiet
 )
 

--- a/app/data/dune-tags.json
+++ b/app/data/dune-tags.json
@@ -213,6 +213,13 @@
     "DA_MQ_FindTheFremen.TheSietch.SietchLocationParent.EscapeTheSietch": [
       "Journey.TheSietch.Progression.Completed"
     ],
+    "DA_MQ_FindTheFremen.TheSietch.SietchLocationParent.SietchInteractions": [
+      "Journey.TheSietch.Interactions.Lesson1Completed",
+      "Journey.TheSietch.Interactions.Lesson2Completed",
+      "Journey.TheSietch.Interactions.Lesson3Completed",
+      "Journey.TheSietch.Interactions.DeathStillInteracted",
+      "Journey.TheSietch.Interactions.SafeInteracted"
+    ],
     "DA_MQ_TheGreatConvention.CalledToACount.DiscussionWithFenring.TalkToCountFenring": [
       "Journey.Chapter2.CalledToACount.Completed"
     ],

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.3.1</Version>
+    <Version>12.3.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.3.1"
+#define MyAppVersion "12.3.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -552,7 +552,7 @@ SET account = jsonb_set(
         COALESCE(a.account, '{}'::jsonb),
         '{returningPlayerAward,eligible}', to_jsonb(true)),
     '{returningPlayerAward,dismissed}', to_jsonb(false))
-WHERE "user" = $funcom;
+WHERE "user" = '$funcom';
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
     if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
@@ -571,7 +571,7 @@ SET account = jsonb_set(
         COALESCE(a.account, '{}'::jsonb),
         '{returningPlayerAward,eligible}', to_jsonb(false)),
     '{returningPlayerAward,dismissed}', to_jsonb(true))
-WHERE "user" = $funcom;
+WHERE "user" = '$funcom';
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
     if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
@@ -592,7 +592,7 @@ function Invoke-DunePlayerDeleteAccount {
 DO `$`$
 DECLARE
     v_account_id bigint := $AccountId;
-    v_funcom text := $funcom;
+    v_funcom text := '$funcom';
 BEGIN
     -- character actors
     DELETE FROM dune.actor_fgl_entities afe

--- a/app/server/lib/PlayersRead.ps1
+++ b/app/server/lib/PlayersRead.ps1
@@ -241,7 +241,7 @@ function Get-DunePlayerExportLive {
     $resolve = Get-DuneRawFuncomId -Ip $Ip -AccountId $AccountId
     if (-not $resolve.ok) { return @{ ok = $false; error = $resolve.error } }
     $funcom = ConvertTo-DuneSqlString $resolve.funcom_id
-    $sql = "SELECT dune.character_transfer_export($funcom)::text AS export_json;"
+    $sql = "SELECT dune.character_transfer_export('$funcom')::text AS export_json;"
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 60
     if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
     $rows = ConvertTo-DuneRowMaps -Result $r

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.3.1"
+$script:ToolVersion = "12.3.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Summary

Bundles two fixes and bumps to **12.3.2**.

### #239 — Returning-Player Award / character export SQL error
`Get-DuneRawFuncomId` returns a hex Funcom `"user"` id (e.g. `7A1728E90111EDDB`) that was injected into SQL **unquoted**, so PostgreSQL 15+ threw `trailing junk after numeric literal` and the write failed. The id is now single-quoted in all four affected queries (Grant / Dismiss Returning-Player Award, Delete Account, character export).

### #236 — Find the Fremen (Trials of Aql) preset journey tags
Verified against a completed live character export, the `find_the_fremen` preset was missing five in-Sietch interaction flags. Added under a new `…TheSietch.SietchLocationParent.SietchInteractions` node:
- `Journey.TheSietch.Interactions.Lesson1Completed` / `Lesson2Completed` / `Lesson3Completed`
- `Journey.TheSietch.Interactions.DeathStillInteracted`
- `Journey.TheSietch.Interactions.SafeInteracted`

The preset now reproduces every Find-the-Fremen journey tag a real completed character holds (12/12).

**Note on the 3rd active-ability slot:** the live export confirms the slot is `FLevelComponent[1].ActiveAbilityTags` (runtime/progression-derived, no stored slot-count field) — it is **not** tag-driven, so no preset can grant it. Preset description already documents this.

### Version
All 5 stamps bumped to 12.3.2; CHANGELOG `[Unreleased]` rolled into `[12.3.2] - 2026-06-16`. Installer built and verified (`DuneServerSetup.exe`, 45.89 MB).