### PR TITLE
Release v12.9.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.8.3"
+      placeholder: "v12.9.0"
     validations:
       required: true
 
@@ -103,11 +103,13 @@ body:
         - Web portal — Map SpinUp (incl. Restart Hagga / Restart Deep Desert)
         - Web portal — Settings (general — paths, ports, providers)
         - Web portal — Settings — Public IP / DDNS (hostname resolve, manual IP, apply)
+        - Web portal — Settings — Database connection (Database port / Test connection — empty Players/Bases/Storage)
         - Web portal — Settings (Dune Server Tool self-updater)
         - Web portal — Tailscale (remote-access / device list)
         - Web portal — Setup Wizard / first-run
         - Web portal — Top menu bar / Help dropdown
         - Web portal — Sidebar / top status bar (server name, port/VM/BG pills, refresh) / window chrome
+        - Web portal — "Web Portal" button / open in default browser hand-off ("page is unavailable")
         - Desktop app shell (DuneShell.exe / WebView2) / PWA install
         - CLI (`dune-server.ps1` / `dune-server.bat`)
         - Installer (`DuneServerSetup.exe`) / first-run setup
@@ -121,7 +123,7 @@ body:
     attributes:
       label: Specific page / button / command
       description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug?
-      placeholder: "e.g. Server Health 'Restart battlegroup' button, Settings > Public IP / DDNS > Save hostname, Settings > Public IP / DDNS > Resolve hostname, Settings > Public IP / DDNS > Apply public IP, Game Config > Server name > Rename & restart, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > Crafting > Repair Cost Weight, Game Config > All Default Settings > Ctrl+C section header, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Market Bot > Reset to defaults, Gameplay Admin > Market Bot > Pricing rules > Market-follow pricing toggle, Gameplay Admin > Market Bot > Pricing rules > Market markup %, Gameplay Admin > Market Bot > Buy side > Over-market guard, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Package > Import tcno.co list, Gameplay Admin > Players > Give Package (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > inventory item > Repair, Gameplay Admin > Players > inventory item > Stack quantity, Gameplay Admin > Storage > container item > Stack quantity, Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Journey > Complete node, Gameplay Admin > Players > Progression > Progression Unlock > Apply Unlock (Atreides Ch3 Start), Gameplay Admin > Players > Tags > search/add tag, Gameplay Admin > Players > Actions > Unlock Trainers > Swordmaster, Gameplay Admin > Players > Actions > Unlock Main Quest > A New Beginning, Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Map SpinUp > Arrakeen loading counter, Map SpinUp > Restart Hagga, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
+      placeholder: "e.g. Server Health 'Restart battlegroup' button, Settings > Public IP / DDNS > Save hostname, Settings > Public IP / DDNS > Resolve hostname, Settings > Public IP / DDNS > Apply public IP, Settings > Database connection > Test connection, Settings > Database port (empty Players/Bases/Storage), Sidebar > Web Portal > Open in browser ('page is unavailable'), Game Config > Server name > Rename & restart, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > Crafting > Repair Cost Weight, Game Config > All Default Settings > Ctrl+C section header, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Market Bot > Reset to defaults, Gameplay Admin > Market Bot > Pricing rules > Market-follow pricing toggle, Gameplay Admin > Market Bot > Pricing rules > Market markup %, Gameplay Admin > Market Bot > Buy side > Over-market guard, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Package > Import tcno.co list, Gameplay Admin > Players > Give Package (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > inventory item > Repair, Gameplay Admin > Players > inventory item > Stack quantity, Gameplay Admin > Storage > container item > Stack quantity, Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Journey > Complete node, Gameplay Admin > Players > Progression > Progression Unlock > Apply Unlock (Atreides Ch3 Start), Gameplay Admin > Players > Tags > search/add tag, Gameplay Admin > Players > Actions > Unlock Trainers > Swordmaster, Gameplay Admin > Players > Actions > Unlock Main Quest > A New Beginning, Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Tailscale > 'Admin console', Database > Backup Schedule presets > Hourly, Map SpinUp > Survival_2, Map SpinUp > Arrakeen loading counter, Map SpinUp > Restart Hagga, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.9.0] - 2026-06-19
+
 ### Added
 
 - **Configurable database port (issue #295).** Settings gains a **Database port**

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.8.3'
+$script:DuneToolVersion = '12.9.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.8.3',
+    [string]$Version = '12.9.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.8.3</Version>
+    <Version>12.9.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.8.3"
+#define MyAppVersion "12.9.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.8.3"
+$script:ToolVersion = "12.9.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Release prep for **v12.9.0** (feature release on top of v12.8.3).

Ships the two fixes merged in #297:
- **#295** — Configurable database port (Settings field + Test connection + clear "can't reach database on :port" message + auto-probe).
- **#280** — Web Portal recovery UX (app window stays open until the browser connects; Copy URL fallback).

### Release chores
- Bumped all **5 version stamps** `12.8.3 → 12.9.0` (`DuneServer.ps1`, `Build-Exe.ps1`, `DuneShell.csproj`, `DuneServer.iss`, `dune-server.ps1`).
- Rolled `CHANGELOG` `[Unreleased]` → `[12.9.0] - 2026-06-19`.
- `bug_report.yml`: bumped `tool_version` placeholder to `v12.9.0`; added **Settings → Database connection** and **Web Portal open-in-browser hand-off** to the "Where did the bug happen?" dropdown and the "Specific page / button" examples.

### Build
- `app\installer\Build-Installer.ps1` succeeded — version preflight (5 stamps match) passed; `DuneServerSetup.exe` (45.93 MB) produced in the canonical output path. Installer bundles the latest `webui` (incl. the DB-port confirm gate).