### PR TITLE
Fix returning-player award writing to non-existent column (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ here cover everything those tags shipped.
 
 ### Fixed
 
+- **Grant / Dismiss Returning-Player Award failed with `column a.account does
+  not exist`.** Both actions (Gameplay Admin → Players) wrote the
+  `returningPlayerAward` flag into a JSONB column named `account` on
+  `dune.accounts` — but that table has no such column (it only holds `id`,
+  `user`, `funcom_id`, `takeoverable`, `platform_id`, `platform_name`), so
+  Postgres rejected every call and nothing was ever written. Verified against a
+  live server that the returning-player reward is actually timestamp-gated state
+  on the player, stored in `dune.encrypted_player_state` (the base table;
+  `dune.player_state` is a view over it that decrypts the character name): a
+  reward is present when `last_returning_player_awarded_time` is set. **Grant**
+  now stamps that column to `now()` and **Dismiss** clears it, keyed by
+  `account_id`, targeting the correct table. (#249)
+
 - **Non-ASCII characters in INI files corrupted into mojibake (e.g. UTF-8
   comment banners in UserGame.ini).** The SSH transport that reads remote files
   (`Invoke-V6Ssh` / `Invoke-DuneSshHidden`) decoded the process output using the

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -540,41 +540,41 @@ function Invoke-DunePlayerAwardIntel {
 
 # ----- Returning Player Award --------------------------------------------
 
+# The returning-player reward is NOT stored on dune.accounts (that table has no
+# JSONB column - the original port wrote to a non-existent "account" column and
+# always errored with "column a.account does not exist", issue #249). Verified
+# against a live server: the reward is timestamp-gated state on the player,
+# stored in dune.encrypted_player_state (the base table; dune.player_state is a
+# view over it that only decrypts the character name). A reward is present when
+# last_returning_player_awarded_time IS NOT NULL, so Grant stamps it to now()
+# and Dismiss clears it. Keyed by account_id.
 function Invoke-DunePlayerGrantReturningAward {
     param([string]$Ip, [long]$AccountId)
-    $resolve = Get-DuneRawFuncomId -Ip $Ip -AccountId $AccountId
-    if (-not $resolve.ok) { return @{ ok = $false; error = $resolve.error } }
-    $funcom = ConvertTo-DuneSqlString $resolve.funcom_id
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
     $sql = @"
-UPDATE dune.accounts a
-SET account = jsonb_set(
-    jsonb_set(
-        COALESCE(a.account, '{}'::jsonb),
-        '{returningPlayerAward,eligible}', to_jsonb(true)),
-    '{returningPlayerAward,dismissed}', to_jsonb(false))
-WHERE "user" = '$funcom';
+UPDATE dune.encrypted_player_state
+SET last_returning_player_awarded_time = now()
+WHERE account_id = $AccountId::bigint
+RETURNING account_id;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
     if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    if ([int]$r.rowCount -lt 1) { return @{ ok = $false; error = "No player state found for account $AccountId." } }
     return @{ ok = $true; message = "Granted returning-player award to account $AccountId." }
 }
 
 function Invoke-DunePlayerDismissReturningAward {
     param([string]$Ip, [long]$AccountId)
-    $resolve = Get-DuneRawFuncomId -Ip $Ip -AccountId $AccountId
-    if (-not $resolve.ok) { return @{ ok = $false; error = $resolve.error } }
-    $funcom = ConvertTo-DuneSqlString $resolve.funcom_id
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
     $sql = @"
-UPDATE dune.accounts a
-SET account = jsonb_set(
-    jsonb_set(
-        COALESCE(a.account, '{}'::jsonb),
-        '{returningPlayerAward,eligible}', to_jsonb(false)),
-    '{returningPlayerAward,dismissed}', to_jsonb(true))
-WHERE "user" = '$funcom';
+UPDATE dune.encrypted_player_state
+SET last_returning_player_awarded_time = NULL
+WHERE account_id = $AccountId::bigint
+RETURNING account_id;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
     if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    if ([int]$r.rowCount -lt 1) { return @{ ok = $false; error = "No player state found for account $AccountId." } }
     return @{ ok = $true; message = "Dismissed returning-player award for account $AccountId." }
 }
 


### PR DESCRIPTION
## Summary

Fixes #249 — **Grant / Dismiss Returning-Player Award** (Gameplay Admin → Players) failed with `column a.account does not exist` and never wrote anything.

## Root cause

Both functions in `app/server/lib/PlayersAdmin.ps1` wrote a `returningPlayerAward` flag into a JSONB column named `account` on `dune.accounts`:

```sql
UPDATE dune.accounts a SET account = jsonb_set(...) WHERE "user" = '...';
```

But `dune.accounts` has **no such column** — it only holds `id`, `user`, `funcom_id`, `takeoverable`, `platform_id`, `platform_name`. So Postgres rejected every call. This was a speculative port that was never validated; nothing in the codebase ever read the value back.

## Fix

Verified against a live server that the returning-player reward is timestamp-gated player state stored in `dune.encrypted_player_state` (the base table; `dune.player_state` is a view over it that only decrypts the character name). A reward is present when `last_returning_player_awarded_time IS NOT NULL`.

- **Grant** → `SET last_returning_player_awarded_time = now()`
- **Dismiss** → `SET last_returning_player_awarded_time = NULL`
- Both keyed by `account_id`, use `RETURNING account_id` + a rowcount check to report "No player state found" when the account doesn't exist.

The corrected `UPDATE`s were validated against the live DB inside a rolled-back transaction (each hits exactly one row, zero data persisted). Route wiring (`account_id`) and the web UI were already correct and are unchanged.

## Notes

- Folds into the still-unreleased **12.5.1**.
- `Get-DuneRawFuncomId` is retained — still used by delete-account.
- Parse-checked under PS 5.1; installer builds clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>