### PR TITLE
release: 12.4.0 — trainer ownership status + Map SpinUp pod restart buttons

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.3.1"
+      placeholder: "v12.4.0"
     validations:
       required: true
 
@@ -87,7 +87,7 @@ body:
         - Web portal — Gameplay Admin — Players — Give Item / Give Package / Give Vehicle Kit (incl. "Allow overflow")
         - Web portal — Gameplay Admin — Players — Cheat Scripts / Dev-Perf Scripts (Live)
         - Web portal — Gameplay Admin — Players — Journey (node browser / complete / reset / wipe)
-        - Web portal — Gameplay Admin — Players — Unlock Trainers / Unlock Main Quest (Progression)
+        - Web portal — Gameplay Admin — Players — Unlock Trainers (skill-tree ownership status) / Unlock Main Quest (Progression)
         - Web portal — Gameplay Admin — Players — Landsraad (contribution editor)
         - Web portal — Gameplay Admin — Bases
         - Web portal — Gameplay Admin — Storage
@@ -96,7 +96,7 @@ body:
         - Web portal — Database (Backup / Restore / SQL Editor)
         - Web portal — Database (Backup Schedule / crontab)
         - Web portal — Sietches (Additional Survival_1 shards)
-        - Web portal — Map SpinUp
+        - Web portal — Map SpinUp (incl. Restart Hagga / Restart Deep Desert)
         - Web portal — Settings (general — paths, ports, providers)
         - Web portal — Settings (Dune Server Tool self-updater)
         - Web portal — Tailscale (remote-access / device list)
@@ -116,7 +116,7 @@ body:
     attributes:
       label: Specific page / button / command
       description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug?
-      placeholder: "e.g. Server Health 'Restart battlegroup' button, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Journey > Complete node, Gameplay Admin > Players > Actions > Unlock Trainers > Swordmaster, Gameplay Admin > Players > Actions > Unlock Main Quest > A New Beginning, Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
+      placeholder: "e.g. Server Health 'Restart battlegroup' button, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Journey > Complete node, Gameplay Admin > Players > Actions > Unlock Trainers > Swordmaster, Gameplay Admin > Players > Actions > Unlock Main Quest > A New Beginning, Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Map SpinUp > Restart Hagga, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.4.0] - 2026-06-16
+
 ### Added
 
 - **Map SpinUp: "Restart Hagga" and "Restart Deep Desert" buttons.** Centered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ here cover everything those tags shipped.
 
 ### Added
 
+- **Map SpinUp: "Restart Hagga" and "Restart Deep Desert" buttons.** Centered
+  above the RAM warning, these delete the running Kubernetes pod(s) for the
+  `Survival_1` (Hagga overworld) and `DeepDesert_1` ServerSets so the operator
+  recreates them fresh in ~60-120s — handy when a map wedges. Backed by a new
+  `POST /api/maps/restart-pods { key }` that matches pods on the fixed
+  `-sg-<map>-pod-` name infix (allow-listed, never user input) and
+  `kubectl delete`s them. Both buttons confirm first and warn that connected
+  players are disconnected.
+
 - **Unlock Trainers now reads present values for the selected character.** Each
   trainer card (Swordmaster, Trooper, Mentat, Bene Gesserit, Planetologist) shows
   an Unlocked / Partial / Locked badge, a `Starter` marker for the character's
@@ -24,7 +33,6 @@ here cover everything those tags shipped.
   `GET /api/gameplay/players/trainer-status?account_id=<id>` read that parses the
   pawn's `FLevelComponent.ModuleData`. The Unlock button reads "Re-grant" once a
   tree is fully owned. Characters with no pawn yet report everything locked.
-
 
 ## [12.3.2] - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Unlock Trainers now reads present values for the selected character.** Each
