### PR TITLE
Grant Reward uses shared item picker (v12.5.5)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.5.4"
+      placeholder: "v12.5.5"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.5.5] - 2026-06-16
+
+### Changed
+
+- **Grant Reward (popup)** (Gameplay → Players → Currency) now uses the shared
+  item picker — search by friendly name, filter by category, and pick from the
+  catalog — instead of a raw "Item template id" text box. Matches the Give Item
+  and storage Add-Item flows, so admins no longer have to know the exact
+  internal template id (e.g. typing "spice" now resolves to the real item).
+
+### Fixed
+
+- Corrected two webui gameplay API read calls to pass ids as query parameters
+  (`account_id`, `player_id`, `actor_id`, `controller_id`) so they match the
+  backend handlers, fixing the previously failing API tests.
+
 ## [12.5.4] - 2026-06-16
 
 ### Removed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.5.4'
+$script:DuneToolVersion = '12.5.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.5.4',
+    [string]$Version = '12.5.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.5.4</Version>
+    <Version>12.5.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.5.4"
+#define MyAppVersion "12.5.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.5.4"
+$script:ToolVersion = "12.5.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -438,7 +438,7 @@ interface ActionDef {
   liveOnly?: boolean      // requires player to be online (RMQ path)
   offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   fields?: ActionField[]
-  custom?: 'give-item' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'refuel-vehicle' | 'starter-class' | 'update-tags'
+  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'refuel-vehicle' | 'starter-class' | 'update-tags'
   balance?: 'solari' | 'scrip' | 'intel'  // show the player's current balance read-only above the form
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
@@ -457,12 +457,9 @@ const ACTIONS: ActionDef[] = [
   { id: 'give-intel', group: 'Currency', label: 'Give Intel', icon: 'BookOpen', offlineOnly: true, balance: 'intel',
     fields: [{ key: 'amount', label: 'Tech Knowledge Points', type: 'number', placeholder: '100' }],
     run: (p, v) => awardIntel(p.controller_id, p.id, Number(v.amount) || 0) },
-  { id: 'grant-live', group: 'Currency', label: 'Grant Reward (popup)', icon: 'Gift',
-    fields: [
-      { key: 'template', label: 'Item template id', type: 'text', placeholder: 'Item_…' },
-      { key: 'amount',   label: 'Amount',           type: 'number', placeholder: '1' },
-    ],
-    run: (p, v) => grantLive(p.controller_id, String(v.template || '').trim(), Number(v.amount) || 1) },
+  { id: 'grant-live', group: 'Currency', label: 'Grant Reward (popup)', icon: 'Gift', custom: 'grant-reward',
+    rowNote: 'Sends a Claim Rewards popup — works online or offline',
+    run: () => Promise.resolve({ message: '' }) },
 
   // ----- Progression -----
   { id: 'award-char-xp', group: 'Progression', label: 'Award Character XP', icon: 'TrendingUp', liveOnly: true,
@@ -775,6 +772,9 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
                 for (let q = 0; q <= 5; q++) await giveItem(player.id, tpl, qty, q, overflow)
                 return { message: `Gave ${tpl} Mk1–Mk6 (x${qty} each) to ${player.name}.` }
               })} />
+          ) : def.custom === 'grant-reward' ? (
+            <GrantRewardForm busy={busy} submitLabel={def.label}
+              onSubmit={(tpl, amount) => runAction(def, () => grantLive(player.controller_id, tpl, amount))} />
           ) : def.custom === 'whisper' ? (
             <WhisperForm busy={busy}
               onSubmit={msg => runAction(def, () => chatWhisper(String(player.id), msg))} />
@@ -865,6 +865,40 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
           )}
         </div>
       )}
+    </div>
+  )
+}
+
+// Grant Reward (popup) form — shared ItemPicker (search + categories + friendly
+// names) + amount. Unlike Give Item this doesn't write to inventory directly; it
+// queues a Claim Rewards popup the player accepts in-game (works online or
+// offline). Renders without a card wrapper — ActionRow provides the container.
+function GrantRewardForm({ busy, submitLabel, onSubmit }: {
+  busy: boolean; submitLabel: string
+  onSubmit: (tpl: string, amount: number) => void
+}) {
+  const [tpl, setTpl]       = useState('')
+  const [name, setName]     = useState('')
+  const [amount, setAmount] = useState('1')
+  return (
+    <div className="space-y-3">
+      <ItemPicker label="Item — type to search by name or template id"
+        value={tpl} displayValue={name || tpl}
+        onChange={(t, item) => { setTpl(t); setName(item ? item.name : '') }}
+        autoFocus disabled={busy} />
+      <div>
+        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Amount</label>
+        <input type="number" min={1} value={amount} disabled={busy}
+          onChange={e => setAmount(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+      </div>
+      <p className="text-[11px] text-text-dim">
+        Queues a <span className="text-text">Claim Rewards</span> popup the player accepts in-game — delivered whether they're online or offline.
+      </p>
+      <button className="btn-primary w-full" disabled={busy || !isValidTemplateId(tpl)}
+        onClick={() => onSubmit(tpl.trim(), Number(amount) || 1)}>
+        {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} {submitLabel}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Replaces the **Grant Reward (popup)** action's raw "Item template id" text box with the shared **ItemPicker** — search by friendly name, filter by category, and pick from the catalog — exactly like the **Give Item** and storage **Add-Item** flows. Admins no longer have to know the internal template id (e.g. typing `spice` now resolves to the real item instead of silently failing to deliver).

Grant Reward keeps its distinct behaviour (queues a *Claim Rewards* popup the player accepts in-game, online or offline) — only the input UX changed. The amount field and the `grantLive(controller_id, template, amount)` call are unchanged; submit is now gated on a valid template id via `isValidTemplateId`.

### Also included
- PR #257 (already merged to `main`): query-param gameplay API read fix + the two previously-failing webui API tests now green (49/49).

## Release
Minor release **v12.5.5**. All 5 version stamps bumped, `CHANGELOG.md` rolled, `bug_report.yml` placeholder updated. Installer built (45.91 MB) at the canonical `app/installer/output/DuneServerSetup.exe`.

## Tests
- `webui` build: ✅ typecheck + vite
- `webui` vitest: ✅ 49/49

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>