### PR TITLE
fix(gameplay): Apply Journey.RewardsUnblocked when unlocking Fremen quest

### DIFF
--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1235,6 +1235,17 @@ function Invoke-DunePlayerUnlockMainQuest {
     }
     $r = Invoke-DunePlayerCompleteJourneyNode -Ip $Ip -AccountId $AccountId -NodeId $Quest
     if (-not $r.ok) { return $r }
+
+    # Apply Journey.RewardsUnblocked for FindTheFremen completion (unlocks 3rd ability slot, prescience, etc.)
+    # This tag is normally set by game code during cutscenes, not by journey node completion.
+    if ($Quest -eq 'DA_MQ_FindTheFremen') {
+        $extraTags = @('Journey.RewardsUnblocked')
+        $bumpRes = Invoke-DuneApplyTagsWithTierBump -Ip $Ip -AccountId $AccountId -Tags $extraTags
+        if (-not $bumpRes.ok) {
+            return @{ ok = $false; error = "apply RewardsUnblocked: $($bumpRes.error)" }
+        }
+    }
+
     return @{ ok = $true; message = "Unlocked main quest $Quest - $($r.nodes) node(s) completed - takes effect on next login"; nodes = $r.nodes }
 }
 


### PR DESCRIPTION
## Summary

Fixes #253 - "Unlock Main Quest (Fremen questline) doesn't unlock 3rd perk slot, prescience, or corpse pickup" when player is offline.

## Root Cause

Investigation found that **there is no explicit tag** for "3rd ability slot unlocked" or similar. The ability slot count is computed at runtime by the server based on journey state.

However, players who complete FindTheFremen naturally have a tag `Journey.RewardsUnblocked` that is **not** applied by journey node completion - it's set by game code during cutscenes/dialogues.

## Changes

When using "Unlock Main Quest" for `DA_MQ_FindTheFremen`, now also applies `Journey.RewardsUnblocked` tag.

## Investigation Details

Compared DB state of a character who completed Fremen naturally vs forced completion:

- **No ability slot tag exists** - searched all tags for ability, perk, slot, prescience, corpse → none found
- **FLevelComponent stores active slots, not max slots** - `ActiveAbilityTags` shows what's equipped
- **Journey tags are correct** - DST already applies `Journey.Act1.Completed`, `Journey.TheSietch.Progression.Completed`, `JourneySets.Fremkit.*`
- **Mystery tag found**: `Journey.RewardsUnblocked` present on natural completion but not in our tag data

## Testing

Build available at `app/installer/output/DuneServerSetup.exe`. Test by:
1. Find a player who hasn't completed Fremen naturally
2. Use "Unlock Main Quest → Find the Fremen" while offline
3. Have them log in and check if 3rd ability/perk slots are unlocked

## Caveat

If this doesn't fix the issue, the unlock mechanism may be something else entirely (e.g., server-side state written only during live cutscene execution), and would need to be documented as a limitation.