### PR TITLE
Fix blueprint import failing on large blueprints ("filename or extension is too long")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Blueprint import no longer fails on large blueprints.** Importing a
+  blueprint with many pieces could fail with `Blueprint import failed:
+  Exception calling "Start" with "0" argument(s): "The filename or extension is
+  too long"`. The generated SQL was passed on the command line, and a big build
+  overflowed the Windows ~32 KB command-line limit. The import now streams the
+  SQL through stdin (the same path already used for bulk market seeding), so
+  blueprints of any size import correctly.
+
 ## [12.8.1] - 2026-06-19
 
 ### Added

--- a/app/server/lib/GameplayWorld.ps1
+++ b/app/server/lib/GameplayWorld.ps1
@@ -553,7 +553,11 @@ END
 `$DST`$;
 "@
 
-    $raw = Invoke-DuneSqlRaw -Ip $Ip -Sql $do -TimeoutSec 180
+    # Stream the DO block through ssh stdin instead of the command line: a large
+    # blueprint (many instances/placeables) builds a multi-KB SQL payload that
+    # overflows the Windows ~32 KB command-line limit, surfacing as
+    # 'The filename or extension is too long' when the ssh process is started.
+    $raw = Invoke-DuneSqlRawStdin -Ip $Ip -Sql $do -TimeoutSec 180
     if (Test-DunePsqlError -Output $raw) {
         return @{ ok = $false; error = (Get-DunePsqlErrorMessage -Output $raw) }
     }


### PR DESCRIPTION
## Discord-reported bug

A user reported that **every** blueprint import failed with:

> Blueprint import failed: Exception calling "Start" with "0" argument(s): "The filename or extension is too long"

## Root cause

`Import-DuneBlueprintLive` builds a single SQL `DO` block containing one inline `VALUES` row per blueprint instance/placeable, then ran it via `Invoke-DuneSqlRaw`, which base64-encodes the SQL and passes it **on the ssh command line**. A blueprint with many pieces produces a multi-KB payload that overflows the Windows ~32 KB command-line limit, and Windows reports that as `The filename or extension is too long` when the ssh process is started.

This is the exact failure mode already documented in `app/server/lib/Database.ps1` for the Seed Market path, which is why the stdin-streaming variant `Invoke-DuneSqlRawStdin` exists.

## Fix

Route the blueprint import `DO` block through `Invoke-DuneSqlRawStdin` (identical signature) so the SQL streams over ssh stdin. The remote command stays tiny regardless of payload size, so blueprints of any size import correctly.

## Notes

- One-line behavioural change + comment; no schema or logic changes.
- `CHANGELOG.md` `[Unreleased]` updated.
- PowerShell parse-check passes; BOM preserved.
- Not live-tested against a DB from this session — confidence is high because the stdin variant is already proven in production for the equivalent bulk market-seed path.