### PR TITLE
Release v12.5.8

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.5.6"
+      placeholder: "v12.5.7"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.5.7"
+      placeholder: "v12.5.8"
     validations:
       required: true
 
@@ -116,7 +116,7 @@ body:
     attributes:
       label: Specific page / button / command
       description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug?
-      placeholder: "e.g. Server Health 'Restart battlegroup' button, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > Crafting > Repair Cost Weight, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Market Bot > Pricing rules > Market-follow pricing toggle, Gameplay Admin > Market Bot > Pricing rules > Market markup %, Gameplay Admin > Market Bot > Buy side > Over-market guard, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > inventory item > Stack quantity, Gameplay Admin > Storage > container item > Stack quantity, Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Journey > Complete node, Gameplay Admin > Players > Actions > Unlock Trainers > Swordmaster, Gameplay Admin > Players > Actions > Unlock Main Quest > A New Beginning, Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Map SpinUp > Arrakeen loading counter, Map SpinUp > Restart Hagga, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
+      placeholder: "e.g. Server Health 'Restart battlegroup' button, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > Crafting > Repair Cost Weight, Game Config > All Default Settings > Ctrl+C section header, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Market Bot > Pricing rules > Market-follow pricing toggle, Gameplay Admin > Market Bot > Pricing rules > Market markup %, Gameplay Admin > Market Bot > Buy side > Over-market guard, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Package > Import tcno.co list, Gameplay Admin > Players > Give Package (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > inventory item > Repair, Gameplay Admin > Players > inventory item > Stack quantity, Gameplay Admin > Storage > container item > Stack quantity, Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Journey > Complete node, Gameplay Admin > Players > Actions > Unlock Trainers > Swordmaster, Gameplay Admin > Players > Actions > Unlock Main Quest > A New Beginning, Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Map SpinUp > Arrakeen loading counter, Map SpinUp > Restart Hagga, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
     validations:
       required: true
 
@@ -169,7 +169,7 @@ body:
   - type: textarea
     id: giveitem_diag
     attributes:
-      label: Give Item / Give Vehicle Kit — item or part that didn't appear (Give Item, Give Package, or a vehicle kit)
+      label: Give Item / Give Package / Give Vehicle Kit — item or part that didn't appear
       description: |
         For items or vehicle parts that show in DST's listing/preview but don't
         appear in-game (player inventory or a storage container).
@@ -180,6 +180,10 @@ body:
           (e.g. `Copper Ingot — CopperBar`). If you only see a number, paste it.
         - Destination: player inventory, or a storage container (and its type).
         - Quantity / quality, and whether it's a stackable resource or equipment.
+        - If this came from **Give Package > Import**, paste the tcno.co
+          item/quantity lines and the package name you saved.
+        - Whether **"Allow overflow (drop to ground)"** was ticked, and whether
+          the player was **online or offline** (overflow only applies online).
         - Did it show in DST's listing? Did it show in-game **after a server zone
           restart** / relog?
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,7 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
-### Changed
-
-- **Wipe Journey now requires a typed double-confirmation.** Because wiping a player's entire journey is extremely destructive and cannot be undone, the action (both the menu item and the "Wipe All" button inside the Journey browser) now requires typing `i acknowledge` to proceed, aligning it with Wipe Codex and Delete Account.
-
-## [12.5.6] - 2026-06-17
+## [12.5.7] - 2026-06-17
 
 ### Added
 
@@ -25,6 +21,10 @@ here cover everything those tags shipped.
   `m_RecyclerOutputWeight` from `[/Script/DuneSandbox.CraftingSettings]`,
   including the existing client-side apply flow so admins can mirror the
   settings into their local `Game.ini`.
+
+### Changed
+
+- **Wipe Journey now requires a typed double-confirmation.** Because wiping a player's entire journey is extremely destructive and cannot be undone, the action (both the menu item and the "Wipe All" button inside the Journey browser) now requires typing `i acknowledge` to proceed, aligning it with Wipe Codex and Delete Account.
 
 ## [12.5.5] - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.5.8] - 2026-06-17
+
+### Added
+
+- **Give Package can import tcno.co item lists.** Paste the two-line
+  `Item name:` / quantity format from tcno.co, let DST resolve names through the
+  item catalog, then review the generated package rows, pick a package name, and
+  save it.
+
+### Fixed
+
+- **Give Item capacity check now treats ammo as stackable.** Light Darts and
+  other picker-only ammo templates are missing `stack_max` in the gameplay item
+  metadata, so DST fell back to one slot per item and falsely rejected valid
+  stack gives (e.g. 500 Light Darts with 111 open slots).
+- **Give Package can allow overflow like Vehicle Kits.** Package gives now pass
+  the overflow/drop-to-ground option through the live RMQ item path instead of
+  always enforcing inventory capacity.
+- **Inventory repair now handles current-only durability items.** Items with a
+  durability block but no catalog/max durability repair to 100 when below 100,
+  or to 200 when between 100 and 200, instead of reporting no usable durability.
+- **Game Config INI section rows support Ctrl+C.** Focus a section row in
+  All Default Settings or Advanced INI contents and press Ctrl+C to copy the
+  bracketed section header.
+
 ## [12.5.7] - 2026-06-17
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.5.6'
+$script:DuneToolVersion = '12.5.7'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.5.7'
+$script:DuneToolVersion = '12.5.8'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.5.7',
+    [string]$Version = '12.5.8',
     [switch]$Quiet
 )
 

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.5.6',
+    [string]$Version = '12.5.7',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.5.6</Version>
+    <Version>12.5.7</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.5.7</Version>
+    <Version>12.5.8</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.5.7"
+#define MyAppVersion "12.5.8"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.5.6"
+#define MyAppVersion "12.5.7"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/resources/remote-scripts/dune-clear-partitions.start
+++ b/app/resources/remote-scripts/dune-clear-partitions.start
@@ -26,6 +26,7 @@ set -u
 LOG=/var/log/dune-clear-partitions.log
 MAP_SUFFIXES="-deepdesert-1 -sh-arrakeen -sh-harkovillage"
 KUBE="/usr/local/bin/k3s kubectl"
