### PR TITLE
Improve battlegroup health status

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.5.6"
+      placeholder: "v12.5.7"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,7 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
-### Changed
-
-- **Wipe Journey now requires a typed double-confirmation.** Because wiping a player's entire journey is extremely destructive and cannot be undone, the action (both the menu item and the "Wipe All" button inside the Journey browser) now requires typing `i acknowledge` to proceed, aligning it with Wipe Codex and Delete Account.
-
-## [12.5.6] - 2026-06-17
+## [12.5.7] - 2026-06-17
 
 ### Added
 
@@ -25,6 +21,10 @@ here cover everything those tags shipped.
   `m_RecyclerOutputWeight` from `[/Script/DuneSandbox.CraftingSettings]`,
   including the existing client-side apply flow so admins can mirror the
   settings into their local `Game.ini`.
+
+### Changed
+
+- **Wipe Journey now requires a typed double-confirmation.** Because wiping a player's entire journey is extremely destructive and cannot be undone, the action (both the menu item and the "Wipe All" button inside the Journey browser) now requires typing `i acknowledge` to proceed, aligning it with Wipe Codex and Delete Account.
 
 ## [12.5.5] - 2026-06-16
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.5.6'
+$script:DuneToolVersion = '12.5.7'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.5.6',
+    [string]$Version = '12.5.7',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.5.6</Version>
+    <Version>12.5.7</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.5.6"
+#define MyAppVersion "12.5.7"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.5.6"
+$script:ToolVersion = "12.5.7"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "12.3.0",
+  "version": "12.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "12.3.0",
+      "version": "12.5.7",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "12.5.6",
+  "version": "12.5.7",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Rename Server Health's BG state row to BG Status and show the Survival_1 phase value
- Reuse the Survival_1 lookup for the login-readiness heartbeat
- Make automatic post-start partition cleanup run in fast mode to avoid long BG start waits

## Validation
- Built web UI with `npm run build`
- Built installer with `app\installer\Build-Installer.ps1`
- Parsed `dune-server.ps1`
- Ran staged gitleaks scan