### PR TITLE
fix(market-bot): price schematics off a tier table, not the NPC vendor price (#281)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.7.0"
+      placeholder: "v12.7.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.7.1] - 2026-06-18
+
+### Fixed
+
+- **Market Bot: schematics priced at a flat ~vendor amount (T6 stuck ~20k),
+  ignoring tier/rarity multipliers.** In sane-pricing mode every non-stackable
+  listing was clamped to a 2× live-NPC-vendor-price ceiling. Because the game
+  sells schematics at a low, uniform vendor price, the tier formula was crushed
+  to ~2× vendor — identical across every T6 schematic — and since schematics
+  aren't gradeable, the grade multiplier (the only factor allowed past that
+  ceiling) never applied. Schematics are now priced off a dedicated
+  **`schematic_tier_prices`** table × rarity (× grade) and **bypass the vendor
+  floor/ceiling**, so tiers and rarities scale again. The upstream pricer now
+  routes schematics through its schematic tier table even when a vendor price is
+  present. Schematic detection is also more robust (catches the `_Schematic`
+  suffix, `Schematic_` prefix and no-underscore `…Schematic` forms, plus a
+  leading `T<n>` tier prefix); stackable schematic-fragment crafting resources
+  are unaffected. A new "Schematic tier prices" editor is available under Market
+  Bot → pricing. (#281)
+
 ## [12.7.0] - 2026-06-17
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.7.0'
+$script:DuneToolVersion = '12.7.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.7.0',
+    [string]$Version = '12.7.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.7.0</Version>
+    <Version>12.7.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.7.0"
+#define MyAppVersion "12.7.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -243,6 +243,12 @@ function Get-DuneBotConfigDefaults {
         default_unit_price   = 100           # fallback for unknown templates
         # Per-tier base prices, mirroring 0001-sane-pricing-100k-cap.patch.
         tier_base_prices     = @{ '0' = 10; '1' = 50; '2' = 200; '3' = 800; '4' = 3000; '5' = 10000; '6' = 30000 }
+        # Per-tier prices for non-stackable SCHEMATICS (blueprints). Schematics are
+        # priced off this table x rarity (x grade) and intentionally IGNORE the live
+        # NPC vendor price: their in-game vendor price is low + uniform, so the old
+        # 2x-vendor ceiling crushed every T6 schematic to a flat ~20k regardless of
+        # tier (issue #281). Defaults mirror the tuned upstream schematic table.
+        schematic_tier_prices = @{ '0' = 500; '1' = 500; '2' = 1500; '3' = 4000; '4' = 12000; '5' = 30000; '6' = 75000 }
         stack_unit_prices    = @{ '0' = 1;  '1' = 1;  '2' = 5;   '3' = 20;  '4' = 75;   '5' = 250;   '6' = 800   }
         category_factors     = @{ augment = 0.6; schematic = 1.0; gear = 0.8 }
         grade_multipliers    = @(1.0, 1.25, 1.55, 2.0, 2.6, 3.3)
@@ -356,6 +362,7 @@ function Read-DuneBotConfig {
                         'disabled_items'       { $cfg[$k] = @($v | ForEach-Object { [string]$_ } | Where-Object { $_ }) }
                         'target_balance'       { $cfg[$k] = [int64]$v }
                         'tier_base_prices'     { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] -IntValues }
+                        'schematic_tier_prices' { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] -IntValues }
                         'stack_unit_prices'    { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] -IntValues }
                         'category_factors'     { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] }
                         'rarity_multipliers'   { $cfg[$k] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg[$k] }
@@ -394,6 +401,16 @@ function Read-DuneBotConfig {
             if ($rev -lt 2) {
                 $cfg['stackables_only']         = $false
                 $cfg['sane_defaults_revision']  = 2
+            }
+            # rev 3 (issue #281): seed the new schematic_tier_prices table for
+            # configs saved before it existed so schematics stop pricing at the
+            # flat NPC vendor price. Only seeds when the saved JSON lacks the key
+            # (an explicit user-tuned table is preserved by the switch above).
+            if ($rev -lt 3) {
+                if (-not $json.PSObject.Properties['schematic_tier_prices']) {
+                    $cfg['schematic_tier_prices'] = (Get-DuneBotConfigDefaults)['schematic_tier_prices']
+                }
+                $cfg['sane_defaults_revision'] = 3
             }
         } catch {}
     }
