### PR TITLE
Surface DST community Discord in Help menu and on the site (+ Community page)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ here cover everything those tags shipped.
 - **Community Discord.** A new **Discord** link in the app menu bar (next to
   Website) and in the **Help** menu opens the DST community server for
   install/setup help, hosting questions, Game Config tips, and release
-  announcements. The marketing site (header, homepage Community section,
-  About page, footer), README, and the issue-template chooser link to it as
-  well.
+  announcements. The marketing site gains a dedicated **Community** page
+  (linked from the header nav), plus a homepage Community section, an About
+  page link, and a footer link; the README and issue-template chooser link to
+  it as well.
 
 ## [12.8.2] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ here cover everything those tags shipped.
 ### Added
 
 - **Community Discord.** A new **Discord** link in the app menu bar (next to
-  Website) opens the DST community server for install/setup help, hosting
-  questions, Game Config tips, and release announcements. The marketing site,
-  README, and the issue-template chooser link to it as well.
+  Website) and in the **Help** menu opens the DST community server for
+  install/setup help, hosting questions, Game Config tips, and release
+  announcements. The marketing site (header, homepage Community section,
+  About page, footer), README, and the issue-template chooser link to it as
+  well.
 
 ## [12.8.2] - 2026-06-19
 

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -14,6 +14,7 @@ const nav = [
   { href: "install", label: "Install" },
   { href: "remote", label: "Remote" },
   { href: "changelog", label: "Changelog" },
+  { href: "community", label: "Community" },
   { href: "about", label: "About" },
 ];
 const url = new URL(Astro.url.pathname, Astro.site);
@@ -89,12 +90,6 @@ const ogImg = new URL(ogImage ?? `${base}og.png`, Astro.site).toString();
             class="text-dune-muted hover:text-dune-text transition-colors"
             rel="noopener"
             target="_blank">Report Issue</a
-          >
-          <a
-            href="https://discord.gg/tj2x7cywSC"
-            class="text-dune-accent hover:text-dune-accent-soft transition-colors"
-            rel="noopener"
-            target="_blank">Discord</a
           >
         </nav>
       </div>

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -39,6 +39,16 @@ import PageHeader from "../components/PageHeader.astro";
       > for the change-control workflow.
     </p>
 
+    <p>
+      For help, tips, and chat with other self-hosters, join the
+      <a
+        href="https://discord.gg/tj2x7cywSC"
+        rel="noopener"
+        class="text-dune-accent hover:text-dune-accent-soft"
+        >DST community Discord</a
+      >. New releases are announced there too.
+    </p>
+
     <h2 class="text-xl font-semibold text-dune-text pt-4">
       How it's put together
     </h2>

