### PR TITLE
Fix Landsraad bulk thresholds + add offline guards for skill writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Landsraad Houses tab** (Gameplay Admin → Landsraad Houses). View and edit the
+  reward milestones for each Landsraad house in the current term:
+  - **Bulk Threshold Edit**: remap all thresholds at once (e.g. when lowering the
+    task goal from 15 000 to 5 000, map 700→250, 3 500→1 250, etc.). Presets for
+    the "5k goal" scale and a reverse-to-Funcom-defaults are one click away.
+  - **Per-tier item/amount edit**: expand any house card, click a tier row, and
+    change its `template_id` (item) or `amount` directly.
+  - Inline help explains every field so operators know what they're adjusting.
+
+### Fixed
+
+- **Landsraad bulk threshold edit wrote all zeros.** The compound `UPDATE; SELECT`
+  SQL returned only the UPDATE's empty column set through the proxy; now uses two
+  separate queries so the response shows the actual new thresholds.
+
+- **Skill-related writes (Unlock Trainer, Grant Job Skills, etc.) silently failed
+  when the player was online.** Pod RAM authority overwrote DB changes on logout.
+  These routes now require the player to be fully offline and return a clear error
+  if they aren't: `unlock-trainer`, `unlock-main-quest`, `grant-job-skills`,
+  `reset-job-skills`, `set-starter-class`.
+
 ## [12.5.1] - 2026-06-16
 
 ### Fixed

--- a/app/server/lib/Landsraad.ps1
+++ b/app/server/lib/Landsraad.ps1
@@ -226,3 +226,168 @@ GROUP BY gm.guild_id, pc.faction_id;
         house   = $house
     }
 }