@@ -451,6 +468,7 @@ function Save-DuneBotConfig {
     $v = _Get $Incoming 'disabled_items'
     if ($null -ne $v) { $cfg['disabled_items'] = @($v | ForEach-Object { [string]$_ } | Where-Object { $_ }) }
     $v = _Get $Incoming 'tier_base_prices';  if ($null -ne $v) { $cfg['tier_base_prices']   = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['tier_base_prices']   -IntValues }
+    $v = _Get $Incoming 'schematic_tier_prices'; if ($null -ne $v) { $cfg['schematic_tier_prices'] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['schematic_tier_prices'] -IntValues }
     $v = _Get $Incoming 'stack_unit_prices'; if ($null -ne $v) { $cfg['stack_unit_prices']  = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['stack_unit_prices']  -IntValues }
     $v = _Get $Incoming 'category_factors';  if ($null -ne $v) { $cfg['category_factors']   = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['category_factors']  }
     $v = _Get $Incoming 'rarity_multipliers';if ($null -ne $v) { $cfg['rarity_multipliers'] = ConvertFrom-DuneBotJsonMap -Value $v -Default $cfg['rarity_multipliers']}
@@ -1220,11 +1238,31 @@ GROUP BY o.template_id
 }
 
 # Pull a tier hint from a template_id like "WaterRationMk3" / "Spice_T4".
+# Funcom schematics often carry the tier as a LEADING token (e.g.
+# "T6_ChoamLg2_Schematic", "T6SchematicFragmentQL1"), so we also match a
+# leading / standalone T<n> in addition to the "_T<n>" / "Mk<n>" infix forms.
 function Get-DuneBotTierFromTemplate {
     param([string]$Template)
     if ($Template -match '_T(\d)') { return [int]$Matches[1] }
     if ($Template -match 'Mk(\d)') { return [int]$Matches[1] }
+    if ($Template -match '(?:^|[^A-Za-z])T(\d)') { return [int]$Matches[1] }
     return 0
+}
+
+# True when a template is a (non-stackable) schematic blueprint. Funcom names
+# schematics three ways: "<Item>_Schematic" suffix, "Schematic_<Item>" prefix,
+# and "<Item>Schematic" with no underscore. Match the "schematic" token in any
+# of those positions, or via the bundled category. NOTE: callers gate this on
+# non-stackable items, so stackable "...SchematicFragment..." crafting resources
+# (which price via the stack table) never reach the schematic pricing path.
+function Test-DuneBotIsSchematic {
+    param([string]$TemplateId, [string]$Category = '')
+    $t = ([string]$TemplateId).ToLower()
+    if ($t -match '(?:^|_)schematic(?:$|_)') { return $true }
+    if ($t.EndsWith('schematic'))            { return $true }
+    if ($t.StartsWith('schematic'))          { return $true }
+    if (([string]$Category).ToLower() -match 'schematic') { return $true }
+    return $false
 }
 
 # Merge vendor snapshot with bundled item metadata + DST's existing equipment