+  trainer card (Swordmaster, Trooper, Mentat, Bene Gesserit, Planetologist) shows
+  an Unlocked / Partial / Locked badge, a `Starter` marker for the character's
+  starting class, and live ownership counts — how many of the trainer's skill
+  blocks and how many of the full job tree the character already has — instead of
+  a blind Unlock button. Backed by a new offline-safe
+  `GET /api/gameplay/players/trainer-status?account_id=<id>` read that parses the
+  pawn's `FLevelComponent.ModuleData`. The Unlock button reads "Re-grant" once a
+  tree is fully owned. Characters with no pawn yet report everything locked.
+
+
 ## [12.3.2] - 2026-06-16
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.3.2'
+$script:DuneToolVersion = '12.4.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.3.2',
+    [string]$Version = '12.4.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.3.2</Version>
+    <Version>12.4.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.3.2"
+#define MyAppVersion "12.4.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Maps.ps1
+++ b/app/server/lib/Maps.ps1
@@ -518,3 +518,91 @@ function Stop-DuneOnDemandMap {
         }
     }
 }
+
+# ---------------------------------------------------------------------------
+# Pod restart — delete the Kubernetes pod(s) backing a map's ServerSet so the
+# operator recreates them fresh. Used by the Map SpinUp page's "Restart" buttons.
+# Pod names follow <bg-id>-sg<map-suffix>-pod-<n> (see
+# app/resources/remote-scripts/dune-clear-partitions.start), so we match on the
+# fixed "-sg-<map>-pod-" infix from the allow-list below — never on user input.
+# This disconnects anyone currently on the map; the operator brings the pod(s)
+# back in ~60-120 s. Survival_1 hosts the persistent Hagga overworld.
+# ---------------------------------------------------------------------------
+$script:DuneRestartablePods = @(
+    @{ Key='survival';   Infix='-sg-survival-1-pod-';   Label='Hagga (Survival_1)' }
+    @{ Key='deepdesert'; Infix='-sg-deepdesert-1-pod-'; Label='Deep Desert'        }
+)
+
+function Restart-DuneMapPods {
+    param([Parameter(Mandatory)][string]$Key)
+    $def = $script:DuneRestartablePods | Where-Object { $_.Key -eq $Key } | Select-Object -First 1
+    if (-not $def) { throw "Unknown restartable pod: $Key" }
+
+    $ctx = Get-DuneMapsContext
+    if (-not $ctx.ok) { return @{ ok=$false; status=$ctx.status; message=$ctx.message; key=$Key } }
+
+    # Single SSH round-trip: list every pod whose name contains the fixed
+    # "-sg-<map>-pod-" infix, delete each (non-blocking), and bracket the
+    # output with sentinels so we can parse found / deleted counts. The infix
+    # is injected via placeholder replace (not PS interpolation) and only ever
+    # comes from the static allow-list above, so there's no shell injection.
+    $bash = @'
+set -u
+KUBE="sudo kubectl"
+INFIX='__INFIX__'
+PODS=$($KUBE get pods -A --no-headers 2>/dev/null | awk -v f="$INFIX" 'index($2,f){print $1" "$2}')
+echo "===PODS==="
+if [ -n "$PODS" ]; then echo "$PODS"; fi
+echo "===DELETE==="
+if [ -n "$PODS" ]; then
+  echo "$PODS" | while read -r ns pod; do
+    [ -z "$ns" ] || [ -z "$pod" ] && continue
+    $KUBE -n "$ns" delete pod "$pod" --wait=false 2>&1
+  done
+fi
+echo "===END==="
+'@
+    $bash = $bash.Replace('__INFIX__', [string]$def.Infix)
+
+    $out = Invoke-V6Ssh -Ip $ctx.vm.ip -Cmd $bash -TimeoutSec 90
+    $raw = (($out -join "`n")).Trim()
+
+    $idxPods = $raw.IndexOf('===PODS===')
+    $idxDel  = $raw.IndexOf('===DELETE===')
+    $idxEnd  = $raw.IndexOf('===END===')
+    if ($idxPods -lt 0 -or $idxDel -lt 0 -or $idxEnd -lt 0) {
+        return @{ ok=$false; status=500; key=$Key; label=$def.Label; raw=$raw; message="Pod restart returned malformed output (missing sentinels): $raw" }
+    }
+    $podsBlock = $raw.Substring($idxPods + '===PODS==='.Length, $idxDel - ($idxPods + '===PODS==='.Length))
+    $delBlock  = $raw.Substring($idxDel  + '===DELETE==='.Length, $idxEnd - ($idxDel + '===DELETE==='.Length))
+
+    $podNames = @(
+        $podsBlock -split "`n" |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ } |
+            ForEach-Object { ($_ -split '\s+')[1] } |
+            Where-Object { $_ }
+    )
+    $podsFound = $podNames.Count
+    $deleted   = @($delBlock -split "`n" | Where-Object { $_ -match '\bdeleted\b' }).Count
+
+    if ($podsFound -eq 0) {
+        return @{
+            ok=$true; key=$Key; label=$def.Label; noop=$true
+            podsFound=0; podsDeleted=0; raw=$raw
+            message="No running $($def.Label) pod(s) found — nothing to restart."
+        }
+    }
+
+    $errish  = ($delBlock -match 'error|Error|ERROR|forbidden|not found')
+    $success = ($deleted -gt 0 -and -not $errish)
+    return @{
+        ok=$success; key=$Key; label=$def.Label
+        podsFound=$podsFound; podsDeleted=$deleted; pods=$podNames; raw=$raw
+        message = if ($success) {
+            "Restarting $($def.Label): deleted $deleted pod(s) — the operator recreates them in ~60-120 s. Anyone on the map was disconnected."
+        } else {
+            ("Pod restart may have failed (found $podsFound, deleted $deleted): " + $delBlock.Trim())
+        }
+    }
+}