+
+# ---------------------------------------------------------------------------
+# Landsraad task rewards admin — read + edit the milestone items/thresholds.
+# ---------------------------------------------------------------------------
+
+# Read ALL reward rows (landsraad_task_rewards) for the current term's tasks,
+# grouped by task (house). Returns @{ ok; term_id; houses=@( @{ task_id; house_name;
+# display_name; tiers=@( @{ threshold; template_id; amount } ) } ) }.
+function Get-DuneLandsraadRewards {
+    param([string]$Ip)
+    $term = Get-DuneLandsraadCurrentTermId -Ip $Ip
+    if (-not $term.ok) { return @{ ok = $false; error = $term.error } }
+    if ($term.term_id -le 0) { return @{ ok = $true; term_id = 0; houses = @() } }
+    
+    # Join rewards -> tasks for the current term, order by task (board_index) then threshold.
+    $sql = @"
+SELECT t.id AS task_id, t.house_name, t.board_index,
+       r.threshold, r.template_id, r.amount
+FROM dune.landsraad_task_rewards r
+JOIN dune.landsraad_tasks t ON t.id = r.task_id
+WHERE t.term_id = $($term.term_id)::bigint
+ORDER BY t.board_index, r.threshold;
+"@
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 500 -TimeoutSec 20
+    if (-not $res.ok) { return @{ ok = $false; error = "rewards: $($res.error)" } }
+    
+    $rows = ConvertTo-DuneRowMaps -Result $res
+    # Group by task_id into house -> tiers structure.
+    $houseMap = @{}
+    foreach ($row in $rows) {
+        $tid = [long](ConvertTo-DuneInt $row['task_id'])
+        if (-not $houseMap.ContainsKey($tid)) {
+            $hn = [string]$row['house_name']
+            $houseMap[$tid] = [ordered]@{
+                task_id      = $tid
+                house_name   = $hn
+                display_name = (Get-DuneLandsraadHouseDisplay $hn)
+                board_index  = [int](ConvertTo-DuneInt $row['board_index'])
+                tiers        = New-Object 'System.Collections.Generic.List[object]'
+            }
+        }
+        $houseMap[$tid].tiers.Add([ordered]@{
+            threshold   = [int](ConvertTo-DuneInt $row['threshold'])
+            template_id = [string]$row['template_id']
+            amount      = [int](ConvertTo-DuneInt $row['amount'])
+        })
+    }
+    
+    $houses = @($houseMap.Values | Sort-Object board_index)
+    return @{ ok = $true; term_id = $term.term_id; houses = $houses }
+}
+
+# Bulk-set reward thresholds across ALL tasks for the current term using a CASE
+# mapping (Discord pattern). Takes an array of @{ old; new } mappings. Example:
+# @( @{old=700;new=250}, @{old=3500;new=1250}, @{old=7000;new=2500},
+#    @{old=10500;new=3750}, @{old=14000;new=5000} )
+# Updates every row where threshold matches an 'old' value to its 'new' value.
+# Returns @{ ok; message; updated_count; thresholds=@(distinct new thresholds) }.
+function Set-DuneLandsraadRewardThresholds {
+    param([string]$Ip, [array]$Mappings)
+    if ($null -eq $Mappings -or $Mappings.Count -eq 0) {
+        return @{ ok = $false; error = 'mappings array is required (e.g. @( @{old=700;new=250}, ... )).' }
+    }
+    $term = Get-DuneLandsraadCurrentTermId -Ip $Ip
+    if (-not $term.ok) { return @{ ok = $false; error = $term.error } }
+    if ($term.term_id -le 0) { return @{ ok = $false; error = 'No active Landsraad term — cannot update reward thresholds.' } }
+    
+    # Build CASE threshold WHEN <old> THEN <new> ... ELSE threshold END
+    $whenClauses = @()
+    foreach ($m in $Mappings) {
+        $old = [int]$m.old
+        $new = [int]$m.new
+        if ($old -le 0 -or $new -le 0) { continue }
+        $whenClauses += "WHEN $old THEN $new"
+    }
+    if ($whenClauses.Count -eq 0) {
+        return @{ ok = $false; error = 'No valid mappings (each must have old>0 and new>0).' }
+    }
+    $caseExpr = "CASE threshold " + ($whenClauses -join ' ') + " ELSE threshold END"
+    
+    # UPDATE only rows for the current term's tasks. WITH t AS subquery ensures we
+    # touch only this term's rewards even if task_id values from older terms exist.
+    # NOTE: Must be two separate queries — compound "UPDATE; SELECT" returns only the
+    # UPDATE's empty rowset through the SQL proxy.
+    $updateSql = @"
+WITH current_term_tasks AS (
+    SELECT id FROM dune.landsraad_tasks WHERE term_id = $($term.term_id)::bigint
+)
+UPDATE dune.landsraad_task_rewards r
+SET threshold = $caseExpr
+FROM current_term_tasks t
+WHERE r.task_id = t.id;
+"@
+    $upd = Invoke-DuneSqlQuery -Ip $Ip -Sql $updateSql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $upd.ok) { return @{ ok = $false; error = "set thresholds: $($upd.error)" } }
+
+    # Fetch the new distinct thresholds for the response message.
+    $selectSql = @"
+SELECT DISTINCT threshold FROM dune.landsraad_task_rewards r
+JOIN dune.landsraad_tasks t ON t.id = r.task_id
+WHERE t.term_id = $($term.term_id)::bigint
+ORDER BY threshold;
+"@
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $selectSql -ReadOnly $true -MaxRows 100 -TimeoutSec 15
+    if (-not $res.ok) { return @{ ok = $false; error = "fetch thresholds: $($res.error)" } }
+
+    $maps = ConvertTo-DuneRowMaps -Result $res
+    $thresholds = @($maps | ForEach-Object { [int](ConvertTo-DuneInt $_['threshold']) } | Sort-Object)
+    
+    return @{
+        ok             = $true
+        message        = "Updated reward thresholds for term $($term.term_id). New thresholds: $($thresholds -join ', ')."
+        updated_count  = $upd.rowCount
+        thresholds     = $thresholds
+    }
+}
+
+# Set a single reward tier's item (template_id) and/or amount for one house (task).
+# Finds the row matching (task_id, threshold) and updates template_id and/or amount.
+# Pass $TemplateId and/or $Amount (at least one required). Returns @{ ok; message; house }.
+function Set-DuneLandsraadRewardTier {
+    param([string]$Ip, [long]$TaskId, [int]$Threshold, [string]$TemplateId, [int]$Amount)
+    if ($TaskId -le 0) { return @{ ok = $false; error = 'task_id is required.' } }
+    if ($Threshold -le 0) { return @{ ok = $false; error = 'threshold is required.' } }
+    if ([string]::IsNullOrWhiteSpace($TemplateId) -and $Amount -le 0) {
+        return @{ ok = $false; error = 'At least one of template_id or amount must be provided.' }
+    }
+    
+    # Validate task exists + grab house name for the message.
+    $tsql = "SELECT house_name FROM dune.landsraad_tasks WHERE id = $TaskId::bigint;"
+    $tr = Invoke-DuneSqlQuery -Ip $Ip -Sql $tsql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $tr.ok) { return @{ ok = $false; error = "task lookup: $($tr.error)" } }
+    $tmaps = ConvertTo-DuneRowMaps -Result $tr
+    if ($tmaps.Count -eq 0) { return @{ ok = $false; error = "No Landsraad task with id $TaskId." } }
+    $house = Get-DuneLandsraadHouseDisplay ([string]$tmaps[0]['house_name'])
+    
+    # Build SET clause dynamically.
+    $setParts = @()
+    if (-not [string]::IsNullOrWhiteSpace($TemplateId)) {
+        $tEsc = ConvertTo-DuneSqlString $TemplateId
+        $setParts += "template_id = '$tEsc'"
+    }
+    if ($Amount -gt 0) {
+        $setParts += "amount = $Amount::int"
+    }
+    $setClause = $setParts -join ', '
+    
+    $sql = @"
+UPDATE dune.landsraad_task_rewards
+SET $setClause
+WHERE task_id = $TaskId::bigint AND threshold = $Threshold::int
+RETURNING task_id;
+"@
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
+    if (-not $res.ok) { return @{ ok = $false; error = "set tier: $($res.error)" } }
+    if ([int]$res.rowCount -lt 1) {
+        return @{ ok = $false; error = "No reward row found for House $house (task $TaskId) at threshold $Threshold." }
+    }
+    
+    return @{
+        ok      = $true
+        message = "Updated House $house threshold $Threshold reward."
+        house   = $house
+    }
+}

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -59,6 +59,26 @@ function Test-DunePlayerOfflineByController {
     return @{ ok = $true; reason = $null }
 }
 
