### PR TITLE
release: v12.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.5.9"
+      placeholder: "v12.6.0"
     validations:
       required: true
 
@@ -88,6 +88,8 @@ body:
         - Web portal — Gameplay Admin — Players — Cheat Scripts / Dev-Perf Scripts (Live)
         - Web portal — Gameplay Admin — Players — Journey (node browser / complete / reset / wipe)
         - Web portal — Gameplay Admin — Players — Unlock Trainers (skill-tree ownership status) / Unlock Main Quest (Progression)
+        - Web portal — Gameplay Admin — Players — Progression Unlock (Ch3 Start / Rank 19 Eligible, Atreides/Harkonnen)
+        - Web portal — Gameplay Admin — Players — Tags (search/add typeahead + tag list)
         - Web portal — Gameplay Admin — Players — Landsraad (contribution editor)
         - Web portal — Gameplay Admin — Bases
         - Web portal — Gameplay Admin — Storage
@@ -116,7 +118,7 @@ body:
     attributes:
       label: Specific page / button / command
       description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug?
-      placeholder: "e.g. Server Health 'Restart battlegroup' button, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > Crafting > Repair Cost Weight, Game Config > All Default Settings > Ctrl+C section header, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Market Bot > Pricing rules > Market-follow pricing toggle, Gameplay Admin > Market Bot > Pricing rules > Market markup %, Gameplay Admin > Market Bot > Buy side > Over-market guard, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Package > Import tcno.co list, Gameplay Admin > Players > Give Package (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > inventory item > Repair, Gameplay Admin > Players > inventory item > Stack quantity, Gameplay Admin > Storage > container item > Stack quantity, Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Journey > Complete node, Gameplay Admin > Players > Actions > Unlock Trainers > Swordmaster, Gameplay Admin > Players > Actions > Unlock Main Quest > A New Beginning, Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Map SpinUp > Arrakeen loading counter, Map SpinUp > Restart Hagga, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
+      placeholder: "e.g. Server Health 'Restart battlegroup' button, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > Crafting > Repair Cost Weight, Game Config > All Default Settings > Ctrl+C section header, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Market Bot > Pricing rules > Market-follow pricing toggle, Gameplay Admin > Market Bot > Pricing rules > Market markup %, Gameplay Admin > Market Bot > Buy side > Over-market guard, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Package > Import tcno.co list, Gameplay Admin > Players > Give Package (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > inventory item > Repair, Gameplay Admin > Players > inventory item > Stack quantity, Gameplay Admin > Storage > container item > Stack quantity, Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Journey > Complete node, Gameplay Admin > Players > Progression > Progression Unlock > Apply Unlock (Atreides Ch3 Start), Gameplay Admin > Players > Tags > search/add tag, Gameplay Admin > Players > Actions > Unlock Trainers > Swordmaster, Gameplay Admin > Players > Actions > Unlock Main Quest > A New Beginning, Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Map SpinUp > Arrakeen loading counter, Map SpinUp > Restart Hagga, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.6.0] - 2026-06-17
+
+### Added
+
+- **Progression Unlock (Players → Progression).** New panel that completes the
+  `DA_FQ_ClimbTheRanks` journey nodes and writes the faction tier tags +
+  reputation for a player. Pick a faction (Atreides or Harkonnen) and a stage —
+  **Ch3 Start** (faction tier 5, start of chapter 3) or **Rank 19 Eligible**
+  (tier 19 plus the Landsraad onboarding nodes) — then **Apply Unlock** or
+  **Reverse Unlock**. Takes effect on the player's next login.
+- **Tag search in the player Tags editor.** The Add box is now a typeahead over
+  the known gameplay-tag catalog: search as you type, see a friendly breadcrumb
+  name above each raw tag id, and pick from an inline scrollable list paginated
+  25 per page. Tags the player already has are excluded from suggestions. Backed
+  by a new `GET /api/gameplay/tags/catalog` endpoint.
+
+### Changed
+
+- **Player Tags list display.** The current tags are now shown as a paginated
+  vertical row list (25 per page) matching the Journey browser, instead of a
+  wrapped chip cloud.
+
 ## [12.5.9] - 2026-06-17
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.5.9'
+$script:DuneToolVersion = '12.6.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.5.9',
+    [string]$Version = '12.6.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.5.9</Version>
+    <Version>12.6.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.5.9"
+#define MyAppVersion "12.6.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.5.9"
+$script:ToolVersion = "12.6.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Release prep for **v12.6.0**.

- Bumps all five version stamps `12.5.9` → `12.6.0` (DuneServer.ps1, Build-Exe.ps1, DuneShell.csproj, DuneServer.iss, dune-server.ps1).
- Rolls `CHANGELOG.md` `[Unreleased]` into `[12.6.0] - 2026-06-17`.
- Refreshes `bug_report.yml`: version placeholder → v12.6.0, adds Progression Unlock + Tags surfaces to the "where" dropdown and the menu-option examples.

Ships the features merged in #270: **Progression Unlock** (Ch3 Start / Rank 19 Eligible, both factions) and the **Tags search typeahead + paginated tag list**.

Installer rebuilt and version-stamp + encoding pre-flights pass.