### PR TITLE
fix(market-bot): pay sellers full Solari on buy (10× underpayment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Market Bot underpaid sellers 10× on buy.** When Duke bought a player's sell
+  listing, the seller payment order (and Duke's balance debit) used the raw
+  stored `item_price` instead of the player-facing Solari value (`item_price ×
+  10`). A listing worth 180,000 Solari paid the seller only 18,000. The payout
+  and debit are now denominated in Solari so sellers receive exactly their
+  listed price. (#274)
+
 ## [12.6.1] - 2026-06-17
 
 ### Fixed

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -1074,6 +1074,13 @@ LIMIT $limit
         $stack     = ConvertTo-DuneInt $row['actual_stack']
         if ($stack -le 0) { $stack = 1 }
         $totalCost = $price * $stack
+        # Player-facing Solari = stored item_price * 10 (the same convention the
+        # sell side uses, and the listing price the seller chose in-game). The
+        # seller payout order + Duke's balance debit are denominated in literal
+        # Solari, so they must use the *display* value, not the raw item_price.
+        # Writing the raw value here underpaid sellers 10x (issue #274).
+        $payoutUnit  = $price * 10
+        $payoutTotal = $totalCost * 10
 
         # Over-market guard: dice hit, but bail if the price is above the window.
         if ($guardOn) {
@@ -1111,7 +1118,7 @@ LIMIT $limit
             }
         }
 
-        $winner = [ordered]@{ template_id = $tmpl; order_id = $orderId; price = ($price * 10); stack = $stack; roll = $roll }
+        $winner = [ordered]@{ template_id = $tmpl; order_id = $orderId; price = $payoutUnit; stack = $stack; roll = $roll }
 
         if ($DryRun) {
             $summary.purchased++   # would-buy count
@@ -1127,12 +1134,12 @@ INSERT INTO dune.dune_exchange_orders
   (exchange_id, access_point_id, owner_id, template_id, expiration_time,
    durability_cur, durability_max, item_price, category_mask, category_depth, is_npc_order)
 VALUES ($($ident.exchangeId), $($ident.accessPointId), $sellerId, '$tmplLit', $orderExpiry,
-        1.0, 1.0, $price, 0, 0, FALSE)
+        1.0, 1.0, $payoutUnit, 0, 0, FALSE)
 RETURNING id AS logid \gset
 INSERT INTO dune.dune_exchange_fulfilled_orders
   (order_id, source_order_id, completion_type, stack_size, original_order_id)
 VALUES (:logid, NULL, 4, $stack, $orderId);
-UPDATE dune.dune_exchange_users SET solari_balance = solari_balance - $totalCost WHERE owner_id = $($ident.ownerId);
+UPDATE dune.dune_exchange_users SET solari_balance = solari_balance - $payoutTotal WHERE owner_id = $($ident.ownerId);
 DELETE FROM dune.dune_exchange_sell_orders WHERE order_id = $orderId;
 DELETE FROM dune.dune_exchange_orders WHERE id = $orderId;
 $itemDelete


### PR DESCRIPTION
Fixes #274.

## Bug
When Duke (Market Bot) bought a player's sell listing, the seller was paid **10× too little**. A `Dew Scythe Mk4` listed at the market rate of **180,000 Solari** paid the seller only **18,000** (confirmed against the live server: seller received 18,000).

## Root cause
In `Invoke-DuneBotBuyTick` (`app/server/lib/GameplayBot.ps1`), the buy transaction wrote the seller payment order with the **raw** stored `item_price`, and debited Duke's `solari_balance` by the **raw** total — but player-facing Solari is `item_price × 10` (the same convention the sell side and the buy-tick summary already use). The game pays a completion-type-4 payout order's `item_price` **literally** (verified: raw 18,000 written → seller received 18,000), so the raw value underpaid by exactly 10×.

## Fix
- Compute `$payoutUnit = $price * 10` and `$payoutTotal = $totalCost * 10` (literal Solari).
- Seller payment order `item_price` → `$payoutUnit`.
- Duke `solari_balance` debit → `$payoutTotal` (Duke's wallet is operator-set literal Solari, so debit matches what the seller receives — no ledger drift).
- The buy-tick summary's `winner.price` now reuses `$payoutUnit` (same value, deduped).
- **Unchanged:** the over-market buy guard still compares raw `item_price` vs the raw reference/median price — that comparison was already correct.

## Verification
- `GameplayBot.ps1` parses clean; UTF-8 BOM intact.
- 39/39 market Pester tests pass.
- Test installer rebuilt to the canonical output path.

## Review notes
This is a **live-economy change** — held for your review, not auto-published. Worth a dry-run buy tick + spot-check of one real buy (seller payout = listed Solari, Duke balance debited the same) before release. The key assumption is that completion-type-4 payout orders are paid literally (no game-side ×10), which the reporter's 18,000 data point confirms.