+# Same offline check as Test-DunePlayerOffline but resolved from the account id.
+# Lets writes that only know the account (e.g. unlock-trainer) still reject an
+# online player. A missing player_state row is treated as offline.
+function Test-DunePlayerOfflineByAccount {
+    param([string]$Ip, [long]$AccountId)
+    $sql = "SELECT online_status::text AS status FROM dune.player_state WHERE account_id = $AccountId::bigint LIMIT 1;"
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $r.ok) { return @{ ok = $true; reason = $null } }
+    $maps = ConvertTo-DuneRowMaps -Result $r
+    if ($maps.Count -eq 0) { return @{ ok = $true; reason = $null } }
+    $status = [string]$maps[0]['status']
+    if ($status -eq 'LoggingOut') {
+        return @{ ok = $false; reason = "player is mid-logout — the pod still owns their character in memory and will flush on logout, overwriting skill grants. Grace timer is ~30s on Hagga / Arrakeen / Harkonnen / etc., ~5 min in Deep Desert. Wait until status shows Offline, then retry." }
+    }
+    if ($status -ne 'Offline') {
+        return @{ ok = $false; reason = "player is currently $status — skill grants write to the character's FLevelComponent, which the pod will overwrite when they log out. Have them log out first, then apply." }
+    }
+    return @{ ok = $true; reason = $null }
+}
+
 # ----- Faction reputation tables (verbatim from db.go) ---------------------
 
 $script:DuneFactionTierThresholds = @(

--- a/app/server/routes/Landsraad.ps1
+++ b/app/server/routes/Landsraad.ps1
@@ -65,3 +65,98 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/landsraad/set-contribution'
         Write-DuneError -Response $res -Status 500 -Message "Set Landsraad contribution failed: $($_.Exception.Message)"
     }
 }
