### PR TITLE
Fix #280 (Web Portal recovery UX) and #295 (configurable DB port)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable database port (issue #295).** Settings gains a **Database port**
+  field (default `15432`) and a **Test connection** button on a new **Database
+  connection** card. DST reads Players / Bases / Storage from the server's
+  in-pod PostgreSQL over this port; servers whose database listens elsewhere
+  (e.g. `15433`) previously showed those pages empty with no error. The test
+  runs `SELECT 1`, reports a clear "can't reach the database on :&lt;port&gt;"
+  message instead of silent empty data, and auto-probes common ports
+  (15432 / 15433 / 5432) to suggest the right one.
+
+### Fixed
+
+- **Web Portal no longer strands you on a "page is unavailable" error (issue
+  #280).** Clicking **Web Portal** used to close the app window immediately, so
+  if your browser couldn't reach `127.0.0.1` (antivirus, VPN or proxy blocking
+  loopback), you were left with a dead page and no UI. The app window now stays
+  open until the browser actually connects, then closes automatically. If the
+  browser can't reach the server, the window stays usable and offers a
+  **Copy portal URL** fallback so you can open it in another browser or after
+  adding a loopback bypass.
+
 ## [12.8.3] - 2026-06-19
 
 ### Added

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -439,6 +439,20 @@ internal sealed class MainForm : Form
             // WebMessageReceived handler can return cleanly first.
             BeginInvoke(new Action(() => { try { Close(); } catch { } }));
         }
+        else if (string.Equals(action, "open", StringComparison.OrdinalIgnoreCase))
+        {
+            // Issue #280: open the portal in the default browser but KEEP this
+            // window open. The React UI waits for the browser to check in with
+            // the server before asking us to close (a separate "close" message),
+            // so a browser that can't reach 127.0.0.1 leaves the user with a
+            // working app window + Copy URL fallback instead of a dead window.
+            if (!string.IsNullOrWhiteSpace(url)) OpenExternal(url);
+        }
+        else if (string.Equals(action, "close", StringComparison.OrdinalIgnoreCase))
+        {
+            // Browser confirmed it reached the server — safe to close now.
+            BeginInvoke(new Action(() => { try { Close(); } catch { } }));
+        }
     }
 
     private static void OpenExternal(string url)

--- a/app/lib/Db-Postgres.ps1
+++ b/app/lib/Db-Postgres.ps1
@@ -29,6 +29,46 @@ function Get-V6SshKeyPath {
     return $null
 }
 
