### PR TITLE
Speed up health load and save DDNS hostname

### DIFF
--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -1050,11 +1050,15 @@ function Get-DuneGameConfig {
 # $DuneServerNameTtlSecs so the frequent status poll repaints from cache; -Force
 # re-reads (used by the manual refresh).
 function Get-DuneServerName {
-    param([switch]$Force)
+    param([switch]$Force, [switch]$CachedOnly)
 
     $age = ([datetime]::UtcNow - $script:DuneServerNameFetched).TotalSeconds
     if (-not $Force -and $script:DuneServerNameCache -ne $null -and $age -lt $script:DuneServerNameTtlSecs) {
         return $script:DuneServerNameCache
+    }
+    if ($CachedOnly) {
+        if ($script:DuneServerNameCache) { return $script:DuneServerNameCache }
+        return ''
     }
 
     $name = ''

--- a/app/server/lib/Ports.ps1
+++ b/app/server/lib/Ports.ps1
@@ -100,22 +100,20 @@ function Get-DunePortStatus {
         return @{ mode = $mode; publicIp = $null; results = @() }
     }
 
-    $pubIp = Get-DunePublicIp
     $now   = Get-Date
-    $cacheAgeOk = $script:DunePortCheckCache -and
-                  ($script:DunePortCheckPubIp -eq $pubIp) -and
-                  (($now - $script:DunePortCheckFetched).TotalSeconds -lt $script:DunePortCheckTtlSecs)
-
-    if (-not $Force.IsPresent -and $cacheAgeOk) {
+    if (-not $Force.IsPresent -and
+        $script:DunePortCheckCache -and
+        (($now - $script:DunePortCheckFetched).TotalSeconds -lt $script:DunePortCheckTtlSecs)) {
         return @{
             mode      = $mode
-            publicIp  = $pubIp
+            publicIp  = $script:DunePortCheckPubIp
             results   = $script:DunePortCheckCache
             cached    = $true
             ageSecs   = [int]($now - $script:DunePortCheckFetched).TotalSeconds
         }
     }
 
+    $pubIp = Get-DunePublicIp
     $results = @()
     foreach ($p in $script:DuneRequiredPorts) {
         $status = switch ($mode) {

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -100,6 +100,25 @@ function Resolve-DunePublicIpHostname {
     return @{ ok=$true; hostname=$hv.hostname; publicIp=$public[0]; candidates=@($public) }
 }
 
+function Save-DunePublicIpHostname {
+    param([string]$Hostname)
+    $hv = Test-DuneDdnsHostname -Hostname $Hostname
+    if (-not $hv.ok) { return $hv }
+
+    $save = {
+        Save-DuneConfig -Config @{
+            PublicIpMode = 'ddns'
+            DdnsHostname = $hv.hostname
+        } | Out-Null
+    }
+    if (Get-Command Invoke-WithDuneLock -ErrorAction SilentlyContinue) {
+        Invoke-WithDuneLock -Name 'config' -Script $save | Out-Null
+    } else {
+        & $save
+    }
+    return @{ ok=$true; hostname=$hv.hostname }
+}
+
 function New-DuneSettingsConfText {
     param(
         [Parameter(Mandatory)][string]$Battlegroup,

--- a/app/server/lib/Status.ps1
+++ b/app/server/lib/Status.ps1
@@ -1,6 +1,11 @@
 ﻿# Status — VM + Battlegroup snapshots via Hyper-V and SSH.
 
 $script:DuneVmName = 'dune-awakening'
+$script:DuneBattlegroupSnapshotCache   = $null
+$script:DuneBattlegroupSnapshotFetched = [datetime]::MinValue
+$script:DuneBattlegroupSnapshotTtlSecs = 8
+$script:DuneBattlegroupSnapshotLock    = [object]::new()
+$script:DuneBattlegroupSnapshotCacheKey = '__cache:status-bg-snapshot'
 
 # Detect whether an SSH private key file is passphrase-protected (encrypted).
 # Returns $true / $false, or $null when it can't be determined (file missing,
@@ -72,7 +77,89 @@ function Get-DuneVmStatus {
     }
 }
 
+function Get-DuneBattlegroupSnapshotCacheEntry {
+    $table = $script:DuneApiLockTable
+    if ($table) {
+        [System.Threading.Monitor]::Enter($table.SyncRoot)
+        try {
+            if ($table.ContainsKey($script:DuneBattlegroupSnapshotCacheKey)) {
+                return $table[$script:DuneBattlegroupSnapshotCacheKey]
+            }
+        } finally {
+            [System.Threading.Monitor]::Exit($table.SyncRoot)
+        }
+        return $null
+    }
+    if ($script:DuneBattlegroupSnapshotCache -eq $null) { return $null }
+    return @{
+        Snapshot = $script:DuneBattlegroupSnapshotCache
+        Fetched  = $script:DuneBattlegroupSnapshotFetched
+    }
+}
+
+function Set-DuneBattlegroupSnapshotCacheEntry {
+    param($Snapshot)
+    $entry = @{
+        Snapshot = $Snapshot
+        Fetched  = [datetime]::UtcNow
+    }
+    $table = $script:DuneApiLockTable
+    if ($table) {
+        [System.Threading.Monitor]::Enter($table.SyncRoot)
+        try {
+            $table[$script:DuneBattlegroupSnapshotCacheKey] = $entry
+        } finally {
+            [System.Threading.Monitor]::Exit($table.SyncRoot)
+        }
+    } else {
+        $script:DuneBattlegroupSnapshotCache = $Snapshot
+        $script:DuneBattlegroupSnapshotFetched = $entry.Fetched
+    }
+}
+
+function Get-DuneBattlegroupSnapshotCached {
+    $entry = Get-DuneBattlegroupSnapshotCacheEntry
+    if (-not $entry) { return $null }
+    $snapshot = $entry.Snapshot
+    $fetched  = [datetime]$entry.Fetched
+    if ($snapshot -ne $null -and (([datetime]::UtcNow - $fetched).TotalSeconds -lt $script:DuneBattlegroupSnapshotTtlSecs)) {
+        return $snapshot
+    }
+    return $null
+}
+
 function Get-DuneBattlegroupSnapshot {
+    param([switch]$Force)
+
+    if (-not $Force.IsPresent) {
+        $cached = Get-DuneBattlegroupSnapshotCached
+        if ($cached -ne $null) { return $cached }
+    }
+
+    $refresh = {
+        if (-not $Force.IsPresent) {
+            $cached = Get-DuneBattlegroupSnapshotCached
+            if ($cached -ne $null) { return $cached }
+        }
+
+        $snapshot = Get-DuneBattlegroupSnapshotFresh
+        Set-DuneBattlegroupSnapshotCacheEntry -Snapshot $snapshot
+        return $snapshot
+    }
+
+    if (Get-Command Invoke-WithDuneLock -ErrorAction SilentlyContinue) {
+        return Invoke-WithDuneLock -Name 'status-bg-snapshot-cache' -TimeoutSec 20 -Script $refresh
+    }
+
+    [System.Threading.Monitor]::Enter($script:DuneBattlegroupSnapshotLock)
+    try {
+        return & $refresh
+    } finally {
+        [System.Threading.Monitor]::Exit($script:DuneBattlegroupSnapshotLock)
+    }
+}
+
+function Get-DuneBattlegroupSnapshotFresh {
     $vm = Get-DuneVmStatus
     $result = @{ available = $false; vm = $vm; output = ''; reason = '' }
 

--- a/app/server/routes/PublicIp.ps1
+++ b/app/server/routes/PublicIp.ps1
@@ -25,6 +25,14 @@ Register-DuneRoute -Method POST -Path '/api/public-ip/resolve' -Handler {
     Write-DuneJson -Response $res -Body @{ ok=$true; hostname=$r.hostname; publicIp=$r.publicIp; candidates=@($r.candidates) }
 }
 
+Register-DuneRoute -Method POST -Path '/api/public-ip/hostname' -Handler {
+    param($req, $res, $routeParams, $body)
+    $hostname = [string](Get-DunePublicIpBodyValue -Body $body -Name 'hostname' -Default '')
+    $r = Save-DunePublicIpHostname -Hostname $hostname
+    if (-not $r.ok) { Write-DuneError -Response $res -Status ([int]$r.status) -Message $r.message; return }
+    Write-DuneJson -Response $res -Body @{ ok=$true; hostname=$r.hostname }
+}
+
 Register-DuneRoute -Method POST -Path '/api/public-ip/validate' -Handler {
     param($req, $res, $routeParams, $body)
     $publicIp = [string](Get-DunePublicIpBodyValue -Body $body -Name 'publicIp' -Default '')

--- a/app/server/routes/Status.ps1
+++ b/app/server/routes/Status.ps1
@@ -10,7 +10,7 @@ Register-DuneRoute -Method GET -Path '/api/status' -Handler {
     try { $ports = Get-DunePortStatus } catch { $ports = $null }
     $serverName = ''
     if ($vm.running -and (Get-Command Get-DuneServerName -ErrorAction SilentlyContinue)) {
-        try { $serverName = Get-DuneServerName } catch { $serverName = '' }
+        try { $serverName = Get-DuneServerName -CachedOnly } catch { $serverName = '' }
     }
     Write-DuneJson -Response $res -Body @{
         vm         = $vm
@@ -27,7 +27,7 @@ Register-DuneRoute -Method POST -Path '/api/status/refresh' -Handler {
     $vm = Get-DuneVmStatus
     $bg = $null
     if ($vm.running) {
-        try { $bg = Get-DuneBattlegroupSnapshot } catch { $bg = @{ available=$false; reason=$_.Exception.Message } }
+        try { $bg = Get-DuneBattlegroupSnapshot -Force } catch { $bg = @{ available=$false; reason=$_.Exception.Message } }
     }
     $ports = $null
     try { $ports = Get-DunePortStatus -Force } catch { $ports = $null }

--- a/tests/PublicIp.Tests.ps1
+++ b/tests/PublicIp.Tests.ps1
@@ -50,6 +50,22 @@ Describe 'DDNS hostname validation' {
     It 'rejects invalid hostname labels' {
         (Test-DuneDdnsHostname -Hostname '-bad.example.com').ok | Should -BeFalse
     }
+
+    It 'saves a normalized hostname without resolving it' {
+        $script:savedPublicIpConfig = $null
+        function Save-DuneConfig {
+            param([hashtable]$Config)
+            $script:savedPublicIpConfig = $Config
+            return $Config
+        }
+
+        $r = Save-DunePublicIpHostname -Hostname 'Your-Server.DDNS.net'
+
+        $r.ok | Should -BeTrue
+        $r.hostname | Should -Be 'your-server.ddns.net'
+        $script:savedPublicIpConfig.PublicIpMode | Should -Be 'ddns'
+        $script:savedPublicIpConfig.DdnsHostname | Should -Be 'your-server.ddns.net'
+    }
 }
 
 Describe 'settings.conf renderer' {

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -35,6 +35,11 @@ type ValidateResponse = {
   publicIp: string
 }
 
+type SaveHostnameResponse = {
+  ok: boolean
+  hostname: string
+}
+
 type ApplyResponse = {
   ok: boolean
   publicIp: string
@@ -56,7 +61,7 @@ export function PublicIpCard() {
   const [manualIp, setManualIp] = useState('')
   const [targetIp, setTargetIp] = useState('')
   const [validatedInput, setValidatedInput] = useState('')
-  const [working, setWorking] = useState<'resolve' | 'validate' | 'apply' | null>(null)
+  const [working, setWorking] = useState<'resolve' | 'save-hostname' | 'validate' | 'apply' | null>(null)
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [steps, setSteps] = useState<PublicIpStep[]>([])
@@ -105,6 +110,25 @@ export function PublicIpCard() {
       setTargetIp(r.publicIp)
       setValidatedInput(r.hostname)
       setMessage(`${r.hostname} resolves to ${r.publicIp}.`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setWorking(null)
+    }
+  }
+
+  async function saveHostname() {
+    setWorking('save-hostname')
+    setError(null)
+    setMessage(null)
+    try {
+      const r = await api<SaveHostnameResponse>('/api/public-ip/hostname', {
+        method: 'POST',
+        body: JSON.stringify({ hostname }),
+      })
+      setHostname(r.hostname)
+      setStatus(prev => prev ? { ...prev, mode: 'ddns', hostname: r.hostname } : prev)
+      setMessage(`Saved ${r.hostname} for future public IP changes.`)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     } finally {
@@ -221,6 +245,10 @@ export function PublicIpCard() {
               onChange={e => { setHostname(e.target.value); clearValidation() }}
               className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-surface-2 border border-border text-text font-mono text-sm placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
             />
+            <button type="button" onClick={() => void saveHostname()} disabled={working !== null || !hostname.trim()} className="btn-secondary shrink-0">
+              <Icon name={working === 'save-hostname' ? 'Loader2' : 'Save'} size={15} className={working === 'save-hostname' ? 'animate-spin' : ''} />
+              Save
+            </button>
             <button type="button" onClick={() => void resolveHostname()} disabled={working !== null || !hostname.trim()} className="btn-secondary shrink-0">
               <Icon name={working === 'resolve' ? 'Loader2' : 'Search'} size={15} className={working === 'resolve' ? 'animate-spin' : ''} />
               Resolve hostname


### PR DESCRIPTION
## Summary
- Cache battlegroup status briefly and avoid duplicate slow SSH status work during initial app load
- Use cached server name on normal status polls and force fresh lookup only on manual refresh
- Add a DDNS hostname Save button and backend config endpoint so hostname can be stored without resolving or applying an IP

## Validation
- `pwsh -NoProfile -File .\tests\Run-Tests.ps1 -Path .\tests\PublicIp.Tests.ps1`
- `npm run build` in `webui`
- `pwsh -NoProfile -File .\app\installer\Build-Installer.ps1`