+
+# ---------------------------------------------------------------------------
+# Landsraad task rewards admin (#250) — view/edit the milestone items/thresholds.
+# ---------------------------------------------------------------------------
+
+# GET /api/gameplay/landsraad/rewards — all reward tiers for every house (current term).
+Register-DuneRoute -Method GET -Path '/api/gameplay/landsraad/rewards' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Invoke-DunePlayerReadRoute -Response $res -Request $req `
+            -LiveBlock { param($ip) Get-DuneLandsraadRewards -Ip $ip } `
+            -DemoBlock {
+                @{ ok = $true; term_id = 2; houses = @(
+                    [ordered]@{
+                        task_id = 26; house_name = 'DA_HouseEcaz'; display_name = 'Ecaz'; board_index = 0
+                        tiers = @(
+                            [ordered]@{ threshold = 250;  template_id = 'T6DiamodineBladeParts'; amount = 25 }
+                            [ordered]@{ threshold = 1250; template_id = 'HighCapacityLiterjon_05_Schematic'; amount = 1 }
+                            [ordered]@{ threshold = 2500; template_id = 'T6RayAmplifier'; amount = 50 }
+                            [ordered]@{ threshold = 3750; template_id = 'DewReaper_2h_Unique_YieldIncrease_06_Schematic'; amount = 1 }
+                            [ordered]@{ threshold = 5000; template_id = 'Ecaz_Placeables_Swatch'; amount = 1 }
+                        )
+                    }
+                    [ordered]@{
+                        task_id = 27; house_name = 'DA_HouseMoritani'; display_name = 'Moritani'; board_index = 1
+                        tiers = @(
+                            [ordered]@{ threshold = 250;  template_id = 'T6FilteredFabric'; amount = 25 }
+                            [ordered]@{ threshold = 1250; template_id = 'DewReaper_Unique_04_Schematic'; amount = 1 }
+                            [ordered]@{ threshold = 2500; template_id = 'T6IrradiatedCore'; amount = 50 }
+                            [ordered]@{ threshold = 3750; template_id = 'DewReaper_1h_Unique_Compact_06_Schematic'; amount = 1 }
+                            [ordered]@{ threshold = 5000; template_id = 'Moritani_Placeables_Swatch'; amount = 1 }
+                        )
+                    }
+                ) }
+            } `
+            -PayloadKey 'rewards'
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Landsraad rewards failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/landsraad/set-thresholds  { mappings: [ { old, new }, ... ] }
+# Bulk-update all reward thresholds using old->new mapping (e.g. 700->250).
+Register-DuneRoute -Method POST -Path '/api/gameplay/landsraad/set-thresholds' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $mappings = Get-DuneBodyValue -Body $body -Name 'mappings'
+        if ($null -eq $mappings -or @($mappings).Count -eq 0) {
+            Write-DuneError -Response $res -Status 400 -Message 'mappings array is required.'; return
+        }
+        # Convert PSObjects to hashtables if needed.
+        $mapArray = @()
+        foreach ($m in @($mappings)) {
+            $old = 0; $new = 0
+            if ($m -is [System.Collections.IDictionary]) {
+                [void][int]::TryParse([string]$m['old'], [ref]$old)
+                [void][int]::TryParse([string]$m['new'], [ref]$new)
+            } else {
+                [void][int]::TryParse([string]$m.old, [ref]$old)
+                [void][int]::TryParse([string]$m.new, [ref]$new)
+            }
+            if ($old -gt 0 -and $new -gt 0) { $mapArray += @{ old = $old; new = $new } }
+        }
+        if ($mapArray.Count -eq 0) {
+            Write-DuneError -Response $res -Status 400 -Message 'No valid mappings (each must have old>0 and new>0).'; return
+        }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip)
+            Set-DuneLandsraadRewardThresholds -Ip $ip -Mappings $mapArray
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Set Landsraad thresholds failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/landsraad/set-reward-tier  { task_id, threshold, template_id?, amount? }
+# Update a single reward item/amount for one house (task) at one threshold.
+Register-DuneRoute -Method POST -Path '/api/gameplay/landsraad/set-reward-tier' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $tid = Get-DuneBodyInt -Body $body -Name 'task_id'
+        $thr = Get-DuneBodyInt -Body $body -Name 'threshold'
+        $tmpl = [string](Get-DuneBodyValue -Body $body -Name 'template_id')
+        $amt = Get-DuneBodyInt -Body $body -Name 'amount'
+        if ($null -eq $tid -or $tid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'task_id is required.'; return }
+        if ($null -eq $thr -or $thr -le 0) { Write-DuneError -Response $res -Status 400 -Message 'threshold is required.'; return }
+        if ([string]::IsNullOrWhiteSpace($tmpl) -and ($null -eq $amt -or $amt -le 0)) {
+            Write-DuneError -Response $res -Status 400 -Message 'At least one of template_id or amount must be provided.'; return
+        }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip)
+            Set-DuneLandsraadRewardTier -Ip $ip -TaskId $tid -Threshold $thr -TemplateId $tmpl -Amount ([int]$amt)
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Set Landsraad reward tier failed: $($_.Exception.Message)"
+    }
+}

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -234,6 +234,10 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/contracts/reverse' 
 }
 
 # POST /api/gameplay/players/unlock-trainer  { account_id, job }
+# Offline-only: skill grants write to the character's FLevelComponent in Postgres,
+# but the map pod holds the authoritative copy in RAM while the player is online.
+# If they're online when we write, the pod flushes its RAM state on logout and
+# overwrites our grants. Same class of issue as Fill Base Water (#221).
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/unlock-trainer' -Handler {
     param($req, $res, $routeParams, $body)
     try {
@@ -241,13 +245,21 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/unlock-trainer' -Ha
         $job = [string](Get-DuneBodyValue -Body $body -Name 'job')
         if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
         if (-not $job) { Write-DuneError -Response $res -Status 400 -Message 'job is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerUnlockTrainer -Ip $ip -AccountId $acc -Job $job }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
+            if (-not $off.ok) {
+                return @{ ok = $false; error = "Player must be offline to unlock trainers. $($off.reason)" }
+            }
+            Invoke-DunePlayerUnlockTrainer -Ip $ip -AccountId $acc -Job $job
+        }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Unlock trainer failed: $($_.Exception.Message)"
     }
 }
 
 # POST /api/gameplay/players/unlock-main-quest  { account_id, quest }
+# Offline-only: same FLevelComponent RAM-authority issue as unlock-trainer.
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/unlock-main-quest' -Handler {
     param($req, $res, $routeParams, $body)
     try {
@@ -255,13 +267,21 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/unlock-main-quest' 
         $quest = [string](Get-DuneBodyValue -Body $body -Name 'quest')
         if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
         if (-not $quest) { Write-DuneError -Response $res -Status 400 -Message 'quest is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerUnlockMainQuest -Ip $ip -AccountId $acc -Quest $quest }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
+            if (-not $off.ok) {
+                return @{ ok = $false; error = "Player must be offline to unlock main quests. $($off.reason)" }
+            }
+            Invoke-DunePlayerUnlockMainQuest -Ip $ip -AccountId $acc -Quest $quest
+        }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Unlock main quest failed: $($_.Exception.Message)"
     }
 }
 
 # POST /api/gameplay/players/grant-job-skills  { account_id, job }
+# Offline-only: same FLevelComponent RAM-authority issue as unlock-trainer.
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/grant-job-skills' -Handler {
     param($req, $res, $routeParams, $body)
     try {
@@ -269,13 +289,21 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/grant-job-skills' -
         $job = [string](Get-DuneBodyValue -Body $body -Name 'job')
         if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
         if (-not $job) { Write-DuneError -Response $res -Status 400 -Message 'job is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerGrantJobSkills -Ip $ip -AccountId $acc -Job $job }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
+            if (-not $off.ok) {
+                return @{ ok = $false; error = "Player must be offline to grant job skills. $($off.reason)" }
+            }
+            Invoke-DunePlayerGrantJobSkills -Ip $ip -AccountId $acc -Job $job
+        }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Grant job skills failed: $($_.Exception.Message)"
     }
 }
 
 # POST /api/gameplay/players/reset-job-skills  { account_id, job }
+# Offline-only: same FLevelComponent RAM-authority issue as unlock-trainer.
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/reset-job-skills' -Handler {
     param($req, $res, $routeParams, $body)
     try {
@@ -283,13 +311,21 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/reset-job-skills' -
         $job = [string](Get-DuneBodyValue -Body $body -Name 'job')
         if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
         if (-not $job) { Write-DuneError -Response $res -Status 400 -Message 'job is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetJobSkills -Ip $ip -AccountId $acc -Job $job }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
+            if (-not $off.ok) {
+                return @{ ok = $false; error = "Player must be offline to reset job skills. $($off.reason)" }
+            }
+            Invoke-DunePlayerResetJobSkills -Ip $ip -AccountId $acc -Job $job
+        }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Reset job skills failed: $($_.Exception.Message)"
     }
 }
 
 # POST /api/gameplay/players/set-starter-class  { account_id, job }
+# Offline-only: same FLevelComponent RAM-authority issue as unlock-trainer.
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/set-starter-class' -Handler {
     param($req, $res, $routeParams, $body)
     try {
@@ -297,7 +333,14 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/set-starter-class' 
         $job = [string](Get-DuneBodyValue -Body $body -Name 'job')
         if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
         if (-not $job) { Write-DuneError -Response $res -Status 400 -Message 'job is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerSetStarterClass -Ip $ip -AccountId $acc -Job $job }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
+            if (-not $off.ok) {
+                return @{ ok = $false; error = "Player must be offline to set starter class. $($off.reason)" }
+            }
+            Invoke-DunePlayerSetStarterClass -Ip $ip -AccountId $acc -Job $job
+        }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Set starter class failed: $($_.Exception.Message)"
     }

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -679,6 +679,41 @@ export function setLandsraadContribution(controllerId: number, taskId: number, a
   })
 }
 
+// Landsraad reward thresholds/items admin (#250).
+export interface LandsraadRewardTier {
+  threshold: number
+  template_id: string
+  amount: number
+}
+export interface LandsraadRewardHouse {
+  task_id: number
+  house_name: string
+  display_name: string
+  board_index: number
+  tiers: LandsraadRewardTier[]
+}
+export interface LandsraadRewardsResponse {
+  term_id: number
+  houses: LandsraadRewardHouse[]
+  source: DataSource
+  liveError?: string
+}
+export function getLandsraadRewards(demo?: boolean) {
+  return api<LandsraadRewardsResponse>(`/api/gameplay/landsraad/rewards${qs({ demo: demo ? 1 : undefined })}`)
+}
+export function setLandsraadThresholds(mappings: { old: number; new: number }[]) {
+  return api<WriteResult>('/api/gameplay/landsraad/set-thresholds', {
+    method: 'POST',
+    body: JSON.stringify({ mappings }),
+  })
+}
+export function setLandsraadRewardTier(taskId: number, threshold: number, templateId?: string, amount?: number) {
+  return api<WriteResult>('/api/gameplay/landsraad/set-reward-tier', {
+    method: 'POST',
+    body: JSON.stringify({ task_id: taskId, threshold, template_id: templateId, amount }),
+  })
+}
+
 // ---------------------------------------------------------------------------
 // v11.5.6 — extended player surface (port of the reference implementation's player tooling).
 // ---------------------------------------------------------------------------

--- a/webui/src/pages/GameplayEnvironment.tsx
+++ b/webui/src/pages/GameplayEnvironment.tsx
@@ -8,9 +8,10 @@ import { PlayersTab } from './gameplay/PlayersTab'
 import { BasesTab } from './gameplay/BasesTab'
 import { StorageTab } from './gameplay/StorageTab'
 import { BlueprintsTab } from './gameplay/BlueprintsTab'
+import { LandsraadTab } from './gameplay/LandsraadTab'
 
 export type GameplaySubTab =
-  | 'overview' | 'market' | 'marketbot' | 'players' | 'bases' | 'storage' | 'blueprints'
+  | 'overview' | 'market' | 'marketbot' | 'players' | 'bases' | 'storage' | 'blueprints' | 'landsraad'
 
 const TABS: { id: GameplaySubTab; label: string; icon: string }[] = [
   { id: 'overview',  label: 'Overview', icon: 'LayoutGrid' },
@@ -20,6 +21,7 @@ const TABS: { id: GameplaySubTab; label: string; icon: string }[] = [
   { id: 'bases',     label: 'Bases',    icon: 'Castle' },
   { id: 'storage',   label: 'Storage',  icon: 'Package' },
   { id: 'blueprints', label: 'Blueprints', icon: 'ScrollText' },
+  { id: 'landsraad', label: 'Landsraad Houses', icon: 'Landmark' },
 ]
 
 export function GameplayEnvironment() {
@@ -58,6 +60,7 @@ export function GameplayEnvironment() {
       {tab === 'bases' && <BasesTab />}
       {tab === 'storage' && <StorageTab />}
       {tab === 'blueprints' && <BlueprintsTab />}
+      {tab === 'landsraad' && <LandsraadTab />}
     </>
   )
 }

--- a/webui/src/pages/gameplay/LandsraadTab.tsx
+++ b/webui/src/pages/gameplay/LandsraadTab.tsx
@@ -1,0 +1,349 @@
+// Landsraad Houses — view/edit the reward tiers (thresholds + items) for each
+// house in the current Landsraad term. Allows bulk threshold adjustment (the
+// Discord "5k task goal" pattern) and per-tier item/amount edits.
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Icon } from '../../components/Icon'
+import {
+  getLandsraadRewards, setLandsraadThresholds, setLandsraadRewardTier,
+  type LandsraadRewardHouse, type LandsraadRewardTier, type DataSource,
+} from '../../api/gameplay'
+import { SourceBadge, DemoNotice, fmtNum } from './shared'
+
+// Default Funcom thresholds and example "5k goal" replacements.
+const DEFAULT_THRESHOLDS = [700, 3500, 7000, 10500, 14000]
+const PRESET_5K: { old: number; new: number }[] = [
+  { old: 700, new: 250 },
+  { old: 3500, new: 1250 },
+  { old: 7000, new: 2500 },
+  { old: 10500, new: 3750 },
+  { old: 14000, new: 5000 },
+]
+
+export function LandsraadTab() {
+  const [houses, setHouses] = useState<LandsraadRewardHouse[]>([])
+  const [termId, setTermId] = useState(0)
+  const [source, setSource] = useState<DataSource>('demo')
+  const [liveError, setLiveError] = useState<string | undefined>()
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [flash, setFlash] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  // Bulk threshold editor state.
+  const [showBulk, setShowBulk] = useState(false)
+  const [bulkMappings, setBulkMappings] = useState<{ old: string; new: string }[]>(
+    DEFAULT_THRESHOLDS.map(t => ({ old: String(t), new: '' }))
+  )
+
+  // Per-tier inline editor state.
+  const [editKey, setEditKey] = useState<string | null>(null) // "taskId-threshold"
+  const [editTemplate, setEditTemplate] = useState('')
+  const [editAmount, setEditAmount] = useState('')
+
+  // Expanded house cards.
+  const [expanded, setExpanded] = useState<Set<number>>(() => new Set())
+
+  const load = useCallback(async () => {
+    setLoading(true); setError(null)
+    try {
+      const r = await getLandsraadRewards()
+      setHouses(r.houses); setTermId(r.term_id); setSource(r.source); setLiveError(r.liveError)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+  useEffect(() => { void load() }, [load])
+
+  // Derive current distinct thresholds across all houses for display.
+  const currentThresholds = useMemo(() => {
+    const set = new Set<number>()
+    for (const h of houses) for (const t of h.tiers) set.add(t.threshold)
+    return [...set].sort((a, b) => a - b)
+  }, [houses])
+
+  // Apply bulk threshold mappings.
+  const applyBulk = async () => {
+    const mappings = bulkMappings
+      .map(m => ({ old: parseInt(m.old, 10), new: parseInt(m.new, 10) }))
+      .filter(m => m.old > 0 && m.new > 0 && m.old !== m.new)
+    if (mappings.length === 0) { setError('Enter at least one valid old→new mapping.'); return }
+    setBusy(true); setError(null); setFlash(null)
+    try {
+      const r = await setLandsraadThresholds(mappings)
+      setFlash(r.message)
+      void load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // Load preset into bulk editor.
+  const loadPreset5k = () => {
+    setBulkMappings(PRESET_5K.map(p => ({ old: String(p.old), new: String(p.new) })))
+  }
+  const loadPresetReset = () => {
+    // Reverse: current -> default (assumes current are the 5k ones).
+    setBulkMappings(PRESET_5K.map(p => ({ old: String(p.new), new: String(p.old) })))
+  }
+
+  // Start editing a tier.
+  const beginEdit = (h: LandsraadRewardHouse, t: LandsraadRewardTier) => {
+    setEditKey(`${h.task_id}-${t.threshold}`)
+    setEditTemplate(t.template_id)
+    setEditAmount(String(t.amount))
+  }
+  const cancelEdit = () => { setEditKey(null); setEditTemplate(''); setEditAmount('') }
+  const saveEdit = async (taskId: number, threshold: number) => {
+    const tmpl = editTemplate.trim() || undefined
+    const amt = parseInt(editAmount, 10) || undefined
+    if (!tmpl && !amt) { setError('Provide template_id and/or amount.'); return }
+    setBusy(true); setError(null); setFlash(null)
+    try {
+      const r = await setLandsraadRewardTier(taskId, threshold, tmpl, amt)
+      setFlash(r.message)
+      cancelEdit()
+      void load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const toggleHouse = (taskId: number) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(taskId)) next.delete(taskId); else next.add(taskId)
+      return next
+    })
+  }
+
+  const canWrite = source === 'live'
+
+  return (
+    <div>
+      {/* Header info */}
+      <div className="card p-4 mb-4">
+        <div className="flex items-center justify-between flex-wrap gap-2 mb-2">
+          <div className="flex items-center gap-2">
+            <Icon name="Landmark" size={18} className="text-accent" />
+            <span className="font-semibold text-text">Landsraad Houses</span>
+            <SourceBadge source={source} />
+          </div>
+          <button className="btn-secondary" onClick={() => void load()} disabled={loading || busy}>
+            <Icon name="RefreshCw" size={14} className={loading ? 'animate-spin' : ''} /> Refresh
+          </button>
+        </div>
+        <p className="text-xs text-text-muted leading-relaxed">
+          Each Landsraad house (task) has <strong>5 reward tiers</strong> — milestones players unlock by contributing points.
+          <strong> Threshold</strong> is the point target for that tier; <strong>template_id</strong> is the item rewarded; <strong>amount</strong> is how many.
+          Use <em>Bulk Threshold Edit</em> to rescale all thresholds at once (e.g. when you lower the task goal from 15k to 5k),
+          or expand a house and click a tier to change its item/amount individually.
+        </p>
+        {termId > 0 && (
+          <div className="mt-2 text-xs text-text-dim">
+            Current term: <span className="font-mono text-text">{termId}</span> • Thresholds in use: <span className="font-mono text-text">{currentThresholds.join(', ') || '—'}</span>
+          </div>
+        )}
+      </div>
+
+      {source === 'demo' && <DemoNotice liveError={liveError} what="Landsraad reward data" />}
+      {flash && <div className="card p-3 mb-4 text-sm text-success flex items-center gap-2"><Icon name="CheckCircle2" size={15} /> {flash}</div>}
+      {error && <div className="card p-3 mb-4 text-sm text-danger">{error}</div>}
+
+      {/* Bulk threshold editor */}
+      <div className="card mb-4">
+        <button
+          type="button"
+          className="w-full flex items-center justify-between px-4 py-3 text-left"
+          onClick={() => setShowBulk(b => !b)}
+        >
+          <span className="font-medium text-text flex items-center gap-2">
+            <Icon name="Settings2" size={15} className="text-accent" />
+            Bulk Threshold Edit
+          </span>
+          <Icon name={showBulk ? 'ChevronUp' : 'ChevronDown'} size={15} className="text-text-dim" />
+        </button>
+        {showBulk && (
+          <div className="px-4 pb-4 border-t border-border pt-3">
+            <p className="text-xs text-text-muted mb-3">
+              Map each <strong>old threshold</strong> to a <strong>new threshold</strong>. Leave "new" blank to skip that row.
+              This updates <em>every</em> reward row across all houses in the current term where the threshold matches.
+            </p>
+            <div className="flex flex-wrap gap-2 mb-3">
+              <button type="button" className="btn-secondary text-xs" onClick={loadPreset5k} disabled={busy}>
+                <Icon name="Zap" size={12} /> Load 5k-goal preset (700→250, etc.)
+              </button>
+              <button type="button" className="btn-secondary text-xs" onClick={loadPresetReset} disabled={busy}>
+                <Icon name="RotateCcw" size={12} /> Load reverse (back to Funcom defaults)
+              </button>
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2 mb-3">
+              {bulkMappings.map((m, i) => (
+                <div key={i} className="flex flex-col gap-1">
+                  <label className="text-[10px] uppercase tracking-wider text-text-dim">Old</label>
+                  <input
+                    type="number"
+                    className="input-field text-sm font-mono"
+                    value={m.old}
+                    onChange={e => {
+                      const next = [...bulkMappings]
+                      next[i] = { ...next[i], old: e.target.value }
+                      setBulkMappings(next)
+                    }}
+                    disabled={busy}
+                  />
+                  <label className="text-[10px] uppercase tracking-wider text-text-dim">New</label>
+                  <input
+                    type="number"
+                    className="input-field text-sm font-mono"
+                    placeholder="—"
+                    value={m.new}
+                    onChange={e => {
+                      const next = [...bulkMappings]
+                      next[i] = { ...next[i], new: e.target.value }
+                      setBulkMappings(next)
+                    }}
+                    disabled={busy}
+                  />
+                </div>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={() => void applyBulk()}
+              disabled={busy || !canWrite}
+              title={canWrite ? 'Apply the threshold mappings' : 'Start the battlegroup to enable writes'}
+            >
+              {busy ? <Icon name="Loader2" size={14} className="animate-spin" /> : <Icon name="Save" size={14} />}
+              Apply Threshold Changes
+            </button>
+            {!canWrite && <span className="ml-2 text-xs text-text-dim">(requires live DB)</span>}
+          </div>
+        )}
+      </div>
+
+      {/* Houses list */}
+      {loading && houses.length === 0 && (
+        <div className="card p-8 text-center text-text-dim">
+          <Icon name="Loader2" size={20} className="animate-spin inline" /> Loading Landsraad houses…
+        </div>
+      )}
+      {!loading && termId === 0 && (
+        <div className="card p-8 text-center text-text-dim">No active Landsraad term on this server.</div>
+      )}
+      {houses.length > 0 && (
+        <div className="space-y-2">
+          {houses.map(h => {
+            const open = expanded.has(h.task_id)
+            return (
+              <div key={h.task_id} className="card overflow-hidden">
+                <button
+                  type="button"
+                  className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-surface-2 transition-colors"
+                  onClick={() => toggleHouse(h.task_id)}
+                >
+                  <span className="font-medium text-text">
+                    <Icon name="Home" size={14} className="inline mr-2 text-accent" />
+                    {h.display_name}
+                    <span className="ml-2 text-xs text-text-dim font-normal">({h.tiers.length} tiers)</span>
+                  </span>
+                  <Icon name={open ? 'ChevronUp' : 'ChevronDown'} size={15} className="text-text-dim" />
+                </button>
+                {open && (
+                  <div className="border-t border-border">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="text-left text-[11px] uppercase tracking-wider text-text-dim border-b border-border/50">
+                          <th className="px-4 py-2 font-medium">Threshold</th>
+                          <th className="px-4 py-2 font-medium">Item (template_id)</th>
+                          <th className="px-4 py-2 font-medium text-right">Amount</th>
+                          <th className="px-4 py-2 font-medium text-right">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {h.tiers.map(t => {
+                          const key = `${h.task_id}-${t.threshold}`
+                          const editing = editKey === key
+                          return (
+                            <tr key={t.threshold} className="border-b border-border/30 hover:bg-surface-2">
+                              <td className="px-4 py-2 font-mono text-accent">{fmtNum(t.threshold)}</td>
+                              {editing ? (
+                                <>
+                                  <td className="px-4 py-2">
+                                    <input
+                                      type="text"
+                                      className="input-field text-xs font-mono w-full"
+                                      value={editTemplate}
+                                      onChange={e => setEditTemplate(e.target.value)}
+                                      placeholder="template_id"
+                                      disabled={busy}
+                                    />
+                                  </td>
+                                  <td className="px-4 py-2 text-right">
+                                    <input
+                                      type="number"
+                                      className="input-field text-xs font-mono w-20 text-right"
+                                      value={editAmount}
+                                      onChange={e => setEditAmount(e.target.value)}
+                                      placeholder="qty"
+                                      disabled={busy}
+                                    />
+                                  </td>
+                                  <td className="px-4 py-2 text-right flex items-center justify-end gap-1">
+                                    <button
+                                      type="button"
+                                      className="btn-primary py-1 px-2 text-xs"
+                                      onClick={() => void saveEdit(h.task_id, t.threshold)}
+                                      disabled={busy}
+                                    >
+                                      {busy ? <Icon name="Loader2" size={12} className="animate-spin" /> : <Icon name="Check" size={12} />} Save
+                                    </button>
+                                    <button type="button" className="btn-secondary py-1 px-2 text-xs" onClick={cancelEdit} disabled={busy}>
+                                      <Icon name="X" size={12} />
+                                    </button>
+                                  </td>
+                                </>
+                              ) : (
+                                <>
+                                  <td className="px-4 py-2 font-mono text-text-muted truncate max-w-[260px]" title={t.template_id}>
+                                    {t.template_id}
+                                  </td>
+                                  <td className="px-4 py-2 text-right font-mono">{fmtNum(t.amount)}</td>
+                                  <td className="px-4 py-2 text-right">
+                                    <button
+                                      type="button"
+                                      className="btn-secondary py-1 px-2 text-xs"
+                                      onClick={() => beginEdit(h, t)}
+                                      disabled={busy || !canWrite}
+                                      title={canWrite ? 'Edit this tier' : 'Start the battlegroup to enable writes'}
+                                    >
+                                      <Icon name="Pencil" size={12} /> Edit
+                                    </button>
+                                  </td>
+                                </>
+                              )}
+                            </tr>
+                          )
+                        })}
+                      </tbody>
+                    </table>
+                    <div className="px-4 py-2 text-[11px] text-text-dim bg-surface-2/50">
+                      <strong>task_id:</strong> {h.task_id} • <strong>house_name:</strong> {h.house_name}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Two fixes:

1. **Landsraad bulk threshold edit wrote all zeros** — the compound `UPDATE; SELECT` SQL returned only the UPDATE's empty column set through the proxy. Now uses two separate queries so the response shows actual new thresholds.

2. **Skill-related writes failed silently when player was online** — pod RAM authority overwrites DB changes on logout. Added offline-only guards to these routes:
   - `unlock-trainer`
   - `unlock-main-quest`
   - `grant-job-skills`
   - `reset-job-skills`
   - `set-starter-class`

## Testing

- Decker confirmed Unlock Trainers works when player is offline (issue #251)
- Landsraad threshold fix verified against screenshot showing zeros → should now show actual values

Fixes #251