+# Resolve the in-pod PostgreSQL port. This is the port the postgres process
+# listens on INSIDE the cluster pod (reached via `kubectl exec -- psql -p`), not
+# a port reachable from Windows. Funcom's stock server uses 15432; the DbPort
+# config key lets operators whose DB is on a different port (e.g. 15433) point
+# DST at it instead of silently seeing empty Players/Bases/Storage. Reads fresh
+# each call (no cache) so a Settings change takes effect without a restart.
+function Get-V6DbPort {
+    $default = 15432
+    try {
+        if (Get-Command Get-DuneDbPort -ErrorAction SilentlyContinue) { return (Get-DuneDbPort) }
+        $cfg = $null
+        if (Get-Command Read-Config -ErrorAction SilentlyContinue) {
+            $cfg = Read-Config
+        } else {
+            $cfgPath = $null
+            if ($script:ConfigFile -and (Test-Path $script:ConfigFile)) { $cfgPath = $script:ConfigFile }
+            elseif (Test-Path "$env:APPDATA\DuneServer\dune-server.config") { $cfgPath = "$env:APPDATA\DuneServer\dune-server.config" }
+            if ($cfgPath) {
+                $cfg = @{}
+                Get-Content $cfgPath | ForEach-Object {
+                    if ($_ -match '^([^#=]+)=(.*)$') { $cfg[$Matches[1].Trim()] = $Matches[2].Trim() }
+                }
+            }
+        }
+        if ($cfg) {
+            $raw = $null
+            if ($cfg -is [System.Collections.IDictionary]) {
+                if ($cfg.Contains('DbPort')) { $raw = [string]$cfg['DbPort'] }
+            } elseif ($cfg.PSObject -and $cfg.PSObject.Properties['DbPort']) {
+                $raw = [string]$cfg.DbPort
+            }
+            $parsed = 0
+            if ($raw -and [int]::TryParse($raw.Trim(), [ref]$parsed) -and $parsed -ge 1 -and $parsed -le 65535) {
+                return $parsed
+            }
+        }
+    } catch {}
+    return $default
+}
+
 function Invoke-V6Ssh {
     param([string]$Ip, [string]$Cmd, [int]$TimeoutSec = 30, [string]$StdinData)
     # Strip CRs from the command — here-strings in CRLF-saved .ps1 files
@@ -234,10 +274,50 @@ function Find-V6DbPod {
 function Invoke-V6Psql {
     param([string]$Ip, [string]$Sql, [int]$TimeoutSec = 30)
     $pod = Find-V6DbPod -Ip $Ip
+    $port = Get-V6DbPort
     $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Sql))
-    $cmd = "echo $b64 | base64 -d | sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p 15432 -t -A 2>&1"
+    $cmd = "echo $b64 | base64 -d | sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p $port -t -A 2>&1"
     $out = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec
     return (($out -join "`n")).Trim()
+}
+
+# Detect a PostgreSQL "can't reach the server" failure in psql output (wrong
+# port, server down) as opposed to a SQL error. Used to surface a clear
+# "can't reach database on :<port>" message instead of empty data.
+function Test-DunePsqlConnError {
+    param([string]$Output)
+    if (-not $Output) { return $false }
+    return ($Output -match '(?i)could not connect to server|Connection refused|could not translate host|server closed the connection|No route to host|Connection timed out')
+}
+
+# Run a lightweight `SELECT 1` against a given (or configured) in-pod port and
+# report whether Postgres is reachable. Powers the Settings "Test connection"
+# button and the auto-probe that suggests a different port (e.g. 15433) when the
+# configured one is dead.
+function Test-DuneDbConnection {
+    param([string]$Ip, [int]$Port = 0, [int]$TimeoutSec = 20)
+    if ($Port -le 0) { $Port = Get-V6DbPort }
+    $result = @{ ok = $false; port = $Port; message = ''; raw = '' }
+    try {
+        $pod = Find-V6DbPod -Ip $Ip
+    } catch {
+        $result.message = "Postgres pod not found. Make sure the battlegroup is running and fully initialized."
+        return $result
+    }
+    $cmd = "sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p $Port -t -A -c 'SELECT 1' 2>&1"
+    $out = (Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec) -join "`n"
+    $result.raw = $out.Trim()
+    if ($out -match '(?m)^\s*1\s*$') {
+        $result.ok = $true
+        $result.message = "Connected to PostgreSQL on port $Port."
+    } elseif (Test-DunePsqlConnError -Output $out) {
+        $result.message = "Can't reach the database on port $Port. The PostgreSQL server is not listening there."
+    } elseif ($out -match '(?i)ERROR|FATAL') {
+        $result.message = "PostgreSQL on port $Port returned an error: $($result.raw)"
+    } else {
+        $result.message = "Unexpected response from port $Port`: $($result.raw)"
+    }
+    return $result
 }
 
 function ConvertFrom-V6PsqlJson {

--- a/app/server/lib/Config.ps1
+++ b/app/server/lib/Config.ps1
@@ -20,8 +20,16 @@ $script:DuneConfigKeys = @(
     'MarketBotAddr',
     'MarketBotToken',
     'DecoupleNoticeAck',
-    'ClientConfigPath'
+    'ClientConfigPath',
+    'DbPort'
 )
+
+# Default in-pod PostgreSQL port. All DST DB access runs as
+# `kubectl exec <db-pod> -- psql -p <port>`, so this is the port the postgres
+# process listens on INSIDE the cluster pod, not a port reachable from Windows.
+# Funcom's stock self-hosted server uses 15432; some setups differ (e.g. 15433),
+# which previously made Players/Bases/Storage show empty with no error.
+$script:DuneDefaultDbPort = 15432
 
 # Keys that ONLY a pre-decouple (<= 11.4.13) build ever wrote into
 # dune-server.config. Their presence on disk is how we know a config was
@@ -81,6 +89,22 @@ function Get-DstOpenInAppWindow {
 # distinct function so callers have a single "resolved config" entry point.
 function Read-DuneConfig {
     return Read-DuneConfigRaw
+}
+
+# Resolve the in-pod PostgreSQL port DST should use. Reads the DbPort config key,
+# validates it as a 1-65535 integer, and falls back to the Funcom default
+# (15432) when unset or invalid.
+function Get-DuneDbPort {
+    $default = if ($script:DuneDefaultDbPort) { $script:DuneDefaultDbPort } else { 15432 }
+    try {
+        $raw = Read-DuneConfigRaw
+        $v = if ($raw.Contains('DbPort')) { [string]$raw['DbPort'] } else { '' }
+        $parsed = 0
+        if ($v -and [int]::TryParse($v.Trim(), [ref]$parsed) -and $parsed -ge 1 -and $parsed -le 65535) {
+            return $parsed
+        }
+    } catch {}
+    return $default
 }
 
 function Save-DuneConfig {

--- a/app/server/lib/ConsoleHost.ps1
+++ b/app/server/lib/ConsoleHost.ps1
@@ -63,6 +63,46 @@ function Clear-DuneAppDetached {
     } catch { }
 }
 
+# Portal browser check-in (issue #280). When the user clicks "Web Portal", the
+# app window must NOT close until we know the external browser actually reached
+# the server (some environments — AV/proxy/CGNAT — block the browser from
+# 127.0.0.1 even though the in-app WebView2 can reach it). The freshly-opened
+# browser tab POSTs /api/portal/checkin, which writes this file; the still-open
+# app window polls /api/portal/checkin-status and only then closes itself.
+# A file is used (not $script: state) because API handlers run in a runspace
+# pool with no shared script scope across requests — same reason the detach
+# flag is file-backed.
+function Get-DunePortalCheckinFile {
+    $dir = Join-Path $env:LOCALAPPDATA 'DuneServer'
+    return (Join-Path $dir 'portal-browser-checkin.flag')
+}
+
+function Set-DunePortalBrowserCheckin {
+    try {
+        $file = Get-DunePortalCheckinFile
+        $dir = Split-Path -Parent $file
+        if (-not (Test-Path -LiteralPath $dir)) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        }
+        Set-Content -LiteralPath $file -Value ((Get-Date).ToString('o')) -Encoding UTF8 -Force
+    } catch { }
+}
+
+function Clear-DunePortalBrowserCheckin {
+    try {
+        $file = Get-DunePortalCheckinFile
+        if (Test-Path -LiteralPath $file) {
+            Remove-Item -LiteralPath $file -Force -ErrorAction SilentlyContinue
+        }
+    } catch { }
+}
+
+function Test-DunePortalBrowserCheckin {
+    try {
+        return (Test-Path -LiteralPath (Get-DunePortalCheckinFile))
+    } catch { return $false }
+}
+
 # Sentinel file consumed by DuneShell's FormClosing teardown AND by the
 # app-window watcher runspace. When this file exists, neither side should
 # tear the backend down on shell close -- the user has opted into

--- a/app/server/lib/Database.ps1
+++ b/app/server/lib/Database.ps1
@@ -36,9 +36,10 @@ function Invoke-DuneSqlRaw {
         [switch]$Csv
     )
     $pod = Find-V6DbPod -Ip $Ip
+    $port = Get-V6DbPort
     $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Sql))
     $flags = if ($Csv) { '-X --csv' } else { '-X -A' }
