### PR TITLE
Wire DST community Discord across app, site, README, and releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,12 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 Discord (general questions, hosting help)
-    url: https://discord.com/users/allcoast
+  - name: 💬 DST Community Discord (help & chat)
+    url: https://discord.gg/tj2x7cywSC
     about: |
-      For "how do I host", VM/network connectivity, port-forwarding,
-      Hyper-V tuning, or general Dune dedicated-server questions,
-      ping @allcoast on Discord. The GitHub issue tracker is for
-      bugs in this tool's code only.
+      Join the DST community server for install/setup help, hosting and
+      networking questions, Game Config tips, and general chat. New releases
+      are posted there too. The GitHub issue tracker is for bugs in this
+      tool's code only.
   - name: 📘 Funcom Self-Hosted Server docs
     url: https://duneawakening.com/self-hosted-servers/
     about: Official setup instructions for the dedicated server itself.

--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -1,0 +1,75 @@
+name: Announce release to Discord
+
+# Posts a formatted message to the DST community Discord #releases channel
+# whenever a GitHub release is published. Uses a Discord webhook URL stored as
+# the repo secret DISCORD_RELEASE_WEBHOOK (the webhook lives in #releases).
+#
+# Also runnable manually (workflow_dispatch) to (re)announce a specific tag,
+# which is handy for testing without cutting a new release.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to announce (leave blank for the latest)'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post release to Discord
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "DISCORD_RELEASE_WEBHOOK is not set; skipping Discord announcement."
+            exit 0
+          fi
+
+          tag="${EVENT_TAG:-${INPUT_TAG:-}}"
+          if [ -z "$tag" ]; then
+            tag=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName)
+          fi
+          echo "Announcing release: $tag"
+
+          rel=$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json name,tagName,body,url)
+          name=$(printf '%s' "$rel" | jq -r '.name // .tagName')
+          url=$(printf '%s' "$rel" | jq -r '.url')
+          # Discord embed descriptions cap at 4096; keep it readable at ~1500.
+          body=$(printf '%s' "$rel" | jq -r '.body // ""' | head -c 1500)
+
+          payload=$(jq -n \
+            --arg t "🚀 $name" \
+            --arg d "$body" \
+            --arg u "$url" \
+            '{
+               username: "DST Releases",
+               embeds: [ {
+                 title: $t,
+                 url: $u,
+                 description: $d,
+                 color: 15844367,
+                 footer: { text: "Download the DuneServerSetup.exe asset from the release page · in-app updater offers it within ~6h" }
+               } ]
+             }')
+
+          http=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -X POST -H "Content-Type: application/json" \
+            -d "$payload" "$WEBHOOK")
+          echo "Discord webhook responded: HTTP $http"
+          case "$http" in
+            2*) echo "Posted $tag to Discord." ;;
+            *)  echo "Discord webhook failed (HTTP $http)."; exit 1 ;;
+          esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Community Discord.** A new **Discord** link in the app menu bar (next to
+  Website) opens the DST community server for install/setup help, hosting
+  questions, Game Config tips, and release announcements. The marketing site,
+  README, and the issue-template chooser link to it as well.
+
 ## [12.8.2] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -761,6 +761,20 @@ sitting at your desk.
 
 ---
 
