### PR TITLE
fix(webui): add missing confirm DELETE to deleteAccount API payload

### DIFF
--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1291,7 +1291,7 @@ export function awardIntel(controllerId: number, pawnId: number, amount: number)
 // PERMANENT — purges the account row + dependent rows. No undo.
 export function deleteAccount(accountId: number) {
   return api<WriteResult>('/api/gameplay/players/delete-account', {
-    method: 'POST', body: JSON.stringify({ account_id: accountId }),
+    method: 'POST', body: JSON.stringify({ account_id: accountId, confirm: 'DELETE' }),
   })
 }
 

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -87,7 +87,7 @@ describe('Phase A — currency / progression writes', () => {
   it('deleteAccount targets /delete-account', async () => {
     await gp.deleteAccount(404)
     expect(last().url).toBe('/api/gameplay/players/delete-account')
-    expect(last().body).toEqual({ account_id: 404 })
+    expect(last().body).toEqual({ account_id: 404, confirm: 'DELETE' })
   })
 })
 


### PR DESCRIPTION
## Summary
The UI was properly asking for the double confirmation (`i acknowledge`), but the API wrapper in `webui/src/api/gameplay.ts` was missing the `confirm: 'DELETE'` payload that the backend `PlayersAdmin.ps1` route explicitly checks for. 

This patches the payload, fixing the backend HTTP 400 error.

## Validation
- `npm test`
- `npm run build`