-    $cmd = "echo $b64 | base64 -d | sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p 15432 -v ON_ERROR_STOP=1 $flags 2>&1"
+    $cmd = "echo $b64 | base64 -d | sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p $port -v ON_ERROR_STOP=1 $flags 2>&1"
     $out = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec
     return ($out -join "`n")
 }
@@ -57,12 +58,13 @@ function Invoke-DuneSqlRawStdin {
         [switch]$Csv
     )
     $pod = Find-V6DbPod -Ip $Ip
+    $port = Get-V6DbPort
     $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Sql))
     $flags = if ($Csv) { '-X --csv' } else { '-X -A' }
     # Remote cmd reads base64 bytes off OUR stdin (which Invoke-V6Ssh writes
     # via -StdinData), decodes them, and feeds the SQL into psql. Total
     # remote command length is < 200 chars regardless of payload size.
-    $cmd = "base64 -d | sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p 15432 -v ON_ERROR_STOP=1 $flags 2>&1"
+    $cmd = "base64 -d | sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p $port -v ON_ERROR_STOP=1 $flags 2>&1"
     $out = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec -StdinData $b64
     return ($out -join "`n")
 }

--- a/app/server/routes/Database.ps1
+++ b/app/server/routes/Database.ps1
@@ -28,6 +28,59 @@ Register-DuneRoute -Method GET -Path '/api/db/info' -Handler {
 }
 
 # -----------------------------------------------------------------------------
+# POST /api/db/test-connection — verify the in-pod PostgreSQL port is reachable.
+# Body (optional): { port: <int>, probe: true|false }
+#   - port  : test this port instead of the saved DbPort (lets Settings test a
+#             value before saving it).
+#   - probe : when the target port is unreachable, also try common alternatives
+#             (15432, 15433, 5432) and report the first one that responds so the
+#             user can switch to it.
+# Returns: { ok, port, message, suggestedPort?, probed? }
+# -----------------------------------------------------------------------------
+Register-DuneRoute -Method POST -Path '/api/db/test-connection' -Handler {
+    param($req, $res, $routeParams, $body)
+    $ctx = Get-DuneDbContext
+    if (-not $ctx.ok) {
+        Write-DuneError -Response $res -Status $ctx.status -Message $ctx.message
+        return
+    }
+    $port = 0
+    $probe = $true
+    if ($body -is [hashtable]) {
+        if ($body.ContainsKey('port'))  { try { $port = [int]$body.port } catch {} }
+        if ($body.ContainsKey('probe')) { $probe = [bool]$body.probe }
+    } elseif ($body) {
+        if ($body.port)  { try { $port = [int]$body.port } catch {} }
+        if ($null -ne $body.probe) { $probe = [bool]$body.probe }
+    }
+
+    try {
+        $result = Test-DuneDbConnection -Ip $ctx.ip -Port $port
+        $out = @{
+            ok      = $result.ok
+            port    = $result.port
+            message = $result.message
+        }
+        if (-not $result.ok -and $probe) {
+            $suggested = $null
+            foreach ($candidate in @(15432, 15433, 5432)) {
+                if ($candidate -eq $result.port) { continue }
+                $alt = Test-DuneDbConnection -Ip $ctx.ip -Port $candidate
+                if ($alt.ok) { $suggested = $candidate; break }
+            }
+            $out.probed = $true
+            if ($suggested) {
+                $out.suggestedPort = $suggested
+                $out.message = "$($result.message) Found PostgreSQL on port $suggested instead — update the Database port to $suggested."
+            }
+        }
+        Write-DuneJson -Response $res -Body $out
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Connection test failed: $($_.Exception.Message)"
+    }
+}
+
+# -----------------------------------------------------------------------------
 # POST /api/db/query — execute SQL.
 # Body: { sql: "...", readOnly: true|false, maxRows: 1000, timeoutSec: 30 }
 # Returns: { ok, columns, rows, rowCount, truncated, message, durationMs, readOnly, maxRows }

--- a/app/server/routes/Portal.ps1
+++ b/app/server/routes/Portal.ps1
@@ -15,6 +15,14 @@
 #      did Start-Process here, the browser would inherit our elevated token
 #      and Chrome/Edge would block the launch ("can't run elevated").
 #
+# Recovery flow (issue #280): the app window does NOT close on hand-off. The
+# freshly-opened browser POSTs /api/portal/checkin once it loads; the app
+# window polls /api/portal/checkin-status and only closes itself after the
+# browser confirms it reached the server. If the browser is blocked from
+# 127.0.0.1 (AV/VPN/proxy) it never checks in, so the user keeps a working app
+# window + a Copy URL fallback instead of a dead "page unavailable" tab.
+# /api/portal/reattach undoes the detach when the user gives up.
+#
 # Next launch of DuneServer.exe detects no surviving DuneShell.exe and treats
 # it as a kill+restart request (see DuneServer.ps1 second-instance branch).
 
