### PR TITLE
feat(database): change backup retention from days to keep-last count

### DIFF
--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -4,9 +4,9 @@
 # Source of truth is a single block in the VM's root crontab, delimited by:
 #   # DST-BACKUP BEGIN
 #   # DST-BACKUP-PRESET: <name>
-#   # DST-BACKUP-RETENTION: <days>
+#   # DST-BACKUP-KEEP-LAST: <count>
 #   <preset cron line(s)>
-#   <retention cron line, if days > 0>
+#   <keep-last cron line, if count > 0>
 #   # DST-BACKUP END
 #
 # Markers are ASCII-only on purpose — they have to round-trip through
@@ -139,13 +139,13 @@ function Invoke-DuneBackupShell {
 }
 
 # -----------------------------------------------------------------------------
-# Build the rendered crontab block from a preset + retention. Returns either
+# Build the rendered crontab block from a preset + keepLast. Returns either
 # a string (the block, including trailing newline) or $null for 'Off'.
 # -----------------------------------------------------------------------------
 function New-DuneBackupBlock {
     param(
         [Parameter(Mandatory)][string]$Preset,
-        [int]$RetentionDays = 0
+        [int]$KeepLast = 0
     )
     if (-not $script:DuneBackupPresets.ContainsKey($Preset)) {
         throw "Unknown preset: $Preset"
@@ -155,16 +155,16 @@ function New-DuneBackupBlock {
     $lines = @()
     $lines += $script:DuneBackupBeginMarker
     $lines += "# DST-BACKUP-PRESET: $Preset"
-    $lines += "# DST-BACKUP-RETENTION: $RetentionDays"
+    $lines += "# DST-BACKUP-KEEP-LAST: $KeepLast"
     foreach ($cronExpr in $script:DuneBackupPresets[$Preset].crons) {
         $lines += "$cronExpr $script:DuneBackupCmd"
     }
-    if ($RetentionDays -gt 0) {
+    if ($KeepLast -gt 0) {
         # Narrow the retention pattern to filenames that match Funcom's own
         # battlegroup-dump naming (<bg>-YYYYMMDD-HHMMSS.backup[.yaml]) so we
         # never delete a manually-named snapshot like 'pre-patch-X.backup'.
-        $namePat = '*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].backup'
-        $find = "find $script:DuneBackupDumpDir -type f \( -name '$namePat' -o -name '$namePat.yaml' \) -mtime +$RetentionDays -delete"
+        $namePat = '*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].backup*'
+        $find = "ls -t $script:DuneBackupDumpDir/$namePat 2>/dev/null | tail -n +$($KeepLast + 1) | xargs -r rm"
         $lines += "15 5 * * * $find"
     }
     $lines += $script:DuneBackupEndMarker
@@ -174,7 +174,7 @@ function New-DuneBackupBlock {
 # -----------------------------------------------------------------------------
 # Parse a crontab string into managed-block + leftover lines.
 # Returns @{ block = <hashtable or $null>; outsideText = string; hasUnmanagedBackupLines = bool }.
-# Block hashtable has: preset, retentionDays, raw, looksTampered.
+# Block hashtable has: preset, keepLast, raw, looksTampered.
 # -----------------------------------------------------------------------------
 function ConvertFrom-DuneBackupCrontab {
     param([string]$CrontabText)
@@ -201,16 +201,16 @@ function ConvertFrom-DuneBackupCrontab {
     $blockInfo = $null
     if ($blockLines.Count -gt 0 -or $CrontabText -match [regex]::Escape($script:DuneBackupBeginMarker)) {
         $preset = $null
-        $retention = 0
+        $keepLast = 0
         foreach ($bl in $blockLines) {
             if ($bl -match '^# DST-BACKUP-PRESET:\s*(\S+)') { $preset = $Matches[1] }
-            elseif ($bl -match '^# DST-BACKUP-RETENTION:\s*(\d+)') { $retention = [int]$Matches[1] }
+            elseif ($bl -match '^# DST-BACKUP-(?:KEEP-LAST|RETENTION):\s*(\d+)') { $keepLast = [int]$Matches[1] }
         }
         if (-not $preset) { $preset = 'Custom' }
         $blockInfo = @{
-            preset        = $preset
-            retentionDays = $retention
-            raw           = ($blockLines -join "`n")
+            preset   = $preset
+            keepLast = $keepLast
+            raw      = ($blockLines -join "`n")
         }
     }
 
@@ -280,16 +280,16 @@ sudo crontab -l 2>&1 || true
 
     $enabled = $false
     $preset = 'Off'
-    $retention = 0
+    $keepLast = 0
     $looksTampered = $false
     $inferredFromUnmanaged = $false
     if ($parsed.block) {
-        $preset    = $parsed.block.preset
-        $retention = $parsed.block.retentionDays
-        $enabled   = ($preset -ne 'Off')
-        # If the rendered block doesn't match the stored preset+retention any
+        $preset   = $parsed.block.preset
+        $keepLast = $parsed.block.keepLast
+        $enabled  = ($preset -ne 'Off')
+        # If the rendered block doesn't match the stored preset+keepLast any
         # more, the operator likely edited it by hand. Surface that to the UI.
-        $expected = (New-DuneBackupBlock -Preset $preset -RetentionDays $retention)
+        $expected = (New-DuneBackupBlock -Preset $preset -KeepLast $keepLast)
         if ($expected) {
             $expectedInner = ($expected.TrimEnd("`n") -split "`n" | Select-Object -Skip 1 | Select-Object -SkipLast 1) -join "`n"
             if ($expectedInner -ne $parsed.block.raw) { $looksTampered = $true }
@@ -311,7 +311,7 @@ sudo crontab -l 2>&1 || true
     return @{
         enabled                   = $enabled
         preset                    = $preset
-        retentionDays             = $retention
+        keepLast                  = $keepLast
         vmTimezone                = $tz
         vmNowUtc                  = $vmNowUtc
         crondRunning              = [bool]$crondRunning
@@ -333,16 +333,16 @@ function Set-DuneBackupSchedule {
     param(
         [Parameter(Mandatory)][string]$Ip,
         [Parameter(Mandatory)][string]$Preset,
-        [int]$RetentionDays = 0
+        [int]$KeepLast = 0
     )
     if (-not $script:DuneBackupPresets.ContainsKey($Preset)) {
         return @{ ok=$false; status=400; message="Unknown preset: $Preset" }
     }
-    if ($RetentionDays -lt 0 -or $RetentionDays -gt 3650) {
-        return @{ ok=$false; status=400; message="retentionDays must be 0..3650 (got $RetentionDays)." }
+    if ($KeepLast -lt 0 -or $KeepLast -gt 1000) {
+        return @{ ok=$false; status=400; message="keepLast must be 0..1000 (got $KeepLast)." }
     }
 
-    $newBlock = New-DuneBackupBlock -Preset $Preset -RetentionDays $RetentionDays
+    $newBlock = New-DuneBackupBlock -Preset $Preset -KeepLast $KeepLast
     $newBlockB64 = if ($newBlock) { [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($newBlock)) } else { '' }
 
     # Whole RMW (read existing crontab, strip our block, append new block,
@@ -434,8 +434,8 @@ sudo crontab -l 2>&1 || true
         if (-not $parsed.block) {
             return @{ ok=$false; status=502; message='Crontab does not contain a DST-BACKUP block after save.' }
         }
-        if ($parsed.block.preset -ne $Preset -or $parsed.block.retentionDays -ne $RetentionDays) {
-            return @{ ok=$false; status=502; message="Verification mismatch: got preset=$($parsed.block.preset), retention=$($parsed.block.retentionDays)." }
+        if ($parsed.block.preset -ne $Preset -or $parsed.block.keepLast -ne $KeepLast) {
+            return @{ ok=$false; status=502; message="Verification mismatch: got preset=$($parsed.block.preset), keepLast=$($parsed.block.keepLast)." }
         }
     }
 

--- a/app/server/routes/BackupSchedule.ps1
+++ b/app/server/routes/BackupSchedule.ps1
@@ -1,7 +1,7 @@
 ﻿# BackupSchedule.ps1 - Routes for the Database page's Backup Schedule card.
 #
 # GET /api/db/backup-schedule         - current schedule + VM cron health
-# PUT /api/db/backup-schedule         - install/replace schedule, body { preset, retentionDays }
+# PUT /api/db/backup-schedule         - install/replace schedule, body { preset, keepLast }
 # GET /api/db/backup-history          - recent .backup files + log tail
 #
 # All routes are VM-gated via Get-DuneBackupContext (defined in
@@ -30,20 +30,20 @@ Register-DuneRoute -Method PUT -Path '/api/db/backup-schedule' -Handler {
         return
     }
     $preset = $null
-    $retention = 0
+    $keepLast = 0
     if ($body -is [hashtable]) {
         if ($body.ContainsKey('preset'))        { $preset    = [string]$body.preset }
-        if ($body.ContainsKey('retentionDays')) { try { $retention = [int]$body.retentionDays } catch { $retention = -1 } }
+        if ($body.ContainsKey('keepLast')) { try { $keepLast = [int]$body.keepLast } catch { $keepLast = -1 } }
     } elseif ($body) {
         if ($body.preset)                       { $preset    = [string]$body.preset }
-        if ($null -ne $body.retentionDays)      { try { $retention = [int]$body.retentionDays } catch { $retention = -1 } }
+        if ($null -ne $body.keepLast)      { try { $keepLast = [int]$body.keepLast } catch { $keepLast = -1 } }
     }
     if (-not $preset) {
         Write-DuneError -Response $res -Status 400 -Message 'Body must include "preset" (string).'
         return
     }
     try {
-        $result = Invoke-WithDuneLock -Name 'backup-schedule' -Script { Set-DuneBackupSchedule -Ip $ctx.ip -Preset $preset -RetentionDays $retention }
+        $result = Invoke-WithDuneLock -Name 'backup-schedule' -Script { Set-DuneBackupSchedule -Ip $ctx.ip -Preset $preset -KeepLast $keepLast }
         if (-not $result.ok) {
             Write-DuneError -Response $res -Status ([int]$result.status) -Message $result.message
             return

--- a/webui/src/api/database.ts
+++ b/webui/src/api/database.ts
@@ -32,10 +32,10 @@ export function getBackupSchedule() {
   return api<BackupSchedule>('/api/db/backup-schedule')
 }
 
-export function putBackupSchedule(opts: { preset: string; retentionDays: number }) {
+export function putBackupSchedule(opts: { preset: string; keepLast: number }) {
   return api<BackupSchedule>('/api/db/backup-schedule', {
     method: 'PUT',
-    body: JSON.stringify({ preset: opts.preset, retentionDays: opts.retentionDays }),
+    body: JSON.stringify({ preset: opts.preset, keepLast: opts.keepLast }),
   })
 }
 

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -362,7 +362,7 @@ export type BackupPreset = {
 export type BackupSchedule = {
   enabled: boolean
   preset: string
-  retentionDays: number
+  keepLast: number
   vmTimezone: string
   vmNowUtc: string
   crondRunning: boolean

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -616,7 +616,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
   // Draft state — initialised from `schedule` when it loads, then locally
   // editable so the user can preview their choice before clicking Save.
   const [draftPreset, setDraftPreset]       = useState<string>('Off')
-  const [draftRetention, setDraftRetention] = useState<number>(30)
+  const [draftKeepLast, setDraftKeepLast]   = useState<number>(8)
 
   const loadAll = useCallback(async () => {
     if (!vmRunning) {
@@ -629,7 +629,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       setSchedule(sched)
       setHistory(hist)
       setDraftPreset(sched.preset === 'Custom' ? 'Off' : sched.preset)
-      setDraftRetention(sched.retentionDays)
+      setDraftKeepLast(sched.keepLast > 0 ? sched.keepLast : (sched.preset === 'Off' ? 8 : 0))
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
       setSchedule(null); setHistory(null)
@@ -649,18 +649,18 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
     // Likewise, if there are still unmanaged lines outside our block, allow
     // saving so the user can clean them up by re-installing.
     if (schedule.hasUnmanagedBackupLines) return true
-    return draftPreset !== schedule.preset || draftRetention !== schedule.retentionDays
-  }, [schedule, draftPreset, draftRetention])
+    return draftPreset !== schedule.preset || draftKeepLast !== schedule.keepLast
+  }, [schedule, draftPreset, draftKeepLast])
 
   async function save() {
     if (!schedule) return
     setSaving(true)
     try {
-      const updated = await putBackupSchedule({ preset: draftPreset, retentionDays: draftRetention })
+      const updated = await putBackupSchedule({ preset: draftPreset, keepLast: draftKeepLast })
       setSchedule(updated)
       setDraftPreset(updated.preset === 'Custom' ? 'Off' : updated.preset)
-      setDraftRetention(updated.retentionDays)
-      showToast('ok', draftPreset === 'Off' ? 'Schedule disabled.' : `Schedule saved (${draftPreset}, retention ${draftRetention}d).`)
+      setDraftKeepLast(updated.keepLast > 0 ? updated.keepLast : (updated.preset === 'Off' ? 8 : 0))
+      showToast('ok', draftPreset === 'Off' ? 'Schedule disabled.' : `Schedule saved (${draftPreset}, keep last ${draftKeepLast}).`)
       // Refresh history in the background so the user sees the new schedule
       // reflected immediately when the next cron run lands.
       void getBackupHistory({ recent: 5, logLines: 50 }).then(setHistory).catch(() => {})
@@ -769,17 +769,17 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
         </label>
         <label className="flex flex-col gap-1 text-xs">
           <span className="text-text-muted font-medium">
-            Retention (days){draftRetention === 0 ? ' — keep forever' : ''}
+            Keep last (count){draftKeepLast === 0 ? ' — keep forever' : ''}
           </span>
           <input
             type="number"
             min={0}
-            max={3650}
+            max={1000}
             step={1}
-            value={draftRetention}
+            value={draftKeepLast}
             onChange={e => {
               const n = parseInt(e.target.value || '0', 10)
-              setDraftRetention(Number.isFinite(n) ? Math.max(0, Math.min(3650, n)) : 0)
+              setDraftKeepLast(Number.isFinite(n) ? Math.max(0, Math.min(1000, n)) : 0)
             }}
             disabled={!vmRunning || loading || saving || draftPreset === 'Off'}
             className="px-2 py-1.5 rounded bg-surface-2 border border-border text-text text-sm font-mono w-full"
@@ -814,9 +814,9 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
           {schedule.enabled
             ? <>
                 <strong className="text-text">{schedule.preset}</strong>
-                {schedule.retentionDays > 0
-                  ? <> · retention <strong className="text-text">{schedule.retentionDays}d</strong></>
-                  : <> · no retention pruning</>}
+                {schedule.keepLast > 0
+                  ? <> · keep last <strong className="text-text">{schedule.keepLast}</strong> backups</>
+                  : <> · keep forever</>}
               </>
             : <strong className="text-text">Off</strong>}
           {' · '}VM time <span className="font-mono">{schedule.vmNowUtc} ({tzLabel})</span>


### PR DESCRIPTION
## Summary
- Change backup retention policy from "retention days" to "keep last N backups".
- Change the default backup behavior so "keep last 8 backups" is selected by default when scheduling is turned on.
- Update UI to reflect the transition from counting by days to a raw count constraint.
- Continue to default to disabled/off for the backup schedule overall.

## Validation
- `npm run build`
- `npm test`
- Parse checked `.ps1` files and ensured BOM format where necessary.