### PR TITLE
Release v12.8.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.8.2"
+      placeholder: "v12.8.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.8.3] - 2026-06-19
+
 ### Added
 
 - **Community Discord.** A new **Discord** link in the app menu bar (next to

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.8.2'
+$script:DuneToolVersion = '12.8.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.8.2',
+    [string]$Version = '12.8.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.8.2</Version>
+    <Version>12.8.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.8.2"
+#define MyAppVersion "12.8.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.8.2"
+$script:ToolVersion = "12.8.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Release v12.8.3

Ships the in-app **community Discord links** added in #292 / #293 (menu-bar Discord link + a "Join the DST Community Discord" entry in the Help menu).

### Version stamps (all five + placeholder → 12.8.3)
- `app/DuneServer.ps1` — `$script:DuneToolVersion`
- `app/build/Build-Exe.ps1` — default `$Version`
- `app/desktop/DuneShell/DuneShell.csproj` — `<Version>`
- `app/installer/DuneServer.iss` — `#define MyAppVersion`
- `dune-server.ps1` — `$script:ToolVersion`
- `.github/ISSUE_TEMPLATE/bug_report.yml` — `tool_version` placeholder

### CHANGELOG
- Rolled `[Unreleased]` into a dated **`[12.8.3] - 2026-06-19`** entry.

### Build
- Installer built clean from this branch → `app/installer/output/DuneServerSetup.exe` (45.92 MB), ready to attach to the GitHub release.

> ⏸️ **Holding at publish per standing rule** — not merging/tagging/releasing without explicit approval. After approval: merge → tag `v12.8.3` from the merge commit → publish release with `DuneServerSetup.exe` as the sole asset.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;