--- a/app/server/lib/PlayersRead.ps1
+++ b/app/server/lib/PlayersRead.ps1
@@ -480,6 +480,91 @@ function Get-DuneTrainerCatalog {
     return @{ ok = $true; trainers = $list; total = $list.Count }
 }
 
+# ----- §1.13a GET /players/trainer-status?account_id=<id> -----------------
+# Per-character skill-tree ownership. Reads the pawn's ModuleData
+# (FLevelComponent.1.ModuleData, keyed by (TagName="...")) plus its
+# StarterSkillTreeTag, then reports per trainer job how many of the trainer's
+# skill blocks and how many of the full job module set the character already
+# has - so the UI can show present values instead of a blind Unlock button.
+# Offline-safe (pure DB read); reports everything locked when no pawn exists.
+function Get-DunePlayerTrainerStatusLive {
+    param([string]$Ip, [long]$AccountId)
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+    $tags = Get-DuneTagsData
+
+    $build = {
+        param([hashtable]$Owned, [string]$StarterJob, [bool]$HasPawn)
+        $jobs = @()
+        foreach ($job in $script:DuneTrainerJobOrder) {
+            if (-not $tags.jobSkillBlocks.ContainsKey($job)) { continue }
+            $blocks = @($tags.jobSkillBlocks[$job] | ForEach-Object { [string]$_ })
+            $modules = if ($tags.jobAllModules.ContainsKey($job)) { @($tags.jobAllModules[$job] | ForEach-Object { [string]$_ }) } else { @() }
+            $blocksOwned = 0
+            foreach ($b in $blocks) { if ($Owned.ContainsKey($b)) { $blocksOwned++ } }
+            $modulesOwned = 0
+            foreach ($mm in $modules) { if ($Owned.ContainsKey($mm)) { $modulesOwned++ } }
+            $jobs += @{
+                job           = [string]$job
+                name          = [string]$script:DuneTrainerJobLabels[$job]
+                blocks_owned  = $blocksOwned
+                blocks_total  = $blocks.Count
+                modules_owned = $modulesOwned
+                modules_total = $modules.Count
+                unlocked      = ($blocks.Count -gt 0 -and $blocksOwned -ge $blocks.Count)
+                is_starter    = ($StarterJob -eq $job)
+            }
+        }
+        return @{ ok = $true; account_id = $AccountId; has_pawn = $HasPawn; jobs = $jobs; total = $jobs.Count }
+    }
+
+    $pawnID = Get-DunePlayerPawnFromAccount -Ip $Ip -AccountId $AccountId
+    if ($pawnID -le 0) { return (& $build @{} '' $false) }
+
+    # Pull every ModuleData key + the starter skill-tree tag in one read.
+    $sql = @"
+SELECT 'module'::text AS kind, jsonb_object_keys(md) AS val
+FROM (
+    SELECT fe.components->'FLevelComponent'->1->'ModuleData' AS md
+    FROM dune.fgl_entities fe
+    JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
+    WHERE afe.actor_id = $pawnID::bigint AND afe.slot_name = 'DuneCharacter'
+    LIMIT 1
+) s
+WHERE md IS NOT NULL
+UNION ALL
+SELECT 'starter'::text AS kind,
+       fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName' AS val
+FROM dune.fgl_entities fe
+JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
+WHERE afe.actor_id = $pawnID::bigint AND afe.slot_name = 'DuneCharacter';
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 5000 -TimeoutSec 30
+    if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    $rows = ConvertTo-DuneRowMaps -Result $r
+
+    # ModuleData keys look like (TagName="Skills.Key.Swordmaster1"); strip to the
+    # inner tag name so they can be matched against the job block / module lists.
+    $owned = @{}
+    $starterTag = ''
+    foreach ($row in $rows) {
+        $kind = [string]$row['kind']
+        $val = [string]$row['val']
+        if ($kind -eq 'starter') { if ($val) { $starterTag = $val }; continue }
+        if (-not $val) { continue }
+        $m = [regex]::Match($val, '"([^"]+)"')
+        $tag = if ($m.Success) { $m.Groups[1].Value } else { $val }
+        $owned[$tag] = $true
+    }
+
+    $starterJob = ''
+    if ($starterTag -and $starterTag.StartsWith('Skills.Key.') -and $starterTag.EndsWith('1')) {
+        $sj = $starterTag.Substring(11)
+        $starterJob = $sj.Substring(0, $sj.Length - 1)
+    }
+
+    return (& $build $owned $starterJob $true)
+}
+
 # ----- §1.14 GET /players/main-quests -------------------------------------
 # Main-quest story lines. Each is a DA_MQ_<Root> subtree in journey_node_tags;
 # completing the root node flips every DA_MQ_<Root>.* journey row complete and