--- a/site/src/pages/community.astro
+++ b/site/src/pages/community.astro
@@ -1,0 +1,113 @@
+---
+import Base from "../layouts/Base.astro";
+import PageHeader from "../components/PageHeader.astro";
+
+const invite = "https://discord.gg/tj2x7cywSC";
+
+const categories = [
+  {
+    name: "Information",
+    body: "Welcome & rules, announcements, releases, and a rolling changelog — new builds are posted here automatically.",
+  },
+  {
+    name: "DST Support",
+    body: "Install & setup, hosting help, Game Config & Landsraad, Gameplay Admin, Market Bot, Cheat Scripts, plus bug-report and feature-request channels.",
+  },
+  {
+    name: "Server Admins",
+    body: "A space for verified self-hosters to swap configs, show off their servers, and coordinate Landsraad events.",
+  },
+  {
+    name: "Community",
+    body: "General chat, introductions, screenshots & clips, and off-topic — hang out with other Dune: Awakening hosts.",
+  },
+];
+
+const helpTopics = [
+  "Installing DST and first-run setup",
+  "Port forwarding, public IP / DDNS, and firewall issues",
+  "Game Config & Landsraad tweaks",
+  "Gameplay Admin, Market Bot, and Cheat Scripts",
+  "General Dune: Awakening dedicated-server questions",
+];
+---
+
+<Base
+  title="Community — DST"
+  description="Join the DST community Discord for install, hosting, and Game Config help, plus release news and chat with other Dune: Awakening self-hosters."
+>
+  <PageHeader
+    eyebrow="Community"
+    title="The DST community"
+    intro="A Discord server for everyone running a self-hosted Dune: Awakening dedicated server with DST — the place to go for help, tips, and release news."
+  />
+
+  <section class="mx-auto max-w-6xl px-6 pb-10">
+    <div
+      class="rounded-xl border border-dune-accent/40 bg-dune-accent/5 p-8 sm:p-10 sm:flex sm:items-center sm:justify-between gap-8"
+    >
+      <div>
+        <h2 class="text-2xl font-semibold mb-2">Get help &amp; hang out</h2>
+        <p class="text-dune-muted leading-relaxed max-w-2xl">
+          Ask install, hosting, and Game Config questions, share configs and
+          screenshots, and get notified the moment a new release drops. It's
+          free and open to everyone.
+        </p>
+      </div>
+      <div class="mt-6 sm:mt-0 shrink-0">
+        <a
+          href={invite}
+          rel="noopener"
+          target="_blank"
+          class="inline-flex items-center gap-2 rounded-lg bg-dune-accent hover:bg-dune-accent-soft text-dune-bg font-medium px-6 py-3 transition-colors"
+        >
+          Join the Discord →
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <section class="mx-auto max-w-6xl px-6 py-8">
+    <h2 class="text-2xl font-semibold mb-6">What you'll find inside</h2>
+    <div class="grid sm:grid-cols-2 gap-6">
+      {
+        categories.map((c) => (
+          <div class="rounded-lg border border-dune-border bg-dune-surface p-6">
+            <h3 class="text-lg font-semibold text-dune-text mb-2">{c.name}</h3>
+            <p class="text-sm text-dune-muted leading-relaxed">{c.body}</p>
+          </div>
+        ))
+      }
+    </div>
+  </section>
+
+  <section class="mx-auto max-w-6xl px-6 py-8">
+    <div class="rounded-xl border border-dune-border bg-dune-surface p-8 sm:p-10">
+      <h2 class="text-2xl font-semibold mb-4">Great for getting help with</h2>
+      <div class="grid sm:grid-cols-2 gap-x-12 gap-y-3 text-dune-muted">
+        {helpTopics.map((t) => <div>✓ {t}</div>)}
+      </div>
+      <p class="mt-8 text-sm text-dune-muted leading-relaxed border-t border-dune-border pt-6">
+        Found a reproducible bug? Please open a
+        <a
+          href="https://github.com/coastal-ms/DST-DuneServerTool/issues/new/choose"
+          rel="noopener"
+          class="text-dune-accent hover:text-dune-accent-soft"
+          >GitHub issue</a
+        > so it can be tracked and fixed — the Discord is best for questions and
+        chat, the issue tracker for anything that needs a code change.
+      </p>
+    </div>
+  </section>
+
+  <section class="mx-auto max-w-6xl px-6 pb-20">
+    <a
+      href={invite}
+      rel="noopener"
+      target="_blank"
+      class="inline-flex items-center gap-2 rounded-lg bg-dune-accent hover:bg-dune-accent-soft text-dune-bg font-medium px-6 py-3 transition-colors"
+    >
+      Join the DST Discord →
+    </a>
+  </section>
+</Base>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -145,6 +145,31 @@ const features = [
           Browse the code →
         </a>
       </div>
+  <section class="mx-auto max-w-6xl px-6 pb-20">
+    <div
+      class="rounded-xl border border-dune-accent/40 bg-dune-accent/5 p-8 sm:p-12 sm:flex sm:items-center sm:justify-between gap-8"
+    >
+      <div>
+        <h2 class="text-2xl sm:text-3xl font-semibold mb-3">
+          Join the DST community
+        </h2>
+        <p class="text-dune-muted leading-relaxed max-w-2xl">
+          The <strong class="text-dune-text">DST community Discord</strong> is the
+          place to go for help — install &amp; setup, hosting and networking
+          questions, Game Config &amp; Landsraad tips, and chat with other
+          self-hosters. New releases are announced there too.
+        </p>
+      </div>
+      <div class="mt-6 sm:mt-0 shrink-0">
+        <a
+          href="https://discord.gg/tj2x7cywSC"
+          rel="noopener"
+          target="_blank"
+          class="inline-flex items-center gap-2 rounded-lg bg-dune-accent hover:bg-dune-accent-soft text-dune-bg font-medium px-6 py-3 transition-colors"
+        >
+          Join the Discord →
+        </a>
+      </div>
     </div>
   </section>
 </Base>

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -256,6 +256,23 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
         </button>
         {open === 'help' && (
           <div className="absolute left-0 top-full mt-1 min-w-[260px] bg-surface border border-border rounded-xl p-1 shadow-xl shadow-black/40 z-50">
+            <a
+              href="https://discord.gg/tj2x7cywSC"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(null)}
+              className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors text-left"
+              title="Join the DST community Discord — install/setup help, hosting questions, Game Config tips, and release announcements."
+            >
+              <Icon name="MessagesSquare" size={14} className="mt-0.5" />
+              <span className="flex-1">
+                <span className="block">Join the DST Community Discord</span>
+                <span className="block text-[11px] text-text-dim">
+                  Community &amp; hosting help, tips, and release news
+                </span>
+              </span>
+              <Icon name="ExternalLink" size={11} className="text-text-dim mt-1" />
+            </a>
             <button
               type="button"
               onClick={onReportIssue}


### PR DESCRIPTION
## What

Deeper wiring of the **DST community Discord** into the app and marketing site (builds on the basic links from #292).

### App
- New **"Join the DST Community Discord"** entry at the top of the **Help** menu (`webui/src/layout/MenuBar.tsx`) — the natural spot users look for help.

### Marketing site
- **Dedicated `/community` page** (`site/src/pages/community.astro`) — what the server offers (category overview), the topics it's great for help with, a note steering bugs to GitHub issues, and Join CTAs. Linked from the header nav (replacing the redundant external Discord nav link).
- **Homepage:** a prominent **"Join the DST community"** call-to-action section.
- **About page:** a community paragraph linking the Discord.
- Footer keeps its Discord link.

All point to the canonical invite `https://discord.gg/tj2x7cywSC`.

## Validation
- `webui` build (tsc + vite) ✅
- `site` build (astro) ✅ — `/community` generates, 9 pages total
- No PowerShell files touched.

CHANGELOG `[Unreleased]` updated.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;