### PR TITLE
feat(players): Progression Unlock UI + tag-search typeahead

### DIFF
--- a/app/server/lib/PlayersRead.ps1
+++ b/app/server/lib/PlayersRead.ps1
@@ -118,6 +118,30 @@ function Get-DuneTagsData {
     return $script:DuneTagsData
 }
 
+# ----- §1.0b GET /tags/catalog --------------------------------------------
+# The universe of known gameplay tags that can be written to a player, drawn
+# from the static catalog (journey_node_tags values + contract_tags values).
+# Used by the player Tags editor to power a typeahead. The frontend derives a
+# friendly label + category from each raw tag string.
+function Get-DuneTagCatalog {
+    $tags = Get-DuneTagsData
+    $set = @{}
+    foreach ($k in $tags.journeyNodeTags.Keys) {
+        foreach ($t in @($tags.journeyNodeTags[$k])) {
+            $s = [string]$t
+            if ($s) { $set[$s] = $true }
+        }
+    }
+    foreach ($k in $tags.contractTags.Keys) {
+        foreach ($t in @($tags.contractTags[$k])) {
+            $s = [string]$t
+            if ($s) { $set[$s] = $true }
+        }
+    }
+    $list = @($set.Keys | Sort-Object)
+    return @{ ok = $true; tags = $list; total = $list.Count }
+}
+
 # ----- §1.1 GET /players/online -------------------------------------------
 function Get-DunePlayersOnlineLive {
     param([string]$Ip)

--- a/app/server/routes/PlayersRead.ps1
+++ b/app/server/routes/PlayersRead.ps1
@@ -202,6 +202,21 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/players/main-quests' -Handle
     }
 }
 
