### PR TITLE
feat(market-bot): add Reset to defaults button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Market Bot: "Reset to defaults" button.** The Market Bot tab now has a
+  one-click button (in the Save bar, shared across all sub-tabs) that restores
+  every buy, list, and pricing setting to its out-of-box default. The bot's
+  enabled (on/off) state is preserved so a reset never silently starts or stops
+  it, and Duke's existing listings are re-priced on the next list tick. The
+  existing "Reset" button (which only discards unsaved edits) was renamed to
+  "Revert" to avoid confusion.
+
 ## [12.7.1] - 2026-06-18
 
 ### Fixed

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -506,6 +506,39 @@ function Save-DuneBotConfig {
     return $cfg
 }
 
+# ---------------------------------------------------------------------------
+# Reset the bot config back to factory defaults. The current enabled (on/off)
+# state is preserved so a reset never silently starts or stops the bot — only
+# the tuning (buy/list/pricing) is restored. Stamps the latest sane-defaults
+# revision so no migration re-runs on next load, and flags relist_pending so
+# the next list tick re-prices Duke's listings from the restored defaults.
+# Returns the saved config.
+# ---------------------------------------------------------------------------
+function Reset-DuneBotConfig {
+    $prevEnabled = $false
+    try { $prevEnabled = [bool](Read-DuneBotConfig)['enabled'] } catch {}
+
+    $cfg = Get-DuneBotConfigDefaults
+    $cfg['enabled'] = $prevEnabled
+    # Latest migration revision (see Read-DuneBotConfig) so a freshly-reset
+    # config is never re-migrated/clobbered on the next read.
+    $cfg['sane_defaults_revision'] = 3
+
+    # Pricing basis is back to defaults -> any existing Duke listings are now
+    # stale; flag a relist so the next list tick wipes + re-prices them.
+    try {
+        $st = Read-DuneBotState
+        $st['relist_pending'] = $true
+        Save-DuneBotState -State $st
+    } catch {}
+
+    $path = Get-DuneBotConfigPath
+    $dir = Split-Path -Parent $path
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    ($cfg | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $path -Encoding UTF8
+    return $cfg
+}
+
 function Read-DuneBotState {
     $state = [ordered]@{
         last_buy_tick     = $null

--- a/app/server/routes/Gameplay.ps1
+++ b/app/server/routes/Gameplay.ps1
@@ -237,6 +237,22 @@ Register-DuneRoute -Method PUT -Path '/api/gameplay/market-bot/config' -Handler 
     }
 }
 
+# POST /api/gameplay/market-bot/config/reset — restore factory defaults.
+# Preserves the current enabled (on/off) state; resets all tuning.
+Register-DuneRoute -Method POST -Path '/api/gameplay/market-bot/config/reset' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $saved = Reset-DuneBotConfig
+        $out = @{}
+        foreach ($k in $saved.Keys) { $out[$k] = $saved[$k] }
+        $out['configured'] = $true
+        $out['source'] = 'live'
+        Write-DuneJson -Response $res -Body $out
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Bot config reset failed: $($_.Exception.Message)"
+    }
+}
+
 # ---------------------------------------------------------------------------
 # POST /api/gameplay/market-bot/exec  (start|stop|restart)
 # Native lifecycle = flip the persisted `enabled` flag; the background

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -388,6 +388,12 @@ export function saveBotConfig(cfg: Partial<BotConfig>) {
   })
 }
 