--- a/app/server/routes/Maps.ps1
+++ b/app/server/routes/Maps.ps1
@@ -17,6 +17,28 @@ Register-DuneRoute -Method POST -Path '/api/maps/fix-partitions' -Handler {
     }
 }
 
+# Static route — restart (delete) the pod(s) backing a map's ServerSet so the
+# operator recreates them fresh. Body: { key: 'survival' | 'deepdesert' }.
+# POST so there's no collision with the GET /api/maps/{key} param route.
+Register-DuneRoute -Method POST -Path '/api/maps/restart-pods' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $key = [string](Get-DuneBodyValue -Body $body -Name 'key')
+        if ([string]::IsNullOrWhiteSpace($key)) {
+            Write-DuneError -Response $res -Status 400 -Message 'key is required (survival or deepdesert).'
+            return
+        }
+        $result = Invoke-WithDuneLock -Name 'ondemand-maps' -Script { Restart-DuneMapPods -Key $key }
+        if (-not $result.ok -and $result.status) {
+            Write-DuneError -Response $res -Status $result.status -Message $result.message
+            return
+        }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
 Register-DuneRoute -Method GET -Path '/api/maps/{key}' -Handler {
     param($req, $res, $routeParams, $body)
     try {

--- a/app/server/routes/PlayersRead.ps1
+++ b/app/server/routes/PlayersRead.ps1
@@ -170,6 +170,23 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/players/trainers' -Handler {
     }
 }
 