@@ -25,6 +33,14 @@ Register-DuneRoute -Method POST -Path '/api/portal/open-in-browser' -Inline -Han
         Set-DuneAppDetached
     } else {
         $script:DuneAppDetached = $true
+    }
+
+    # Reset any stale browser check-in so the app window's poll only reacts to
+    # the browser we're about to open (issue #280 recovery flow). The window
+    # stays open until that fresh browser tab checks in (or the user gives up
+    # and uses the Copy URL fallback).
+    if (Get-Command Clear-DunePortalBrowserCheckin -ErrorAction SilentlyContinue) {
+        Clear-DunePortalBrowserCheckin
     }
 
     $url = $null
@@ -50,6 +66,44 @@ Register-DuneRoute -Method POST -Path '/api/portal/open-in-browser' -Inline -Han
         ok       = $true
         detached = $true
         url      = $url
-        message  = 'App window will close; portal opens in default browser. Server stays running.'
+        message  = 'Opening portal in your default browser. The app window stays open until the browser connects.'
     }
+}
+
+# POST /api/portal/checkin — the freshly-opened external browser tab calls this
+# on load to prove it reached the local server. The app window polls
+# /api/portal/checkin-status and closes itself once this fires (issue #280).
+Register-DuneRoute -Method POST -Path '/api/portal/checkin' -Inline -Handler {
+    param($req, $res, $routeParams, $body)
+    if (Get-Command Set-DunePortalBrowserCheckin -ErrorAction SilentlyContinue) {
+        Set-DunePortalBrowserCheckin
+    }
+    Write-DuneJson -Response $res -Body @{ ok = $true; checkedIn = $true }
+}
+
+# GET /api/portal/checkin-status — polled by the app window after it hands the
+# portal off to the browser. Returns checkedIn=true once the browser has loaded.
+Register-DuneRoute -Method GET -Path '/api/portal/checkin-status' -Inline -Handler {
+    param($req, $res, $routeParams, $body)
+    $checkedIn = $false
+    if (Get-Command Test-DunePortalBrowserCheckin -ErrorAction SilentlyContinue) {
+        $checkedIn = [bool](Test-DunePortalBrowserCheckin)
+    }
+    Write-DuneJson -Response $res -Body @{ ok = $true; checkedIn = $checkedIn }
+}
+
+# POST /api/portal/reattach — the user cancelled the browser hand-off (the
+# browser couldn't reach the server). Clear the detach flag so closing the app
+# window tears the server down normally again, and drop any check-in marker.
+Register-DuneRoute -Method POST -Path '/api/portal/reattach' -Inline -Handler {
+    param($req, $res, $routeParams, $body)
+    if (Get-Command Clear-DuneAppDetached -ErrorAction SilentlyContinue) {
+        Clear-DuneAppDetached
+    } else {
+        $script:DuneAppDetached = $false
+    }
+    if (Get-Command Clear-DunePortalBrowserCheckin -ErrorAction SilentlyContinue) {
+        Clear-DunePortalBrowserCheckin
+    }
+    Write-DuneJson -Response $res -Body @{ ok = $true; detached = $false }
 }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -435,6 +435,15 @@ $bgSetupPath   = "$($cfg.SteamPath)\battlegroup-management"
 # Default existing installs (no PortCheckMode in config) to built-in.
 $portCheckMode = if ($cfg.PortCheckMode) { $cfg.PortCheckMode } else { 'builtin' }
 $portCheckUrl  = $cfg.PortCheckUrlTemplate
+# In-pod PostgreSQL port (default 15432). Configurable via the DbPort key so
+# servers whose DB listens elsewhere (e.g. 15433) still work.
+$dbPort        = 15432
+if ($cfg.ContainsKey('DbPort') -and "$($cfg['DbPort'])".Trim()) {
+    $parsedDbPort = 0
+    if ([int]::TryParse("$($cfg['DbPort'])".Trim(), [ref]$parsedDbPort) -and $parsedDbPort -ge 1 -and $parsedDbPort -le 65535) {
+        $dbPort = $parsedDbPort
+    }
+}
 
 # Sample ports we probe (representative of each forwarded range).
 # UDP 7777-7810 is checked at first + last; TCP 31982 is single-port.