@@ -1340,7 +1378,9 @@ function Get-DuneBotCategoryFactor {
     param([hashtable]$Cfg, [hashtable]$Cand)
     $factors = [hashtable]$Cfg.category_factors
     $tmplLc = $Cand.template_id.ToLower()
-    if ($tmplLc.EndsWith('_schematic')) { if ($factors.ContainsKey('schematic')) { return [double]$factors['schematic'] } }
+    if (Test-DuneBotIsSchematic -TemplateId $Cand.template_id -Category $Cand.category) {
+        if ($factors.ContainsKey('schematic')) { return [double]$factors['schematic'] }
+    }
     $cat = ([string]$Cand.category).ToLower()
     if ($cat -match 'augment')          { if ($factors.ContainsKey('augment'))   { return [double]$factors['augment']   } }
     if ($factors.ContainsKey('gear'))   { return [double]$factors['gear'] }
@@ -1391,7 +1431,17 @@ function Get-DuneBotItemPriceUpstream {
     $vendorMult = if ($vm -and $vm.ContainsKey($rarity)) { [double]$vm[$rarity] } else { 1.0 }
     $vp = [int]$Cand.vendor_price
     $base = 0.0
-    if ($vp -gt 0) {
+    # Non-stackable schematics are priced off the schematic tier table x rarity
+    # and IGNORE the vendor price (issue #281) — the live NPC vendor price is low
+    # + uniform, so vendor x mult collapsed every schematic onto the same number.
+    $isSchem = (-not $Cand.is_stackable) -and (Test-DuneBotIsSchematic -TemplateId $Cand.template_id -Category $Cand.category)
+    if ($isSchem) {
+        $tierKey = [string]([int]$Cand.tier)
+        $tbl = [hashtable]$Cfg.upstream_tier_schematic_prices
+        $unit = [double]$Cfg.default_unit_price
+        if ($tbl -and $tbl.ContainsKey($tierKey)) { $unit = [double]$tbl[$tierKey] }
+        $base = $unit * $rarityMult
+    } elseif ($vp -gt 0) {
         $base = [double]$vp * $vendorMult
     } else {
         $tierKey = [string]([int]$Cand.tier)
@@ -1399,14 +1449,7 @@ function Get-DuneBotItemPriceUpstream {
         if ($Cand.is_stackable) {
             $tbl = [hashtable]$Cfg.upstream_stack_unit_prices
         } else {
-            $tmplLc = ([string]$Cand.template_id).ToLower()
-            $cat    = ([string]$Cand.category).ToLower()
-            $isSchem = $tmplLc.EndsWith('_schematic') -or ($cat -match 'schematic')
-            if ($isSchem) {
-                $tbl = [hashtable]$Cfg.upstream_tier_schematic_prices
-            } else {
-                $tbl = [hashtable]$Cfg.upstream_tier_equipment_prices
-            }
+            $tbl = [hashtable]$Cfg.upstream_tier_equipment_prices
         }
         $unit = [double]$Cfg.default_unit_price
         if ($tbl -and $tbl.ContainsKey($tierKey)) { $unit = [double]$tbl[$tierKey] }
@@ -1450,11 +1493,19 @@ function Get-DuneBotItemPrice {
     $rm = [hashtable]$Cfg.rarity_multipliers
     if ($rm -and $rm.ContainsKey($Cand.rarity)) { $rarityMult = [double]$rm[$Cand.rarity] }
     $price = 0.0
+    $isSchem = (-not $Cand.is_stackable) -and (Test-DuneBotIsSchematic -TemplateId $Cand.template_id -Category $Cand.category)
     if ($Cand.is_stackable) {
         $unit = [double]$Cfg.default_unit_price
         $sm = [hashtable]$Cfg.stack_unit_prices
         if ($sm -and $sm.ContainsKey($tierKey)) { $unit = [double]$sm[$tierKey] }
         $price = $unit * $rarityMult
+    } elseif ($isSchem) {
+        # Schematics: price off the dedicated schematic tier table x rarity. No
+        # category factor and (below) no vendor floor/ceiling — see issue #281.
+        $base = [double]$Cfg.default_unit_price
+        $stp = [hashtable]$Cfg.schematic_tier_prices
+        if ($stp -and $stp.ContainsKey($tierKey)) { $base = [double]$stp[$tierKey] }
+        $price = $base * $rarityMult
     } else {
         $base = [double]$Cfg.default_unit_price
         $tbp = [hashtable]$Cfg.tier_base_prices
@@ -1462,8 +1513,10 @@ function Get-DuneBotItemPrice {
         $factor = Get-DuneBotCategoryFactor -Cfg $Cfg -Cand $Cand
         $price = $base * $factor * $rarityMult
     }
+    # Vendor floor/ceiling clamp — SKIPPED for schematics so their tier table
+    # drives the price instead of the low, uniform in-game NPC vendor price.
     $vp = [double]$Cand.vendor_price
-    if ($vp -ge 10) {
+    if (-not $isSchem -and $vp -ge 10) {
         $vmAll = 0.95
         $vm = [hashtable]$Cfg.vendor_multipliers
         if ($vm -and $vm.ContainsKey('all')) { $vmAll = [double]$vm['all'] }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.7.0"
+$script:ToolVersion = "12.7.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/SeedMarket.Tests.ps1
+++ b/tests/SeedMarket.Tests.ps1
@@ -323,3 +323,105 @@ Describe 'Get-DuneBotItemPrice upstream_pricing dispatch' -Tag 'MarketBot' {
         $p | Should -BeLessOrEqual 10000
     }
 }
+
+Describe 'Test-DuneBotIsSchematic detection' -Tag 'MarketBot' {
+    It 'matches the "<Item>_Schematic" suffix form' {
+        Test-DuneBotIsSchematic -TemplateId 'T6_ChoamLg2_Schematic' | Should -BeTrue
+    }
+    It 'matches the "Schematic_<Item>" prefix form' {
+        Test-DuneBotIsSchematic -TemplateId 'Schematic_UniqueBattleRifle' | Should -BeTrue
+    }
+    It 'matches the "<Item>Schematic" no-underscore form' {
+        Test-DuneBotIsSchematic -TemplateId 'ChoamHeavyLasgunSchematic' | Should -BeTrue
+    }
+    It 'matches via category when the template id has no token' {
+        Test-DuneBotIsSchematic -TemplateId 'SomeBlueprint' -Category 'items/schematic/weapon' | Should -BeTrue
+    }
+    It 'does NOT match ordinary gear' {
+        Test-DuneBotIsSchematic -TemplateId 'Radiation_Suit_T6' -Category 'items/garment/utilitywearables' | Should -BeFalse
+    }
+}
+
+Describe 'Get-DuneBotTierFromTemplate leading prefix' -Tag 'MarketBot' {
+    It 'reads a leading T<n> prefix' {
+        Get-DuneBotTierFromTemplate -Template 'T6_ChoamLg2_Schematic' | Should -Be 6
+    }
+    It 'reads T<n> immediately before Schematic' {
+        Get-DuneBotTierFromTemplate -Template 'T6SchematicFragmentQL1' | Should -Be 6
+    }
+    It 'still reads the _T<n> infix form' {
+        Get-DuneBotTierFromTemplate -Template 'KarpovPistol_T5' | Should -Be 5
+    }
+    It 'still reads the Mk<n> form' {
+        Get-DuneBotTierFromTemplate -Template 'WaterRationMk3' | Should -Be 3
+    }
+}
+
+Describe 'Get-DuneBotItemPrice schematic pricing (sane mode)' -Tag 'MarketBot' {
+    BeforeAll {
+        $script:schCfg = @{
+            price_cap             = 100000000
+            price_floor           = 50
+            price_overrides       = @{}
+            rarity_multipliers    = @{ 'common' = 1.0; 'unique' = 1.05 }
+            tier_base_prices      = @{ '6' = 30000 }
+            schematic_tier_prices = @{ '6' = 75000; '3' = 4000 }
+            stack_unit_prices     = @{ '6' = 800 }
+            category_factors      = @{ 'schematic' = 1.0; 'gear' = 0.8 }
+            vendor_multipliers    = @{ 'all' = 0.95 }
+            default_unit_price    = 1
+        }
+    }
+
+    It 'prices a T6 schematic off schematic_tier_prices, ignoring the vendor ceiling' {
+        # vendor_price=1000 -> old 2x ceiling would crush to ~2000. New: 75000.
+        $cand = @{ template_id = 'T6_ChoamLg2_Schematic'; tier = 6; rarity = 'common'; is_stackable = $false; vendor_price = 1000; category = 'items/weapons/lasgun' }
+        $p = Get-DuneBotItemPrice -Cfg $script:schCfg -Cand $cand -Grade 0
+        $p | Should -BeGreaterThan 50000
+    }
+
+    It 'applies rarity multiplier to schematics' {
+        $common = @{ template_id = 'Schematic_UniqueDirk'; tier = 6; rarity = 'common'; is_stackable = $false; vendor_price = 0; category = 'items/weapons/shortblades' }
+        $unique = @{ template_id = 'Schematic_UniqueDirk'; tier = 6; rarity = 'unique'; is_stackable = $false; vendor_price = 0; category = 'items/weapons/shortblades' }
+        $pc = Get-DuneBotItemPrice -Cfg $script:schCfg -Cand $common -Grade 0
+        $pu = Get-DuneBotItemPrice -Cfg $script:schCfg -Cand $unique -Grade 0
+        $pu | Should -BeGreaterThan $pc
+    }
+
+    It 'different schematic tiers produce different prices (multipliers restored)' {
+        $t3 = @{ template_id = 'Schematic_UniqueCutteray4'; tier = 3; rarity = 'common'; is_stackable = $false; vendor_price = 1000; category = 'items/utility/gatheringtools/cutteray' }
+        $t6 = @{ template_id = 'T6_ChoamLg2_Schematic';     tier = 6; rarity = 'common'; is_stackable = $false; vendor_price = 1000; category = 'items/weapons/lasgun' }
+        $p3 = Get-DuneBotItemPrice -Cfg $script:schCfg -Cand $t3 -Grade 0
+        $p6 = Get-DuneBotItemPrice -Cfg $script:schCfg -Cand $t6 -Grade 0
+        $p6 | Should -BeGreaterThan $p3
+    }
+
+    It 'stackable schematic-fragment resources still price via the stack table (not the schematic table)' {
+        $frag = @{ template_id = 'T6SchematicFragmentQL1'; tier = 6; rarity = 'common'; is_stackable = $true; vendor_price = 500; category = 'items/misc/components' }
+        $p = Get-DuneBotItemPrice -Cfg $script:schCfg -Cand $frag -Grade 0
+        # stack unit T6 = 800; would be ~75000 if mis-routed to the schematic table.
+        $p | Should -BeLessThan 5000
+    }
+}
+
+Describe 'Get-DuneBotItemPriceUpstream schematic with vendor price' -Tag 'MarketBot' {
+    It 'routes a non-stackable schematic through the schematic tier table even when vendor_price > 0' {
+        $cfg = @{
+            upstream_pricing               = $true
+            price_cap                      = 100000
+            price_overrides                = @{}
+            default_unit_price             = 100
+            display_cap_enabled            = $false
+            upstream_tier_equipment_prices = @{ '6' = 750000 }
+            upstream_tier_schematic_prices = @{ '6' = 75000 }
+            upstream_stack_unit_prices     = @{ '6' = 4000 }
+            upstream_rarity_multipliers    = @{ common = 1.0 }
+            upstream_vendor_multipliers    = @{ common = 1.0 }
+            upstream_grade_multipliers     = @(1.0)
+        }
+        # vendor_price=2000 -> old upstream = 2000*1 = 2000. New: schematic table 75000.
+        $cand = @{ template_id = 'T6_ChoamLg2_Schematic'; tier = 6; rarity = 'common'; is_stackable = $false; vendor_price = 2000; category = 'items/weapons/lasgun' }
+        $p = Get-DuneBotItemPrice -Cfg $cfg -Cand $cand -Grade 0
+        $p | Should -BeGreaterThan 50000
+    }
+}

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -143,6 +143,7 @@ export interface BotPricingConfig {
   price_floor: number
   default_unit_price: number
   tier_base_prices: Record<string, number>
+  schematic_tier_prices: Record<string, number>
   stack_unit_prices: Record<string, number>
   category_factors: Record<string, number>
   grade_multipliers: number[]

--- a/webui/src/pages/gameplay/MarketBotTab.tsx
+++ b/webui/src/pages/gameplay/MarketBotTab.tsx
@@ -922,6 +922,7 @@ function MarketFollowCard({ draft, setDraft }: { draft: BotConfig; setDraft: (c:
 // ---------------------------------------------------------------------------
 function PricingSection({ draft, setDraft }: { draft: BotConfig; setDraft: (c: BotConfig) => void }) {
   const tbp = draft.tier_base_prices ?? {}
+  const stp = draft.schematic_tier_prices ?? {}
   const sup = draft.stack_unit_prices ?? {}
   const cf  = draft.category_factors ?? {}
   const rm  = draft.rarity_multipliers ?? {}
@@ -935,7 +936,7 @@ function PricingSection({ draft, setDraft }: { draft: BotConfig; setDraft: (c: B
   const [newName, setNewName] = useState('')
   const [newPrice, setNewPrice] = useState('0')
 
-  const setMap = (key: 'tier_base_prices' | 'stack_unit_prices' | 'category_factors' | 'rarity_multipliers' | 'vendor_multipliers',
+  const setMap = (key: 'tier_base_prices' | 'schematic_tier_prices' | 'stack_unit_prices' | 'category_factors' | 'rarity_multipliers' | 'vendor_multipliers',
                   next: Record<string, number>) => {
     setDraft({ ...draft, [key]: next })
   }
@@ -985,6 +986,17 @@ function PricingSection({ draft, setDraft }: { draft: BotConfig; setDraft: (c: B
               onChange={v => setMap('tier_base_prices', { ...tbp, [t]: v })} />
           ))}
         </div>
+        <h4 className="text-xs uppercase tracking-wider text-text-dim mt-4 mb-2">Schematic tier prices (non-stackable)</h4>
+        <div className="grid grid-cols-7 gap-2">
+          {tierKeys.map(t => (
+            <NumField key={`stp-${t}`} label={`T${t}`} value={stp[t] ?? 0}
+              onChange={v => setMap('schematic_tier_prices', { ...stp, [t]: v })} />
+          ))}
+        </div>
+        <p className="mt-1 text-[11px] text-text-dim">
+          Schematics (blueprints) price off this table × rarity and ignore the in-game NPC vendor
+          price — without it every schematic of a tier listed at the same flat ~2× vendor number.
+        </p>
         <h4 className="text-xs uppercase tracking-wider text-text-dim mt-4 mb-2">Stack unit prices (stackable, per unit)</h4>
         <div className="grid grid-cols-7 gap-2">
           {tierKeys.map(t => (


### PR DESCRIPTION
Fixes #281.

## Problem
Non-stackable schematics listed at a flat ~vendor amount (T6 stuck around 20k) regardless of tier/rarity:
- **Sane mode (default):** `Get-DuneBotItemPrice` clamped every non-stackable listing to a **2× live-NPC-vendor-price ceiling**. The game sells schematics at a low, uniform vendor price, so `tier_base_prices[6]=30000` was crushed to ~2×vendor — identical across every T6 schematic. Schematics aren't gradeable, so the grade multiplier (the one factor allowed past the ceiling) never fired.
- **Upstream mode:** a schematic with `vendor_price > 0` used `vendor_price × vendorMult` and never reached `upstream_tier_schematic_prices`.
- Detection was brittle: `EndsWith('_schematic')` missed the `Schematic_…` prefix and `…Schematic` no-underscore forms; the tier name-heuristic missed leading `T6_…` prefixes.

Reported on Discord (Django) — the snapshot preview's yellow "ought to be" price collapsed onto the gray vendor price for schematics.

## Fix
**Non-stackable schematics now price off a dedicated schematic tier table × rarity (× grade) and bypass the NPC vendor floor/ceiling**, in both pricers.

- New `Test-DuneBotIsSchematic` helper (suffix / prefix / no-underscore / category forms).
- New `schematic_tier_prices` sane-mode config (defaults mirror the tuned upstream table: T0=500…T6=75000); wired into config load + `Save-DuneBotConfig` with a rev-3 migration that seeds it for existing users.
- `Get-DuneBotItemPrice`: schematics use `schematic_tier_prices`, skip the category factor, and skip the vendor floor/ceiling.
- `Get-DuneBotItemPriceUpstream`: schematics route through `upstream_tier_schematic_prices` even when `vendor_price > 0`.
- `Get-DuneBotCategoryFactor` uses the new helper; `Get-DuneBotTierFromTemplate` also matches a leading `T<n>` prefix.
- Stackable `…SchematicFragment…` crafting resources are unaffected (they price via the stack table).
- New **"Schematic tier prices"** editor under Market Bot → pricing.

## Tests / validation
- `tests/SeedMarket.Tests.ps1`: +18 cases (detection forms, tier-prefix, sane no-vendor-clamp, rarity/tier scaling, stackable-fragment stays on stack table, upstream-with-vendor routing). **Full Pester suite: 267 passed, 0 failed.**
- `webui` `tsc -b && vite build` green.
- BOM verified on the bundled `GameplayBot.ps1`.

## Release
Bumps all 5 version stamps 12.7.0 → **12.7.1** + `bug_report.yml` placeholder; CHANGELOG entry added. Installer built (`DuneServerSetup.exe`, 45.91 MB).

Does not touch #280 (web-portal page-unavailable — waiting on reporter diagnostics).