+# GET /api/gameplay/tags/catalog  (known gameplay tag universe for the Tags editor typeahead)
+Register-DuneRoute -Method GET -Path '/api/gameplay/tags/catalog' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $payload = Get-DuneTagCatalog
+        Write-DuneJson -Response $res -Body @{
+            tags   = $payload.tags
+            total  = $payload.total
+            source = 'catalog'
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Tag catalog failed: $($_.Exception.Message)"
+    }
+}
+
 # GET /api/gameplay/contracts  (contract tag catalog)
 Register-DuneRoute -Method GET -Path '/api/gameplay/contracts' -Handler {
     param($req, $res, $routeParams, $body)

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1171,11 +1171,96 @@ export function filterCatalog(catalog: CatalogItem[], query: string, limit = 20,
   return out.slice(0, limit).map(o => o.item)
 }
 
-export interface PackageImportItem extends GiveItemEntry {
-  name: string
+// ---------------------------------------------------------------------------
+// Tag catalog — the universe of known gameplay tags (Contract.*, DialogueFlags.*,
+// Journey.*, etc.) that can be written to a player. Powers the Tags editor
+// typeahead. The backend serves the raw tag strings; we derive a friendly label
+// + category client-side so the picker reads "Friendly Name  raw.tag.id".
+// ---------------------------------------------------------------------------
+export interface TagCatalogEntry {
+  tag: string       // raw tag string written to the player
+  label: string     // friendly, humanized breadcrumb label
+  category: string  // first dotted segment (Contract, DialogueFlags, Journey, …)
 }
 
-export interface PackageImportResult {
+/** First dotted segment of a tag, e.g. "Contract" — used as a coarse category. */
+export function tagCategory(tag: string): string {
+  const i = tag.indexOf('.')
+  return (i > 0 ? tag.slice(0, i) : tag).trim()
+}
+
+/** Humanize one tag segment: de-CamelCase, split letter/digit runs, drop underscores. */
+function humanizeSegment(seg: string): string {
+  return seg
+    .replace(/_/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Za-z])([0-9])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** Friendly breadcrumb label for a tag, e.g.
+ *  "Contract.Tracking.Completed.SeronVarlin.Contract1" ->
+ *  "Contract › Tracking › Completed › Seron Varlin › Contract 1". */
+export function tagFriendlyLabel(tag: string): string {
+  const parts = tag.split('.').map(humanizeSegment).filter(Boolean)
+  return parts.length ? parts.join(' › ') : tag
+}
+
+let _tagCatalogCache: TagCatalogEntry[] | null = null
+let _tagCatalogPromise: Promise<TagCatalogEntry[]> | null = null
+
+interface TagCatalogResponse { tags?: string[]; total?: number; source?: string }
+
+/** Load + cache the known-tag catalog (~400 entries). Fetched once per session. */
+export function getTagCatalog(): Promise<TagCatalogEntry[]> {
+  if (_tagCatalogCache) return Promise.resolve(_tagCatalogCache)
+  if (_tagCatalogPromise) return _tagCatalogPromise
+  _tagCatalogPromise = api<TagCatalogResponse>('/api/gameplay/tags/catalog').then(r => {
+    const flat = (r.tags || [])
+      .map(t => String(t).trim())
+      .filter(Boolean)
+      .map(tag => ({ tag, label: tagFriendlyLabel(tag), category: tagCategory(tag) }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+    _tagCatalogCache = flat
+    _tagCatalogPromise = null
+    return flat
+  }).catch(e => {
+    _tagCatalogPromise = null
+    throw e
+  })
+  return _tagCatalogPromise
+}
+
+/**
+ * Case-insensitive filter over friendly label OR raw tag. Entries whose tag is
+ * in `exclude` (tags the player already has) are dropped. Empty query returns
+ * the first `limit` entries so focusing the field shows a browsable list.
+ */
+export function filterTagCatalog(
+  catalog: TagCatalogEntry[], query: string, limit = 50, exclude?: Set<string>,
+): TagCatalogEntry[] {
+  const q = query.trim().toLowerCase()
+  const avail = exclude && exclude.size > 0 ? catalog.filter(e => !exclude.has(e.tag)) : catalog
+  if (!q) return avail.slice(0, limit)
+  const out: { entry: TagCatalogEntry; rank: number }[] = []
+  for (const e of avail) {
+    const tag = e.tag.toLowerCase()
+    const lbl = e.label.toLowerCase()
+    let rank = -1
+    if (tag === q || lbl === q)                 rank = 0
+    else if (tag.startsWith(q))                 rank = 1
+    else if (lbl.startsWith(q))                 rank = 2
+    else if (tag.includes(q) || lbl.includes(q)) rank = 3
+    if (rank >= 0) out.push({ entry: e, rank })
+  }
+  out.sort((a, b) => a.rank - b.rank || a.entry.label.localeCompare(b.entry.label))
+  return out.slice(0, limit).map(o => o.entry)
+}
+
+export interface PackageImportItem extends GiveItemEntry {
+  name: string
+}export interface PackageImportResult {
   items: PackageImportItem[]
   warnings: string[]
 }
@@ -1541,15 +1626,18 @@ export function teleportToPlayer(sourcePawnId: number, targetPawnId: number) {
   })
 }
 
-export function progressionUnlock(pawnId: number, nodeIds: string[]) {
+// Progression Unlock — completes the DA_FQ_ClimbTheRanks journey nodes for the
+// chosen faction and writes the faction tier tags + reputation. preset picks how
+// far: 'ch3_start' (tier 5) or 'rank19_eligible' (tier 19, +Landsraad nodes).
+export function progressionUnlock(actorId: number, faction: string, preset: string) {
   return api<WriteResult>('/api/gameplay/players/progression-unlock', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, node_ids: nodeIds }),
+    method: 'POST', body: JSON.stringify({ actor_id: actorId, faction, preset }),
   })
 }
 
-export function progressionReverse(pawnId: number, nodeIds: string[]) {
+export function progressionReverse(actorId: number, faction: string, preset: string) {
   return api<WriteResult>('/api/gameplay/players/progression-reverse', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, node_ids: nodeIds }),
+    method: 'POST', body: JSON.stringify({ actor_id: actorId, faction, preset }),
   })
 }
 

