### PR TITLE
feat(ui): show server name in the header status bar (v12.7.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.6.2"
+      placeholder: "v12.7.0"
     validations:
       required: true
 
@@ -104,7 +104,7 @@ body:
         - Web portal — Tailscale (remote-access / device list)
         - Web portal — Setup Wizard / first-run
         - Web portal — Top menu bar / Help dropdown
-        - Web portal — Sidebar / status bar / window chrome
+        - Web portal — Sidebar / top status bar (server name, port/VM/BG pills, refresh) / window chrome
         - Desktop app shell (DuneShell.exe / WebView2) / PWA install
         - CLI (`dune-server.ps1` / `dune-server.bat`)
         - Installer (`DuneServerSetup.exe`) / first-run setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.7.0] - 2026-06-17
+
+### Added
+
+- **Server name shown in the top header.** The player-facing server name (the
+  battlegroup title shown in the in-game server browser, e.g. "Reapers") now
+  renders, large and centered, between the tool name and the status pills so you
+  can tell at a glance which server the tool is managing. Read from the
+  battlegroup CRD (`spec.title`) over SSH and cached (5 min TTL); the manual
+  refresh button re-reads it. Hidden when the VM is down or no battlegroup exists.
+
 ## [12.6.2] - 2026-06-17
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.6.2'
+$script:DuneToolVersion = '12.7.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.6.2',
+    [string]$Version = '12.7.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.6.2</Version>
+    <Version>12.7.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.6.2"
+#define MyAppVersion "12.7.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -262,6 +262,15 @@ $script:DuneGameConfigLiveGlobDir    = '/var/lib/rancher/k3s/storage/*/Saved/Use
 $script:DuneGameConfigTplGamePath    = '/home/dune/.dune/download/scripts/setup/config/UserGame.ini'
 $script:DuneGameConfigTplEnginePath  = '/home/dune/.dune/download/scripts/setup/config/UserEngine.ini'
 
+# Cached, player-facing server name shown in the in-game server browser. This is
+# the battlegroup title (CRD spec.title, e.g. "Reapers") — NOT Bgd.ServerDisplayName
+# (which is the per-Sietch/world label). Read from the battlegroup CRD over SSH so
+# the header status bar can show it; cached with a short TTL so the 10 s status poll
+# never pays for a fresh SSH read every tick.
+$script:DuneServerNameCache   = $null
+$script:DuneServerNameFetched = [datetime]::MinValue
+$script:DuneServerNameTtlSecs = 300
+
 # Where each player applies the "client-side too" settings. These keys are read
 # by BOTH server and client; changing them server-side only takes full effect
 # once each player mirrors them in their LOCAL client config. Funcom's setup
@@ -1032,6 +1041,49 @@ function Get-DuneGameConfig {
             managedSections = (Get-DuneIniManagedSectionNames -Raw $engineRaw)
         }
     }
+}
+
+# Player-facing server name (the battlegroup title shown in the in-game server
+# browser, e.g. "Reapers") for the status header. Read from the battlegroup CRD's
+# spec.title, falling back to the operator-managed annotation. Returns '' when the
+# VM is down, no battlegroup exists, or SSH is unavailable. Cached for
+# $DuneServerNameTtlSecs so the frequent status poll repaints from cache; -Force
+# re-reads (used by the manual refresh).
+function Get-DuneServerName {
+    param([switch]$Force)
+
+    $age = ([datetime]::UtcNow - $script:DuneServerNameFetched).TotalSeconds
+    if (-not $Force -and $script:DuneServerNameCache -ne $null -and $age -lt $script:DuneServerNameTtlSecs) {
+        return $script:DuneServerNameCache
+    }
+
+    $name = ''
+    try {
+        $ctx = Get-DuneGameConfigContext
+        if ($ctx.ok -and (Get-Command Get-V6Battlegroup -ErrorAction SilentlyContinue)) {
+            $info = Get-V6Battlegroup -Ip $ctx.ip
+            $bg   = $info.Bg
+            $title = $null
+            if ($bg.PSObject.Properties['spec'] -and $bg.spec.PSObject.Properties['title']) {
+                $title = "$($bg.spec.title)"
+            }
+            if ([string]::IsNullOrWhiteSpace($title) -and
+                $bg.PSObject.Properties['metadata'] -and
+                $bg.metadata.PSObject.Properties['annotations']) {
+                $ann = $bg.metadata.annotations
+                if ($ann.PSObject.Properties['igw.funcom.com/battlegroup-title']) {
+                    $title = "$($ann.'igw.funcom.com/battlegroup-title')"
+                }
+            }
+            if ($title) { $name = $title.Trim() }
+        }
+    } catch {
+        $name = if ($script:DuneServerNameCache) { $script:DuneServerNameCache } else { '' }
+    }
+
+    $script:DuneServerNameCache   = $name
+    $script:DuneServerNameFetched = [datetime]::UtcNow
+    return $name
 }
 
 # Quoted-key lookup for the writer (string keys that must be wrapped in quotes).

