### PR TITLE
Add Crafting Game Config settings

### DIFF
--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -59,6 +59,7 @@ $script:DuneGcSecTimeOfDay = '/Script/DuneSandbox.TimeOfDaySettings'
 $script:DuneGcSecRespawn   = '/Script/DuneSandbox.RespawnSettings'
 $script:DuneGcSecEncounters = '/Script/DuneSandbox.EncountersSubsystem'
 $script:DuneGcSecContracts = '/Script/DuneSandbox.ContractsSubsystem'
+$script:DuneGcSecCrafting  = '/Script/DuneSandbox.CraftingSettings'
 
 # Funcom stores ALL Landsraad settings as scalar members inside ONE nested struct
 # value: [/Script/DuneSandbox.LandsraadSettings] Data=(m_TaskGoalAmount=5000.0,...).
@@ -77,7 +78,7 @@ $script:DuneGcLandsraadStructKey = 'Data'
 # test showing an actual effect through that channel.
 $script:DuneGameConfigCategoryOrder = @(
     'Server Identity','Network','Survival','Hydration','Loot & Death',
-    'Resources & Economy','Building','Inventory','Guilds & Economy',
+    'Resources & Economy','Crafting','Building','Inventory','Guilds & Economy',
     'Storm Cycle','Landsraad','PvP & Security','Spice','Taxation','Encounters','Sandworm','Vehicles'
 )
 