+export function resetBotConfig() {
+  return api<BotConfig>('/api/gameplay/market-bot/config/reset', {
+    method: 'POST',
+  })
+}
+
 export function runBotTick(dryRun: boolean) {
   return api<BotTickResult>(`/api/gameplay/market-bot/tick${dryRun ? '?dry=1' : ''}`, {
     method: 'POST',

--- a/webui/src/pages/gameplay/MarketBotTab.tsx
+++ b/webui/src/pages/gameplay/MarketBotTab.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import { ItemPicker } from '../../components/ItemPicker'
 import {
-  getBotStatus, getBotConfig, saveBotConfig, runBotTick, runBotListTick,
+  getBotStatus, getBotConfig, saveBotConfig, resetBotConfig, runBotTick, runBotListTick,
   startBotSeedMarket, abortBotSeedMarket, botExec,
   setBotBalance, clearBotListings, clearBotError, getBotVendorSnapshot,
   type BotStatus, type BotConfig, type BotTickResult, type BotListTickResult,
@@ -32,6 +32,7 @@ export function MarketBotTab() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+  const [resetting, setResetting] = useState(false)
   const [saveMsg, setSaveMsg] = useState<string | null>(null)
   const [tick, setTick] = useState<BotTickResult | null>(null)
   const [ticking, setTicking] = useState(false)
@@ -82,6 +83,23 @@ export function MarketBotTab() {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     } finally { setSaving(false) }
+  }
+
+  // Restore every Market Bot tuning value to its factory default. The bot's
+  // enabled (on/off) state is preserved server-side so a reset never silently
+  // starts or stops it. Any in-progress Duke listings get re-priced on the
+  // next list tick (the backend flags relist_pending).
+  const resetToDefaults = async () => {
+    if (!window.confirm("Reset all Market Bot settings to their defaults?\n\nThis restores every buy, list, and pricing value to the out-of-box defaults. Duke's on/off state is kept, and his existing listings will be re-priced on the next list tick. This cannot be undone.")) return
+    setResetting(true); setSaveMsg(null); setError(null)
+    try {
+      const restored = await resetBotConfig()
+      setConfig(restored); setDraft(structuredClone(restored))
+      setSaveMsg('Settings reset to defaults.')
+      getBotStatus().then(setStatus).catch(() => {})
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally { setResetting(false) }
   }
 
   const toggleEnabled = async (v: boolean) => {
@@ -410,8 +428,11 @@ export function MarketBotTab() {
           <button className="btn-primary" disabled={!dirty || saving} onClick={() => { void save() }}>
             <Icon name={saving ? 'Loader2' : 'Save'} size={15} className={saving ? 'animate-spin' : ''} /> Save config
           </button>
-          <button className="btn-secondary" disabled={!dirty || saving} onClick={() => setDraft(structuredClone(config))}>
-            Reset
+          <button className="btn-secondary" disabled={!dirty || saving} onClick={() => setDraft(structuredClone(config))} title="Discard unsaved edits and revert to the last saved configuration">
+            Revert
+          </button>
+          <button className="btn-secondary" disabled={saving || resetting} onClick={() => { void resetToDefaults() }} title="Restore every Market Bot setting to its factory default (keeps the bot's on/off state)">
+            <Icon name={resetting ? 'Loader2' : 'RotateCcw'} size={15} className={resetting ? 'animate-spin' : ''} /> Reset to defaults
           </button>
           {saveMsg && <span className="text-xs text-success">{saveMsg}</span>}
           {error && <span className="text-xs text-danger break-words">{error}</span>}


### PR DESCRIPTION
## What

Adds a one-click **"Reset to defaults"** button to the Market Bot tab. Several users have asked for a way to undo their tuning and get back to a known-good baseline.

## Behaviour

- Restores **every** buy, list, and pricing setting to its out-of-box default.
- **Preserves the bot's enabled (on/off) state** — a reset never silently starts or stops Duke, only resets the tuning.
- Flags `relist_pending` so Duke's existing listings are re-priced on the next list tick.
- Confirm-gated (`window.confirm`) since it can't be undone.

## Changes

- **`app/server/lib/GameplayBot.ps1`** — new `Reset-DuneBotConfig` (writes `Get-DuneBotConfigDefaults`, keeps `enabled`, stamps latest sane-defaults revision so no migration re-runs, flags relist).
- **`app/server/routes/Gameplay.ps1`** — new `POST /api/gameplay/market-bot/config/reset`.
- **`webui/src/api/gameplay.ts`** — new `resetBotConfig()`.
- **`webui/src/pages/gameplay/MarketBotTab.tsx`** — button + handler in the shared Save bar. Renamed the existing "Reset" (discards unsaved edits) → **"Revert"** to disambiguate the two.
- **`CHANGELOG.md`** — `[Unreleased]` entry.

## Validation

- Both `.ps1` files parse clean.
- webui `tsc -b` + `vite build` pass.
- 53/53 SeedMarket Pester tests pass.