### PR TITLE
Remove Grant/Dismiss Returning-Player Award (v12.5.4)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.5.1"
+      placeholder: "v12.5.4"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.5.4] - 2026-06-16
+
+### Removed
+
+- **Grant / Dismiss Returning-Player Award** player actions (Gameplay Admin →
+  Players → Identity). Removed the two actions along with their API routes
+  (`/api/gameplay/players/returning-player-award`,
+  `/api/gameplay/players/dismiss-returning-player-award`) and backend handlers.
+
 ## [12.5.3] - 2026-06-17
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.5.3'
+$script:DuneToolVersion = '12.5.4'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.5.3',
+    [string]$Version = '12.5.4',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.5.3</Version>
+    <Version>12.5.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.5.3"
+#define MyAppVersion "12.5.4"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -1,5 +1,5 @@
 ﻿# PlayersAdmin.ps1 — v11.5.9 player admin extras ported from the reference implementation.
-# Covers §2 currency writes + §7 returning-award/delete-account + shared helpers
+# Covers §2 currency writes + §7 delete-account + shared helpers
 # (faction tables, char-XP table, offline check, raw funcom-id lookup).
 #
 # Style mirrors lib/GameplayPlayers.ps1: every Invoke-DunePlayer* takes -Ip
@@ -8,7 +8,7 @@
 
 # ----- Common helpers ------------------------------------------------------
 
-# accounts."user" string — used by returning-award, delete-account.
+# accounts."user" string — used by delete-account.
 function Get-DuneRawFuncomId {
     param([string]$Ip, [long]$AccountId)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
@@ -556,46 +556,6 @@ function Invoke-DunePlayerAwardIntel {
         message = "Set Intel to $newIntel (was $cur, delta $IntelDelta) for player $pawn."
         intel = $newIntel
     }
-}
-
-# ----- Returning Player Award --------------------------------------------
-
-# The returning-player reward is NOT stored on dune.accounts (that table has no
-# JSONB column - the original port wrote to a non-existent "account" column and
-# always errored with "column a.account does not exist", issue #249). Verified
-# against a live server: the reward is timestamp-gated state on the player,
-# stored in dune.encrypted_player_state (the base table; dune.player_state is a
-# view over it that only decrypts the character name). A reward is present when
-# last_returning_player_awarded_time IS NOT NULL, so Grant stamps it to now()
-# and Dismiss clears it. Keyed by account_id.
-function Invoke-DunePlayerGrantReturningAward {
-    param([string]$Ip, [long]$AccountId)
-    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
-    $sql = @"
-UPDATE dune.encrypted_player_state
-SET last_returning_player_awarded_time = now()
-WHERE account_id = $AccountId::bigint
-RETURNING account_id;
-"@
-    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
-    if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
-    if ([int]$r.rowCount -lt 1) { return @{ ok = $false; error = "No player state found for account $AccountId." } }
-    return @{ ok = $true; message = "Granted returning-player award to account $AccountId." }
-}
-
-function Invoke-DunePlayerDismissReturningAward {
-    param([string]$Ip, [long]$AccountId)
-    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
-    $sql = @"
-UPDATE dune.encrypted_player_state
-SET last_returning_player_awarded_time = NULL
-WHERE account_id = $AccountId::bigint
-RETURNING account_id;
-"@
-    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
-    if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
-    if ([int]$r.rowCount -lt 1) { return @{ ok = $false; error = "No player state found for account $AccountId." } }
-    return @{ ok = $true; message = "Dismissed returning-player award for account $AccountId." }
 }
 
 # ----- Delete Account (DESTRUCTIVE) --------------------------------------

--- a/app/server/routes/PlayersAdmin.ps1
+++ b/app/server/routes/PlayersAdmin.ps1
@@ -1,5 +1,5 @@
 ﻿# PlayersAdmin.ps1 — v11.5.9 player admin routes ported from the reference implementation §2 + §7.
-# Currency / progression writes + returning-player-award + delete-account.
+# Currency / progression writes + delete-account.
 # Uses Invoke-DunePlayerWriteRoute + Get-DuneBodyInt/Value from routes/GameplayPlayers.ps1.
 
 # POST /api/gameplay/players/give-scrip  { actor_id, delta, currency_id? }
@@ -111,30 +111,6 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/players/char-xp' -Handler {
             -PayloadKey 'char_xp'
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Get char XP failed: $($_.Exception.Message)"
-    }
-}
-
-# POST /api/gameplay/players/returning-player-award  { account_id }
-Register-DuneRoute -Method POST -Path '/api/gameplay/players/returning-player-award' -Handler {
-    param($req, $res, $routeParams, $body)
-    try {
-        $aid = Get-DuneBodyInt -Body $body -Name 'account_id'
-        if ($null -eq $aid -or $aid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerGrantReturningAward -Ip $ip -AccountId $aid }
-    } catch {
-        Write-DuneError -Response $res -Status 500 -Message "Grant returning award failed: $($_.Exception.Message)"
-    }
-}
-
-# POST /api/gameplay/players/dismiss-returning-player-award  { account_id }
-Register-DuneRoute -Method POST -Path '/api/gameplay/players/dismiss-returning-player-award' -Handler {
-    param($req, $res, $routeParams, $body)
-    try {
-        $aid = Get-DuneBodyInt -Body $body -Name 'account_id'
-        if ($null -eq $aid -or $aid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerDismissReturningAward -Ip $ip -AccountId $aid }
-    } catch {
-        Write-DuneError -Response $res -Status 500 -Message "Dismiss returning award failed: $($_.Exception.Message)"
     }
 }
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.5.3"
+$script:ToolVersion = "12.5.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1288,18 +1288,6 @@ export function awardIntel(controllerId: number, pawnId: number, amount: number)
   })
 }
 