@@ -707,9 +716,10 @@ function Get-OnlinePlayers {
     $pgNs  = $parts[0].Trim()
     $pgPod = $parts[1].Trim()
 
-    # Query online players. The cluster's postgres listens on 15432 (not default 5432).
+    # Query online players. The cluster's postgres listens on $dbPort (default
+    # 15432, configurable via the DbPort config key).
     $sql = "SELECT character_name FROM player_state WHERE online_status = 'Online' AND character_name IS NOT NULL ORDER BY character_name;"
-    $cmd = "sudo k3s kubectl exec -n '$pgNs' '$pgPod' -- env PGPASSWORD=dune psql -h 127.0.0.1 -p 15432 -U dune -d dune -t -A -c `"$sql`" 2>&1"
+    $cmd = "sudo k3s kubectl exec -n '$pgNs' '$pgPod' -- env PGPASSWORD=dune psql -h 127.0.0.1 -p $dbPort -U dune -d dune -t -A -c `"$sql`" 2>&1"
     $raw = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" $cmd
     $rawText = ($raw | Out-String)
     if ($LASTEXITCODE -ne 0 -or $rawText -match 'error|FATAL|ERROR') {

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
+import { useEffect } from 'react'
 import { AppShell } from './layout/AppShell'
 import { Dashboard } from './pages/Dashboard'
 import { Commands } from './pages/Commands'
@@ -16,6 +17,7 @@ import { Broadcasts } from './pages/Broadcasts'
 import { PageStub } from './pages/PageStub'
 import { StatusProvider } from './hooks/useStatus'
 import { isLocalViewer } from './util/viewer'
+import { api } from './api/client'
 import { PageErrorBoundary } from './components/PageErrorBoundary'
 
 // Wrap every route subtree in an error boundary so an unhandled render
@@ -35,6 +37,19 @@ export default function App() {
   // backend /ws/terminal route enforces this too — this is just the UX
   // half so the page doesn't render an empty failing terminal.
   const showTerminal = isLocalViewer()
+
+  // Issue #280: when the portal is loaded in a real browser (not the app's
+  // own WebView2 window), tell the server the browser reached it. The app
+  // window that handed the portal off polls for this and only then closes
+  // itself — so a browser blocked from 127.0.0.1 leaves the app window usable
+  // instead of stranding the user on a "page unavailable" error.
+  useEffect(() => {
+    const inShell = !!(window as unknown as { chrome?: { webview?: unknown } }).chrome?.webview
+    if (!inShell && isLocalViewer()) {
+      api('/api/portal/checkin', { method: 'POST' }).catch(() => { /* best effort */ })
+    }
+  }, [])
+
   return (
     <StatusProvider>
       <AppShell>

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { Icon } from '../components/Icon'
 import { NAV_ITEMS, GROUP_LABELS, GROUP_ORDER } from '../nav'
@@ -28,6 +28,15 @@ export function Sidebar({ collapsed }: Props) {
   const [showPortalConfirm, setShowPortalConfirm] = useState(false)
   const [portalDetaching, setPortalDetaching] = useState(false)
   const [portalError, setPortalError] = useState<string | null>(null)
+  // Issue #280 recovery flow: after handing the portal to the default browser
+  // we keep the app window open until the browser checks in with the server.
+  // 'confirm' = pre-flight dialog · 'waiting' = browser opened, polling for
+  // check-in · 'failed' = browser never reached the server (offer Copy URL +
+  // close anyway).
+  const [portalPhase, setPortalPhase] = useState<'confirm' | 'waiting' | 'failed'>('confirm')
+  const [portalUrl, setPortalUrl] = useState<string | null>(null)
+  const [portalCopied, setPortalCopied] = useState(false)
+  const portalCancelRef = useRef(false)
 
   // "Web Portal" is meaningful only inside the native shell. In a regular
   // browser tab the user is already in their browser, so we hide the button.
@@ -37,6 +46,7 @@ export function Sidebar({ collapsed }: Props) {
     if (portalDetaching) return
     setPortalDetaching(true)
     setPortalError(null)
+    portalCancelRef.current = false
     try {
       // Tell the server to flag itself as "intentionally detached" — the
       // app-window watcher in ConsoleHost.ps1 reads this flag and skips the
@@ -45,20 +55,79 @@ export function Sidebar({ collapsed }: Props) {
         '/api/portal/open-in-browser', { method: 'POST' },
       )
       if (!r?.url) throw new Error('Server did not return a portal URL.')
+      setPortalUrl(r.url)
       const wv = getWebView2()
       if (wv) {
-        wv.postMessage({ action: 'open-and-close', url: r.url })
+        // Open the browser but KEEP this window open. We wait for the freshly
+        // opened browser tab to check in with the server (proving it could
+        // actually reach 127.0.0.1) before closing ourselves. If it never
+        // checks in, the user keeps a working app window + Copy URL fallback
+        // instead of being stranded on a "page unavailable" error (issue #280).
+        wv.postMessage({ action: 'open', url: r.url })
+        setPortalPhase('waiting')
+        void waitForBrowserCheckin()
       } else {
         // Browser fallback: just open the URL in a new tab. We can't close
         // our own window from a regular browser tab.
         window.open(r.url, '_blank', 'noopener')
+        setShowPortalConfirm(false)
       }
-      setShowPortalConfirm(false)
     } catch (e) {
       setPortalError(e instanceof Error ? e.message : String(e))
     } finally {
       setPortalDetaching(false)
     }
+  }
+
+  // Poll the server until the browser we just opened checks in, then close the
+  // app window. Times out into the 'failed' state so the user can copy the URL
+  // or close anyway.
+  const waitForBrowserCheckin = async () => {
+    const deadline = Date.now() + 30000
+    while (Date.now() < deadline) {
+      await new Promise(res => setTimeout(res, 1200))
+      if (portalCancelRef.current) return
+      let checkedIn = false
+      try {
+        const s = await api<{ checkedIn: boolean }>('/api/portal/checkin-status')
+        checkedIn = !!s?.checkedIn
+      } catch { /* transient — keep polling */ }
+      if (portalCancelRef.current) return
+      if (checkedIn) {
+        const wv = getWebView2()
+        if (wv) wv.postMessage({ action: 'close' })
+        return
+      }
+    }
+    if (!portalCancelRef.current) setPortalPhase('failed')
+  }
+
+  // User gave up on the browser hand-off — re-attach so a normal window close
+  // tears the server down again, and reset the dialog.
+  const onCancelPortalHandoff = async () => {
+    portalCancelRef.current = true
+    try { await api('/api/portal/reattach', { method: 'POST' }) } catch { /* best effort */ }
+    setShowPortalConfirm(false)
+    setPortalPhase('confirm')
+    setPortalUrl(null)
+    setPortalError(null)
+  }
+
+  // Browser confirmed unreachable but the user wants to close anyway (server
+  // stays running because it's already detached; they can paste the URL into a
+  // working browser later).
+  const onCloseAnyway = () => {
+    const wv = getWebView2()
+    if (wv) wv.postMessage({ action: 'close' })
+  }
+
+  const onCopyPortalUrl = async () => {
+    if (!portalUrl) return
+    try {
+      await navigator.clipboard.writeText(portalUrl)
+      setPortalCopied(true)
+      setTimeout(() => setPortalCopied(false), 2000)
+    } catch { /* clipboard blocked — the URL is shown in the box to copy manually */ }
   }
 
   const groups = GROUP_ORDER.map(g => ({
@@ -163,8 +232,8 @@ export function Sidebar({ collapsed }: Props) {
         {inShellWindow && (
           <button
             type="button"
-            onClick={() => { setPortalError(null); setShowPortalConfirm(true) }}
-            title="Open the portal in your default web browser and close this app window"
+            onClick={() => { setPortalError(null); setPortalPhase('confirm'); setShowPortalConfirm(true) }}
+            title="Open the portal in your default web browser (the app window stays open until the browser connects)"
             className={
               collapsed
                 ? 'w-full flex items-center justify-center h-8 rounded-md border border-accent/30 text-accent-bright/90 hover:text-accent-bright hover:bg-accent/10 hover:border-accent/50 transition-colors'
@@ -200,7 +269,7 @@ export function Sidebar({ collapsed }: Props) {
       {showPortalConfirm && createPortal(
         <div
           className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4"
-          onClick={() => { if (!portalDetaching) setShowPortalConfirm(false) }}
+          onClick={() => { if (!portalDetaching && portalPhase === 'confirm') setShowPortalConfirm(false) }}
         >
           <div
             className="card p-5 max-w-md w-full text-text"
@@ -210,41 +279,114 @@ export function Sidebar({ collapsed }: Props) {
               <Icon name="ExternalLink" size={16} className="text-accent" />
               <h3 className="text-sm font-semibold uppercase tracking-widest text-accent">Open in web browser</h3>
             </div>
-            <p className="text-sm text-text-muted mb-2">
-              The Dune Server Tool <strong>app window will close</strong> and the portal will open in your <strong>default web browser</strong>.
-            </p>
-            <p className="text-sm text-text-muted mb-2">
-              Your server keeps running in the background — the browser tab will work normally.
-            </p>
-            <p className="text-sm text-text-muted">
-              Reopen Dune Server Tool any time to bring the app window back (the running server will be restarted).
-            </p>
-            {portalError && (
-              <div className="mt-3 text-xs text-red-400 bg-red-950/40 border border-red-900/60 rounded px-3 py-2">
-                {portalError}
-              </div>
+
+            {portalPhase === 'confirm' && (
+              <>
+                <p className="text-sm text-text-muted mb-2">
+                  The portal will open in your <strong>default web browser</strong>. The app window <strong>stays open</strong> until the browser connects, then closes automatically.
+                </p>
+                <p className="text-sm text-text-muted mb-2">
+                  Your server keeps running in the background — the browser tab will work normally.
+                </p>
+                <p className="text-sm text-text-muted">
+                  Reopen Dune Server Tool any time to bring the app window back (the running server will be restarted).
+                </p>
+                {portalError && (
+                  <div className="mt-3 text-xs text-red-400 bg-red-950/40 border border-red-900/60 rounded px-3 py-2">
+                    {portalError}
+                  </div>
+                )}
+                <div className="mt-4 flex flex-col gap-2">
+                  <button
+                    className="btn-primary w-full justify-center"
+                    onClick={() => { void onOpenWebPortal() }}
+                    disabled={portalDetaching}
+                  >
+                    <Icon name={portalDetaching ? 'Loader2' : 'ExternalLink'} size={12} className={portalDetaching ? 'animate-spin' : ''} />
+                    {portalDetaching ? 'Opening…' : 'Open in browser'}
+                  </button>
+                  <button
+                    className="btn-secondary w-full justify-center"
+                    onClick={() => setShowPortalConfirm(false)}
+                    disabled={portalDetaching}
+                  >
+                    <Icon name="X" size={12} /> Cancel
+                  </button>
+                </div>
+              </>
             )}
-            <div className="mt-4 flex flex-col gap-2">
-              <button
-                className="btn-primary w-full justify-center"
-                onClick={() => { void onOpenWebPortal() }}
-                disabled={portalDetaching}
-              >
-                <Icon name={portalDetaching ? 'Loader2' : 'ExternalLink'} size={12} className={portalDetaching ? 'animate-spin' : ''} />
-                {portalDetaching ? 'Opening…' : 'Open in browser'}
-              </button>
-              <button
-                className="btn-secondary w-full justify-center"
-                onClick={() => setShowPortalConfirm(false)}
-                disabled={portalDetaching}
-              >
-                <Icon name="X" size={12} /> Cancel
-              </button>
-            </div>
+
+            {portalPhase === 'waiting' && (
+              <>
+                <p className="text-sm text-text-muted mb-3 flex items-center gap-2">
+                  <Icon name="Loader2" size={14} className="animate-spin text-accent" />
+                  Waiting for your browser to open the portal…
+                </p>
+                <p className="text-xs text-text-dim mb-3">
+                  This window will close automatically once your browser connects. If your browser shows a “page unavailable” error, it may be blocked from reaching the server (antivirus, VPN or proxy) — use the URL below.
+                </p>
+                {portalUrl && <PortalUrlBox url={portalUrl} copied={portalCopied} onCopy={onCopyPortalUrl} />}
+                <div className="mt-4 flex flex-col gap-2">
+                  <button
+                    className="btn-secondary w-full justify-center"
+                    onClick={() => { void onCancelPortalHandoff() }}
+                  >
+                    <Icon name="X" size={12} /> Cancel — keep app window open
+                  </button>
+                </div>
+              </>
+            )}
+
+            {portalPhase === 'failed' && (
+              <>
+                <p className="text-sm text-text-muted mb-2 flex items-center gap-2">
+                  <Icon name="AlertTriangle" size={14} className="text-warning" />
+                  Your browser didn’t reach the server.
+                </p>
+                <p className="text-xs text-text-dim mb-3">
+                  The app window is still working, so nothing is lost. Your browser is likely blocked from <span className="font-mono">127.0.0.1</span> by antivirus, a VPN, or a proxy. Copy the URL below and open it in another browser, or add a loopback bypass and try again.
+                </p>
+                {portalUrl && <PortalUrlBox url={portalUrl} copied={portalCopied} onCopy={onCopyPortalUrl} />}
+                <div className="mt-4 flex flex-col gap-2">
+                  <button
+                    className="btn-secondary w-full justify-center"
+                    onClick={() => { void onCancelPortalHandoff() }}
+                  >
+                    <Icon name="ArrowLeft" size={12} /> Keep using the app window
+                  </button>
+                  <button
+                    className="btn-ghost w-full justify-center text-text-dim"
+                    onClick={onCloseAnyway}
+                    title="Close the app window anyway — the server stays running so you can open the URL later"
+                  >
+                    <Icon name="X" size={12} /> Close app window anyway
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         </div>,
         document.body,
       )}
     </aside>
+  )
+}
+
+function PortalUrlBox({ url, copied, onCopy }: { url: string; copied: boolean; onCopy: () => void }) {
+  return (
+    <div className="flex items-center gap-2">
+      <code className="flex-1 min-w-0 truncate text-xs bg-black/40 border border-border rounded px-2 py-1.5 font-mono" title={url}>
+        {url}
+      </code>
+      <button
+        type="button"
+        onClick={onCopy}
+        className="btn-secondary shrink-0"
+        title="Copy portal URL"
+      >
+        <Icon name={copied ? 'Check' : 'Copy'} size={13} />
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
   )
 }

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -35,6 +35,9 @@ const FIELDS: {
   { key: 'PortCheckUrlTemplate', label: 'Port-check URL template',
     placeholder: 'https://example.com/check?ip={ip}&port={port}&protocol={protocol}',
     help: 'Used when mode is "custom". Tokens: {ip} {port} {protocol}' },
+  { key: 'DbPort', label: 'Database port',
+    placeholder: '15432',
+    help: 'In-pod PostgreSQL port DST queries for Players / Bases / Storage. Funcom\'s default is 15432 — change it only if your server\'s database listens elsewhere (e.g. 15433). Use "Test connection" below after changing it.' },
 ]
 
 export function Settings() {
@@ -51,6 +54,13 @@ export function Settings() {
   const [sshRotateMsg, setSshRotateMsg] = useState<string | null>(null)
   const [openingBat, setOpeningBat] = useState(false)
   const [batMsg, setBatMsg] = useState<string | null>(null)
+  // Database connection test (issue #295): verify the configured in-pod
+  // PostgreSQL port is reachable, and surface a clear message + suggested port
+  // instead of silently showing empty Players / Bases / Storage.
+  const [dbTesting, setDbTesting] = useState(false)
+  const [dbTestMsg, setDbTestMsg] = useState<string | null>(null)
+  const [dbTestOk, setDbTestOk] = useState<boolean | null>(null)
+  const [dbSuggestedPort, setDbSuggestedPort] = useState<number | null>(null)
   // dune-admin VM cache: companion admin tool caches a stale BG snapshot
   // on the VM at ~/.dune/sh-<bg-id>*.yaml; clearing it forces its setup
   // wizard to re-discover the live DB password etc.
@@ -111,6 +121,35 @@ export function Settings() {
     } finally {
       setOpeningBat(false)
     }
+  }
+  async function onTestDbConnection() {
+    setDbTesting(true)
+    setDbTestMsg(null)
+    setDbTestOk(null)
+    setDbSuggestedPort(null)
+    try {
+      const raw = (values['DbPort'] ?? '').trim()
+      const port = raw ? Number(raw) : undefined
+      const r = await api<{ ok: boolean; port: number; message: string; suggestedPort?: number }>(
+        '/api/db/test-connection',
+        { method: 'POST', body: JSON.stringify({ port: Number.isFinite(port) ? port : undefined, probe: true }) },
+      )
+      setDbTestOk(r.ok)
+      setDbTestMsg(r.message)
+      if (r.suggestedPort) setDbSuggestedPort(r.suggestedPort)
+    } catch (e) {
+      setDbTestOk(false)
+      setDbTestMsg(e instanceof Error ? e.message : String(e))
+    } finally {
+      setDbTesting(false)
+    }
+  }
+  function applySuggestedPort() {
+    if (dbSuggestedPort == null) return
+    setValues(v => ({ ...v, DbPort: String(dbSuggestedPort) }))
+    setDbSuggestedPort(null)
+    setDbTestMsg('Database port updated — click "Save settings" below to persist it, then test again.')
+    setDbTestOk(null)
   }
   async function onRotateSshKey() {
     if (!window.confirm('Generate a NEW SSH key?\n\nThis regenerates the key and authorizes it on the dune-awakening VM. The VM must be running.\n\nA console window will open and ask for the \'dune\' user\'s password — you MUST type it there to authorize the new key on the VM. If you close that prompt without entering the password, DST will be locked out of the server until you re-run this. The console will tell you if authorization succeeded.')) return
@@ -400,6 +439,52 @@ export function Settings() {
       <RemoteAccessCard />
 
       <PublicIpCard />
+
+      {/* --- Database connection (issue #295) --- */}
+      <div className="card mb-4 p-6">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <Icon name="Database" size={18} className="text-text-muted" />
+              <h2 className="text-lg font-semibold">Database connection</h2>
+            </div>
+            <p className="text-sm text-text-dim">
+              DST reads Players, Bases and Storage from the server's PostgreSQL
+              database on port <span className="font-mono">{(values['DbPort'] ?? '').trim() || '15432'}</span>.
+              If those pages are empty, the database may be listening on a
+              different port — set it in <span className="font-medium">Database port</span> below
+              and test it here. The VM must be running.
+            </p>
+            {dbTestMsg && (
+              <p className={`mt-2 text-xs flex items-center gap-1.5 ${dbTestOk === false ? 'text-danger' : dbTestOk === true ? 'text-success' : 'text-text-dim'}`}>
+                <Icon name={dbTestOk === false ? 'AlertCircle' : dbTestOk === true ? 'CheckCircle2' : 'Info'} size={13} />
+                {dbTestMsg}
+              </p>
+            )}
+            {dbSuggestedPort != null && (
+              <button
+                type="button"
+                onClick={applySuggestedPort}
+                className="mt-2 btn-secondary"
+              >
+                <Icon name="ArrowRight" size={14} /> Use port {dbSuggestedPort}
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              type="button"
+              onClick={() => void onTestDbConnection()}
+              disabled={dbTesting}
+              title="Run SELECT 1 against the configured database port"
+              className="btn-secondary"
+            >
+              <Icon name={dbTesting ? 'Loader2' : 'PlugZap'} size={15} className={dbTesting ? 'animate-spin' : ''} />
+              {dbTesting ? 'Testing…' : 'Test connection'}
+            </button>
+          </div>
+        </div>
+      </div>
 
       {/* --- dune-admin VM cache (companion admin tool, decoupled in 12.x) --- */}
       <div className="card mb-4 p-6">

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -277,6 +277,26 @@ export function Settings() {
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault()
+    // Confirm gate (issue #295): changing the database port silently breaks
+    // Players/Bases/Storage if it's wrong, so make the user acknowledge it and
+    // — importantly — show the OLD value so they can write it down before
+    // changing it.
+    const newDbPort = (values['DbPort'] ?? '').trim()
+    const oldDbPortRaw = (cfg?.values?.DbPort ?? '').trim()
+    const oldDbPort = oldDbPortRaw || '15432 (default)'
+    if (newDbPort !== oldDbPortRaw) {
+      const target = newDbPort || '15432 (default)'
+      const ok = window.confirm(
+        `Change the database port?\n\n`
+        + `  Current port:  ${oldDbPort}\n`
+        + `  New port:      ${target}\n\n`
+        + `Write down the current port (${oldDbPort}) in case you need to switch back. `
+        + `DST queries PostgreSQL on this port for Players, Bases and Storage — if it's `
+        + `wrong, those pages show up empty. Use "Test connection" to verify the new port.\n\n`
+        + `Save this change?`,
+      )
+      if (!ok) return
+    }
     setSaving(true)
     setError(null)
     setSaved(null)


### PR DESCRIPTION
Fixes #280 and #295.

## #295 — Configurable database port
Root cause: DST hardcoded the in-pod PostgreSQL port `15432` (it queries it via `kubectl exec -- psql -p 15432`). Servers whose DB listens elsewhere (e.g. `15433`) showed **empty Players / Bases / Storage with no error**, and there was no in-app way to change or test it.

- New `DbPort` config key (default `15432`) + `Get-DuneDbPort` / `Get-V6DbPort` resolvers.
- Replaced the hardcoded `-p 15432` in `Db-Postgres.ps1`, `Database.ps1`, and the `dune-server.ps1` CLI online-player query.
- New **Database connection** card in Settings: a **Database port** field + **Test connection** button.
- `POST /api/db/test-connection` runs `SELECT 1`, returns a clear **"can't reach the database on :&lt;port&gt;"** message instead of silent empty data, and auto-probes `15432 / 15433 / 5432` to suggest the right port (with a one-click "Use port N").

## #280 — Web Portal "page is unavailable" recovery
Root cause: clicking **Web Portal** closed the app window immediately on hand-off. If the external browser couldn't reach `127.0.0.1` (AV / VPN / proxy blocking loopback), the user was left with a dead "page unavailable" tab and no UI.

- The app window now **stays open until the browser confirms it reached the server**, then closes automatically.
- File-based check-in signal (API handlers run in a runspace pool with no shared `$script:` scope — same pattern as `detached.flag`):
  - `POST /api/portal/checkin` — the freshly-opened browser tab calls this on load.
  - `GET /api/portal/checkin-status` — polled by the app window.
  - `POST /api/portal/reattach` — undoes the detach when the user gives up.
- `DuneShell` handles new `open` (open browser, keep window) and `close` messages (kept `open-and-close` for back-compat).
- Sidebar shows a **waiting** state, a **Copy portal URL** fallback, and a reattach / "close anyway" path if the browser can't connect.

## Validation
- `279/279` Pester + `51/51` webui (vitest) tests pass.
- `webui` `tsc -b` + `vite build` clean; `DuneShell` `.NET` builds clean.
- All edited bundled `.ps1` files retain their UTF-8 BOM.

No version-stamp bump here — that follows in the release-prep PR.