@@ -129,6 +130,10 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecConsole; Key='Dune.GlobalMiningOutputMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Global Mining Multiplier'; Help='Scales hand-mining resource output.'; Category='Resources & Economy' }
     @{ Section=$script:DuneGcSecConsole; Key='Dune.GlobalVehicleMiningOutputMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Vehicle Mining Multiplier'; Help='Scales vehicle-mining resource output.'; Category='Resources & Economy' }
     @{ Section=$script:DuneGcSecConsole; Key='SecurityZones.PvpResourceMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='PvP Resource Multiplier'; Help='Resource yield multiplier inside PvP zones.'; Category='Resources & Economy' }
+
+    # --- Crafting ---
+    @{ Section=$script:DuneGcSecCrafting; Key='m_RepairCostWeight'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Repair Cost Weight'; Help='Scales repair costs. Also needs client-side apply.'; ClientApply=$true; Category='Crafting' }
+    @{ Section=$script:DuneGcSecCrafting; Key='m_RecyclerOutputWeight'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Recycler Output Weight'; Help='Scales recycler output. Also needs client-side apply.'; ClientApply=$true; Category='Crafting' }
 
     # --- Building ---
     @{ Section=$script:DuneGcSecBuilding; Key='m_MaxNumLandclaimSegments'; File='game'; Type='int'; Min=1; Default='6'; Label='Max Landclaim Segments'; Help='Maximum territory claim segments. Also needs client-side apply.'; ClientApply=$true; Category='Building' }
@@ -261,16 +266,16 @@ $script:DuneGameConfigTplEnginePath  = '/home/dune/.dune/download/scripts/setup/
 # by BOTH server and client; changing them server-side only takes full effect
 # once each player mirrors them in their LOCAL client config. Funcom's setup
 # template flags some keys as "!Needs to also be applied to each client!"
-# (corroborated for the two BuildingSettings keys by the snapetech RE index of
-# Funcom's shipped DefaultGame.ini). The remaining flagged keys were confirmed by
-# live in-game testing on a self-hosted server: the change had NO effect until the
+# (corroborated for BuildingSettings by the snapetech RE index of Funcom's
+# shipped DefaultGame.ini). The remaining flagged keys were confirmed by live
+# in-game testing on a self-hosted server: the change had NO effect until the
 # same value was also set in the client Game.ini. Sections currently flagged
-# ClientApply=$true above: DuneGameMode (Survival: health + damage to NPCs/players
-# + water + starting water + building damage + inventory weight; Progression: XP +
-# progression speed + fame; Harvesting: harvest amount + harvest health),
-# PlayerOnlineStateSettings (reconnect grace), ItemDeteriorationConstants
-# (durability/decay), BuildingSettings, InventorySystemSettings,
-# CoriolisSubsystem, SpiceHarvestingSystem, SandwormSettings.
+# ClientApply=$true above include DuneGameMode, PlayerOnlineStateSettings,
+# ItemDeteriorationConstants, CraftingSettings, BuildingSettings,
+# InventorySystemSettings, CoriolisSubsystem, LandsraadSettings,
+# SpiceHarvestingSystem, SandstormConfig, HydrationSubsystem,
+# DuneSandboxGameModeBase, SpiceAddictionSubsystem, RespawnSettings,
+# EncountersSubsystem, ContractsSubsystem, and SandwormSettings.
 $script:DuneGameConfigClientPath = '%LOCALAPPDATA%\DuneSandbox\Saved\Config\WindowsClient\Game.ini'
 
 # Build the post-save "apply this on each client too" reminder from a set of

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -10,6 +10,7 @@ BeforeAll {
 
     $script:SecBuilding  = '/Script/DuneSandbox.BuildingSettings'
     $script:SecInventory = '/Script/DuneSandbox.InventorySystemSettings'
+    $script:SecCrafting  = '/Script/DuneSandbox.CraftingSettings'
 
     # Count how many times a given section header occurs in rendered output.
     function Get-HeaderCount {
@@ -231,6 +232,70 @@ Describe 'DuneGameConfigSchema: only proven m_Global*Multiplier keys remain' -Ta
         foreach ($k in $removed) {
             $keys.ContainsKey($k) | Should -BeFalse -Because "$k was proven/assumed no-op via UserGame.ini and removed (issue #225)"
         }
+    }
+}
+
+Describe 'DuneGameConfigSchema: CraftingSettings fields' -Tag 'GameConfig' {
+
+    It 'exposes repair and recycler weights as server-and-client game settings' {
+        $fields = @{}
+        foreach ($f in $script:DuneGameConfigSchema) { $fields[$f.Key] = $f }
+
+        foreach ($k in @('m_RepairCostWeight', 'm_RecyclerOutputWeight')) {
+            $fields.ContainsKey($k) | Should -BeTrue
+            $fields[$k].Section | Should -Be $script:SecCrafting
+            $fields[$k].File | Should -Be 'game'
+            $fields[$k].Type | Should -Be 'float'
+            $fields[$k].Default | Should -Be '1.0'
+            $fields[$k].ClientApply | Should -BeTrue
+        }
+    }
+
+    It 'includes Crafting in the curated schema API order' {
+        $cats = @((Get-DuneGameConfigSchemaApi) | ForEach-Object { $_.category })
+        $cats | Should -Contain 'Crafting'
+        ([array]::IndexOf($cats, 'Crafting')) | Should -BeGreaterThan ([array]::IndexOf($cats, 'Resources & Economy'))
+        ([array]::IndexOf($cats, 'Crafting')) | Should -BeLessThan ([array]::IndexOf($cats, 'Building'))
+    }
+
+    It 'returns repair and recycler weights in the client-apply notice after server save' {
+        $notice = Get-DuneGameConfigClientApplyNotice -Updates @(
+            @{ file='game'; section=$script:SecCrafting; key='m_RepairCostWeight'; value='0.5' },
+            @{ file='game'; section=$script:SecCrafting; key='m_RecyclerOutputWeight'; value='2.0' }
+        )
+        $items = @($notice.items)
+        $items.Count | Should -Be 2
+        @($items | ForEach-Object { $_.key }) | Should -Contain 'm_RepairCostWeight'
+        @($items | ForEach-Object { $_.key }) | Should -Contain 'm_RecyclerOutputWeight'
+        foreach ($it in $items) {
+            $it.section | Should -Be $script:SecCrafting
+        }
+    }
+
+    It 'persists repair and recycler weights into the server-side managed block' {
+        $out = ConvertTo-DuneIniManaged -Raw '' -Updates @(
+            @{ section=$script:SecCrafting; key='m_RepairCostWeight'; value='0.5' },
+            @{ section=$script:SecCrafting; key='m_RecyclerOutputWeight'; value='2.0' }
+        ) -QuotedKeys @{}
+
+        (Get-HeaderCount -Raw $out -Name $script:SecCrafting) | Should -Be 1
+        $out.IndexOf('[' + $script:SecCrafting + ']') | Should -BeGreaterThan ($out.IndexOf($script:DstManagedBegin))
+        (Get-EffectiveValue -Raw $out -Section $script:SecCrafting -Key 'm_RepairCostWeight') | Should -Be '0.5'
+        (Get-EffectiveValue -Raw $out -Section $script:SecCrafting -Key 'm_RecyclerOutputWeight') | Should -Be '2.0'
+    }
+
+    It 'allows the client-side writer to persist repair and recycler weights' {
+        $dir = (Get-PSDrive TestDrive).Root
+        $result = Save-DuneGameConfigClient -Dir $dir -Updates @(
+            @{ key='m_RepairCostWeight'; value='0.25' },
+            @{ key='m_RecyclerOutputWeight'; value='1.75' }
+        )
+
+        $result.ok | Should -BeTrue
+        $raw = [IO.File]::ReadAllText((Join-Path $dir 'Game.ini'))
+        (Get-HeaderCount -Raw $raw -Name $script:SecCrafting) | Should -Be 1
+        (Get-EffectiveValue -Raw $raw -Section $script:SecCrafting -Key 'm_RepairCostWeight') | Should -Be '0.25'
+        (Get-EffectiveValue -Raw $raw -Section $script:SecCrafting -Key 'm_RecyclerOutputWeight') | Should -Be '1.75'
     }
 }
 


### PR DESCRIPTION
## Summary
- add Crafting category to curated Game Config schema
- expose `m_RepairCostWeight` and `m_RecyclerOutputWeight` under `[/Script/DuneSandbox.CraftingSettings]`
- mark both settings as client-applied so DST can mirror them into local client `Game.ini`
- add GameConfig tests for schema, server write, client-apply notice, and client-side write

## Validation
- `Invoke-Pester -Path tests\GameConfig.Tests.ps1 -Tag GameConfig -CI`
- `npm run build` in `webui`
- `pwsh app\installer\Build-Installer.ps1`