### PR TITLE
Release 12.5.1: Game Config bool-toggle fix + cheat-script double-confirm

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.5.0"
+      placeholder: "v12.5.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ here cover everything those tags shipped.
 
 ### Changed
 
+- **Coriolis Storm Seeds: correct the valid seed range.** The seed inputs (farm /
+  per-map / per-partition) now accept **-1** (auto / clear a forced seed) and cap
+  at **0–11**, matching the game's 12 pre-built Coriolis world layouts
+  (`m_CycleSeeds`). Previously the boxes rejected `-1` and **Reroll** generated a
+  meaningless multi-billion value; Reroll now picks a random `0–11`. Validation is
+  enforced in the UI, the route, and the seed-write functions.
+
 - **Cheat Scripts and Dev / Perf Scripts now require a double confirmation.**
   Firing a cheat script or dev/perf script (Gameplay Admin → Players → Live)
   prompts twice — an initial confirm plus a typed `i acknowledge` — matching the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ here cover everything those tags shipped.
 
 ### Fixed
 
+- **Non-ASCII characters in INI files corrupted into mojibake (e.g. UTF-8
+  comment banners in UserGame.ini).** The SSH transport that reads remote files
+  (`Invoke-V6Ssh` / `Invoke-DuneSshHidden`) decoded the process output using the
+  Windows console code page (CP850 / Windows-1252) instead of UTF-8, so any
+  non-ASCII bytes — like the box-drawing banners in a hand-edited `UserGame.ini`
+  — came back as garbage. A subsequent Game Config save then re-encoded that
+  garbage as UTF-8 and wrote it to disk, permanently corrupting the file. The
+  transport now decodes remote stdout/stderr as UTF-8 (a strict superset of
+  ASCII, so a no-op for normal output), preserving non-ASCII content end to end.
+
 - **Game Config boolean toggles reverting to Off after switching On (Coriolis
   Auto-Spawn and any default-`True` toggle).** Toggling a bool whose value
   matched its schema default correctly triggers a reset — the key is removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ here cover everything those tags shipped.
   meaningless multi-billion value; Reroll now picks a random `0–11`. Validation is
   enforced in the UI, the route, and the seed-write functions.
 
+- **Coriolis Storm Seeds: fix every map name collapsing into one row.** The read
+  path round-tripped the map / partition name arrays as JSON text through the
+  psql CSV layer; the embedded commas and quotes collided with CSV field parsing,
+  so all map names merged into a single space-joined "Per map" row (and per-map
+  **Apply** then failed with "map (string) is required"). The query now lets
+  Postgres split the arrays with `unnest()` and returns one clean scalar row per
+  map / partition, so each map lists and applies individually.
+
 - **Cheat Scripts and Dev / Perf Scripts now require a double confirmation.**
   Firing a cheat script or dev/perf script (Gameplay Admin → Players → Live)
   prompts twice — an initial confirm plus a typed `i acknowledge` — matching the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.5.1] - 2026-06-16
+
+### Fixed
+
+- **Game Config boolean toggles reverting to Off after switching On (Coriolis
+  Auto-Spawn and any default-`True` toggle).** Toggling a bool whose value
+  matched its schema default correctly triggers a reset — the key is removed
+  from the user INI so it falls back to the default — but a stale copy of that
+  same key left behind in a *different / unmanaged* INI section could shadow the
+  canonical value, so the UI re-read the old `False` and the switch snapped back
+  to Off. The INI writer now strips a touched key from **every** section,
+  including unmanaged body sections, so the declared section is authoritative
+  and the toggle sticks. Added regression tests covering the stale-unmanaged-copy
+  case.
+
+### Changed
+
+- **Cheat Scripts and Dev / Perf Scripts now require a double confirmation.**
+  Firing a cheat script or dev/perf script (Gameplay Admin → Players → Live)
+  prompts twice — an initial confirm plus a typed `i acknowledge` — matching the
+  existing guard on destructive actions like wipe-codex and delete-account.
+
 ## [12.5.0] - 2026-06-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ here cover everything those tags shipped.
   Postgres split the arrays with `unnest()` and returns one clean scalar row per
   map / partition, so each map lists and applies individually.
 
