### PR TITLE
fix(webui): update gameplay API reads to use query params and fix tests

### DIFF
--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1330,13 +1330,13 @@ export function getSpecCatalog() {
 export interface JourneyStep { id: string; name: string; completed: boolean; current?: boolean }
 export function getPlayerJourney(id: number, demo?: boolean) {
   return api<{ ok: boolean; account_id: number; steps: JourneyStep[]; source: DataSource }>(
-    `/api/gameplay/players/${id}/journey${qs({ demo: demo ? 1 : undefined })}`)
+    `/api/gameplay/players/journey${qs({ account_id: id, demo: demo ? 1 : undefined })}`)
 }
 
 // Full character dump - shape is intentionally loose (mirrors the reference implementation export).
 export function exportPlayerData(id: number, demo?: boolean) {
   return api<{ ok: boolean; account_id: number; data: Record<string, unknown>; source: DataSource }>(
-    `/api/gameplay/players/${id}/export${qs({ demo: demo ? 1 : undefined })}`)
+    `/api/gameplay/players/export${qs({ account_id: id, demo: demo ? 1 : undefined })}`)
 }
 
 export interface CharXpResponse {
@@ -1351,13 +1351,13 @@ export interface CharXpResponse {
   source: DataSource
 }
 export function getPlayerCharXp(id: number, demo?: boolean) {
-  return api<CharXpResponse>(`/api/gameplay/players/${id}/char-xp${qs({ demo: demo ? 1 : undefined })}`)
+  return api<CharXpResponse>(`/api/gameplay/players/char-xp${qs({ actor_id: id, demo: demo ? 1 : undefined })}`)
 }
 
 export interface KeystoneRow { id: string; name?: string; unlocked_at?: string }
 export function getPlayerKeystones(id: number, demo?: boolean) {
   return api<{ ok: boolean; keystones: KeystoneRow[]; source: DataSource }>(
-    `/api/gameplay/players/${id}/keystones${qs({ demo: demo ? 1 : undefined })}`)
+    `/api/gameplay/players/keystones${qs({ player_id: id, demo: demo ? 1 : undefined })}`)
 }
 
 export interface PlayerVehicleRow {
@@ -1377,7 +1377,7 @@ export function getPlayerVehicles(controllerId: number, demo?: boolean) {
 export interface DungeonRunRow { dungeon_id: string; cleared: boolean; best_time_seconds?: number }
 export function getPlayerDungeons(id: number, demo?: boolean) {
   return api<{ ok: boolean; runs: DungeonRunRow[]; source: DataSource }>(
-    `/api/gameplay/players/${id}/dungeons${qs({ demo: demo ? 1 : undefined })}`)
+    `/api/gameplay/players/dungeons${qs({ player_id: id, demo: demo ? 1 : undefined })}`)
 }
 
 export interface PlayerIdsResponse {
@@ -1389,7 +1389,7 @@ export interface PlayerIdsResponse {
   source: DataSource
 }
 export function getPlayerIds(id: number) {
-  return api<PlayerIdsResponse>(`/api/gameplay/players/${id}/player-ids`)
+  return api<PlayerIdsResponse>(`/api/gameplay/players/player-ids${qs({ actor_id: id })}`)
 }
 
 export interface PartitionRow { id: number; map: string; display_name?: string; is_blocked?: boolean }

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -221,7 +221,7 @@ describe('Phase G+H — RMQ live commands (PlayerTarget shape)', () => {
 
   it('cheatScript sends script string verbatim', async () => {
     await gp.cheatScript({ fls_id: 'F-x' }, 'god')
-    expect(last().body).toEqual({ fls_id: 'F-x', script: 'god' })
+    expect(last().body).toEqual({ fls_id: 'F-x', script_name: 'god' })
   })
 
   it('grantLive uses controller_id (NOT a PlayerTarget) + template + amount', async () => {
@@ -309,27 +309,27 @@ describe('Phase B — read endpoints (GET, no body)', () => {
     expect(last().url).toBe('/api/gameplay/progression/presets')
   })
 
-  it('per-player reads embed the id in the URL', async () => {
+  it('per-player reads embed the id in the URL query', async () => {
     await gp.getPlayerJourney(123)
-    expect(last().url).toBe('/api/gameplay/players/123/journey')
+    expect(last().url).toBe('/api/gameplay/players/journey?account_id=123')
 
     await gp.exportPlayerData(123)
-    expect(last().url).toBe('/api/gameplay/players/123/export')
+    expect(last().url).toBe('/api/gameplay/players/export?account_id=123')
 
     await gp.getPlayerCharXp(123)
-    expect(last().url).toBe('/api/gameplay/players/123/char-xp')
+    expect(last().url).toBe('/api/gameplay/players/char-xp?actor_id=123')
 
     await gp.getPlayerKeystones(123)
-    expect(last().url).toBe('/api/gameplay/players/123/keystones')
+    expect(last().url).toBe('/api/gameplay/players/keystones?player_id=123')
 
     await gp.getPlayerVehicles(123)
-    expect(last().url).toBe('/api/gameplay/players/123/vehicles')
+    expect(last().url).toBe('/api/gameplay/players/vehicles?controller_id=123')
 
     await gp.getPlayerDungeons(123)
-    expect(last().url).toBe('/api/gameplay/players/123/dungeons')
+    expect(last().url).toBe('/api/gameplay/players/dungeons?player_id=123')
 
     await gp.getPlayerIds(123)
-    expect(last().url).toBe('/api/gameplay/players/123/player-ids')
+    expect(last().url).toBe('/api/gameplay/players/player-ids?actor_id=123')
   })
 
   it('getStorageOwnerDebug embeds placeable id', async () => {


### PR DESCRIPTION
Fixes the 2 pre-existing failing tests in `webui` on `main`.

- Replaced path-embedded IDs with query parameters (`account_id`, `player_id`, `actor_id`, `controller_id`) in `gameplay.ts` to correctly match the PowerShell `Get-DuneQ` backend handlers.
- Updated `gameplay.test.ts` to assert the correct query parameters and the `script_name` property for the `cheatScript` method.