--- a/webui/src/components/TagPicker.tsx
+++ b/webui/src/components/TagPicker.tsx
@@ -1,0 +1,170 @@
+// TagPicker — typeahead autocomplete for the known gameplay-tag catalog.
+// Used in the player Tags editor. Lazy-loads the catalog on first focus, filters
+// on every keystroke against the friendly label OR the raw tag, and renders the
+// matches as an INLINE, scrollable, paginated list (25 per page) directly under
+// the input — not a floating popup, so it scrolls normally even when the editor
+// sits at the bottom of a long page. Tags the player already has are excluded.
+// Picking a row emits the raw tag string.
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { Icon } from './Icon'
+import { filterTagCatalog, getTagCatalog, type TagCatalogEntry } from '../api/gameplay'
+
+const PAGE_SIZE = 25
+
+interface Props {
+  value: string
+  onChange: (text: string) => void
+  /** Called when a suggestion is chosen — receives the raw tag string. */
+  onPick: (tag: string) => void
+  /** Called on Enter when no suggestion is active — lets the parent add the raw typed text. */
+  onEnterRaw?: () => void
+  /** Tags the player already has — excluded from suggestions. */
+  exclude?: string[]
+  placeholder?: string
+  autoFocus?: boolean
+  disabled?: boolean
+}
+
+export function TagPicker({ value, onChange, onPick, onEnterRaw, exclude, placeholder, autoFocus, disabled }: Props) {
+  const inputId = useId()
+  const [catalog, setCatalog] = useState<TagCatalogEntry[] | null>(null)
+  const [catalogError, setCatalogError] = useState<string | null>(null)
+  const [catalogLoading, setCatalogLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [active, setActive] = useState(0)
+  const [page, setPage] = useState(0)
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const ensureCatalog = useCallback(() => {
+    if (catalog || catalogLoading) return
+    setCatalogLoading(true)
+    getTagCatalog()
+      .then(setCatalog)
+      .catch(e => setCatalogError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setCatalogLoading(false))
+  }, [catalog, catalogLoading])
+
+  const excludeSet = useMemo(() => new Set(exclude || []), [exclude])
+  const matches: TagCatalogEntry[] = catalog
+    ? filterTagCatalog(catalog, value, Number.MAX_SAFE_INTEGER, excludeSet)
+    : []
+
+  const pageCount = Math.max(1, Math.ceil(matches.length / PAGE_SIZE))
+  const pageClamped = Math.min(page, pageCount - 1)
+  const visible = matches.slice(pageClamped * PAGE_SIZE, pageClamped * PAGE_SIZE + PAGE_SIZE)
+
+  // Close when clicking outside the picker.
+  useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (wrapRef.current?.contains(e.target as Node)) return
+      setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [])
+
+  // Keep the highlighted row scrolled into view within the list.
+  useEffect(() => {
+    if (!open) return
+    listRef.current?.querySelector<HTMLElement>(`[data-idx="${active}"]`)?.scrollIntoView({ block: 'nearest' })
+  }, [active, open])
+
+  const setQuery = (text: string) => { onChange(text); setOpen(true); setActive(0); setPage(0) }
+  const goPage = (p: number) => { setPage(Math.max(0, Math.min(p, pageCount - 1))); setActive(0) }
+
+  const pick = (e: TagCatalogEntry) => { onPick(e.tag); setActive(0) }
+
+  const onKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      if (!open && catalog) { setOpen(true); setActive(0) }
+      else setActive(a => Math.min(a + 1, Math.max(visible.length - 1, 0)))
+      e.preventDefault()
+    } else if (e.key === 'ArrowUp') {
+      setActive(a => Math.max(a - 1, 0)); e.preventDefault()
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (open && visible.length > 0) pick(visible[active])
+      else onEnterRaw?.()
+    } else if (e.key === 'Escape') {
+      setOpen(false); e.preventDefault()
+    }
+  }
+
+  return (
+    <div ref={wrapRef} className="relative flex-1 min-w-0">
+      <div className="relative">
+        <input
+          id={inputId}
+          type="text"
+          autoComplete="off"
+          spellCheck={false}
+          disabled={disabled}
+          autoFocus={autoFocus}
+          value={value}
+          placeholder={placeholder || 'Search tags…'}
+          onFocus={() => { ensureCatalog(); setOpen(true) }}
+          onChange={e => setQuery(e.target.value)}
+          onKeyDown={onKey}
+          className="w-full pl-9 pr-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
+        />
+        <Icon name="Search" size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-dim pointer-events-none" />
+      </div>
+
+      {open && (
+        <div className="mt-2 rounded-lg border border-border bg-surface overflow-hidden">
+          <div className="flex items-center justify-between px-3 py-1.5 border-b border-border text-[11px] text-text-dim">
+            <span>
+              {catalogLoading ? 'Loading tag catalog…'
+                : catalogError ? <span className="text-danger">Load failed</span>
+                : `${matches.length} match${matches.length === 1 ? '' : 'es'}`}
+            </span>
+            {pageCount > 1 && (
+              <span className="flex items-center gap-2">
+                <button type="button" className="px-1.5 py-0.5 rounded hover:bg-surface-2 disabled:opacity-40"
+                  disabled={pageClamped <= 0} onMouseDown={ev => { ev.preventDefault(); goPage(pageClamped - 1) }}>
+                  <Icon name="ChevronLeft" size={13} />
+                </button>
+                <span className="tabular-nums">Page {pageClamped + 1} / {pageCount}</span>
+                <button type="button" className="px-1.5 py-0.5 rounded hover:bg-surface-2 disabled:opacity-40"
+                  disabled={pageClamped >= pageCount - 1} onMouseDown={ev => { ev.preventDefault(); goPage(pageClamped + 1) }}>
+                  <Icon name="ChevronRight" size={13} />
+                </button>
+              </span>
+            )}
+          </div>
+
+          <div ref={listRef} className="max-h-72 overflow-y-auto overscroll-contain divide-y divide-border/60">
+            {catalogError && (
+              <div className="px-3 py-2 text-xs text-danger">{catalogError}</div>
+            )}
+            {!catalogLoading && !catalogError && matches.length === 0 && (
+              <div className="px-3 py-2 text-xs text-text-dim">
+                {value.trim().length > 0
+                  ? <>No known tags match "{value}". Press <span className="text-text">Add</span> to use it anyway.</>
+                  : 'No more tags to add.'}
+              </div>
+            )}
+            {visible.map((e, i) => (
+              <div
+                key={e.tag}
+                data-idx={i}
+                role="button"
+                tabIndex={-1}
+                onMouseEnter={() => setActive(i)}
+                onMouseDown={ev => { ev.preventDefault(); pick(e) }}
+                className={`px-3 py-2 cursor-pointer flex flex-col gap-0.5 ${
+                  i === active ? 'bg-surface-2' : 'hover:bg-surface-2/60'
+                }`}
+              >
+                <span className="text-sm text-text">{e.label}</span>
+                <span className="text-[11px] font-mono text-text-dim truncate">{e.tag}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -260,6 +260,7 @@ function SpecRow({ name, track, canWrite, busy, onGrantMax, onReset, onAdd5k }: 
 // Tags — chip list with add/remove + Save button. Writes the full set in
 // one POST (matches backend's replace semantics).
 // ---------------------------------------------------------------------------
+const TAGS_PAGE_SIZE = 25
 export function TagsSection({ player, canWrite, demo, refreshKey, flash, onChanged }: SectionProps) {
   const [tags, setTags] = useState<string[]>([])
   const [draft, setDraft] = useState('')
@@ -268,6 +269,7 @@ export function TagsSection({ player, canWrite, demo, refreshKey, flash, onChang
   const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  const [tagPage, setTagPage] = useState(0)
 
   useEffect(() => {
     let alive = true
@@ -304,6 +306,12 @@ export function TagsSection({ player, canWrite, demo, refreshKey, flash, onChang
     }
   }
 
+  const filteredTags = tags
+
+  const tagPageCount = Math.max(1, Math.ceil(filteredTags.length / TAGS_PAGE_SIZE))
+  const tagPageClamped = Math.min(tagPage, tagPageCount - 1)
+  const tagRows = filteredTags.slice(tagPageClamped * TAGS_PAGE_SIZE, (tagPageClamped + 1) * TAGS_PAGE_SIZE)
+
   if (loading) return <Loading label="Loading tags…" />
 
   return (
@@ -319,7 +327,7 @@ export function TagsSection({ player, canWrite, demo, refreshKey, flash, onChang
         <div className="flex gap-2 items-start">
           <TagPicker value={draft} onChange={setDraft} exclude={tags}
             onPick={addTagValue} onEnterRaw={add} disabled={busy}
-            placeholder="Search tags by name or id…" />
+            placeholder="Search tags to add by name or id…" />
           <button className="btn-secondary" onClick={add} disabled={busy || !draft.trim()}>
             <Icon name="Plus" size={13} /> Add
           </button>
@@ -329,24 +337,41 @@ export function TagsSection({ player, canWrite, demo, refreshKey, flash, onChang
         </div>
       )}
 
-      <div className="card p-3">
-        {tags.length === 0 ? (
-          <div className="text-sm text-text-dim">No tags. Add one above.</div>
-        ) : (
-          <div className="flex flex-wrap gap-2">
-            {tags.map(t => (
-              <span key={t} className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full bg-surface-2 border border-border text-xs text-text">
-                {t}
+      {tags.length === 0 ? (
+        <EmptyBox msg="No tags. Add one above." />
+      ) : (
+        <>
+          <div className="space-y-1">
+            {tagRows.map(t => (
+              <div key={t} className="card px-3 py-2 flex items-center gap-2">
+                <span className="flex-1 min-w-0 font-mono text-xs text-text truncate" title={t}>{t}</span>
                 {canWrite && !unsupported && (
-                  <button className="text-text-dim hover:text-danger" onClick={() => remove(t)} title="Remove">
-                    <Icon name="X" size={11} />
+                  <button type="button" className="btn-secondary text-[11px] px-2 py-1 text-error shrink-0"
+                    onClick={() => remove(t)} title="Remove tag">
+                    <Icon name="X" size={11} /> Remove
                   </button>
                 )}
-              </span>
+              </div>
             ))}
           </div>
-        )}
-      </div>
+
+          {tagPageCount > 1 && (
+            <div className="flex items-center justify-between text-xs text-text-dim">
+              <span>{fmtNum(filteredTags.length)} tag(s) · page {tagPageClamped + 1} of {tagPageCount}</span>
+              <div className="flex gap-1">
+                <button type="button" className="btn-secondary px-2 py-1" disabled={tagPageClamped <= 0}
+                  onClick={() => setTagPage(p => Math.max(0, p - 1))}>
+                  <Icon name="ChevronLeft" size={13} />
+                </button>
+                <button type="button" className="btn-secondary px-2 py-1" disabled={tagPageClamped >= tagPageCount - 1}
+                  onClick={() => setTagPage(p => Math.min(tagPageCount - 1, p + 1))}>
+                  <Icon name="ChevronRight" size={13} />
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
     </div>
   )
 }

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -10,9 +10,11 @@
 import { useCallback, useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react'
 import { Icon } from '../../../components/Icon'
 import { ItemPicker } from '../../../components/ItemPicker'
+import { TagPicker } from '../../../components/TagPicker'
 import {
   awardCharXp, awardIntel, awardSpecXp, cheatScript, cleanPlayerInventory,
   applyProgressionPreset, getProgressionPresets,
+  progressionUnlock, progressionReverse,
   deleteAccount, deleteInventoryItem, deleteTutorials,
   fillWater, getPlayerEvents, getPlayerSpecs,
   getPlayerStats, getPlayerTags, giveFactionRep, giveItem,
@@ -277,8 +279,9 @@ export function TagsSection({ player, canWrite, demo, refreshKey, flash, onChang
     return () => { alive = false }
   }, [player.account_id, demo, refreshKey])
 
-  const add = () => {
-    const t = draft.trim()
+  const add = () => addTagValue(draft)
+  const addTagValue = (raw: string) => {
+    const t = raw.trim()
     if (!t) return
     if (tags.includes(t)) { setDraft(''); return }
     setTags([...tags, t].sort())
@@ -312,9 +315,23 @@ export function TagsSection({ player, canWrite, demo, refreshKey, flash, onChang
         </div>
       )}
 
+      {canWrite && !unsupported && (
+        <div className="flex gap-2 items-start">
+          <TagPicker value={draft} onChange={setDraft} exclude={tags}
+            onPick={addTagValue} onEnterRaw={add} disabled={busy}
+            placeholder="Search tags by name or id…" />
+          <button className="btn-secondary" onClick={add} disabled={busy || !draft.trim()}>
+            <Icon name="Plus" size={13} /> Add
+          </button>
+          <button className="btn-primary" onClick={save} disabled={busy || !dirty}>
+            <Icon name="Save" size={13} /> Save
+          </button>
+        </div>
+      )}
+
       <div className="card p-3">
         {tags.length === 0 ? (
-          <div className="text-sm text-text-dim">No tags. Add one below.</div>
+          <div className="text-sm text-text-dim">No tags. Add one above.</div>
         ) : (
           <div className="flex flex-wrap gap-2">
             {tags.map(t => (
@@ -330,21 +347,6 @@ export function TagsSection({ player, canWrite, demo, refreshKey, flash, onChang
           </div>
         )}
       </div>
-
-      {canWrite && !unsupported && (
-        <div className="flex gap-2">
-          <input type="text" value={draft} onChange={e => setDraft(e.target.value)}
-            placeholder="Add tag (e.g. VIP, Banned, Verified)…" maxLength={64}
-            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add() } }}
-            className="flex-1 px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
-          <button className="btn-secondary" onClick={add} disabled={busy || !draft.trim()}>
-            <Icon name="Plus" size={13} /> Add
-          </button>
-          <button className="btn-primary" onClick={save} disabled={busy || !dirty}>
-            <Icon name="Save" size={13} /> Save
-          </button>
-        </div>
-      )}
     </div>
   )
 }
@@ -439,7 +441,7 @@ interface ActionDef {
   liveOnly?: boolean      // requires player to be online (RMQ path)
   offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   fields?: ActionField[]
-  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'refuel-vehicle' | 'starter-class' | 'update-tags'
+  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'update-tags'
   balance?: 'solari' | 'scrip' | 'intel'  // show the player's current balance read-only above the form
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
@@ -489,6 +491,9 @@ const ACTIONS: ActionDef[] = [
     run: (p, v) => setFactionTier(p.controller_id, String(v.faction || 'atreides').trim(), Number(v.tier) || 0) },
   { id: 'apply-progression-preset', group: 'Progression', label: 'Apply Quick Preset', icon: 'Zap', custom: 'quick-presets',
     rowNote: 'Completes a story/journey chapter instantly',
+    run: () => Promise.resolve({ message: '' }) },
+  { id: 'progression-unlock', group: 'Progression', label: 'Progression Unlock', icon: 'Milestone', custom: 'progression-unlock',
+    rowNote: 'Completes DA_FQ_ClimbTheRanks journey nodes + writes faction tier tags',
     run: () => Promise.resolve({ message: '' }) },
   { id: 'unlock-trainers', group: 'Progression', label: 'Unlock Trainers', icon: 'GraduationCap', custom: 'unlock-trainers',
     rowNote: 'Complete a skill-trainer quest line + grant its skill tree — separated by trainer',
@@ -844,6 +849,16 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
               onSubmit={(quest, name) => runAction(def, async () => {
                 const r = await unlockMainQuest(player.account_id, quest)
                 return { message: r.message || `Unlocked main quest "${name}" for ${player.name}.` }
+              })} />
+          ) : def.custom === 'progression-unlock' ? (
+            <ProgressionUnlockForm busy={busy}
+              onUnlock={(faction, preset, presetName) => runAction(def, async () => {
+                const r = await progressionUnlock(player.id, faction, preset)
+                return { message: r.message || `Progression unlock (${presetName}) applied for ${player.name}.` }
+              })}
+              onReverse={(faction, preset, presetName) => runAction(def, async () => {
+                const r = await progressionReverse(player.id, faction, preset)
+                return { message: r.message || `Progression unlock (${presetName}) reversed for ${player.name}.` }
               })} />
           ) : def.custom === 'give-package' ? (
             <GivePackageForm busy={busy} playerName={player.name}
@@ -1660,6 +1675,60 @@ function UnlockMainQuestForm({ busy, onSubmit }: { busy: boolean; onSubmit: (que
         onClick={() => onSubmit(sel, chosen?.name || sel)}>
         {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Flag" size={13} />} Unlock Main Quest
       </button>
+    </div>
+  )
+}
+
+// Progression Unlock — faction + stage picker that drives the existing
+// progression-unlock / progression-reverse routes. Completes the
+// DA_FQ_ClimbTheRanks journey nodes for the chosen faction and writes the
+// faction tier tags + reputation. 'Ch3 Start' = tier 5 (start of chapter 3);
+// 'Rank 19 Eligible' = tier 19 + the Landsraad onboarding nodes. Works for both
+// Atreides and Harkonnen. Takes effect on next login.
+const PROGRESSION_PRESETS: { value: string; label: string }[] = [
+  { value: 'ch3_start', label: 'Ch3 Start' },
+  { value: 'rank19_eligible', label: 'Rank 19 Eligible' },
+]
+function ProgressionUnlockForm({ busy, onUnlock, onReverse }: {
+  busy: boolean
+  onUnlock: (faction: string, preset: string, presetName: string) => void
+  onReverse: (faction: string, preset: string, presetName: string) => void
+}) {
+  const [faction, setFaction] = useState('atreides')
+  const [preset, setPreset] = useState('ch3_start')
+  const presetName = PROGRESSION_PRESETS.find(p => p.value === preset)?.label || preset
+  const selectCls = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50'
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Faction</label>
+          <select value={faction} disabled={busy} className={selectCls} onChange={e => setFaction(e.target.value)}>
+            <option value="atreides">Atreides</option>
+            <option value="harkonnen">Harkonnen</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Stage</label>
+          <select value={preset} disabled={busy} className={selectCls} onChange={e => setPreset(e.target.value)}>
+            {PROGRESSION_PRESETS.map(p => <option key={p.value} value={p.value}>{p.label}</option>)}
+          </select>
+        </div>
+      </div>
+      <div className="text-[11px] text-text-muted">
+        Completes the <span className="text-text">DA_FQ_ClimbTheRanks</span> journey nodes and writes the faction tier tags + reputation.
+        {' '}<span className="text-text">Ch3 Start</span> sets tier 5; <span className="text-text">Rank 19 Eligible</span> sets tier 19 and adds the Landsraad onboarding nodes. Takes effect on next login.
+      </div>
+      <div className="flex gap-2">
+        <button className="btn-primary flex-1" disabled={busy}
+          onClick={() => onUnlock(faction, preset, presetName)}>
+          {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Milestone" size={13} />} Apply Unlock
+        </button>
+        <button className="btn-ghost flex-1" disabled={busy}
+          onClick={() => onReverse(faction, preset, presetName)}>
+          {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Undo2" size={13} />} Reverse Unlock
+        </button>
+      </div>
     </div>
   )
 }

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -124,12 +124,13 @@ describe('Phase C/D/E/F — items, vehicles, teleport, progression, jobs', () =>
   })
 
   it('progressionUnlock + progressionReverse + applyProgressionPreset', async () => {
-    await gp.progressionUnlock(11, ['n1', 'n2'])
-    expect(last().body).toEqual({ pawn_id: 11, node_ids: ['n1', 'n2'] })
+    await gp.progressionUnlock(11, 'atreides', 'ch3_start')
+    expect(last().url).toBe('/api/gameplay/players/progression-unlock')
+    expect(last().body).toEqual({ actor_id: 11, faction: 'atreides', preset: 'ch3_start' })
 
-    await gp.progressionReverse(11, ['n1'])
+    await gp.progressionReverse(11, 'harkonnen', 'rank19_eligible')
     expect(last().url).toBe('/api/gameplay/players/progression-reverse')
-    expect(last().body).toEqual({ pawn_id: 11, node_ids: ['n1'] })
+    expect(last().body).toEqual({ actor_id: 11, faction: 'harkonnen', preset: 'rank19_eligible' })
 
     await gp.applyProgressionPreset(11, 'survival-starter')
     expect(last().url).toBe('/api/gameplay/players/progression/apply-preset')


### PR DESCRIPTION
## Summary

Two player-admin features, both wired to existing/extended backend routes.

### Progression Unlock (Players → Progression)
- New panel surfacing the existing `progression-unlock` / `progression-reverse` routes that previously had **no UI**.
- Faction picker (**Atreides / Harkonnen**) + stage picker (**Ch3 Start** = tier 5, **Rank 19 Eligible** = tier 19 + Landsraad onboarding nodes) + **Apply Unlock** / **Reverse Unlock**.
- Completes the `DA_FQ_ClimbTheRanks` journey nodes and writes faction tier tags + reputation. Takes effect next login.
- Fixed the stale `progressionUnlock`/`progressionReverse` API fns (were `pawn_id, node_ids`) to the real backend contract (`actor_id, faction, preset`); updated the test.

### Tags editor typeahead (Players → Tags)
- New `TagPicker`: search-as-you-type over the known gameplay-tag catalog.
- **Friendly names** (breadcrumb, e.g. `Contract › Tracking › Completed › Seron Varlin › Contract 1`) above the raw tag id.
- **Excludes tags the player already has** from suggestions.
- Results render as an **inline, scrollable list paginated 25 per page** (replaces the floating popup that opened off-screen and couldn't scroll).
- Search bar moved **above** the current-tags chips.
- New backend route `GET /api/gameplay/tags/catalog` (`Get-DuneTagCatalog`) serving the union of `journey_node_tags` + `contract_tags` from `dune-tags.json` (414 tags).

## Verification
- webui build + typecheck clean; 51/51 vitest tests pass; new files lint clean.
- PowerShell files parse-check OK; installer build passes version-stamp + encoding pre-flights.
- Backend route smoke-tested: returns 414 tags.

## Notes
- No version bump (feature work, not a release).
- Scoped strictly to feature files; unrelated local working-tree edits to `eslint.config.js` / `tests/_TestHelpers.ps1` were intentionally left out.