+WAIT_ATTEMPTS="${DUNE_CLEAR_ATTEMPTS:-60}"
 
 ts() { date "+%Y-%m-%d %H:%M:%S"; }
 log() { echo "[$(ts)] $*" >> "$LOG"; }
@@ -33,7 +34,7 @@ log() { echo "[$(ts)] $*" >> "$LOG"; }
 log "dune-clear-partitions: start"
 
 # Wait up to 5 min for k3s API + igwsss CRD to be available.
-for i in $(seq 1 60); do
+for i in $(seq 1 "$WAIT_ATTEMPTS"); do
   if $KUBE get igwsss --all-namespaces >/dev/null 2>&1; then
     log "api + igwsss CRD ready after ${i} attempts"
     break
@@ -61,7 +62,7 @@ has_expected_match() {
 # Wait up to 5 min for at least one expected map igwsss object to exist.
 # This is the race-window fix: CRD can be reachable before the server-operator
 # has created the per-map ServerSetScale instances during a fresh boot.
-for i in $(seq 1 60); do
+for i in $(seq 1 "$WAIT_ATTEMPTS"); do
   if [ -n "$(has_expected_match)" ]; then
     log "expected map igwsss object(s) present after ${i} attempts"
     break

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -235,6 +235,28 @@ function Format-DuneFloatForSql {
     return $Value.ToString([System.Globalization.CultureInfo]::InvariantCulture)
 }
 
+function ConvertTo-DuneBool {
+    param($Value)
+    if ($Value -is [bool]) { return $Value }
+    $s = ([string]$Value).Trim()
+    return ($s -in @('1', 't', 'true', 'y', 'yes'))
+}
+
+function Resolve-DuneRepairDurabilityTarget {
+    param(
+        [double]$CatalogMax,
+        [double]$ItemMax,
+        [double]$ItemCurrent,
+        [double]$ItemDecayedMax,
+        [bool]$HasCurrent = $false
+    )
+    $target = [Math]::Max([Math]::Max([Math]::Max($CatalogMax, $ItemMax), $ItemCurrent), $ItemDecayedMax)
+    if ($target -le 0 -and -not $HasCurrent) { return 0.0 }
+    if ($target -lt 100) { return 100.0 }
+    if ($target -gt 100 -and $target -lt 200) { return 200.0 }
+    return $target
+}
+
 # Repair item (repair-item): set MaxDurability/CurrentDurability/DecayedMaxDurability
 # to GREATEST(catalog.max_durability, item.MaxDurability, item.CurrentDurability,
 # item.DecayedMaxDurability). The catalog (gameplay-item-data.json) carries the
@@ -251,7 +273,8 @@ function Invoke-DunePlayerRepairItem {
 SELECT template_id,
        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0)        AS m,
        COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0)    AS c,