+## Community & support
+
+Join the **DST community Discord** for install/setup help, hosting and
+networking questions, Game Config tips, release announcements, and general
+chat with other self-hosters:
+
+> 👉 [**Join the DST Discord**](https://discord.gg/tj2x7cywSC)
+
+It's the best place for "how do I…" questions and hosting help. For anything
+that needs a code fix, please still open a GitHub issue (below) so it's
+tracked publicly.
+
+---
+
 ## Reporting issues
 
 Hit a bug, error, or unexpected behavior? **Please open a GitHub issue**
@@ -785,9 +799,10 @@ pre-fills most of this for you and opens the GitHub form in your browser.
 **Sanitize first** — remove IPs, hostnames, usernames, and any key file
 contents before submitting.
 
-Discord pings to `@allcoast` are fine for quick questions, but use the
-issue tracker for anything that needs a fix — it keeps the history public
-so other admins can find the same answer.
+Quick questions are also welcome in the [DST community
+Discord](https://discord.gg/tj2x7cywSC), but use the issue tracker for
+anything that needs a fix — it keeps the history public so other admins can
+find the same answer.
 
 ---
 

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -90,6 +90,12 @@ const ogImg = new URL(ogImage ?? `${base}og.png`, Astro.site).toString();
             rel="noopener"
             target="_blank">Report Issue</a
           >
+          <a
+            href="https://discord.gg/tj2x7cywSC"
+            class="text-dune-accent hover:text-dune-accent-soft transition-colors"
+            rel="noopener"
+            target="_blank">Discord</a
+          >
         </nav>
       </div>
     </header>
@@ -113,8 +119,13 @@ const ogImg = new URL(ogImage ?? `${base}og.png`, Astro.site).toString();
           > license.
         </div>
         <div class="font-mono text-xs">
-          by Coastal · Discord
-          <span class="text-dune-text">@allcoast</span>
+          by Coastal ·
+          <a
+            href="https://discord.gg/tj2x7cywSC"
+            class="text-dune-text underline decoration-dotted hover:text-dune-accent"
+            rel="noopener"
+            target="_blank">Join the Discord</a
+          >
         </div>
       </div>
     </footer>

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -382,15 +382,28 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
         )}
       </div>
 
-      {/* Marketing site link, pushed to the far right of the menu bar.
-          ml-auto consumes the remaining horizontal space so this sits flush
-          right while the page groups + Help stay left-aligned. */}
+      {/* Community Discord + marketing site links, pushed to the far right of
+          the menu bar. ml-auto on the first one consumes the remaining
+          horizontal space so this pair sits flush right while the page groups
+          + Help stay left-aligned. */}
+      <a
+        href="https://discord.gg/tj2x7cywSC"
+        target="_blank"
+        rel="noopener noreferrer"
+        onMouseEnter={() => { if (open !== null) setOpen(null) }}
+        className="ml-auto mr-1 px-3 h-7 inline-flex items-center gap-1.5 rounded-md text-text-muted hover:text-text hover:bg-surface-2/80 transition-colors"
+        title="Join the DST community Discord — community help, DST support, and hosting help"
+      >
+        <Icon name="MessagesSquare" size={14} />
+        <span>Discord</span>
+        <Icon name="ExternalLink" size={11} className="text-text-dim" />
+      </a>
       <a
         href="https://coastal-ms.github.io/DST-DuneServerTool/"
         target="_blank"
         rel="noopener noreferrer"
         onMouseEnter={() => { if (open !== null) setOpen(null) }}
-        className="ml-auto mr-1 px-3 h-7 inline-flex items-center gap-1.5 rounded-md text-text-muted hover:text-text hover:bg-surface-2/80 transition-colors"
+        className="mr-1 px-3 h-7 inline-flex items-center gap-1.5 rounded-md text-text-muted hover:text-text hover:bg-surface-2/80 transition-colors"
         title="Open the Dune Server Tool website — screenshots, install guide, and changelog"
       >
         <Icon name="Globe" size={14} />


### PR DESCRIPTION
## What

Wires the new **DST community Discord** into every place users land, and restores release auto-posting.

### User-facing links (all point to the community invite)
- **App** — a **Discord** link in the menu bar, next to Website (`webui/src/layout/MenuBar.tsx`)
- **Marketing site** — Discord in the header nav + a "Join the Discord" footer link (`site/src/layouts/Base.astro`)
- **README** — a new **Community & support** section + a link from *Reporting issues*
- **Issue template chooser** — the Discord contact link now points at the community server invite (`.github/ISSUE_TEMPLATE/config.yml`)

### Release automation
- **`.github/workflows/discord-release.yml`** — on `release: published`, posts a formatted embed to the Discord `#releases` channel via the `DISCORD_RELEASE_WEBHOOK` repo secret (already configured). Also `workflow_dispatch` for re-announcing any tag.

## Validation
- `webui` build (tsc + vite) ✅
- `site` build (astro) ✅
- No PowerShell files touched.

## Notes
The Discord server itself (roles, categories, channels, content) is already built and populated out-of-band; this PR is just the in-product/site/repo wiring. CHANGELOG `[Unreleased]` updated.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;