-export function returningPlayerAward(accountId: number) {
-  return api<WriteResult>('/api/gameplay/players/returning-player-award', {
-    method: 'POST', body: JSON.stringify({ account_id: accountId }),
-  })
-}
-
-export function dismissReturningPlayerAward(accountId: number) {
-  return api<WriteResult>('/api/gameplay/players/dismiss-returning-player-award', {
-    method: 'POST', body: JSON.stringify({ account_id: accountId }),
-  })
-}
-
 // PERMANENT — purges the account row + dependent rows. No undo.
 export function deleteAccount(accountId: number) {
   return api<WriteResult>('/api/gameplay/players/delete-account', {

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -14,7 +14,7 @@ import {
   awardCharXp, awardIntel, awardSpecXp, cheatScript, cleanPlayerInventory,
   applyProgressionPreset, getProgressionPresets,
   deleteAccount, deleteInventoryItem, deleteTutorials,
-  dismissReturningPlayerAward, fillWater, getPlayerEvents, getPlayerSpecs,
+  fillWater, getPlayerEvents, getPlayerSpecs,
   getPlayerStats, getPlayerTags, giveFactionRep, giveItem,
   giveScrip, giveSolari, grantAllKeystones, grantLive, grantMaxSpec,
   kickPlayer, refuelVehicle, renamePlayer, repairGear, repairInventoryItem,
@@ -22,7 +22,7 @@ import {
   setItemDurability, setItemStack, setItemWater,
   resetAllKeystones, resetAllSpecs, resetJourney, resetProgressionLive, resetSpec,
   restoreDestroyed,
-  returningPlayerAward, setFactionTier, setPlayerTags, setSkillPoints,
+  setFactionTier, setPlayerTags, setSkillPoints,
   setStarterClass, teleportToPlayer, updatePlayerTags, wipeCodex, wipeJourney,
   chatWhisper, isValidTemplateId, getItemCatalog,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
@@ -595,10 +595,6 @@ const ACTIONS: ActionDef[] = [
       }
       return wipeCodex(p.account_id)
     } },
-  { id: 'returning-award', group: 'Identity', label: 'Grant Returning-Player Award', icon: 'Star',
-    run: p => returningPlayerAward(p.account_id) },
-  { id: 'dismiss-returning', group: 'Identity', label: 'Dismiss Returning-Player Award', icon: 'X',
-    run: p => dismissReturningPlayerAward(p.account_id) },
 
   // ----- Danger Zone -----
   { id: 'delete-account', group: 'Danger', label: 'Delete Account (permanent)', icon: 'AlertTriangle',

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -84,14 +84,6 @@ describe('Phase A — currency / progression writes', () => {
     expect(last().body).toEqual({ actor_id: 123, pawn_id: 99, delta: 50 })
   })
 
-  it('returningPlayerAward + dismiss... only need account_id', async () => {
-    await gp.returningPlayerAward(5)
-    expect(last().body).toEqual({ account_id: 5 })
-    await gp.dismissReturningPlayerAward(5)
-    expect(last().url).toBe('/api/gameplay/players/dismiss-returning-player-award')
-    expect(last().body).toEqual({ account_id: 5 })
-  })
-
   it('deleteAccount targets /delete-account', async () => {
     await gp.deleteAccount(404)
     expect(last().url).toBe('/api/gameplay/players/delete-account')


### PR DESCRIPTION
Cuts the two **Returning-Player Award** player actions (Gameplay Admin → Players → Identity) and everything behind them.

### Removed
- `Grant Returning-Player Award` and `Dismiss Returning-Player Award` actions in `webui/src/pages/gameplay/players/sections.tsx` (+ unused imports)
- Web API client fns `returningPlayerAward` / `dismissReturningPlayerAward` (`webui/src/api/gameplay.ts`) and their test
- API routes `POST /api/gameplay/players/returning-player-award` and `.../dismiss-returning-player-award` (`app/server/routes/PlayersAdmin.ps1`)
- Backend handlers `Invoke-DunePlayerGrantReturningAward` / `Invoke-DunePlayerDismissReturningAward` (`app/server/lib/PlayersAdmin.ps1`) + stale header comments

### Release
- Bumped all five version stamps `12.5.3 → 12.5.4`
- Rolled `## [Unreleased]` into `## [12.5.4]` with a **Removed** entry
- Refreshed `bug_report.yml` `tool_version` placeholder

### Validation
- `webui` build ✅, typecheck ✅
- webui tests: 47 pass; the only 2 failures (getPlayerVehicles/getPlayerDungeons URL) are **pre-existing on `main`**, unrelated to this change
- Parse-check ✅ on both edited `.ps1` files

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>