-       COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) AS d
+       COALESCE((stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) AS d,
+       (stats->'FItemStackAndDurabilityStats'->1 ? 'CurrentDurability') AS has_c
 FROM dune.items
 WHERE id = $ItemId::bigint
   AND stats ? 'FItemStackAndDurabilityStats';
@@ -267,7 +290,8 @@ WHERE id = $ItemId::bigint
     $itemCur = [double]([string]$rows[0]['c'])
     $itemDec = [double]([string]$rows[0]['d'])
     $catMax  = Get-DuneItemCatalogMaxDurability -TemplateId $tmpl
-    $target  = [Math]::Max([Math]::Max([Math]::Max($catMax, $itemMax), $itemCur), $itemDec)
+    $hasCur  = ConvertTo-DuneBool $rows[0]['has_c']
+    $target  = Resolve-DuneRepairDurabilityTarget -CatalogMax $catMax -ItemMax $itemMax -ItemCurrent $itemCur -ItemDecayedMax $itemDec -HasCurrent $hasCur
     if ($target -le 0) {
         return @{ ok = $true; message = "Item $ItemId has no usable durability value — left untouched." }
     }

--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -29,13 +29,27 @@ function Resolve-DuneItemVolume {
     return 0.0
 }
 
-# Max stack size for a template: catalogued stack_max wins, else the largest
-# stack_size seen live for that template+quality, else 1. Mirrors the reference
-# implementation resolveStackMax.
+# Picker-only ammo templates are absent from gameplay-item-data.json, so they
+# have no catalogued stack_max even though the game stacks them.
+$script:DuneKnownStackableItemLimits = @{
+    Ammo              = 500
+    HeavyAmmo         = 500
+    InfantryRocketAmmo = 500
+    Napalm            = 500
+    RocketAmmo        = 500
+}
+
+# Max stack size for a template: catalogued stack_max wins, else known
+# picker-only stackables, else the largest stack_size seen live for that
+# template+quality, else 1. Mirrors the reference implementation resolveStackMax
+# with DST catalog backfill for items missing from gameplay-item-data.json.
 function Resolve-DuneStackMax {
     param([Parameter(Mandatory)] [string] $Ip, [Parameter(Mandatory)] [string] $Template, [long] $Quality = 0)
     $rule = Get-DuneGameplayItemRule -TemplateId $Template
     if ($rule -and $rule.ContainsKey('stack_max') -and [int]$rule.stack_max -gt 0) { return [int]$rule.stack_max }
+    if ($script:DuneKnownStackableItemLimits.ContainsKey($Template)) {
+        return [int]$script:DuneKnownStackableItemLimits[$Template]
+    }
     $safe = ($Template -replace "'", "''")
     $sql = "SELECT COALESCE(MAX(stack_size), 0)::text AS s FROM dune.items WHERE template_id = '$safe' AND quality_level = $Quality::bigint;"
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 10

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -363,7 +363,7 @@ WHERE template_id = 'ContractItem'
 # Bulk give: loops the existing single-template give. Items is an array of
 # @{ template = '...'; qty = N; quality = M }.
 function Invoke-DunePlayerGiveItemsBulk {
-    param([string]$Ip, [long]$PawnId, $Items, [string]$FlsId)
+    param([string]$Ip, [long]$PawnId, $Items, [string]$FlsId, [bool]$AllowOverflow = $false)
     if ($PawnId -le 0) { return @{ ok = $false; error = 'pawn_id is required.' } }
     if (-not $Items -or @($Items).Count -eq 0) {
         return @{ ok = $false; error = 'items[] is required.' }
@@ -395,7 +395,7 @@ function Invoke-DunePlayerGiveItemsBulk {
         if ($qty -le 0) { $qty = 1 }
         if ($isOnline -and $qlevel -le 0 -and -not [string]::IsNullOrWhiteSpace($fls)) {
             # Online + default quality → RMQ live (instant, no relog)
-            $r = Invoke-DunePlayerGiveItemLive -Ip $Ip -ActorId $PawnId -FlsId $fls -Template $tmpl -Quantity ([int]$qty) -Durability 1.0
+            $r = Invoke-DunePlayerGiveItemLive -Ip $Ip -ActorId $PawnId -FlsId $fls -Template $tmpl -Quantity ([int]$qty) -Durability 1.0 -AllowOverflow $AllowOverflow
             if ($r.ok -and -not $r.path) { $r['path'] = 'rmq' }
         } else {
             # Offline, OR online with custom quality / unresolved fls → SQL
@@ -440,7 +440,8 @@ function Invoke-DunePlayerRepairGear {
 SELECT i.id, i.template_id,
        COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0)        AS m,
        COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0)    AS c,
-       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) AS d
+       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) AS d,
+       (i.stats->'FItemStackAndDurabilityStats'->1 ? 'CurrentDurability') AS has_c
 FROM dune.items i
 JOIN dune.inventories inv ON inv.id = i.inventory_id
 WHERE inv.actor_id = $PawnId::bigint
@@ -457,7 +458,8 @@ WHERE inv.actor_id = $PawnId::bigint
         $iCur = [double]([string]$r['c'])
         $iDec = [double]([string]$r['d'])
         $cMax = Get-DuneItemCatalogMaxDurability -TemplateId $tmpl
-        $target = [Math]::Max([Math]::Max([Math]::Max($cMax, $iMax), $iCur), $iDec)
+        $hasCur = ConvertTo-DuneBool $r['has_c']
+        $target = Resolve-DuneRepairDurabilityTarget -CatalogMax $cMax -ItemMax $iMax -ItemCurrent $iCur -ItemDecayedMax $iDec -HasCurrent $hasCur
         if ($target -gt 0) {
             $iid  = [long]$r['id']
             $tval = Format-DuneFloatForSql -Value $target
@@ -514,7 +516,8 @@ function Invoke-DunePlayerRestoreDestroyedGear {
 SELECT i.id, i.template_id,
        COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::float8, 0)        AS m,
        COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability')::float8, 0)    AS c,
-       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) AS d
+       COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::float8, 0) AS d,
+       (i.stats->'FItemStackAndDurabilityStats'->1 ? 'CurrentDurability') AS has_c
 FROM dune.items i
 JOIN dune.inventories inv ON inv.id = i.inventory_id
 WHERE inv.actor_id = $PawnId::bigint
@@ -532,7 +535,8 @@ WHERE inv.actor_id = $PawnId::bigint
         $iCur = [double]([string]$r['c'])
         $iDec = [double]([string]$r['d'])
         $cMax = Get-DuneItemCatalogMaxDurability -TemplateId $tmpl
-        $target = [Math]::Max([Math]::Max([Math]::Max($cMax, $iMax), $iCur), $iDec)
+        $hasCur = ConvertTo-DuneBool $r['has_c']
+        $target = Resolve-DuneRepairDurabilityTarget -CatalogMax $cMax -ItemMax $iMax -ItemCurrent $iCur -ItemDecayedMax $iDec -HasCurrent $hasCur
         if ($target -gt 0) {
             $iid  = [long]$r['id']
             $tval = Format-DuneFloatForSql -Value $target

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -6,16 +6,17 @@
 # §3 — Items / inventory
 # ---------------------------------------------------------------------------
 
-# POST /api/gameplay/players/give-items  { pawn_id, items:[{template,qty,quality}] }
+# POST /api/gameplay/players/give-items  { pawn_id, items:[{template,qty,quality}], allow_overflow? }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-items' -Handler {
     param($req, $res, $routeParams, $body)
     try {
         $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
         $items = Get-DuneBodyValue -Body $body -Name 'items'
         $fls = [string](Get-DuneBodyValue -Body $body -Name 'fls_id')
+        $overflow = [bool](Get-DuneBodyValue -Body $body -Name 'allow_overflow')
         if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
         if ($null -eq $items) { Write-DuneError -Response $res -Status 400 -Message 'items[] is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerGiveItemsBulk -Ip $ip -PawnId $pawn -Items $items -FlsId $fls }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerGiveItemsBulk -Ip $ip -PawnId $pawn -Items $items -FlsId $fls -AllowOverflow $overflow }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Give items failed: $($_.Exception.Message)"
     }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.5.6"
+$script:ToolVersion = "12.5.7"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -830,7 +830,8 @@ function Invoke-DuneRemotePartitionScript {
     # removes the staged copy. No persistent install, no boot script, no cron.
     # Returns @{ ok; rc; output }. Best-effort - never throws.
     param(
-        [Parameter(Mandatory)][string]$Ip
+        [Parameter(Mandatory)][string]$Ip,
+        [int]$WaitAttempts = 60
     )
     $local = Get-DuneRemotePartitionScriptPath
     if (-not $local) {
@@ -859,13 +860,13 @@ function Invoke-DuneRemotePartitionScript {
     }
     $output = & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
                     -i "$sshKey" "$sshUser@$Ip" `
-                    "sudo -n sh $remoteTmp; rc=`$?; rm -f $remoteTmp; exit `$rc" 2>&1
+                    "sudo -n DUNE_CLEAR_ATTEMPTS=$WaitAttempts sh $remoteTmp; rc=`$?; rm -f $remoteTmp; exit `$rc" 2>&1
     $rc = $LASTEXITCODE
     return @{ ok = ($rc -eq 0); rc = $rc; output = @($output) }
 }
 
 function Invoke-OnDemandPartitionClear {
-    # Best-effort wrapper: settle for DelaySec to let the Funcom server-operator
+    # Best-effort wrapper: optionally settle for DelaySec to let the Funcom server-operator
     # finish reconciling on-demand ServerSets (otherwise the script runs before
     # partitions are pinned and finds nothing to clear), stage the bundled
     # script to /tmp on the VM, run it once with sudo, remove it, then tail
@@ -877,7 +878,8 @@ function Invoke-OnDemandPartitionClear {
     param(
         [Parameter(Mandatory)][string]$Ip,
         [int]$DelaySec = 30,
-        [string]$Phase = 'post-start'
+        [string]$Phase = 'post-start',
+        [switch]$Fast
     )
     Write-Host ""
     Write-Host "[$Phase] Clearing on-demand map partition pins (auto-fix so DeepDesert / Arrakeen / Harko spawn on demand)..." -ForegroundColor Cyan
@@ -887,7 +889,8 @@ function Invoke-OnDemandPartitionClear {
         Start-Sleep -Seconds $DelaySec
     }
 
-    $result = Invoke-DuneRemotePartitionScript -Ip $Ip
+    $waitAttempts = if ($Fast) { 1 } else { 60 }
+    $result = Invoke-DuneRemotePartitionScript -Ip $Ip -WaitAttempts $waitAttempts
     $runOut = $result.output
     $runRc  = $result.rc
 
@@ -1464,7 +1467,7 @@ while ($true) {
         # the next player without manual intervention. Skipped if `bg start`
         # itself failed (no point waiting on operator that never reconciled).
         if ($bgStartExit -eq 0) {
-            Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 15 -Phase 'post-startup'
+            Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'post-startup' -Fast
         } else {
             Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
         }
@@ -2138,11 +2141,10 @@ while ($true) {
     # partition pins so DD/Arrakeen/Harko spawn for the next player without
     # the user having to invoke fix-on-demand-maps manually.
     if ($bgFallbackExit -eq 0 -and ($cmdName -eq 'start' -or $cmdName -eq 'restart')) {
-        # 'start' brings up a battlegroup that was not running, on an already-up
-        # VM; the operator pins on-demand ServerSets quickly, so a short settle
-        # is enough. 'restart' keeps the longer delay (battlegroup churn).
-        $settleSec = if ($cmdName -eq 'start') { 9 } else { 45 }
-        Invoke-OnDemandPartitionClear -Ip $ip -DelaySec $settleSec -Phase "post-$cmdName"
+        # Run in fast mode: no fixed settle delay and only one remote wait pass.
+        # The persistent VM watchdog / manual Fix Partitions command covers
+        # slower post-reconcile drift without making every start feel hung.
+        Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase "post-$cmdName" -Fast
     }
 
     # After start/restart, resolve director port

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.5.7"
+$script:ToolVersion = "12.5.8"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/PlayersRmq.Tests.ps1
+++ b/tests/PlayersRmq.Tests.ps1
@@ -1,0 +1,56 @@
+# Tests pure helper behavior in PlayersRmq.ps1.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'Gameplay.ps1'
+    Import-DstLib 'PlayersRmq.ps1'
+}
+
+Describe 'Resolve-DuneStackMax' -Tag 'Pure' {
+    BeforeEach {
+        function global:Invoke-DuneSqlQuery {
+            return @{ ok = $true; rows = @(@{ s = '0' }) }
+        }
+    }
+
+    AfterEach {
+        Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+    }
+
+    It 'uses gameplay-item-data stack_max when present' {
+        Resolve-DuneStackMax -Ip '1.2.3.4' -Template 'CopperBar' -Quality 0 | Should -Be 500
+    }
+
+    It 'treats Light Darts as one stack per 500 items' {
+        Resolve-DuneStackMax -Ip '1.2.3.4' -Template 'Ammo' -Quality 0 | Should -Be 500
+    }
+
+    It 'keeps catalog-only launchers non-stackable' {
+        Resolve-DuneStackMax -Ip '1.2.3.4' -Template 'RocketLauncher_2' -Quality 0 | Should -Be 1
+    }
+
+    It 'counts 500 Light Darts as one new slot in the capacity guard' {
+        $script:queryCount = 0
+        function global:Invoke-DuneSqlQuery {
+            $script:queryCount++
+            if ($script:queryCount -eq 1) {
+                return @{
+                    ok      = $true
+                    columns = @('inv_id', 'max_slots', 'max_vol')
+                    rows    = @(, @('101', '150', '-1'))
+                }
+            }
+            return @{
+                ok      = $true
+                columns = @('t', 'ss', 'vov')
+                rows    = @(1..39 | ForEach-Object { , @("Existing$_", '1', '-1') })
+            }
+        }
+
+        $r = Test-DuneInventoryCapacity -Ip '1.2.3.4' -PawnId 24 -Template 'Ammo' -Quantity 500 -Quality 0
+
+        $r.ok         | Should -BeTrue
+        $r.new_stacks | Should -Be 1
+        $r.free_slots | Should -Be 111
+    }
+}

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -76,6 +76,23 @@ Describe 'Get-DuneSqlAffected' -Tag 'Pure' {
     }
 }
 
+Describe 'Resolve-DuneRepairDurabilityTarget' -Tag 'Pure' {
+    It 'keeps no-current empty durability blocks untouched' {
+        Resolve-DuneRepairDurabilityTarget -CatalogMax 0 -ItemMax 0 -ItemCurrent 0 -ItemDecayedMax 0 -HasCurrent $false | Should -Be 0
+    }
+    It 'repairs current-only zero or low durability items to 100' {
+        Resolve-DuneRepairDurabilityTarget -CatalogMax 0 -ItemMax 0 -ItemCurrent 0 -ItemDecayedMax 0 -HasCurrent $true | Should -Be 100
+        Resolve-DuneRepairDurabilityTarget -CatalogMax 0 -ItemMax 0 -ItemCurrent 50 -ItemDecayedMax 0 -HasCurrent $true | Should -Be 100
+    }
+    It 'rounds current-only values between 100 and 200 up to 200' {
+        Resolve-DuneRepairDurabilityTarget -CatalogMax 0 -ItemMax 0 -ItemCurrent 150 -ItemDecayedMax 0 -HasCurrent $true | Should -Be 200
+    }
+    It 'preserves known higher catalog or item caps' {
+        Resolve-DuneRepairDurabilityTarget -CatalogMax 400 -ItemMax 0 -ItemCurrent 50 -ItemDecayedMax 0 -HasCurrent $true | Should -Be 400
+        Resolve-DuneRepairDurabilityTarget -CatalogMax 0 -ItemMax 250 -ItemCurrent 50 -ItemDecayedMax 0 -HasCurrent $true | Should -Be 250
+    }
+}
+
 Describe 'Invoke-DunePlayerUpdateTags' -Tag 'TagsDelta' {
     BeforeEach {
         $script:capturedSql = $null
@@ -85,6 +102,7 @@ Describe 'Invoke-DunePlayerUpdateTags' -Tag 'TagsDelta' {
             return @{ ok = $true; message = 'SELECT 1' }
         }
     }
+
     AfterEach {
         Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
     }
@@ -117,5 +135,51 @@ Describe 'Invoke-DunePlayerUpdateTags' -Tag 'TagsDelta' {
     It 'skips blank tags after trimming' {
         Invoke-DunePlayerUpdateTags -Ip '1.2.3.4' -AccountId 7 -Add @('  ', 'real') -Remove @() | Out-Null
         $script:capturedSql | Should -Match "ARRAY\['real'\]::text\[\]"
+    }
+}
+
+Describe 'Invoke-DunePlayerGiveItemsBulk overflow' -Tag 'Pure' {
+    BeforeEach {
+        $script:liveArgs = $null
+        function global:Get-DuneBodyValue {
+            param($Body, [string]$Name)
+            if ($Body -is [System.Collections.IDictionary] -and $Body.Contains($Name)) { return $Body[$Name] }
+            if ($null -ne $Body -and $Body.PSObject.Properties[$Name]) { return $Body.$Name }
+            return $null
+        }
+        function global:Get-DuneBodyInt {
+            param($Body, [string]$Name)
+            $v = Get-DuneBodyValue -Body $Body -Name $Name
+            if ($null -eq $v -or $v -eq '') { return $null }
+            return [int64]$v
+        }
+        function global:Test-DunePlayerOffline { return @{ ok = $false } }
+        function global:Resolve-DuneFlsIdOrError { return @{ ok = $true; fls_id = 'fls-test' } }
+        function global:Invoke-DunePlayerGiveItemLive {
+            param($Ip, $ActorId, $FlsId, $Template, $Quantity, $Durability, $AllowOverflow)
+            $script:liveArgs = @{
+                Ip = $Ip; ActorId = $ActorId; FlsId = $FlsId; Template = $Template
+                Quantity = $Quantity; Durability = $Durability; AllowOverflow = $AllowOverflow
+            }
+            return @{ ok = $true; path = 'rmq' }
+        }
+    }
+    AfterEach {
+        Remove-Item function:global:Get-DuneBodyValue -ErrorAction SilentlyContinue
+        Remove-Item function:global:Get-DuneBodyInt -ErrorAction SilentlyContinue
+        Remove-Item function:global:Test-DunePlayerOffline -ErrorAction SilentlyContinue
+        Remove-Item function:global:Resolve-DuneFlsIdOrError -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DunePlayerGiveItemLive -ErrorAction SilentlyContinue
+    }
+
+    It 'passes AllowOverflow to live package item gives' {
+        $items = @(@{ template = 'Ammo'; qty = 500; quality = 0 })
+
+        $r = Invoke-DunePlayerGiveItemsBulk -Ip '1.2.3.4' -PawnId 24 -Items $items -AllowOverflow $true
+
+        $r.ok | Should -BeTrue
+        $script:liveArgs.AllowOverflow | Should -BeTrue
+        $script:liveArgs.Template | Should -Be 'Ammo'
+        $script:liveArgs.Quantity | Should -Be 500
     }
 }

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "12.3.0",
+  "version": "12.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "12.3.0",
+      "version": "12.5.7",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webui",
-  "version": "12.5.7",
+  "version": "12.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webui",
-      "version": "12.5.7",
+      "version": "12.5.8",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "12.5.7",
+  "version": "12.5.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "12.5.6",
+  "version": "12.5.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1171,6 +1171,64 @@ export function filterCatalog(catalog: CatalogItem[], query: string, limit = 20,
   return out.slice(0, limit).map(o => o.item)
 }
 
+export interface PackageImportItem extends GiveItemEntry {
+  name: string
+}
+
+export interface PackageImportResult {
+  items: PackageImportItem[]
+  warnings: string[]
+}
+
+function normalizePackageItemName(s: string): string {
+  return s.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+export function parseTcnoPackageText(raw: string, catalog: CatalogItem[]): PackageImportResult {
+  const lines = raw.split(/\r?\n/).map(l => l.trim()).filter(Boolean)
+  const byName = new Map<string, CatalogItem>()
+  const byTemplate = new Map<string, CatalogItem>()
+  for (const item of catalog) {
+    const nameKey = normalizePackageItemName(item.name)
+    const templateKey = normalizePackageItemName(item.template_id)
+    if (nameKey && !byName.has(nameKey)) byName.set(nameKey, item)
+    if (templateKey && !byTemplate.has(templateKey)) byTemplate.set(templateKey, item)
+  }
+
+  const items: PackageImportItem[] = []
+  const warnings: string[] = []
+  for (let i = 0; i < lines.length; i += 2) {
+    const nameLine = lines[i] ?? ''
+    const qtyLine = lines[i + 1] ?? ''
+    if (!nameLine.endsWith(':')) {
+      warnings.push(`Line ${i + 1}: expected "Item name:"`)
+      continue
+    }
+    if (!qtyLine) {
+      warnings.push(`Line ${i + 2}: missing quantity for ${nameLine.slice(0, -1).trim()}`)
+      continue
+    }
+    const itemName = nameLine.slice(0, -1).trim()
+    const qty = Number.parseInt(qtyLine, 10)
+    if (!Number.isFinite(qty) || qty < 1) {
+      warnings.push(`Line ${i + 2}: invalid quantity "${qtyLine}" for ${itemName}`)
+      continue
+    }
+    const key = normalizePackageItemName(itemName)
+    const match = byName.get(key) ?? byTemplate.get(key)
+    if (!match) {
+      warnings.push(`Unknown item "${itemName}"`)
+      continue
+    }
+    items.push({ template: match.template_id, name: match.name, qty, quality: 0 })
+  }
+
+  if (lines.length % 2 === 1 && lines.length > 0 && !lines[lines.length - 1]?.endsWith(':')) {
+    warnings.push(`Line ${lines.length}: quantity has no item name`)
+  }
+  return { items, warnings }
+}
+
 export interface FillWaterResponse {
   ok: boolean
   message: string
@@ -1419,9 +1477,9 @@ export function getProgressionPresets() {
 // ---------------------------------------------------------------------------
 
 export interface GiveItemEntry { template: string; qty: number; quality?: number }
-export function giveItems(pawnId: number, items: GiveItemEntry[]) {
+export function giveItems(pawnId: number, items: GiveItemEntry[], allowOverflow = false) {
   return api<WriteResult>('/api/gameplay/players/give-items', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, items }),
+    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, items, allow_overflow: allowOverflow }),
   })
 }
 

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -38,26 +38,8 @@ function healthClass(v: string | undefined): string {
   return 'text-text'
 }
 
-// BG state shown under Battlegroup Info is the Funcom operator's "Status"
-// column — a kube-operator reconcile phase. It normally sits in
-// "Reconciling" / "Reconciling Ready" while the battlegroup is perfectly
-// healthy, so both healthy and reconciling are surfaced as a green "Healthy".
-// Yellow/red are reserved for genuine transitions or faults — the per-component
-// Database / Gateway / Director rows below show real component health.
-function bgStateDisplay(v: string | undefined): { cls: string; label: string } {
-  const raw = (v ?? '').trim()
-  const s = raw.toLowerCase()
-  if (!s) return { cls: 'text-text-dim', label: '—' }
-  // Genuine fault → red.
-  if (/(fail|error|unhealthy|crash|degraded|fault|stopp|\bfalse\b)/.test(s)) {
-    return { cls: 'text-danger', label: raw }
-  }
-  // Healthy or reconciling → green "Healthy".
-  if (/(healthy|ready|reconcil|running|\btrue\b)/.test(s)) {
-    return { cls: 'text-success', label: 'Healthy' }
-  }
-  // Anything else (starting / updating / pending …) is an in-progress transition.
-  return { cls: 'text-warning', label: raw }
+function findSurvivalServer(servers: BgGameServer[]): BgGameServer | undefined {
+  return servers.find(s => /survival[_-]?1/i.test(s.map))
 }
 
 function GameServerRow({ s }: { s: BgGameServer }) {
@@ -83,7 +65,7 @@ function survivalHeartbeat(servers: BgGameServer[], loading: boolean): {
   label: string
   beating: boolean
 } {
-  const sv = servers.find(s => /survival[_-]?1/i.test(s.map))
+  const sv = findSurvivalServer(servers)
   if (!sv) {
     if (loading) return { cls: 'text-text-dim', label: 'No signal', beating: false }
     return { cls: 'text-danger', label: 'Not Ready', beating: true }
@@ -122,6 +104,7 @@ export function Dashboard() {
   const bg = BG_STYLES[bgState]
   const bgInfo = status?.bg?.info ?? null
   const gameServers = status?.bg?.gameServers ?? []
+  const survivalPhase = findSurvivalServer(gameServers)?.phase?.trim() || ''
   const ports = status?.ports
   const tcp = ports?.results.filter(r => r.protocol === 'TCP') ?? []
   const openTcp = tcp.filter(r => r.status === 'open').length
@@ -255,15 +238,9 @@ export function Dashboard() {
             <p className="text-sm text-text-dim italic">No battlegroup info yet.</p>
           ) : (
             <dl className="grid grid-cols-[110px_1fr] gap-x-3 gap-y-1 text-sm leading-snug">
-              <dt className="text-text-dim" title="Funcom BG operator's overall state. 'Reconciling' is the operator's normal steady state while it manages the battlegroup, so it's reported as Healthy. The DB / Gateway / Director rows below show actual component health.">BG state</dt>
-              <dd className={bgStateDisplay(bgInfo.status).cls} title={`Operator status: ${bgInfo.status || 'unknown'}`}>
-                {bgStateDisplay(bgInfo.status).label}
-                {/reconcil/i.test(bgInfo.status || '') && (
-                  <span className="ml-2 text-[10px] uppercase tracking-wider text-text-dim font-normal"
-                        title="The BG operator is reconciling — its steady state while managing the battlegroup, usually settling a map spin-up/down. The DB / Gateway / Director rows below show actual component health.">
-                    reconciling
-                  </span>
-                )}
+              <dt className="text-text-dim" title="Survival_1 game-server phase. This is the login-facing battlegroup status signal.">BG Status</dt>
+              <dd className={healthClass(survivalPhase)} title={`Survival_1 phase: ${survivalPhase || 'unknown'}`}>
+                {survivalPhase || '—'}
               </dd>
               <dt className="text-text-dim">Database</dt>
               <dd className={healthClass(bgInfo.database)}>{bgInfo.database || '—'}</dd>

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, type FormEvent, type ReactElement } from 'react'
+import { useState, useEffect, useMemo, useCallback, type FormEvent, type KeyboardEvent, type ReactElement } from 'react'
 import { PageHeader } from '../components/PageHeader'
 import { Icon } from '../components/Icon'
 import { useStatus } from '../hooks/useStatus'
@@ -110,6 +110,19 @@ function valuesEqual(a: string, b: string): boolean {
     if (Number.isFinite(na) && Number.isFinite(nb)) return na === nb
   }
   return ta.toLowerCase() === tb.toLowerCase()
+}
+
+function copyTextToClipboard(text: string) {
+  const write = navigator.clipboard?.writeText(text)
+  if (write) void write.catch(() => { /* clipboard may be unavailable */ })
+}
+
+function copyIniSectionFromKey(e: KeyboardEvent<HTMLElement>, sectionName: string) {
+  if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'c') {
+    e.preventDefault()
+    e.stopPropagation()
+    copyTextToClipboard(`[${sectionName}]`)
+  }
 }
 
 // Build a human-readable result message for a client-apply that signifies what
@@ -1906,7 +1919,9 @@ function DefaultsSectionCard({
       <button
         type="button"
         onClick={onToggle}
+        onKeyDown={e => copyIniSectionFromKey(e, section.name)}
         className="w-full flex items-center justify-between px-3 py-2 bg-surface-2 hover:bg-surface-3 transition-colors text-left"
+        title={`Click to ${expanded ? 'collapse' : 'expand'}; Ctrl+C copies [${section.name}]`}
       >
         <span className="flex items-center gap-2 min-w-0">
           <Icon name={expanded ? 'ChevronDown' : 'ChevronRight'} size={13} className="shrink-0 text-text-muted" />
@@ -2094,7 +2109,12 @@ function AdvancedIniBrowser({ cfg }: { cfg: GameConfigResponse }) {
 function IniSectionBlock({ section }: { section: GameConfigIniSection }) {
   return (
     <div className="border border-border rounded-lg overflow-hidden">
-      <div className="flex items-center justify-between px-3 py-2 bg-surface-2">
+      <div
+        tabIndex={0}
+        onKeyDown={e => copyIniSectionFromKey(e, section.name)}
+        className="flex items-center justify-between px-3 py-2 bg-surface-2 focus:outline-none focus:ring-2 focus:ring-accent/50"
+        title={`Ctrl+C copies [${section.name}]`}
+      >
         <span className="font-mono text-xs text-text truncate" title={section.name}>[{section.name}]</span>
         {section.managed && (
           <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-accent/15 text-accent-bright shrink-0">
@@ -2205,4 +2225,3 @@ function SandwormConfirmModal({
     </div>
   )
 }
-

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -25,6 +25,7 @@ import {
   setFactionTier, setPlayerTags, setSkillPoints,
   setStarterClass, teleportToPlayer, updatePlayerTags, wipeCodex, wipeJourney,
   chatWhisper, isValidTemplateId, getItemCatalog,
+  parseTcnoPackageText,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
   getLandsraadOverview, getLandsraadPlayerContributions, setLandsraadContribution,
   getPlayerJourneyNodes, completeJourneyNode, resetJourneyNode,
@@ -846,8 +847,8 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
               })} />
           ) : def.custom === 'give-package' ? (
             <GivePackageForm busy={busy} playerName={player.name}
-              onGive={(items, pkgName) => runAction(def, async () => {
-                await giveItems(player.id, items)
+              onGive={(items, pkgName, overflow) => runAction(def, async () => {
+                await giveItems(player.id, items, overflow)
                 const n = items.length
                 return { message: `Gave package "${pkgName}" — ${n} item${n === 1 ? '' : 's'} to ${player.name}.` }
               })} />
@@ -994,16 +995,18 @@ interface PkgDraftRow { template: string; name: string; qty: string; quality: st
 
 function GivePackageForm({ busy, playerName, onGive }: {
   busy: boolean; playerName: string
-  onGive: (items: GiveItemEntry[], pkgName: string) => void
+  onGive: (items: GiveItemEntry[], pkgName: string, allowOverflow: boolean) => void
 }) {
   const [packages, setPackages] = useState<ItemPackage[]>([])
   const [loading, setLoading]   = useState(true)
   const [err, setErr]           = useState<string | null>(null)
   const [selectedId, setSelectedId] = useState('')
-  const [mode, setMode]         = useState<'list' | 'edit'>('list')
+  const [mode, setMode]         = useState<'list' | 'edit' | 'import'>('list')
   const [draftId, setDraftId]   = useState<string | undefined>(undefined)
   const [draftName, setDraftName] = useState('')
   const [draftRows, setDraftRows] = useState<PkgDraftRow[]>([])
+  const [importText, setImportText] = useState('')
+  const [overflow, setOverflow] = useState(false)
   const [saving, setSaving]     = useState(false)
 
   const load = useCallback(async (preferId?: string) => {
@@ -1030,6 +1033,11 @@ function GivePackageForm({ busy, playerName, onGive }: {
     setDraftId(undefined); setDraftName('')
     setDraftRows([{ template: '', name: '', qty: '1', quality: '0' }])
     setErr(null); setMode('edit')
+  }
+  const startImport = () => {
+    setDraftId(undefined); setDraftName('')
+    setImportText('')
+    setErr(null); setMode('import')
   }
   const startEdit = () => {
     if (!selected) return
@@ -1067,6 +1075,70 @@ function GivePackageForm({ busy, playerName, onGive }: {
     } finally {
       setSaving(false)
     }
+  }
+
+  const importPackage = async () => {
+    setSaving(true); setErr(null)
+    try {
+      const catalog = await getItemCatalog()
+      const parsed = parseTcnoPackageText(importText, catalog)
+      if (parsed.warnings.length > 0) {
+        setErr(parsed.warnings.join(' '))
+        return
+      }
+      if (parsed.items.length === 0) {
+        setErr('Paste at least one item and quantity.')
+        return
+      }
+      setDraftId(undefined)
+      setDraftName(draftName.trim() || 'Imported package')
+      setDraftRows(parsed.items.map(it => ({
+        template: it.template,
+        name: it.name,
+        qty: String(it.qty),
+        quality: String(it.quality ?? 0),
+      })))
+      setMode('edit')
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (mode === 'import') {
+    return (
+      <div className="space-y-3">
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Package name</label>
+          <input type="text" value={draftName} disabled={saving} maxLength={80}
+            placeholder="e.g. Deep Desert run kit"
+            onChange={e => setDraftName(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+        </div>
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Paste tcno.co item list</label>
+          <textarea value={importText} disabled={saving} rows={10}
+            placeholder={'Complex Machinery:\n50\nDuraluminum Ingot:\n150'}
+            onChange={e => setImportText(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+          <div className="mt-1 text-[11px] text-text-dim">
+            Format: item name line ending with ":" followed by quantity on the next line.
+          </div>
+        </div>
+        {err && <div className="text-xs text-error">{err}</div>}
+        <div className="grid grid-cols-2 gap-2">
+          <button className="btn-secondary" disabled={saving}
+            onClick={() => { setMode('list'); setErr(null) }}>
+            Cancel
+          </button>
+          <button className="btn-primary" disabled={saving || !importText.trim()}
+            onClick={() => void importPackage()}>
+            {saving ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Upload" size={13} />} Import to editor
+          </button>
+        </div>
+      </div>
+    )
   }
 
   if (mode === 'edit') {
@@ -1161,15 +1233,19 @@ function GivePackageForm({ busy, playerName, onGive }: {
         </>
       )}
       {err && <div className="text-xs text-error">{err}</div>}
+      {selected && <OverflowToggle checked={overflow} disabled={busy || saving} onChange={setOverflow} />}
       {selected && (
         <button className="btn-primary w-full" disabled={busy || saving}
-          onClick={() => onGive(selected.items, selected.name)}>
+          onClick={() => onGive(selected.items, selected.name, overflow)}>
           {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} Give to {playerName}
         </button>
       )}
-      <div className="grid grid-cols-3 gap-2">
+      <div className="grid grid-cols-4 gap-2">
         <button className="btn-secondary" disabled={busy || saving} onClick={startNew}>
           <Icon name="Plus" size={13} /> New
+        </button>
+        <button className="btn-secondary" disabled={busy || saving} onClick={startImport}>
+          <Icon name="Upload" size={13} /> Import
         </button>
         <button className="btn-secondary" disabled={busy || saving || !selected} onClick={startEdit}>
           <Icon name="Pencil" size={13} /> Edit

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -92,14 +92,14 @@ describe('Phase A — currency / progression writes', () => {
 })
 
 describe('Phase C/D/E/F — items, vehicles, teleport, progression, jobs', () => {
-  it('giveItems forwards the items array', async () => {
+  it('giveItems forwards the items array and overflow flag', async () => {
     const items = [
       { template: 'sword', qty: 1, quality: 5 },
       { template: 'shield', qty: 2 },
     ]
-    await gp.giveItems(11, items)
+    await gp.giveItems(11, items, true)
     expect(last().url).toBe('/api/gameplay/players/give-items')
-    expect(last().body).toEqual({ pawn_id: 11, items })
+    expect(last().body).toEqual({ pawn_id: 11, items, allow_overflow: true })
   })
 
   it('repairGear / repairVehicle / refuelVehicle hit the right URLs', async () => {
@@ -430,3 +430,41 @@ describe('flattenItemCatalog — catalog shape parsing', () => {
   })
 })
 
+describe('parseTcnoPackageText', () => {
+  const catalog: gp.CatalogItem[] = [
+    { template_id: 'ComplexMachinery', name: 'Complex Machinery', category: 'Resources' },
+    { template_id: 'DuraluminumRod', name: 'Duraluminum Ingot', category: 'Resources' },
+    { template_id: 'PlastaniumBar', name: 'Plastanium Ingot', category: 'Resources' },
+    { template_id: 'Silicone', name: 'Silicone Block', category: 'Resources' },
+    { template_id: 'MelangeSpice', name: 'Spice Melange', category: 'Resources' },
+  ]
+
+  it('imports tcno two-line item/quantity format by display name', () => {
+    const parsed = gp.parseTcnoPackageText(`Complex Machinery:
+50
+Duraluminum Ingot:
+150
+Plastanium Ingot:
+70
+Silicone Block:
+104
+Spice Melange:
+39`, catalog)
+
+    expect(parsed.warnings).toEqual([])
+    expect(parsed.items).toEqual([
+      { template: 'ComplexMachinery', name: 'Complex Machinery', qty: 50, quality: 0 },
+      { template: 'DuraluminumRod', name: 'Duraluminum Ingot', qty: 150, quality: 0 },
+      { template: 'PlastaniumBar', name: 'Plastanium Ingot', qty: 70, quality: 0 },
+      { template: 'Silicone', name: 'Silicone Block', qty: 104, quality: 0 },
+      { template: 'MelangeSpice', name: 'Spice Melange', qty: 39, quality: 0 },
+    ])
+  })
+
+  it('reports unknown names without creating partial hidden failures', () => {
+    const parsed = gp.parseTcnoPackageText('Mystery Goo:\n5', catalog)
+
+    expect(parsed.items).toEqual([])
+    expect(parsed.warnings).toEqual(['Unknown item "Mystery Goo"'])
+  })
+})


### PR DESCRIPTION
## Summary
- Fix Give Item stack capacity for ammo templates missing gameplay stack metadata.
- Add tcno.co item-list import flow for Give Package, with package naming/review before save.
- Allow online Give Package overflow to drop extra items to the ground.
- Repair current-only durability stats to 100/200 fallback targets instead of leaving valid damaged gear untouched.
- Add Ctrl+C copy for Game Config script/INI section headers.
- Bump release version to 12.5.8 and refresh release notes/bug-report diagnostics.

## Validation
- `Invoke-Pester -Path tests\PlayersWrites.Tests.ps1,tests\PlayersRmq.Tests.ps1 -CI`
- `cd webui; npm run test -- --run tests/api/gameplay.test.ts`
- `cd webui; npm run build`
- `pwsh app\installer\Build-Installer.ps1`
- `git diff --check`

## Release artifact
- Built installer: `app\installer\output\DuneServerSetup.exe`

## Notes
- `gitleaks detect --redact` still reports 5 pre-existing findings in `app/server/lib/Rmq.ps1`, `webui/src/pages/MapSpinUp.tsx`, `app/web/xterm.js`, and `app/data/gameplay-item-data.json`; none are from this release change.