+- **Coriolis Storm Seeds: bulk "apply to all" and "reset all to game default".**
+  The Farm control is now clearly labelled as the apply-to-everything action
+  ("Farm — all maps + partitions" / "Apply to all"), and a new **Reset all to
+  game default** button clears every forced seed (farm + every map + every
+  partition) back to `-1` (auto) in one click. Both reuse the cascading farm
+  write, each behind its own confirmation.
+
 - **Cheat Scripts and Dev / Perf Scripts now require a double confirmation.**
   Firing a cheat script or dev/perf script (Gameplay Admin → Players → Live)
   prompts twice — an initial confirm plus a typed `i acknowledge` — matching the

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.5.0'
+$script:DuneToolVersion = '12.5.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.5.0',
+    [string]$Version = '12.5.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.5.0</Version>
+    <Version>12.5.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.5.0"
+#define MyAppVersion "12.5.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/lib/Db-Postgres.ps1
+++ b/app/lib/Db-Postgres.ps1
@@ -56,6 +56,14 @@ function Invoke-V6Ssh {
     $psi.RedirectStandardError  = $true
     $psi.UseShellExecute        = $false
     $psi.CreateNoWindow         = $true
+    # Decode the remote process output as UTF-8. Without this the StreamReader
+    # falls back to the Windows console code page (CP850 / Windows-1252), which
+    # mojibakes any non-ASCII bytes — e.g. UTF-8 box-drawing comment banners in
+    # UserGame.ini. Once such a mangled string is written back to disk (Game
+    # Config save re-encodes as UTF-8) the file is permanently corrupted. UTF-8
+    # is a strict superset of ASCII so this is a no-op for the common case.
+    $psi.StandardOutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    $psi.StandardErrorEncoding  = [System.Text.UTF8Encoding]::new($false)
     if ($StdinData) { $psi.RedirectStandardInput = $true }
 
     # PS 5.1 lacks ProcessStartInfo.ArgumentList — build the command line
@@ -161,6 +169,10 @@ function Invoke-DuneSshHidden {
     $psi.RedirectStandardError  = $true
     $psi.UseShellExecute        = $false
     $psi.CreateNoWindow         = $true
+    # Decode remote output as UTF-8 (see Invoke-V6Ssh) so non-ASCII bytes from
+    # the pod aren't mojibaked by the Windows console code page.
+    $psi.StandardOutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    $psi.StandardErrorEncoding  = [System.Text.UTF8Encoding]::new($false)
 
     # Build argv. Same quoting strategy as Invoke-V6Ssh: only quote args
     # that contain whitespace or quotes, and escape any embedded ".

--- a/app/server/lib/CoriolisAdmin.ps1
+++ b/app/server/lib/CoriolisAdmin.ps1
@@ -16,51 +16,56 @@
 # ----------------------------------------------------------------------------
 # Read — current farm / map / partition seeds.
 # ----------------------------------------------------------------------------
+# Postgres does the array-splitting via unnest() and emits ONE clean scalar row
+# per farm / map / partition. This avoids round-tripping JSON arrays through the
+# psql CSV layer (commas + quotes inside array_to_json text collided with CSV
+# field parsing, collapsing every map name into a single space-joined string).
+# unnest(arr_a, arr_b, ...) zips the parallel arrays element-wise.
 $script:DuneCoriolisSeedsSql = @'
-SELECT
-    COALESCE(farm_seed, 0)                              AS farm_seed,
-    COALESCE(array_to_json(map_names)::text, '[]')      AS map_names_json,
-    COALESCE(array_to_json(map_seeds)::text, '[]')      AS map_seeds_json,
-    COALESCE(array_to_json(partitions_ids)::text, '[]') AS partition_ids_json,
-    COALESCE(array_to_json(partitions_map)::text, '[]') AS partition_maps_json,
-    COALESCE(array_to_json(partitions_seeds)::text, '[]') AS partition_seeds_json
-FROM dune.debug_get_coriolis_seeds();
+WITH s AS (
+    SELECT farm_seed, map_names, map_seeds,
+           partitions_ids, partitions_map, partitions_seeds
+    FROM dune.debug_get_coriolis_seeds()
+)
+SELECT 'farm'::text AS kind, NULL::bigint AS partition_id,
+       ''::text AS map_name, COALESCE(s.farm_seed, -1) AS seed
+FROM s
+UNION ALL
+SELECT 'map'::text, NULL::bigint, mm.map_name, COALESCE(mm.seed, -1)
+FROM s, unnest(s.map_names, s.map_seeds) AS mm(map_name, seed)
+UNION ALL
+SELECT 'partition'::text, pp.pid, pp.map_name, COALESCE(pp.seed, -1)
+FROM s, unnest(s.partitions_ids, s.partitions_map, s.partitions_seeds)
+        AS pp(pid, map_name, seed);
 '@
 
 function Get-DuneCoriolisSeedsLive {
     param([string]$Ip)
-    $soft = Invoke-DuneSqlSoft -Ip $Ip -Sql $script:DuneCoriolisSeedsSql -MaxRows 1 -TimeoutSec 15
+    $soft = Invoke-DuneSqlSoft -Ip $Ip -Sql $script:DuneCoriolisSeedsSql -MaxRows 2000 -TimeoutSec 15
     if (-not $soft.ok) { return @{ ok = $false; error = $soft.error } }
     if ($soft.unsupported) {
         return @{ ok = $true; unsupported = $true; farm_seed = 0; maps = @(); partitions = @() }
     }
-    $maps = ConvertTo-DuneRowMaps -Result $soft.raw
-    if ($maps.Count -lt 1) {
-        return @{ ok = $true; farm_seed = 0; maps = @(); partitions = @() }
-    }
-    $r = $maps[0]
-    $farm = [int](ConvertTo-DuneInt $r['farm_seed'])
-    $mapNames  = @(); $mapSeeds = @()
-    $partIds   = @(); $partMaps = @(); $partSeeds = @()
-    try { $mapNames  = @(ConvertFrom-Json ([string]$r['map_names_json'])) } catch {}
-    try { $mapSeeds  = @(ConvertFrom-Json ([string]$r['map_seeds_json'])) } catch {}
-    try { $partIds   = @(ConvertFrom-Json ([string]$r['partition_ids_json'])) } catch {}
-    try { $partMaps  = @(ConvertFrom-Json ([string]$r['partition_maps_json'])) } catch {}
-    try { $partSeeds = @(ConvertFrom-Json ([string]$r['partition_seeds_json'])) } catch {}
-
+    $rows = ConvertTo-DuneRowMaps -Result $soft.raw
+    $farm = 0
     $maps = @()
-    for ($i = 0; $i -lt $mapNames.Count; $i++) {
-        $maps += [ordered]@{
-            map  = [string]$mapNames[$i]
-            seed = if ($i -lt $mapSeeds.Count) { [int](ConvertTo-DuneInt $mapSeeds[$i]) } else { 0 }
-        }
-    }
     $partitions = @()
-    for ($i = 0; $i -lt $partIds.Count; $i++) {
-        $partitions += [ordered]@{
-            partition_id = ConvertTo-DuneInt $partIds[$i]
-            map          = if ($i -lt $partMaps.Count)  { [string]$partMaps[$i] } else { '' }
-            seed         = if ($i -lt $partSeeds.Count) { [int](ConvertTo-DuneInt $partSeeds[$i]) } else { 0 }
+    foreach ($r in $rows) {
+        switch ([string]$r['kind']) {
+            'farm' { $farm = [int](ConvertTo-DuneInt $r['seed']) }
+            'map'  {
+                $maps += [ordered]@{
+                    map  = [string]$r['map_name']
+                    seed = [int](ConvertTo-DuneInt $r['seed'])
+                }
+            }
+            'partition' {
+                $partitions += [ordered]@{
+                    partition_id = ConvertTo-DuneInt $r['partition_id']
+                    map          = [string]$r['map_name']
+                    seed         = [int](ConvertTo-DuneInt $r['seed'])
+                }
+            }
         }
     }
     return @{ ok = $true; farm_seed = $farm; maps = $maps; partitions = $partitions }

--- a/app/server/lib/CoriolisAdmin.ps1
+++ b/app/server/lib/CoriolisAdmin.ps1
@@ -88,7 +88,7 @@ function Get-DuneCoriolisSeedsDemo {
 # ----------------------------------------------------------------------------
 function Invoke-DuneCoriolisSetFarmSeed {
     param([string]$Ip, [int]$Seed)
-    if ($Seed -lt 0) { return @{ ok = $false; error = 'Seed must be a non-negative 32-bit integer.' } }
+    if ($Seed -lt -1 -or $Seed -gt 11) { return @{ ok = $false; error = 'Seed must be -1 (auto) or 0-11 (one of the 12 Coriolis world layouts).' } }
     $sql = "SELECT dune.debug_set_farm_seed($Seed::int);"
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
@@ -98,7 +98,7 @@ function Invoke-DuneCoriolisSetFarmSeed {
 function Invoke-DuneCoriolisSetMapSeed {
     param([string]$Ip, [string]$Map, [int]$Seed)
     if (-not $Map) { return @{ ok = $false; error = 'map name is required.' } }
-    if ($Seed -lt 0) { return @{ ok = $false; error = 'Seed must be a non-negative 32-bit integer.' } }
+    if ($Seed -lt -1 -or $Seed -gt 11) { return @{ ok = $false; error = 'Seed must be -1 (auto) or 0-11 (one of the 12 Coriolis world layouts).' } }
     $safeMap = ConvertTo-DuneSqlString $Map
     $sql = "SELECT dune.debug_set_map_seed('$safeMap'::text, $Seed::int);"
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
@@ -109,7 +109,7 @@ function Invoke-DuneCoriolisSetMapSeed {
 function Invoke-DuneCoriolisSetPartitionSeed {
     param([string]$Ip, [long]$PartitionId, [int]$Seed)
     if ($PartitionId -le 0) { return @{ ok = $false; error = 'partition_id is required.' } }
-    if ($Seed -lt 0) { return @{ ok = $false; error = 'Seed must be a non-negative 32-bit integer.' } }
+    if ($Seed -lt -1 -or $Seed -gt 11) { return @{ ok = $false; error = 'Seed must be -1 (auto) or 0-11 (one of the 12 Coriolis world layouts).' } }
     $sql = "SELECT dune.debug_set_partition_seed($PartitionId::bigint, $Seed::int);"
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -771,10 +771,21 @@ function ConvertTo-DuneIniManaged {
         # m_CycleDurationInDays under both DuneGameMode and SandStormConfig) makes
         # edits/resets unpredictable — DST would update one copy while a stale copy
         # in another section shadows it. So whenever we touch a key, first strip it
-        # from EVERY other managed section, then set/remove it in the target.
+        # from EVERY other section, then set/remove it in the target.
+        #
+        # This includes UNMANAGED body sections: a stale/foreign copy of the key
+        # under a non-canonical section (e.g. an older DST schema that placed
+        # m_bCoriolisAutoSpawnEnabled under CoriolisSubsystem, or a hand edit) would
+        # otherwise survive a reset-to-default and shadow our write via the UI's
+        # by-key fallback — leaving the setting stuck on its old value (the
+        # "Coriolis Auto-Spawn won't toggle back On" bug). Consolidating every
+        # occurrence into the declared section makes that section authoritative.
         $key = "$($u.key)"
         foreach ($other in $managed) {
             if ($other -ne $entry) { Remove-DuneScalarFromBody -Body $other.body -Key $key }
+        }
+        foreach ($other in $remaining) {
+            Remove-DuneScalarFromBody -Body $other.body -Key $key
         }
         if ($u['remove']) {
             # Reset-to-default: strip the key so the default is implied, not written.

--- a/app/server/routes/CoriolisAdmin.ps1
+++ b/app/server/routes/CoriolisAdmin.ps1
@@ -37,7 +37,7 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/coriolis/set-farm-seed' -Ha
     param($req, $res, $routeParams, $body)
     try {
         $seed = Get-DuneBodyInt -Body $body -Name 'seed'
-        if ($null -eq $seed -or $seed -lt 0) { Write-DuneError -Response $res -Status 400 -Message 'seed (non-negative integer) is required.'; return }
+        if ($null -eq $seed -or $seed -lt -1 -or $seed -gt 11) { Write-DuneError -Response $res -Status 400 -Message 'seed must be -1 (auto) or 0-11.'; return }
         Invoke-DunePlayerWriteRoute -Response $res -Action {
             param($ip) Invoke-DuneCoriolisSetFarmSeed -Ip $ip -Seed ([int]$seed)
         }
@@ -54,7 +54,7 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/coriolis/set-map-seed' -Han
         if ($body -and $body.PSObject.Properties['map']) { $map = [string]$body.map }
         $seed = Get-DuneBodyInt -Body $body -Name 'seed'
         if (-not $map) { Write-DuneError -Response $res -Status 400 -Message 'map (string) is required.'; return }
-        if ($null -eq $seed -or $seed -lt 0) { Write-DuneError -Response $res -Status 400 -Message 'seed (non-negative integer) is required.'; return }
+        if ($null -eq $seed -or $seed -lt -1 -or $seed -gt 11) { Write-DuneError -Response $res -Status 400 -Message 'seed must be -1 (auto) or 0-11.'; return }
         Invoke-DunePlayerWriteRoute -Response $res -Action {
             param($ip) Invoke-DuneCoriolisSetMapSeed -Ip $ip -Map $map -Seed ([int]$seed)
         }
@@ -71,7 +71,7 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/coriolis/set-partition-seed
         $partId = Get-DuneBodyInt -Body $body -Name 'partition_id'
         $seed = Get-DuneBodyInt -Body $body -Name 'seed'
         if ($null -eq $partId -or $partId -le 0) { Write-DuneError -Response $res -Status 400 -Message 'partition_id (positive integer) is required.'; return }
-        if ($null -eq $seed -or $seed -lt 0) { Write-DuneError -Response $res -Status 400 -Message 'seed (non-negative integer) is required.'; return }
+        if ($null -eq $seed -or $seed -lt -1 -or $seed -gt 11) { Write-DuneError -Response $res -Status 400 -Message 'seed must be -1 (auto) or 0-11.'; return }
         Invoke-DunePlayerWriteRoute -Response $res -Action {
             param($ip) Invoke-DuneCoriolisSetPartitionSeed -Ip $ip -PartitionId ([long]$partId) -Seed ([int]$seed)
         }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.5.0"
+$script:ToolVersion = "12.5.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -339,6 +339,39 @@ Describe 'GameConfig: single-section-per-key consistency' -Tag 'GameConfig' {
         $out | Should -Match 'm_bIsDbWipeEnabled'
     }
 
+    It 'reset-to-default strips a stale copy from an UNMANAGED body section (Coriolis Auto-Spawn toggle-on bug)' {
+        # A foreign/older placement of the key sits in an unmanaged section the
+        # update does not target. Toggling the field back to its default sends
+        # remove=$true against the canonical section; without scrubbing the body
+        # copy it would survive and shadow the read (stuck on the old value).
+        $foreign = '/Script/DuneSandbox.CoriolisSubsystem'
+        $raw = "[$foreign]`n" +
+               "m_bCoriolisAutoSpawnEnabled=False`n" +
+               "m_CycleDurationInDays=7`n"
+        $canonical = '/Script/DuneSandbox.SandStormConfig'
+        $updates = @(@{ section = $canonical; key = 'm_bCoriolisAutoSpawnEnabled'; value = 'True'; remove = $true })
+        $out = ConvertTo-DuneIniManaged -Raw $raw -Updates $updates -QuotedKeys @{}
+        $byKey = Get-DuneIniEffectiveByKey -Raw $out
+        # The shadow copy is gone, so the UI falls back to the schema default (On).
+        $byKey['m_bCoriolisAutoSpawnEnabled'] | Should -BeNullOrEmpty
+        # An unrelated key in that foreign section is untouched.
+        $byKey['m_CycleDurationInDays'] | Should -Be '7'
+    }
+
+    It 'setting a value consolidates a stale UNMANAGED body copy into the canonical section' {
+        $foreign = '/Script/DuneSandbox.CoriolisSubsystem'
+        $raw = "[$foreign]`n" +
+               "m_bCoriolisAutoSpawnEnabled=False`n"
+        $canonical = '/Script/DuneSandbox.SandStormConfig'
+        $updates = @(@{ section = $canonical; key = 'm_bCoriolisAutoSpawnEnabled'; value = 'False'; remove = $false })
+        $out = ConvertTo-DuneIniManaged -Raw $raw -Updates $updates -QuotedKeys @{}
+        # Exactly one occurrence of the key, and it lives under the canonical section.
+        $hits = @(($out -replace "`r", '' -split "`n") | Where-Object { $_.Trim() -match '^m_bCoriolisAutoSpawnEnabled\s*=' })
+        $hits.Count | Should -Be 1
+        $eff = Get-DuneIniEffective -Raw $out
+        $eff["$canonical||m_bCoriolisAutoSpawnEnabled"] | Should -Be 'False'
+    }
+
     It 'Get-DuneIniEffectiveByKey returns last-wins value regardless of section' {
         $raw = "[/Script/DuneSandbox.DuneGameMode]`n" +
                "m_CycleDurationInDays=36500`n" +

--- a/webui/src/pages/gameplay/players/coriolis.tsx
+++ b/webui/src/pages/gameplay/players/coriolis.tsx
@@ -94,6 +94,13 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
     setFarmDraft(String(seed))
   }
   const stay = () => setFarmDraft(String(farmSeed))
+  // Revert every scope (farm + all maps + all partitions) to the game default
+  // (-1 = no forced seed / auto). The farm write already cascades to every map
+  // and partition, so a single -1 farm apply clears them all.
+  const resetAllDefault = () => {
+    if (!confirm('Reset ALL Coriolis seeds — farm, every map, and every partition — to game default (-1 = auto)?\n\nThis clears every forced seed so the game picks layouts on its own. Where a seed actually changes, the next storm tick runs the usual cleanup. No undo.')) return
+    run(() => setCoriolisFarmSeed(-1), 'Reset all seeds to game default')
+  }
 
   if (loading) {
     return (
@@ -125,7 +132,8 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
         <strong>0–11</strong> (the 12 pre-built layouts); enter <strong>-1</strong> to clear a forced
         seed (auto). Changing a seed triggers cleanup (corpses, loose loot) on next storm tick. Use
         <em>Stay on current</em> to lock the layout across resets, or <em>Reroll</em> to pick a fresh
-        random one.
+        random one. <strong>Farm</strong> stamps one seed onto every map + partition at once;
+        <strong>Reset all to game default</strong> clears every forced seed back to -1.
       </p>
 
       {/* Severe-consequences warning + lock gate. These settings rewrite world-reset
@@ -160,10 +168,10 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
       </div>
 
       {unlocked && (<>
-      {/* Farm scope */}
+      {/* Farm scope — applies to every map + partition at once */}
       <div className="rounded-lg border border-border bg-surface-2/40 p-3 space-y-2">
         <div className="flex items-center justify-between">
-          <div className="text-sm font-medium text-text">Farm (all maps)</div>
+          <div className="text-sm font-medium text-text">Farm — all maps + partitions</div>
           <div className="font-mono text-xs text-text-dim">current: {farmSeed}</div>
         </div>
         <div className="flex items-center gap-2">
@@ -183,8 +191,21 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
           <button className="btn-secondary text-xs" disabled={busy} onClick={stay} title="Reset draft to current seed (no change on apply)">
             <Icon name="Lock" size={12} /> Stay
           </button>
-          <button className="btn-primary text-xs" disabled={busy || farmDraft === ''} onClick={applyFarm}>
-            <Icon name="Check" size={12} /> Apply
+          <button className="btn-primary text-xs" disabled={busy || farmDraft === ''} onClick={applyFarm} title="Stamp this seed onto every map and partition">
+            <Icon name="Check" size={12} /> Apply to all
+          </button>
+        </div>
+        <div className="flex items-center justify-between gap-2 pt-1 border-t border-border/60">
+          <p className="text-[11px] text-text-dim">
+            Clear every forced seed (farm + all maps + all partitions) back to the game default.
+          </p>
+          <button
+            className="btn-secondary text-xs text-warning border-warning/40"
+            disabled={busy}
+            onClick={resetAllDefault}
+            title="Set farm, every map, and every partition back to -1 (auto)"
+          >
+            <Icon name="RotateCcw" size={12} /> Reset all to game default
           </button>
         </div>
       </div>

--- a/webui/src/pages/gameplay/players/coriolis.tsx
+++ b/webui/src/pages/gameplay/players/coriolis.tsx
@@ -73,24 +73,24 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
 
   const applyFarm = () => {
     const seed = Number(farmDraft)
-    if (!Number.isFinite(seed) || seed < 0) return flash('Farm seed must be a non-negative integer.', 'err')
+    if (!Number.isFinite(seed) || seed < -1 || seed > 11) return flash('Farm seed must be -1 (auto) or 0-11.', 'err')
     if (!confirm(`Set FARM coriolis seed to ${seed}?\n\nThis cascades to every map + partition and (when changed) cleans up corpses / coriolis-affected loose state.`)) return
     run(() => setCoriolisFarmSeed(seed), 'Set farm seed')
   }
   const applyMap = (map: string) => {
     const seed = Number(mapDrafts[map])
-    if (!Number.isFinite(seed) || seed < 0) return flash(`Map seed for ${map} must be a non-negative integer.`, 'err')
+    if (!Number.isFinite(seed) || seed < -1 || seed > 11) return flash(`Map seed for ${map} must be -1 (auto) or 0-11.`, 'err')
     if (!confirm(`Set MAP "${map}" coriolis seed to ${seed}?\n\nCascades to that map's partitions.`)) return
     run(() => setCoriolisMapSeed(map, seed), `Set ${map} seed`)
   }
   const applyPart = (p: CoriolisPartition) => {
     const seed = Number(partDrafts[p.partition_id])
-    if (!Number.isFinite(seed) || seed < 0) return flash(`Partition seed must be a non-negative integer.`, 'err')
+    if (!Number.isFinite(seed) || seed < -1 || seed > 11) return flash(`Partition seed must be -1 (auto) or 0-11.`, 'err')
     if (!confirm(`Set PARTITION ${p.partition_id} (${p.map}) coriolis seed to ${seed}?`)) return
     run(() => setCoriolisPartitionSeed(p.partition_id, seed), `Set partition ${p.partition_id} seed`)
   }
   const reroll = () => {
-    const seed = Math.floor(Math.random() * 2_000_000_000) + 1
+    const seed = Math.floor(Math.random() * 12)
     setFarmDraft(String(seed))
   }
   const stay = () => setFarmDraft(String(farmSeed))
@@ -121,9 +121,11 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
       </div>
 
       <p className="text-xs text-text-dim">
-        World-reset seeds drive Coriolis storm layout (spawns, dunes, loot scatter). Changing a seed
-        triggers cleanup (corpses, loose loot) on next storm tick. Use <em>Stay on current</em> to
-        lock the layout across resets, or <em>Reroll</em> to pick a fresh random one.
+        World-reset seeds drive Coriolis storm layout (spawns, dunes, loot scatter). Valid seeds are
+        <strong>0–11</strong> (the 12 pre-built layouts); enter <strong>-1</strong> to clear a forced
+        seed (auto). Changing a seed triggers cleanup (corpses, loose loot) on next storm tick. Use
+        <em>Stay on current</em> to lock the layout across resets, or <em>Reroll</em> to pick a fresh
+        random one.
       </p>
 
       {/* Severe-consequences warning + lock gate. These settings rewrite world-reset
@@ -167,7 +169,8 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
         <div className="flex items-center gap-2">
           <input
             type="number"
-            min={0}
+            min={-1}
+            max={11}
             value={farmDraft}
             onChange={e => setFarmDraft(e.target.value)}
             disabled={busy}
@@ -197,7 +200,8 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
                 <span className="font-mono text-[11px] text-text-dim w-24">cur: {m.seed}</span>
                 <input
                   type="number"
-                  min={0}
+                  min={-1}
+                  max={11}
                   value={mapDrafts[m.map] ?? ''}
                   onChange={e => setMapDrafts(d => ({ ...d, [m.map]: e.target.value }))}
                   disabled={busy}
@@ -226,7 +230,8 @@ export function CoriolisAdmin({ flash }: { flash: Flash }) {
                 <span className="font-mono text-[11px] text-text-dim w-24">cur: {p.seed}</span>
                 <input
                   type="number"
-                  min={0}
+                  min={-1}
+                  max={11}
                   value={partDrafts[p.partition_id] ?? ''}
                   onChange={e => setPartDrafts(d => ({ ...d, [p.partition_id]: e.target.value }))}
                   disabled={busy}

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -553,10 +553,16 @@ const ACTIONS: ActionDef[] = [
   { id: 'whisper', group: 'Live', label: 'Whisper', icon: 'MessageCircle', liveOnly: true, custom: 'whisper',
     run: () => Promise.resolve({ message: '' }) },
   { id: 'cheat-script', group: 'Live', label: 'Cheat Scripts', icon: 'Terminal', liveOnly: true, custom: 'cheat-scripts',
-    rowNote: 'Fire a server cheat script — loadouts, XP, unlock skills/abilities. Online only',
+    doubleConfirm: true,
+    rowNote: 'Fire a server cheat script — loadouts, XP, unlock skills/abilities. Online only · Double confirmation required',
+    confirm: p => `Run a cheat script on ${p.name}?\n\n` +
+      `This is the FIRST of two confirmations. Cheat scripts run server-side game commands (loadouts, XP, skill/ability unlocks) and cannot be undone. If you continue, the next step asks you to type an acknowledgement before the script fires.`,
     run: () => Promise.resolve({ message: '' }) },
   { id: 'dev-scripts', group: 'Live', label: 'Dev / Perf Scripts', icon: 'FlaskConical', liveOnly: true, custom: 'dev-scripts',
-    rowNote: 'Developer performance-test harnesses (hitch tests). Playtest-only, online only',
+    doubleConfirm: true,
+    rowNote: 'Developer performance-test harnesses (hitch tests). Playtest-only, online only · Double confirmation required',
+    confirm: p => `Run a dev/perf script on ${p.name}?\n\n` +
+      `This is the FIRST of two confirmations. These are developer performance-test harnesses that change the running game session. If you continue, the next step asks you to type an acknowledgement before the script fires.`,
     run: () => Promise.resolve({ message: '' }) },
 
   // ----- Identity -----
@@ -787,12 +793,28 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
           ) : def.custom === 'cheat-scripts' ? (
             <CheatScriptForm busy={busy}
               onSubmit={name => runAction(def, async () => {
+                const typed = window.prompt(
+                  `SECOND confirmation — fire cheat script "${name}" on ${player.name}.\n` +
+                  `This runs a server-side cheat command and cannot be undone.\n\n` +
+                  `Type  i acknowledge  to proceed:`
+                ) || ''
+                if (typed.trim().toLowerCase() !== 'i acknowledge') {
+                  return Promise.reject(new Error('Did not type "i acknowledge" — cheat script aborted.'))
+                }
                 await cheatScript({ actor_id: player.id }, name)
                 return { message: `Sent cheat script "${name}" to ${player.name}.` }
               })} />
           ) : def.custom === 'dev-scripts' ? (
             <DevScriptForm busy={busy}
               onSubmit={name => runAction(def, async () => {
+                const typed = window.prompt(
+                  `SECOND confirmation — fire dev script "${name}" on ${player.name}.\n` +
+                  `This runs a server-side dev/perf command and cannot be undone.\n\n` +
+                  `Type  i acknowledge  to proceed:`
+                ) || ''
+                if (typed.trim().toLowerCase() !== 'i acknowledge') {
+                  return Promise.reject(new Error('Did not type "i acknowledge" — dev script aborted.'))
+                }
                 await cheatScript({ actor_id: player.id }, name)
                 return { message: `Sent dev script "${name}" to ${player.name}.` }
               })} />


### PR DESCRIPTION
## Summary

Patch release **12.5.1** bundling two fixes on top of the shipped 12.5.0.

### Fixed — Game Config boolean toggles reverting to Off after switching On
Toggling a bool whose value matched its schema default correctly triggers a reset (the key is removed from the user INI so it falls back to the default), but a stale copy of that same key left behind in a **different / unmanaged** INI section could shadow the canonical value — so the UI re-read the old `False` and the switch snapped back to Off (the **Coriolis Auto-Spawn** symptom). `ConvertTo-DuneIniManaged` now strips a touched key from **every** section, including unmanaged body sections, so the declared section is authoritative and the toggle sticks. Adds regression tests for the stale-unmanaged-copy case.

### Changed — Cheat Scripts and Dev / Perf Scripts now require a double confirmation
Firing a cheat/dev-perf script (Gameplay Admin → Players → Live) now prompts twice — an initial confirm plus a typed `i acknowledge` — matching the existing guard on destructive actions like wipe-codex and delete-account.

### Release prep
- Bumped all 5 version stamps `12.5.0 → 12.5.1`
- Rolled `[Unreleased]` → `[12.5.1] - 2026-06-16` in the changelog
- Refreshed the bug-report template `tool_version` placeholder

## Verification
- All 5 version stamps match (build gate green); non-ASCII `.ps1` files retain UTF-8 BOM; 76 `.ps1` parse under PS 5.1
- webui builds clean; Pester INI suite passes incl. 2 new regression tests
- Full installer built successfully → `DuneServerSetup.exe` (v12.5.1)

## Notes
Cheat-script *delivery* was verified byte-for-byte identical to the live dune-admin reference (same `ServerCommand`/`PlayerId`/`ScriptName`, envelope, auth token, exchange, routing) — "fires but no in-game effect" is a server-side INI definition limitation, not a DST wire bug. No change needed there.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;