### PR TITLE
Use generic Public IP examples

### DIFF
--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -15,7 +15,7 @@ function Test-DuneIPv4Literal {
 function Test-DunePublicIPv4 {
     param([string]$Ip)
     if (-not (Test-DuneIPv4Literal -Ip $Ip)) {
-        return @{ ok = $false; status = 400; message = 'Enter a valid IPv4 address, for example 50.123.76.96.' }
+        return @{ ok = $false; status = 400; message = 'Enter a valid IPv4 address, for example 8.8.8.8.' }
     }
     $parts = @($Ip -split '\.' | ForEach-Object { [int]$_ })
     $a = $parts[0]; $b = $parts[1]
@@ -59,7 +59,7 @@ function Test-DuneDdnsHostname {
     $h = ([string]$Hostname).Trim().ToLowerInvariant()
     if ([string]::IsNullOrWhiteSpace($h)) { return @{ ok=$false; status=400; message='Enter a DDNS hostname.' } }
     if ($h.Length -gt 253 -or $h -notmatch '^[a-z0-9][a-z0-9.-]*[a-z0-9]$' -or $h -match '\.\.' -or $h -notmatch '\.') {
-        return @{ ok=$false; status=400; message='Enter a valid hostname, for example dunecoastal.myvnc.com.' }
+        return @{ ok=$false; status=400; message='Enter a valid hostname, for example your-server.ddns.net.' }
     }
     foreach ($label in @($h -split '\.')) {
         if ($label.Length -lt 1 -or $label.Length -gt 63 -or $label -notmatch '^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$') {

--- a/tests/PublicIp.Tests.ps1
+++ b/tests/PublicIp.Tests.ps1
@@ -10,9 +10,9 @@ Describe 'Public IP validation' {
     }
 
     It 'accepts a public IPv4 literal' {
-        $r = Assert-DuneManualPublicIp -PublicIp '50.123.76.96'
+        $r = Assert-DuneManualPublicIp -PublicIp '8.8.8.8'
         $r.ok | Should -BeTrue
-        $r.publicIp | Should -Be '50.123.76.96'
+        $r.publicIp | Should -Be '8.8.8.8'
     }
 
     It 'rejects malformed IPv4' {
@@ -22,7 +22,7 @@ Describe 'Public IP validation' {
     }
 
     It 'rejects private IPv4' {
-        $r = Assert-DuneManualPublicIp -PublicIp '192.168.23.219'
+        $r = Assert-DuneManualPublicIp -PublicIp '192.168.1.50'
         $r.ok | Should -BeFalse
         $r.message | Should -Match 'private'
     }
@@ -33,8 +33,8 @@ Describe 'Public IP validation' {
     }
 
     It 'rejects unchanged last-applied IP' {
-        function global:Read-DuneConfig { @{ LastAppliedPublicIp = '50.123.76.96' } }
-        $r = Assert-DuneManualPublicIp -PublicIp '50.123.76.96'
+        function global:Read-DuneConfig { @{ LastAppliedPublicIp = '8.8.8.8' } }
+        $r = Assert-DuneManualPublicIp -PublicIp '8.8.8.8'
         $r.ok | Should -BeFalse
         $r.status | Should -Be 409
     }
@@ -42,9 +42,9 @@ Describe 'Public IP validation' {
 
 Describe 'DDNS hostname validation' {
     It 'normalizes a valid hostname' {
-        $r = Test-DuneDdnsHostname -Hostname 'DuneCoastal.MyVNC.com'
+        $r = Test-DuneDdnsHostname -Hostname 'Your-Server.DDNS.net'
         $r.ok | Should -BeTrue
-        $r.hostname | Should -Be 'dunecoastal.myvnc.com'
+        $r.hostname | Should -Be 'your-server.ddns.net'
     }
 
     It 'rejects invalid hostname labels' {
@@ -54,17 +54,17 @@ Describe 'DDNS hostname validation' {
 
 Describe 'settings.conf renderer' {
     It 'renders exactly four lines' {
-        $text = New-DuneSettingsConfText -Battlegroup 'sh-test' -Image 'registry.funcom.com/funcom/self-hosting/seabass-server:1988751-0-shipping' -VmIp '192.168.23.219' -PublicIp '50.123.76.96'
+        $text = New-DuneSettingsConfText -Battlegroup 'sh-test' -Image 'registry.funcom.com/funcom/self-hosting/seabass-server:1988751-0-shipping' -VmIp '192.168.1.50' -PublicIp '8.8.8.8'
         $lines = $text -split "`n"
         $lines.Count | Should -Be 5
         $lines[0] | Should -Be 'sh-test'
         $lines[1] | Should -Be 'registry.funcom.com/funcom/self-hosting/seabass-server:1988751-0-shipping'
-        $lines[2] | Should -Be '192.168.23.219'
-        $lines[3] | Should -Be '50.123.76.96'
+        $lines[2] | Should -Be '192.168.1.50'
+        $lines[3] | Should -Be '8.8.8.8'
         $lines[4] | Should -Be ''
     }
 
     It 'rejects embedded JSON image lines' {
-        { New-DuneSettingsConfText -Battlegroup 'sh-test' -Image '{"image":"bad"}' -VmIp '192.168.23.219' -PublicIp '50.123.76.96' } | Should -Throw
+        { New-DuneSettingsConfText -Battlegroup 'sh-test' -Image '{"image":"bad"}' -VmIp '192.168.1.50' -PublicIp '8.8.8.8' } | Should -Throw
     }
 }

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -217,7 +217,7 @@ export function PublicIpCard() {
             <input
               type="text"
               value={hostname}
-              placeholder="dunecoastal.myvnc.com"
+              placeholder="your-server.ddns.net"
               onChange={e => { setHostname(e.target.value); clearValidation() }}
               className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-surface-2 border border-border text-text font-mono text-sm placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
             />
@@ -234,7 +234,7 @@ export function PublicIpCard() {
             <input
               type="text"
               value={manualIp}
-              placeholder="50.123.76.96"
+              placeholder="8.8.8.8"
               onChange={e => { setManualIp(e.target.value); clearValidation() }}
               className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-surface-2 border border-border text-text font-mono text-sm placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
             />


### PR DESCRIPTION
## Summary
- replace maintainer-specific DDNS hostname and public IP examples with generic examples
- update Public IP tests to avoid real deployment values
- rebuild canonical installer output with the generic placeholder

## Validation
- `Invoke-Pester -Path .\tests\PublicIp.Tests.ps1,.\tests\ServerLoad.Tests.ps1 -CI`
- `npm run build`
- `pwsh app\installer\Build-Installer.ps1`
- source/dist scan for old hostname/IP values