+# GET /api/gameplay/players/trainer-status?account_id=<id>
+#   Per-character skill-tree ownership for the Unlock Trainers UI.
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/trainer-status' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $aid = 0L
+        [void][Int64]::TryParse((Get-DuneQ $req 'account_id'), [ref]$aid)
+        if ($aid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
+        Invoke-DunePlayerReadRoute -Response $res -Request $req `
+            -LiveBlock { param($ip) Get-DunePlayerTrainerStatusLive -Ip $ip -AccountId $aid } `
+            -DemoBlock { @{ ok = $true; account_id = $aid; has_pawn = $false; jobs = @(); total = 0 } } `
+            -PayloadKey 'jobs'
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Trainer status failed: $($_.Exception.Message)"
+    }
+}
+
 # GET /api/gameplay/players/main-quests  (main-quest story line catalog)
 Register-DuneRoute -Method GET -Path '/api/gameplay/players/main-quests' -Handler {
     param($req, $res, $routeParams, $body)

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.3.2"
+$script:ToolVersion = "12.4.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1488,6 +1488,17 @@ export function getTrainerCatalog() {
   return api<{ ok: boolean; trainers: TrainerInfo[]; total: number; source: DataSource }>(
     '/api/gameplay/players/trainers')
 }
+// Per-character skill-tree ownership, used to show present values in the UI.
+export interface TrainerStatus {
+  job: string; name: string
+  blocks_owned: number; blocks_total: number
+  modules_owned: number; modules_total: number
+  unlocked: boolean; is_starter: boolean
+}
+export function getTrainerStatus(accountId: number) {
+  return api<{ ok: boolean; account_id: number; has_pawn: boolean; jobs: TrainerStatus[]; total: number; source: DataSource }>(
+    `/api/gameplay/players/trainer-status?account_id=${accountId}`)
+}
 export function unlockTrainer(accountId: number, job: string) {
   return api<WriteResult>('/api/gameplay/players/unlock-trainer', {
     method: 'POST', body: JSON.stringify({ account_id: accountId, job }),

--- a/webui/src/api/maps.ts
+++ b/webui/src/api/maps.ts
@@ -77,3 +77,22 @@ export function fixOnDemandPartitions() {
     method: 'POST',
   })
 }
+
+export interface RestartPodsResult {
+  ok: boolean
+  key: string
+  label?: string
+  noop?: boolean
+  podsFound?: number
+  podsDeleted?: number
+  pods?: string[]
+  raw?: string
+  message?: string
+}
+
+// key: 'survival' (Hagga / Survival_1) | 'deepdesert' (Deep Desert)
+export function restartMapPods(key: 'survival' | 'deepdesert') {
+  return api<RestartPodsResult>('/api/maps/restart-pods', {
+    method: 'POST', body: JSON.stringify({ key }),
+  })
+}

--- a/webui/src/pages/MapSpinUp.tsx
+++ b/webui/src/pages/MapSpinUp.tsx
@@ -20,7 +20,7 @@ import { PageHeader } from '../components/PageHeader'
 import { Icon } from '../components/Icon'
 import { ApiError } from '../api/client'
 import { getMapSpinUp, setMapSpinUp, type SpinUpMap } from '../api/mapSpinUp'
-import { fixOnDemandPartitions } from '../api/maps'
+import { fixOnDemandPartitions, restartMapPods } from '../api/maps'
 
 // Most-used maps pinned to the front by default — these fill the first row.
 // Everything else keeps the backend's order beneath them. Users can drag any
@@ -66,6 +66,7 @@ export function MapSpinUp() {
   const [busy, setBusy] = useState<string | null>(null)
   const [fixBusy, setFixBusy] = useState(false)
   const [fixLog, setFixLog] = useState<string | null>(null)
+  const [restartBusy, setRestartBusy] = useState<string | null>(null)
   const [order, setOrder] = useState<string[] | null>(null)
 
   const refresh = useCallback(async () => {
@@ -122,6 +123,30 @@ export function MapSpinUp() {
       setError(e instanceof ApiError ? e.message : String(e))
     } finally {
       setFixBusy(false)
+    }
+  }, [])
+
+  const onRestartPods = useCallback(async (key: 'survival' | 'deepdesert', label: string) => {
+    const ok = window.confirm(
+      `Restart the ${label} pod(s)?\n\n`
+      + 'This deletes the running Kubernetes pod(s); the operator recreates them '
+      + 'fresh in about 60-120 seconds.\n\n'
+      + 'Anyone currently on the map will be disconnected. '
+      + (key === 'survival'
+        ? 'Survival_1 hosts the persistent Hagga overworld, so this affects the main world.'
+        : 'Use this when Deep Desert is stuck or misbehaving.'),
+    )
+    if (!ok) return
+    setRestartBusy(key); setMessage(null); setError(null); setFixLog(null)
+    try {
+      const r = await restartMapPods(key)
+      setMessage(r.message ?? `${label} restart requested.`)
+      if (!r.ok) setError(r.message ?? 'The restart may not have applied.')
+      if (r.raw) setFixLog(r.raw)
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : String(e))
+    } finally {
+      setRestartBusy(null)
     }
   }, [])
 
@@ -204,6 +229,27 @@ export function MapSpinUp() {
           </>
         }
       />
+
+      <div className="mb-4 flex flex-wrap items-center justify-center gap-3">
+        <button
+          className="btn-secondary"
+          onClick={() => { void onRestartPods('survival', 'Hagga (Survival_1)') }}
+          disabled={loading || busy !== null || fixBusy || restartBusy !== null}
+          title="Delete and recreate the Survival_1 (Hagga overworld) pod(s). Disconnects anyone on the main world; the operator brings them back in ~60-120s."
+        >
+          <Icon name={restartBusy === 'survival' ? 'Loader2' : 'RotateCcw'} size={15} className={restartBusy === 'survival' ? 'animate-spin' : ''} />
+          {restartBusy === 'survival' ? 'Restarting…' : 'Restart Hagga'}
+        </button>
+        <button
+          className="btn-secondary"
+          onClick={() => { void onRestartPods('deepdesert', 'Deep Desert') }}
+          disabled={loading || busy !== null || fixBusy || restartBusy !== null}
+          title="Delete and recreate the DeepDesert_1 pod(s). Disconnects anyone in Deep Desert; the operator brings them back in ~60-120s."
+        >
+          <Icon name={restartBusy === 'deepdesert' ? 'Loader2' : 'RotateCcw'} size={15} className={restartBusy === 'deepdesert' ? 'animate-spin' : ''} />
+          {restartBusy === 'deepdesert' ? 'Restarting…' : 'Restart Deep Desert'}
+        </button>
+      </div>
 
       <div className="mb-4 rounded-lg border border-warning/60 bg-warning/15 px-4 py-3 flex items-start gap-3">
         <Icon name="AlertTriangle" size={20} className="shrink-0 mt-0.5 text-warning" />

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -27,12 +27,12 @@ import {
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
   getLandsraadOverview, getLandsraadPlayerContributions, setLandsraadContribution,
   getPlayerJourneyNodes, completeJourneyNode, resetJourneyNode,
-  getTrainerCatalog, unlockTrainer, resetTrainerSkills,
+  getTrainerCatalog, getTrainerStatus, unlockTrainer, resetTrainerSkills,
   getMainQuestCatalog, unlockMainQuest,
   type Player, type PlayerEvent, type PlayerStats, type ProgressionPreset, type SpecTrackFull,
   type CatalogItem, type ItemPackage, type GiveItemEntry,
   type LandsraadHouse, type LandsraadIniSetting,
-  type JourneyNode, type TrainerInfo, type MainQuestInfo,
+  type JourneyNode, type TrainerInfo, type TrainerStatus, type MainQuestInfo,
 } from '../../../api/gameplay'
 import { VEHICLE_CATALOG, VEHICLE_KIT_FUEL_TEMPLATE, VEHICLE_KIT_TORCH_TEMPLATE, type VehicleTemplate } from '../../../data/vehicles'
 import { fmtNum, fmtSolari } from '../shared'
@@ -774,7 +774,7 @@ function ActionRow({ def, player, busy, open, danger, onToggle, runAction }: {
             <QuickPresetsForm busy={busy}
               onSubmit={presetId => runAction(def, () => applyProgressionPreset(player.account_id, presetId))} />
           ) : def.custom === 'unlock-trainers' ? (
-            <UnlockTrainersForm busy={busy}
+            <UnlockTrainersForm busy={busy} accountId={player.account_id}
               onUnlock={(job, name) => runAction(def, async () => {
                 const r = await unlockTrainer(player.account_id, job)
                 return { message: r.message || `Unlocked ${name} trainer for ${player.name}.` }
@@ -1319,28 +1319,45 @@ function QuickPresetsForm({ busy, onSubmit }: { busy: boolean; onSubmit: (preset
   )
 }
 
-// Self-contained Unlock-Trainers form. Fetches the skill-trainer catalog on
-// mount and renders one card per trainer type (separated by trainer), each with
-// an "Unlock" button (completes the trainer's quest line + grants the full job
+// Self-contained Unlock-Trainers form. Fetches the skill-trainer catalog AND
+// the selected character's current ownership on mount, then renders one card
+// per trainer type (separated by trainer). Each card shows present values —
+// which skill blocks / tree modules the character already has — plus an
+// "Unlock" button (completes the trainer's quest line + grants the full job
 // skill tree) and a "Reset Skill Tree" button. Renders without a card wrapper.
-function UnlockTrainersForm({ busy, onUnlock, onReset }: {
+function UnlockTrainersForm({ busy, accountId, onUnlock, onReset }: {
   busy: boolean
+  accountId: number
   onUnlock: (job: string, name: string) => void
   onReset: (job: string, name: string) => void
 }) {
   const [trainers, setTrainers] = useState<TrainerInfo[]>([])
+  const [status, setStatus] = useState<Record<string, TrainerStatus>>({})
+  const [hasPawn, setHasPawn] = useState(true)
   const [loading, setLoading] = useState(true)
   const [err, setErr] = useState('')
 
   useEffect(() => {
     let alive = true
     setLoading(true)
-    getTrainerCatalog()
-      .then(r => { if (alive) setTrainers(r.trainers || []) })
+    Promise.all([
+      getTrainerCatalog(),
+      getTrainerStatus(accountId).catch(() => null),
+    ])
+      .then(([cat, st]) => {
+        if (!alive) return
+        setTrainers(cat.trainers || [])
+        if (st) {
+          setHasPawn(st.has_pawn)
+          const map: Record<string, TrainerStatus> = {}
+          for (const j of st.jobs || []) map[j.job] = j
+          setStatus(map)
+        }
+      })
       .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
       .finally(() => { if (alive) setLoading(false) })
     return () => { alive = false }
-  }, [])
+  }, [accountId])
 
   if (loading) return <div className="text-sm text-text-dim flex items-center gap-2"><Icon name="Loader2" size={13} className="animate-spin" /> Loading trainers…</div>
   if (err) return <div className="text-sm text-danger">{err}</div>
@@ -1351,18 +1368,51 @@ function UnlockTrainersForm({ busy, onUnlock, onReset }: {
       <div className="text-[11px] text-text-muted">
         Completes the trainer's starting quest line and grants the full job skill tree. Works online or offline — takes effect on next login.
       </div>
+      {!hasPawn && (
+        <div className="text-[11px] text-warning">
+          This character has no pawn yet (never logged in) — current skill data can't be read, so everything shows as locked.
+        </div>
+      )}
       <div className="space-y-2">
-        {trainers.map(t => (
+        {trainers.map(t => {
+          const st = status[t.job]
+          const owned = st?.blocks_owned ?? 0
+          const total = st?.blocks_total ?? t.skill_count
+          const isUnlocked = st?.unlocked ?? false
+          const isPartial = !isUnlocked && owned > 0
+          return (
           <div key={t.job} className="rounded-lg border border-border bg-surface-2 px-3 py-2">
             <div className="flex items-center gap-2 mb-1.5">
               <Icon name="GraduationCap" size={14} className="shrink-0 text-text-dim" />
               <span className="flex-1 min-w-0 text-sm text-text font-medium">{t.name}</span>
-              <span className="text-[11px] text-text-dim">{t.contract_count} quest{t.contract_count === 1 ? '' : 's'} · {t.skill_count} skill block{t.skill_count === 1 ? '' : 's'}</span>
+              {st?.is_starter && (
+                <span className="text-[10px] uppercase tracking-wide rounded px-1.5 py-0.5 bg-surface-3 text-text-dim border border-border">Starter</span>
+              )}
+              {st && (
+                isUnlocked ? (
+                  <span className="text-[10px] font-medium rounded px-1.5 py-0.5 bg-success/15 text-success border border-success/30">Unlocked</span>
+                ) : isPartial ? (
+                  <span className="text-[10px] font-medium rounded px-1.5 py-0.5 bg-warning/15 text-warning border border-warning/30">Partial</span>
+                ) : (
+                  <span className="text-[10px] font-medium rounded px-1.5 py-0.5 bg-surface-3 text-text-dim border border-border">Locked</span>
+                )
+              )}
+            </div>
+            <div className="flex items-center gap-2 mb-1.5 text-[11px] text-text-dim">
+              <span>{t.contract_count} quest{t.contract_count === 1 ? '' : 's'}</span>
+              <span>·</span>
+              <span>{owned}/{total} skill block{total === 1 ? '' : 's'}</span>
+              {st && st.modules_total > 0 && (
+                <>
+                  <span>·</span>
+                  <span>{st.modules_owned}/{st.modules_total} tree skills</span>
+                </>
+              )}
             </div>
             <div className="flex gap-2">
               <button type="button" className="btn-primary flex-1 text-xs" disabled={busy}
                 onClick={() => onUnlock(t.job, t.name)}>
-                {busy ? <Icon name="Loader2" size={12} className="animate-spin" /> : <Icon name="Unlock" size={12} />} Unlock
+                {busy ? <Icon name="Loader2" size={12} className="animate-spin" /> : <Icon name="Unlock" size={12} />} {isUnlocked ? 'Re-grant' : 'Unlock'}
               </button>
               <button type="button" className="btn-secondary shrink-0 text-xs" disabled={busy}
                 onClick={() => onReset(t.job, t.name)} title="Reset this job's skill tree">
@@ -1370,7 +1420,8 @@ function UnlockTrainersForm({ busy, onUnlock, onReset }: {
               </button>
             </div>
           </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
## What

Two user-facing features, bundled as release **12.4.0**.

### 1. Unlock Trainers reads present values
Each trainer card (Swordmaster, Trooper, Mentat, Bene Gesserit, Planetologist) now shows the selected character's actual skill-tree ownership — an **Unlocked / Partial / Locked** badge, a `Starter` marker for the starting class, and live counts (skill blocks owned + how much of the full job tree). The Unlock button reads **Re-grant** once a tree is fully owned.

Backed by a new offline-safe read `GET /api/gameplay/players/trainer-status?account_id=<id>` that parses the pawn's `FLevelComponent.ModuleData`. Characters with no pawn report everything locked.

### 2. Map SpinUp — Restart Hagga / Restart Deep Desert
Two centered buttons above the RAM warning delete the running Kubernetes pod(s) for the `Survival_1` (Hagga overworld) and `DeepDesert_1` ServerSets so the operator recreates them fresh in ~60–120s — handy when a map wedges.

Backed by `POST /api/maps/restart-pods { key }`, which matches pods on the fixed `-sg-<map>-pod-` name infix (allow-listed, never user input) and `kubectl delete`s them. Both buttons confirm first and warn that connected players are disconnected.

## Verified against the live VM
- Read-only pod discovery confirmed the real names: `...-sg-survival-1-pod-1` and `...-sg-deepdesert-1-pod-8`, both matched by the allow-list infixes.
- **Live delete test (Deep Desert):** ran the exact production bash → pod deleted from its namespace → operator recreated it `Running` within ~7s. Hagga/survival delete was intentionally not run (persistent overworld, live players) but uses the identical code path.
- `npm run build` (tsc -b + vite) and PS 5.1 parse pre-flight pass; installer built clean (all 5 version stamps = 12.4.0, BOM check OK).

## Release housekeeping
- Bumped all 5 version stamps to 12.4.0.
- Rolled `CHANGELOG.md` Unreleased → `[12.4.0] - 2026-06-16`.
- Refreshed `bug_report.yml` (version placeholder, Map SpinUp + Unlock Trainers dropdown entries, Restart-Hagga example).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>