### PR TITLE
Fix Reset Journey account action

### DIFF
--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1000,6 +1000,32 @@ WHERE account_id = $AccountId::bigint
     return @{ ok = $true; message = "Reset $NodeId$extra"; tags_removed = $removeTags.Count }
 }
 
+function Invoke-DunePlayerResetJourneyNodes {
+    param([string]$Ip, [long]$AccountId)
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+
+    $upd = @"
+UPDATE dune.journey_story_node
+SET complete_condition_state = 'false'::jsonb,
+    has_pending_reward       = false
+WHERE account_id = $AccountId::bigint;
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $upd -ReadOnly $false -MaxRows 1 -TimeoutSec 60
+    if (-not $r.ok) { return @{ ok = $false; error = "reset journey nodes: $($r.error)" } }
+    $updated = Get-DuneSqlAffected $r
+
+    $allTags = Get-DuneAllJourneyTags
+    $extra = ''
+    if ($allTags.Count -gt 0) {
+        $arr = ConvertTo-DunePgTextArray $allTags
+        $rt = "SELECT dune.update_player_tags($AccountId::bigint, ARRAY[]::text[], $arr);"
+        $rr = Invoke-DuneSqlQuery -Ip $Ip -Sql $rt -ReadOnly $false -MaxRows 1 -TimeoutSec 60
+        if (-not $rr.ok) { return @{ ok = $false; error = "remove all journey tags: $($rr.error)" } }
+        $extra = ", removed $($allTags.Count) journey tag(s)"
+    }
+    return @{ ok = $true; message = "Reset journey for account $AccountId - reset $updated node(s)$extra"; nodes = $updated; tags_removed = $allTags.Count }
+}
+
 function Invoke-DunePlayerWipeJourneyNodes {
     param([string]$Ip, [long]$AccountId)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
@@ -1423,4 +1449,3 @@ LIMIT 1;
 
     return @{ ok = $true; result = $out }
 }
-

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -163,15 +163,18 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/journey/complete' -
     }
 }
 
-# POST /api/gameplay/players/journey/reset  { account_id, node_id }
+# POST /api/gameplay/players/journey/reset  { account_id, node_id? }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/journey/reset' -Handler {
     param($req, $res, $routeParams, $body)
     try {
         $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
         $node = [string](Get-DuneBodyValue -Body $body -Name 'node_id')
         if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
-        if (-not $node) { Write-DuneError -Response $res -Status 400 -Message 'node_id is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerResetJourneyNode -Ip $ip -AccountId $acc -NodeId $node }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            if ($node) { Invoke-DunePlayerResetJourneyNode -Ip $ip -AccountId $acc -NodeId $node }
+            else { Invoke-DunePlayerResetJourneyNodes -Ip $ip -AccountId $acc }
+        }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Reset journey failed: $($_.Exception.Message)"
     }

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -142,6 +142,7 @@ describe('Phase C/D/E/F — items, vehicles, teleport, progression, jobs', () =>
 
     await gp.resetJourney(5)
     expect(last().url).toBe('/api/gameplay/players/journey/reset')
+    expect(last().body).toEqual({ account_id: 5 })
 
     await gp.wipeJourney(5)
     expect(last().url).toBe('/api/gameplay/players/journey/wipe')
@@ -428,5 +429,4 @@ describe('flattenItemCatalog — catalog shape parsing', () => {
     expect(out.map(i => i.template_id)).toEqual(['Alpha', 'Zeta'])
   })
 })
-
 


### PR DESCRIPTION
## Summary
- Allow `/api/gameplay/players/journey/reset` to reset the whole account journey when `node_id` is omitted
- Preserve node-specific reset behavior for the journey browser
- Assert the account-only API payload in gameplay API tests

## Validation
- `npm test`
- `npm run build`
- PowerShell parse check for changed route/lib files
- gitleaks scan on touched files