--- a/app/server/routes/Status.ps1
+++ b/app/server/routes/Status.ps1
@@ -8,11 +8,16 @@ Register-DuneRoute -Method GET -Path '/api/status' -Handler {
     }
     $ports = $null
     try { $ports = Get-DunePortStatus } catch { $ports = $null }
+    $serverName = ''
+    if ($vm.running -and (Get-Command Get-DuneServerName -ErrorAction SilentlyContinue)) {
+        try { $serverName = Get-DuneServerName } catch { $serverName = '' }
+    }
     Write-DuneJson -Response $res -Body @{
-        vm    = $vm
-        bg    = $bg
-        ports = $ports
-        ts    = (Get-Date).ToString('o')
+        vm         = $vm
+        bg         = $bg
+        ports      = $ports
+        serverName = $serverName
+        ts         = (Get-Date).ToString('o')
     }
 }
 
@@ -26,10 +31,15 @@ Register-DuneRoute -Method POST -Path '/api/status/refresh' -Handler {
     }
     $ports = $null
     try { $ports = Get-DunePortStatus -Force } catch { $ports = $null }
+    $serverName = ''
+    if ($vm.running -and (Get-Command Get-DuneServerName -ErrorAction SilentlyContinue)) {
+        try { $serverName = Get-DuneServerName -Force } catch { $serverName = '' }
+    }
     Write-DuneJson -Response $res -Body @{
-        vm    = $vm
-        bg    = $bg
-        ports = $ports
-        ts    = (Get-Date).ToString('o')
+        vm         = $vm
+        bg         = $bg
+        ports      = $ports
+        serverName = $serverName
+        ts         = (Get-Date).ToString('o')
     }
 }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.6.2"
+$script:ToolVersion = "12.7.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -59,6 +59,7 @@ export type StatusSnapshot = {
   vm: VmStatus
   bg: BattlegroupSnapshot | null
   ports: PortStatus | null
+  serverName?: string | null
   ts: string
 }
 

--- a/webui/src/layout/StatusBar.tsx
+++ b/webui/src/layout/StatusBar.tsx
@@ -35,14 +35,28 @@ export function StatusBar() {
   const ports = status?.ports ?? null
   const bgKey = (status?.bg?.state ?? 'unknown') as BgState | 'unknown'
   const bg    = BG_STYLES[bgKey] ?? BG_STYLES.unknown
+  const serverName = (status?.serverName ?? '').trim()
 
   return (
-    <header className="h-14 shrink-0 border-b border-border bg-surface/60 backdrop-blur-md px-5 flex items-center justify-between">
-      <div className="flex items-center gap-2 text-sm text-text-muted">
+    <header className="h-14 shrink-0 border-b border-border bg-surface/60 backdrop-blur-md px-5 flex items-center justify-between gap-4">
+      <div className="flex items-center gap-2 text-sm text-text-muted shrink-0">
         <Icon name="Server" size={16} className="text-text-dim" />
         <span>Dune Self Host Server Tool</span>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex-1 flex items-center justify-center min-w-0">
+        {serverName && (
+          <div className="flex items-center gap-2 min-w-0">
+            <Icon name="Server" size={20} className="text-accent shrink-0" />
+            <span
+              className="text-[22px] leading-none font-semibold tracking-tight text-text truncate"
+              title={`Server: ${serverName}`}
+            >
+              {serverName}
+            </span>
+          </div>
+        )}
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
         <span className={portPillClass(ports, 7777, 'UDP')} title="Game server ports (forward on your router/firewall)">
           <Icon name="Plug" size={11} /> 7777–7810 UDP
         </span>


### PR DESCRIPTION
## What

Shows the player-facing **server name** (the battlegroup title from the in-game server browser, e.g. **Reapers**) large and centered in the header, between "Dune Self Host Server Tool" and the status pills.

## Source (verified against a live VM)

- `Bgd.ServerDisplayName` is the **per-Sietch** name (e.g. "Coastal") — not what we want.
- The real server name is the battlegroup CRD **`spec.title`** (mirrored to the `igw.funcom.com/battlegroup-title` annotation).

## How

- New cached `Get-DuneServerName` reads `spec.title` via the existing `Get-V6Battlegroup` helper, falling back to the annotation. Returns `''` when the VM is down or no battlegroup exists.
- In-memory cache (5 min TTL) — reset on each app launch, so it refreshes every session; also re-pulled by the manual refresh button. Nothing hardcoded.
- `/api/status` (cached) and `/api/status/refresh` (forced) now return `serverName`.
- Frontend: `StatusBar.tsx` renders it centered at 22px; hidden when empty.

## Release

- Bumps all 5 version stamps to **12.7.0**, rolls `CHANGELOG.md`, and refreshes `bug_report.yml` (placeholder + status-bar surface).

## Validation

- PowerShell parse-checks pass; edited `.ps1` retain UTF-8 BOM.
- `webui` build + typecheck green.
- Installer builds to the canonical output (45.91 MB).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>