### PR TITLE
Fix Public IP apply: re-enable API pool, stream progress, harden the full IP/director migration

### DIFF
--- a/app/DuneServer-Linux.ps1
+++ b/app/DuneServer-Linux.ps1
@@ -180,6 +180,10 @@ Initialize-DuneLog -Path $script:DuneLogFilePath
 
 . (Join-Path $serverDir 'HttpServer.ps1')
 
+# Re-assert after dot-sourcing HttpServer.ps1 so the API handler pool always
+# gets a valid ServerDir (see DuneServer.ps1 for the full rationale).
+$script:DuneServerDir = $serverDir
+
 $libDir = Join-Path $serverDir 'lib'
 if (Test-Path $libDir) {
     Get-ChildItem -Path $libDir -Filter '*.ps1' | ForEach-Object { . $_.FullName }

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -556,6 +556,12 @@ Initialize-DuneLog -Path $script:DuneLogFilePath
 
 . (Join-Path $serverDir 'HttpServer.ps1')
 
+# Re-assert the server dir AFTER dot-sourcing HttpServer.ps1. Its top-level
+# declaration is guarded, but re-setting here is a second guarantee that the
+# API handler pool (issue #47) gets a valid ServerDir and never silently falls
+# back to single-threaded inline dispatch (which freezes the UI on slow ops).
+$script:DuneServerDir = $serverDir
+
 # Web-portal lib modules (Config, Status, Ports, Characters, etc.)
 $libDir = Join-Path $serverDir 'lib'
 if (Test-Path $libDir) {

--- a/app/server/HttpServer.ps1
+++ b/app/server/HttpServer.ps1
@@ -22,7 +22,14 @@ $script:DuneApiInFlight  = $null   # synchronized list of {Ps;Handle;Release} fo
 $script:DuneApiLockTable = $null   # shared synchronized name -> SemaphoreSlim registry (named locks)
 $script:DuneApiCtx       = $null   # immutable server-context injected into every worker
 $script:DuneApiMax       = 16      # max concurrent handlers == pool max == gate count
-$script:DuneServerDir    = $null   # server/ dir (for the pool's startup dot-sources)
+# server/ dir (for the pool's startup dot-sources). Guard the declaration: the
+# entrypoint (DuneServer.ps1 / DuneServer-Linux.ps1) sets this BEFORE dot-sourcing
+# us, so an unconditional `= $null` here would clobber it back to empty and the API
+# handler pool would silently fall back to single-threaded inline dispatch (every
+# slow handler then head-of-line-blocks the whole UI — the bug issue #47 fixed).
+if (-not (Get-Variable -Name DuneServerDir -Scope Script -ErrorAction SilentlyContinue)) {
+    $script:DuneServerDir = $null
+}
 
 # ---------- MIME ---------------------------------------------------------------
 

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -1,5 +1,98 @@
 # PublicIp - Settings-driven public IP / DDNS switch.
 
+# Server dir captured at lib load time so the async apply runspace (and the API
+# pool runspaces) don't depend on $script:DuneServerDir being set in their
+# runspace. $PSScriptRoot here is server/lib, so server/ is one level up. Same
+# pattern as GameplayBot.ps1.
+$script:DunePublicIpServerDir = $null
+try {
+    if ($PSScriptRoot -and (Test-Path -LiteralPath $PSScriptRoot)) {
+        $candidate = Split-Path -Parent $PSScriptRoot
+        if ($candidate -and (Test-Path -LiteralPath $candidate)) { $script:DunePublicIpServerDir = $candidate }
+    }
+} catch {}
+
+# ----------------------------------------------------------------------------
+# Apply progress state file. The apply is a multi-minute, destructive operation
+# (rewrites VM network config, settings.conf, K3s node, NAT, restarts the
+# battlegroup). It runs in a dedicated background runspace and streams its
+# per-step progress to this file so the UI can poll it without holding the
+# request open. Surviving on disk also means a browser reload / force-close /
+# brief disconnect mid-apply resumes showing live progress instead of a dead
+# spinner.
+# ----------------------------------------------------------------------------
+function Get-DunePublicIpApplyStatePath {
+    Join-Path $env:APPDATA 'DuneServer\public-ip-apply-state.json'
+}
+
+function New-DunePublicIpApplyIdleState {
+    return @{ phase = 'idle'; running = $false; steps = @(); updated = (Get-Date).ToUniversalTime().ToString('o') }
+}
+
+function Read-DunePublicIpApplyState {
+    $path = Get-DunePublicIpApplyStatePath
+    if (-not (Test-Path -LiteralPath $path)) { return (New-DunePublicIpApplyIdleState) }
+    try {
+        $raw = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
+        if ([string]::IsNullOrWhiteSpace($raw)) { return (New-DunePublicIpApplyIdleState) }
+        return ($raw | ConvertFrom-Json)
+    } catch {
+        return (New-DunePublicIpApplyIdleState)
+    }
+}
+
+function Save-DunePublicIpApplyState {
+    param([Parameter(Mandatory)]$State)
+    $path = Get-DunePublicIpApplyStatePath
+    $dir  = Split-Path -Parent $path
+    try { if (-not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null } } catch {}
+    $json = $State | ConvertTo-Json -Depth 8
+    $tmp  = "$path.tmp"
+    $write = {
+        Set-Content -LiteralPath $tmp -Value $json -Encoding UTF8 -Force
+        Move-Item -LiteralPath $tmp -Destination $path -Force
+    }
+    # Serialize concurrent writers (worker + a stop request) when the named-lock
+    # helper is available; otherwise best-effort direct write.
+    if (Get-Command Invoke-WithDuneLock -ErrorAction SilentlyContinue) {
+        try { Invoke-WithDuneLock -Name 'public-ip-apply-state' -TimeoutSec 5 -Script $write } catch { & $write }
+    } else { & $write }
+}
+
+function Get-DunePublicIpApplyStatus {
+    # Self-heal a stale 'running' flag: if the worker crashed hard (or the tool
+    # was killed) the file can be stuck running. Treat a run with no update for
+    # >15 min as failed so the UI's Apply button re-enables.
+    $st = Read-DunePublicIpApplyState
+    try {
+        $running = $false
+        if ($st -is [hashtable]) { $running = [bool]$st['running'] } else { $running = [bool]$st.running }
+        if ($running) {
+            $updated = if ($st -is [hashtable]) { $st['updated'] } else { $st.updated }
+            $dtu = $null
+            if ($updated -is [datetime]) {
+                $dtu = if (([datetime]$updated).Kind -eq [System.DateTimeKind]::Utc) { [datetime]$updated } else { ([datetime]$updated).ToUniversalTime() }
+            } elseif ($updated) {
+                $parsed = [datetime]::MinValue
+                if ([datetime]::TryParse([string]$updated, $null, [System.Globalization.DateTimeStyles]::RoundtripKind, [ref]$parsed)) {
+                    $dtu = if ($parsed.Kind -eq [System.DateTimeKind]::Utc) { $parsed } else { $parsed.ToUniversalTime() }
+                }
+            }
+            if ($dtu -and (((Get-Date).ToUniversalTime() - $dtu).TotalMinutes -gt 15)) {
+                    $st = @{
+                        phase = 'error'; running = $false
+                        steps = @(if ($st -is [hashtable]) { $st['steps'] } else { $st.steps })
+                        error = 'Apply stalled (no progress for over 15 minutes). It may have crashed; re-check the server before retrying.'
+                        updated = (Get-Date).ToUniversalTime().ToString('o')
+                        finished = (Get-Date).ToUniversalTime().ToString('o')
+                    }
+                    Save-DunePublicIpApplyState -State $st
+                }
+            }
+    } catch {}
+    return $st
+}
+
 function Test-DuneIPv4Literal {
     param([string]$Ip)
     if ([string]::IsNullOrWhiteSpace($Ip)) { return $false }
@@ -220,16 +313,36 @@ function Invoke-DunePublicIpHostRoute {
 
 function Invoke-DunePublicIpApply {
     param([Parameter(Mandatory)][string]$PublicIp, [string]$Mode = 'manual', [string]$Hostname = '')
+
     $steps = [System.Collections.Generic.List[object]]::new()
+    $state = @{
+        phase = 'running'; running = $true
+        mode = $Mode; hostname = $Hostname; publicIp = ([string]$PublicIp).Trim()
+        steps = @(); started = (Get-Date).ToUniversalTime().ToString('o')
+        updated = (Get-Date).ToUniversalTime().ToString('o'); finished = $null; error = ''
+    }
+    # Persist the current step list to the on-disk state file so the UI poll
+    # streams progress live. Reads $steps/$state from the enclosing scope.
+    $pub = {
+        param([string]$Phase)
+        if ($Phase) { $state.phase = $Phase }
+        $state.steps = @($steps)
+        $state.updated = (Get-Date).ToUniversalTime().ToString('o')
+        try { Save-DunePublicIpApplyState -State $state } catch {}
+    }
+
     try {
         Invoke-WithDuneLock -Name 'public-ip-change' -TimeoutSec 5 -Script {
             $target = ([string]$PublicIp).Trim()
             $steps.Add((New-DunePublicIpStepResult 'validate' 'Validate target IP' 'running' "Checking $target.")) | Out-Null
+            & $pub 'running'
             $valid = Assert-DuneManualPublicIp -PublicIp $target
             if (-not $valid.ok) { throw $valid.message }
             $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'validate' 'Validate target IP' 'done' "Target $target accepted."
+            & $pub
 
             $steps.Add((New-DunePublicIpStepResult 'preflight' 'Preflight host and VM' 'running' 'Checking VM and SSH.')) | Out-Null
+            & $pub
             $vm = Get-DuneVmStatus
             if (-not $vm.exists) { throw "VM '$($vm.name)' does not exist." }
             if (-not $vm.running) { throw "VM '$($vm.name)' is not running." }
@@ -245,25 +358,36 @@ function Invoke-DunePublicIpApply {
                 throw $reason
             }
             $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'preflight' 'Preflight host and VM' 'done' "VM $($vm.ip) reachable."
+            & $pub
 
             $steps.Add((New-DunePublicIpStepResult 'host-route' 'Update Windows host route' 'running' "Adding route for $target.")) | Out-Null
+            & $pub
             $routeMsg = Invoke-DunePublicIpHostRoute -PublicIp $target -VmIp $vm.ip
             $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'host-route' 'Update Windows host route' 'done' $routeMsg
+            & $pub
 
-            $remoteScript = @'
+            # --- Phase 1: VM network + persistent files + K3s --------------------
+            # FAILSAFES baked into the bash: abort BEFORE writing settings.conf if
+            # the battlegroup/VM/image can't be discovered (the blank-settings.conf
+            # brick), assert all 4 settings.conf lines are non-blank after writing,
+            # and patch the legacy dune-network-local-external.start boot script
+            # that hardcodes an old public IP and silently re-adds it on reboot.
+            $remoteNetwork = @'
 set -eu
 NEW_IP="$1"
 VM_IP="$2"
-
 step() { printf '\n=== %s ===\n' "$1"; }
 
 step discover
 BG_NS=$(sudo kubectl get battlegroups -A --no-headers -o custom-columns=':metadata.namespace' 2>/dev/null | head -1 | tr -d ' ')
 BG_NAME=$(sudo kubectl get battlegroups -A --no-headers -o custom-columns=':metadata.name' 2>/dev/null | head -1 | tr -d ' ')
 IMAGE=$(sudo kubectl get battlegroup "$BG_NAME" -n "$BG_NS" -o jsonpath='{.spec.serverGroup.template.spec.sets[0].image}' 2>/dev/null || true)
-if [ -z "$IMAGE" ]; then IMAGE=$(sed -n '2p' /home/dune/.dune/settings.conf 2>/dev/null || true); fi
-case "$IMAGE" in registry.funcom.com/funcom/self-hosting/seabass-server:*) ;; *) IMAGE="registry.funcom.com/funcom/self-hosting/seabass-server:1988751-0-shipping";; esac
-if [ -z "$BG_NS" ] || [ -z "$BG_NAME" ]; then echo "No battlegroup found"; exit 2; fi
+if [ -z "$IMAGE" ]; then IMAGE=$(sed -n '2p' /home/dune/.dune/settings.conf 2>/dev/null | tr -d ' \r'); fi
+# Hard abort if anything essential is missing -- NEVER write a blank settings.conf.
+[ -n "$BG_NS" ]   || { echo "DISCOVER_FAIL: battlegroup namespace not found"; exit 2; }
+[ -n "$BG_NAME" ] || { echo "DISCOVER_FAIL: battlegroup name not found"; exit 2; }
+[ -n "$VM_IP" ]   || { echo "DISCOVER_FAIL: VM IP is empty"; exit 2; }
+case "$IMAGE" in registry.funcom.com/funcom/self-hosting/seabass-server:*) ;; *) echo "DISCOVER_FAIL: no valid seabass-server image (got '$IMAGE')"; exit 2;; esac
 printf 'BG=%s NS=%s IMAGE=%s\n' "$BG_NAME" "$BG_NS" "$IMAGE"
 
 step alias
@@ -303,8 +427,22 @@ sudo -u dune mkdir -p /home/dune/.dune
 if [ -f /home/dune/.dune/settings.conf ]; then sudo cp /home/dune/.dune/settings.conf "/home/dune/.dune/settings.conf.bak.$(date -u +%Y%m%d%H%M%S)"; fi
 printf '%s\n%s\n%s\n%s\n' "$BG_NAME" "$IMAGE" "$VM_IP" "$NEW_IP" | sudo tee /home/dune/.dune/settings.conf >/dev/null
 sudo chown dune:dune /home/dune/.dune/settings.conf
-test "$(sudo wc -l < /home/dune/.dune/settings.conf | tr -d ' ')" = "4"
+# FAILSAFE: every line must be present AND non-blank (not just a line count of 4).
+S1=$(sed -n '1p' /home/dune/.dune/settings.conf); S2=$(sed -n '2p' /home/dune/.dune/settings.conf)
+S3=$(sed -n '3p' /home/dune/.dune/settings.conf); S4=$(sed -n '4p' /home/dune/.dune/settings.conf)
+{ [ -n "$S1" ] && [ -n "$S2" ] && [ -n "$S3" ] && [ -n "$S4" ]; } || { echo "SETTINGS_FAIL: settings.conf has a blank line ($S1|$S2|$S3|$S4)"; exit 3; }
+case "$S2" in registry.funcom.com/funcom/self-hosting/seabass-server:*) ;; *) echo "SETTINGS_FAIL: line 2 is not a seabass-server image"; exit 3;; esac
 sed -n '1,4p' /home/dune/.dune/settings.conf
+
+step bootscript
+F=/etc/local.d/dune-network-local-external.start
+if [ -f "$F" ]; then
+  sudo cp "$F" "$F.bak.$(date -u +%Y%m%d%H%M%S)"
+  sudo sed -i "s/^PUBLIC_IP=.*/PUBLIC_IP='$NEW_IP'/" "$F"
+  grep -n "^PUBLIC_IP=" "$F" || true
+else
+  echo "no legacy external boot script (ok)"
+fi
 
 step runner
 runner=/usr/local/bin/k3s-custom-runner.sh
@@ -322,9 +460,6 @@ NODE=$(sudo kubectl get nodes --no-headers -o custom-columns=':metadata.name' | 
 sudo kubectl annotate node "$NODE" "k3s.io/external-ip=$NEW_IP" --overwrite
 sudo kubectl patch node "$NODE" --subresource=status --type=merge -p "{\"status\":{\"addresses\":[{\"type\":\"InternalIP\",\"address\":\"$VM_IP\"},{\"type\":\"ExternalIP\",\"address\":\"$NEW_IP\"},{\"type\":\"Hostname\",\"address\":\"$NODE\"}]}}" >/dev/null
 sudo kubectl get node "$NODE" -o wide
-
-step helper
-if [ -x /home/dune/.dune/bin/battlegroup ]; then /home/dune/.dune/bin/battlegroup change-battlegroup-ip "$NEW_IP" || true; else echo "battlegroup helper not found"; fi
 
 step nat
 cat > /tmp/dune-iptables.start <<EOF
@@ -348,38 +483,106 @@ EOF
 sudo install -m 0755 /tmp/dune-iptables.start /etc/local.d/dune-iptables.start
 rm -f /tmp/dune-iptables.start
 sh -n /etc/local.d/dune-iptables.start
+# Strip stale game-port DNAT rules that point at an OLD public IP (not NEW_IP).
+sudo iptables -t nat -S PREROUTING 2>/dev/null | grep -- '--dport 7777:7810' | grep -v -- "--to-destination $NEW_IP" | sed 's/^-A /-D /' | while read -r r; do sudo iptables -t nat $r 2>/dev/null || true; done
 MQ_IP=$(sudo kubectl get endpoints --all-namespaces -o wide 2>/dev/null | grep mq-game | awk '{print $3}' | cut -d, -f1 | cut -d: -f1 | head -1)
-sudo iptables -t nat -I PREROUTING 1 -d "$VM_IP" -p udp --dport 7777:7810 -j DNAT --to-destination "$NEW_IP"
-if [ -n "$MQ_IP" ]; then sudo iptables -t nat -I PREROUTING 1 -d "$NEW_IP" -p tcp --dport 31982 -j DNAT --to-destination "${MQ_IP}:5672"; fi
-echo "NAT refreshed"
+sudo iptables -t nat -C PREROUTING -d "$VM_IP" -p udp --dport 7777:7810 -j DNAT --to-destination "$NEW_IP" 2>/dev/null || sudo iptables -t nat -I PREROUTING 1 -d "$VM_IP" -p udp --dport 7777:7810 -j DNAT --to-destination "$NEW_IP"
+if [ -n "$MQ_IP" ]; then sudo iptables -t nat -C PREROUTING -d "$NEW_IP" -p tcp --dport 31982 -j DNAT --to-destination "${MQ_IP}:5672" 2>/dev/null || sudo iptables -t nat -I PREROUTING 1 -d "$NEW_IP" -p tcp --dport 31982 -j DNAT --to-destination "${MQ_IP}:5672"; fi
+echo "NETWORK_DONE"
+'@
+            $steps.Add((New-DunePublicIpStepResult 'vm-network' 'Update VM network, settings.conf, K3s, NAT' 'running' 'Applying network + persistent-config changes over SSH.')) | Out-Null
+            & $pub
+            $rawNet = Invoke-DunePublicIpRemoteScript -Ip $vm.ip -Script $remoteNetwork -Arguments @($target, $vm.ip) -TimeoutSec 180
+            $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'vm-network' 'Update VM network, settings.conf, K3s, NAT' 'done' 'eth0 alias, interfaces, settings.conf (validated), boot script, K3s ExternalIP, and NAT updated.' $rawNet
+            & $pub
 
-step pods
-sudo kubectl -n "$BG_NS" delete pod -l app.kubernetes.io/part-of="$BG_NAME" --wait=false 2>/dev/null || true
-sudo kubectl -n "$BG_NS" get pod --field-selector=status.phase=Running --no-headers 2>/dev/null |
-  awk '/-sg-/ {print $1}' |
-  xargs -r sudo kubectl -n "$BG_NS" delete pod --wait=false 2>/dev/null || true
-for i in $(seq 1 36); do
+            # --- Phase 2: battlegroup IP propagation + restart + readiness ------
+            # Runs the canonical change-battlegroup-ip helper (feeding menu choice
+            # "1" = public IP) so the director / HOST_DATACENTER_IP_ADDRESS update,
+            # then RE-VERIFIES settings.conf integrity (the helper can blank it) and
+            # repairs + restarts if needed, then waits for the serversets to come
+            # ready (graceful: a slow boot is reported, not treated as failure).
+            $remoteBgIp = @'
+set -eu
+NEW_IP="$1"
+VM_IP="$2"
+step() { printf '\n=== %s ===\n' "$1"; }
+BG_NS=$(sudo kubectl get battlegroups -A --no-headers -o custom-columns=':metadata.namespace' 2>/dev/null | head -1 | tr -d ' ')
+BG_NAME=$(sudo kubectl get battlegroups -A --no-headers -o custom-columns=':metadata.name' 2>/dev/null | head -1 | tr -d ' ')
+[ -n "$BG_NS" ] && [ -n "$BG_NAME" ] || { echo "DISCOVER_FAIL: battlegroup not found"; exit 2; }
+BGBIN=/home/dune/.dune/bin/battlegroup
+
+step change-ip
+if [ -x "$BGBIN" ]; then
+  printf '1\n' | "$BGBIN" change-battlegroup-ip "$NEW_IP" || echo "change-battlegroup-ip returned non-zero (continuing; integrity check + restart will recover)"
+else
+  echo "battlegroup helper not found; falling back to restart"
+  "$BGBIN" restart 2>/dev/null || true
+fi
+
+step settings-integrity
+need_fix=0
+for n in 1 2 3 4; do v=$(sed -n "${n}p" /home/dune/.dune/settings.conf 2>/dev/null); [ -z "$v" ] && need_fix=1; done
+L2=$(sed -n '2p' /home/dune/.dune/settings.conf 2>/dev/null | tr -d ' \r')
+case "$L2" in registry.funcom.com/funcom/self-hosting/seabass-server:*) ;; *) need_fix=1;; esac
+if [ "$need_fix" = "1" ]; then
+  echo "settings.conf was corrupted (blank/bad line) -- repairing from discovered values"
+  IMAGE=$(sudo kubectl get battlegroup "$BG_NAME" -n "$BG_NS" -o jsonpath='{.spec.serverGroup.template.spec.sets[0].image}' 2>/dev/null || true)
+  case "$IMAGE" in registry.funcom.com/funcom/self-hosting/seabass-server:*) ;; *) echo "REPAIR_FAIL: no valid image available to rewrite settings.conf"; exit 3;; esac
+  sudo cp /home/dune/.dune/settings.conf "/home/dune/.dune/settings.conf.bak.$(date -u +%Y%m%d%H%M%S)" 2>/dev/null || true
+  printf '%s\n%s\n%s\n%s\n' "$BG_NAME" "$IMAGE" "$VM_IP" "$NEW_IP" | sudo tee /home/dune/.dune/settings.conf >/dev/null
+  sudo chown dune:dune /home/dune/.dune/settings.conf
+  "$BGBIN" restart 2>/dev/null || true
+fi
+sed -n '1,4p' /home/dune/.dune/settings.conf
+
+step wait
+ready=0
+for i in $(seq 1 60); do
   surv=$(sudo kubectl -n "$BG_NS" get serverset "$BG_NAME-sg-survival-1" -o jsonpath='{.status.ready}' 2>/dev/null || echo 0)
   over=$(sudo kubectl -n "$BG_NS" get serverset "$BG_NAME-sg-overmap" -o jsonpath='{.status.ready}' 2>/dev/null || echo 0)
-  [ "$surv" = "1" ] && [ "$over" = "1" ] && break
+  if [ "$surv" = "1" ] && [ "$over" = "1" ]; then ready=1; break; fi
   sleep 5
 done
-sudo kubectl -n "$BG_NS" get serverset | awk 'NR==1 || /survival-1|overmap|deepdesert-1/'
+sudo kubectl -n "$BG_NS" get serverset 2>/dev/null | awk 'NR==1 || /survival-1|overmap|deepdesert-1/' || true
 
 step verify
-sudo kubectl get node "$NODE" -o wide
-sudo kubectl -n "$BG_NS" get battlegroup "$BG_NAME" -o wide || true
-echo "Done"
+NODE=$(sudo kubectl get nodes --no-headers -o custom-columns=':metadata.name' | head -1 | tr -d ' ')
+sudo kubectl annotate node "$NODE" "k3s.io/external-ip=$NEW_IP" --overwrite >/dev/null 2>&1 || true
+sudo kubectl patch node "$NODE" --subresource=status --type=merge -p "{\"status\":{\"addresses\":[{\"type\":\"InternalIP\",\"address\":\"$VM_IP\"},{\"type\":\"ExternalIP\",\"address\":\"$NEW_IP\"},{\"type\":\"Hostname\",\"address\":\"$NODE\"}]}}" >/dev/null 2>&1 || true
+EXT=$(sudo kubectl get node "$NODE" -o jsonpath='{range .status.addresses[?(@.type=="ExternalIP")]}{.address}{end}' 2>/dev/null || true)
+ALIAS_OK=no
+/sbin/ip -4 -o addr show dev eth0 | awk '{print $4}' | cut -d/ -f1 | grep -qx "$NEW_IP" && ALIAS_OK=yes
+BGPHASE=$(sudo kubectl -n "$BG_NS" get battlegroup "$BG_NAME" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+printf 'EXTERNALIP=%s\nALIAS_OK=%s\nBG_PHASE=%s\nREADY=%s\n' "$EXT" "$ALIAS_OK" "$BGPHASE" "$ready"
+echo "BGIP_DONE"
 '@
-            $steps.Add((New-DunePublicIpStepResult 'vm' 'Update VM and Dune stack' 'running' 'Applying documented IP-change workflow over SSH.')) | Out-Null
-            $raw = Invoke-DunePublicIpRemoteScript -Ip $vm.ip -Script $remoteScript -Arguments @($target, $vm.ip) -TimeoutSec 420
-            $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'vm' 'Update VM and Dune stack' 'done' 'VM alias, persistent files, K3s, NAT, and pods updated.' $raw
+            $steps.Add((New-DunePublicIpStepResult 'bg-ip' 'Propagate IP to battlegroup + restart' 'running' 'Running change-battlegroup-ip, repairing settings.conf if needed, and waiting for servers.')) | Out-Null
+            & $pub
+            $rawBg = Invoke-DunePublicIpRemoteScript -Ip $vm.ip -Script $remoteBgIp -Arguments @($target, $vm.ip) -TimeoutSec 600
 
-            $steps.Add((New-DunePublicIpStepResult 'verify-port' 'Verify RabbitMQ port' 'running' "Checking TCP $target:31982.")) | Out-Null
+            $ready = ($rawBg -match '(?m)^READY=1\s*$')
+            $extIp = ''
+            if ($rawBg -match '(?m)^EXTERNALIP=([0-9.]+)\s*$') { $extIp = $Matches[1] }
+            $bgDetail = if ($ready) { 'Battlegroup IP propagated; servers reported ready.' } else { 'Battlegroup IP propagated; servers still coming up (this can take a few more minutes - check Server Health).' }
+            $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'bg-ip' 'Propagate IP to battlegroup + restart' 'done' $bgDetail $rawBg
+            & $pub
+
+            # --- Verify --------------------------------------------------------
+            $steps.Add((New-DunePublicIpStepResult 'verify' 'Verify external IP + RabbitMQ port' 'running' "Checking node ExternalIP and TCP $target:31982.")) | Out-Null
+            & $pub
             $tcp = $false
             try { $tcp = Test-NetConnection -ComputerName $target -Port 31982 -InformationLevel Quiet -WarningAction SilentlyContinue } catch { $tcp = $false }
-            if (-not $tcp) { throw "Test-NetConnection $target -Port 31982 failed." }
-            $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'verify-port' 'Verify RabbitMQ port' 'done' "TCP $target:31982 is reachable."
+            $extOk = ($extIp -eq $target)
+            if (-not $tcp) {
+                $detail = "TCP $target:31982 not reachable yet"
+                if (-not $ready) { $detail += ' (servers still starting)' }
+                throw "$detail. Node ExternalIP=$extIp. If servers are still booting, retry the check from Server Health shortly."
+            }
+            $vdetail = "TCP $target:31982 reachable."
+            if ($extOk) { $vdetail += " Node ExternalIP=$target." } else { $vdetail += " WARNING: node ExternalIP reported '$extIp'." }
+            $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'verify' 'Verify external IP + RabbitMQ port' 'done' $vdetail
+            & $pub
 
             Save-DuneConfig -Config @{
                 PublicIpMode = $Mode
@@ -389,12 +592,97 @@ echo "Done"
                 LastAppliedPublicIp = $target
             } | Out-Null
         }
+        $state.phase = 'done'; $state.running = $false
+        $state.finished = (Get-Date).ToUniversalTime().ToString('o')
+        & $pub 'done'
         return @{ ok=$true; publicIp=$PublicIp; steps=@($steps) }
     } catch {
         if ($steps.Count -gt 0 -and $steps[$steps.Count - 1].status -eq 'running') {
             $last = $steps[$steps.Count - 1]
             $steps[$steps.Count - 1] = New-DunePublicIpStepResult $last.id $last.label 'failed' $_.Exception.Message $last.raw
         }
+        $state.phase = 'error'; $state.running = $false; $state.error = $_.Exception.Message
+        $state.finished = (Get-Date).ToUniversalTime().ToString('o')
+        & $pub 'error'
         return @{ ok=$false; publicIp=$PublicIp; error=$_.Exception.Message; steps=@($steps) }
+    }
+}
+
+# Launch Invoke-DunePublicIpApply in a dedicated background runspace and return
+# immediately. The apply streams progress to the state file (Save-DunePublicIpApplyState)
+# which the UI polls via GET /api/public-ip/apply/status. Running off the API pool
+# keeps all request workers free during the multi-minute apply. Mirrors
+# Start-DuneBotSeedAsync in GameplayBot.ps1.
+function Start-DunePublicIpApplyAsync {
+    param(
+        [Parameter(Mandatory)][string]$PublicIp,
+        [string]$Mode = 'manual',
+        [string]$Hostname = '',
+        [string]$ServerDir
+    )
+    if (-not $ServerDir) { $ServerDir = $script:DunePublicIpServerDir }
+
+    $st = Read-DunePublicIpApplyState
+    $running = $false
+    try { if ($st -is [hashtable]) { $running = [bool]$st['running'] } else { $running = [bool]$st.running } } catch {}
+    if ($running) {
+        return @{ ok = $false; running = $true; error = 'A public IP change is already in progress.' }
+    }
+    if (-not $ServerDir -or -not (Test-Path -LiteralPath $ServerDir)) {
+        return @{ ok = $false; error = "Start-DunePublicIpApplyAsync: server dir not found ('$ServerDir')." }
+    }
+
+    $target = ([string]$PublicIp).Trim()
+    # Stamp 'starting' synchronously so the next status poll sees running=true.
+    Save-DunePublicIpApplyState -State @{
+        phase = 'starting'; running = $true
+        mode = $Mode; hostname = $Hostname; publicIp = $target
+        steps = @(@{ id='client'; label='Apply request sent'; status='running'; detail='Starting the public IP change on the server.' })
+        started = (Get-Date).ToUniversalTime().ToString('o')
+        updated = (Get-Date).ToUniversalTime().ToString('o'); finished = $null; error = ''
+    }
+
+    try {
+        $rs = [runspacefactory]::CreateRunspace()
+        $rs.ApartmentState = 'MTA'
+        $rs.ThreadOptions  = 'ReuseThread'
+        $rs.Open()
+        $ps = [powershell]::Create()
+        $ps.Runspace = $rs
+        $script:DunePublicIpApplyRunspace = @{ ps = $ps; rs = $rs; handle = $null; started = (Get-Date).ToUniversalTime() }
+        [void]$ps.AddScript({
+            param($ServerDir, $PublicIp, $Mode, $Hostname)
+            try {
+                $boot = Join-Path $ServerDir 'lib\Bootstrap.ps1'
+                if (Test-Path $boot) { . $boot }
+                Get-ChildItem -Path (Join-Path $ServerDir 'lib') -Filter '*.ps1' | ForEach-Object {
+                    if ($_.Name -ieq 'Bootstrap.ps1') { return }
+                    try { . $_.FullName } catch {}
+                }
+                [void](Invoke-DunePublicIpApply -PublicIp $PublicIp -Mode $Mode -Hostname $Hostname)
+            } catch {
+                try {
+                    Save-DunePublicIpApplyState -State @{
+                        phase = 'error'; running = $false
+                        publicIp = $PublicIp
+                        steps = @(@{ id='client'; label='Apply request sent'; status='failed'; detail="Apply runspace crashed: $($_.Exception.Message)" })
+                        error = "Apply runspace crashed: $($_.Exception.Message)"
+                        updated = (Get-Date).ToUniversalTime().ToString('o')
+                        finished = (Get-Date).ToUniversalTime().ToString('o')
+                    }
+                } catch {}
+            }
+        }).AddArgument($ServerDir).AddArgument($target).AddArgument($Mode).AddArgument($Hostname)
+        $script:DunePublicIpApplyRunspace.handle = $ps.BeginInvoke()
+        return @{ ok = $true; running = $true; message = 'Public IP change started.' }
+    } catch {
+        Save-DunePublicIpApplyState -State @{
+            phase = 'error'; running = $false; publicIp = $target
+            steps = @(@{ id='client'; label='Apply request sent'; status='failed'; detail="Failed to spawn apply runspace: $($_.Exception.Message)" })
+            error = "Failed to spawn apply runspace: $($_.Exception.Message)"
+            updated = (Get-Date).ToUniversalTime().ToString('o')
+            finished = (Get-Date).ToUniversalTime().ToString('o')
+        }
+        return @{ ok = $false; running = $false; error = "Failed to spawn apply runspace: $($_.Exception.Message)" }
     }
 }

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -332,7 +332,7 @@ function Invoke-DunePublicIpApply {
     }
 
     try {
-        Invoke-WithDuneLock -Name 'public-ip-change' -TimeoutSec 5 -Script {
+        $applyWork = {
             $target = ([string]$PublicIp).Trim()
             $steps.Add((New-DunePublicIpStepResult 'validate' 'Validate target IP' 'running' "Checking $target.")) | Out-Null
             & $pub 'running'
@@ -611,6 +611,15 @@ echo "BGIP_DONE"
                 LastAppliedPublicIp = $target
             } | Out-Null
         }
+        # Serialize concurrent applies when the named-lock helper is available
+        # (HttpServer.ps1). The async launcher's running-flag already guards
+        # against double-runs, so fall back to running directly if the helper
+        # isn't loaded in this runspace.
+        if (Get-Command Invoke-WithDuneLock -ErrorAction SilentlyContinue) {
+            Invoke-WithDuneLock -Name 'public-ip-change' -TimeoutSec 5 -Script $applyWork
+        } else {
+            & $applyWork
+        }
         $state.phase = 'done'; $state.running = $false
         $state.finished = (Get-Date).ToUniversalTime().ToString('o')
         & $pub 'done'
@@ -674,6 +683,10 @@ function Start-DunePublicIpApplyAsync {
             try {
                 $boot = Join-Path $ServerDir 'lib\Bootstrap.ps1'
                 if (Test-Path $boot) { . $boot }
+                # Load HttpServer.ps1 too so Invoke-WithDuneLock / Get-DuneLock
+                # (defined there, not in lib/) are available to the apply.
+                $http = Join-Path $ServerDir 'HttpServer.ps1'
+                if (Test-Path $http) { . $http }
                 Get-ChildItem -Path (Join-Path $ServerDir 'lib') -Filter '*.ps1' | ForEach-Object {
                     if ($_.Name -ieq 'Bootstrap.ps1') { return }
                     try { . $_.FullName } catch {}

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -536,6 +536,25 @@ if [ "$need_fix" = "1" ]; then
 fi
 sed -n '1,4p' /home/dune/.dune/settings.conf
 
+step utilities-ip
+# change-battlegroup-ip updates the game servers but NOT the utility pods'
+# HOST_DATACENTER_IP_ADDRESS (director / serverGateway / textRouter / etc.),
+# leaving them advertising the OLD public IP. Reconcile every utility's env to
+# NEW_IP so they relaunch correct. Requires jq (ships with the k3s tooling);
+# skipped gracefully if absent.
+if command -v jq >/dev/null 2>&1; then
+  for u in $(sudo kubectl get battlegroup "$BG_NAME" -n "$BG_NS" -o json 2>/dev/null | jq -r '.spec.utilities // {} | keys[]' 2>/dev/null); do
+    idx=$(sudo kubectl get battlegroup "$BG_NAME" -n "$BG_NS" -o json 2>/dev/null | jq -r --arg u "$u" '((.spec.utilities[$u].spec.envVars // []) | map(.name) | index("HOST_DATACENTER_IP_ADDRESS")) // -1' 2>/dev/null)
+    { [ -z "$idx" ] || [ "$idx" = "-1" ] || [ "$idx" = "null" ]; } && continue
+    cur=$(sudo kubectl get battlegroup "$BG_NAME" -n "$BG_NS" -o jsonpath="{.spec.utilities.$u.spec.envVars[$idx].value}" 2>/dev/null)
+    if [ -n "$cur" ] && [ "$cur" != "$NEW_IP" ]; then
+      sudo kubectl patch battlegroup "$BG_NAME" -n "$BG_NS" --type=json -p "[{\"op\":\"replace\",\"path\":\"/spec/utilities/$u/spec/envVars/$idx/value\",\"value\":\"$NEW_IP\"}]" >/dev/null 2>&1 && echo "reconciled utility '$u' HOST_DATACENTER_IP_ADDRESS: $cur -> $NEW_IP"
+    fi
+  done
+else
+  echo "jq not available; skipping utility HOST_DATACENTER_IP_ADDRESS reconcile"
+fi
+
 step wait
 ready=0
 for i in $(seq 1 60); do

--- a/app/server/routes/PublicIp.ps1
+++ b/app/server/routes/PublicIp.ps1
@@ -36,7 +36,9 @@ Register-DuneRoute -Method POST -Path '/api/public-ip/hostname' -Handler {
 Register-DuneRoute -Method POST -Path '/api/public-ip/validate' -Handler {
     param($req, $res, $routeParams, $body)
     $publicIp = [string](Get-DunePublicIpBodyValue -Body $body -Name 'publicIp' -Default '')
-    $v = Assert-DuneManualPublicIp -PublicIp $publicIp
+    # Allow re-validating an already-applied IP: this is a repair/re-assert tool,
+    # so re-applying the same IP (when the VM config has drifted) is valid.
+    $v = Assert-DuneManualPublicIp -PublicIp $publicIp -AllowUnchanged
     if (-not $v.ok) { Write-DuneError -Response $res -Status ([int]$v.status) -Message $v.message; return }
     Write-DuneJson -Response $res -Body @{ ok=$true; publicIp=$v.publicIp }
 }
@@ -67,14 +69,14 @@ Register-DuneRoute -Method POST -Path '/api/public-ip/apply' -Handler {
             Write-DuneError -Response $res -Status 409 -Message "DDNS changed before apply. $($r.hostname) now resolves to $(@($r.candidates) -join ', '), not $resolvedIp."
             return
         }
-        $v = Assert-DuneManualPublicIp -PublicIp $resolvedIp
+        $v = Assert-DuneManualPublicIp -PublicIp $resolvedIp -AllowUnchanged
         if (-not $v.ok) { Write-DuneError -Response $res -Status ([int]$v.status) -Message $v.message; return }
         $target = $resolvedIp
         $launch = Start-DunePublicIpApplyAsync -PublicIp $target -Mode 'ddns' -Hostname $r.hostname
     }
     elseif ($mode -eq 'manual') {
         $publicIp = [string](Get-DunePublicIpBodyValue -Body $body -Name 'publicIp' -Default '')
-        $v = Assert-DuneManualPublicIp -PublicIp $publicIp
+        $v = Assert-DuneManualPublicIp -PublicIp $publicIp -AllowUnchanged
         if (-not $v.ok) { Write-DuneError -Response $res -Status ([int]$v.status) -Message $v.message; return }
         $target = $v.publicIp
         $launch = Start-DunePublicIpApplyAsync -PublicIp $target -Mode 'manual'

--- a/app/server/routes/PublicIp.ps1
+++ b/app/server/routes/PublicIp.ps1
@@ -41,6 +41,15 @@ Register-DuneRoute -Method POST -Path '/api/public-ip/validate' -Handler {
     Write-DuneJson -Response $res -Body @{ ok=$true; publicIp=$v.publicIp }
 }
 
+Register-DuneRoute -Method GET -Path '/api/public-ip/apply/status' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Write-DuneJson -Response $res -Body (Get-DunePublicIpApplyStatus)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
 Register-DuneRoute -Method POST -Path '/api/public-ip/apply' -Handler {
     param($req, $res, $routeParams, $body)
     if (-not $body) { Write-DuneError -Response $res -Status 400 -Message 'Missing JSON body.'; return }
@@ -48,6 +57,7 @@ Register-DuneRoute -Method POST -Path '/api/public-ip/apply' -Handler {
     $confirmed = [bool](Get-DunePublicIpBodyValue -Body $body -Name 'confirmed' -Default $false)
     if (-not $confirmed) { Write-DuneError -Response $res -Status 400 -Message 'Confirmation is required before applying a public IP change.'; return }
 
+    $target = ''
     if ($mode -eq 'ddns') {
         $hostname = [string](Get-DunePublicIpBodyValue -Body $body -Name 'hostname' -Default '')
         $resolvedIp = [string](Get-DunePublicIpBodyValue -Body $body -Name 'resolvedIp' -Default '')
@@ -59,21 +69,27 @@ Register-DuneRoute -Method POST -Path '/api/public-ip/apply' -Handler {
         }
         $v = Assert-DuneManualPublicIp -PublicIp $resolvedIp
         if (-not $v.ok) { Write-DuneError -Response $res -Status ([int]$v.status) -Message $v.message; return }
-        $result = Invoke-DunePublicIpApply -PublicIp $resolvedIp -Mode 'ddns' -Hostname $r.hostname
-        if (-not $result.ok) { Write-DuneJson -Response $res -Status 500 -Body $result; return }
-        Write-DuneJson -Response $res -Body $result
-        return
+        $target = $resolvedIp
+        $launch = Start-DunePublicIpApplyAsync -PublicIp $target -Mode 'ddns' -Hostname $r.hostname
     }
-
-    if ($mode -eq 'manual') {
+    elseif ($mode -eq 'manual') {
         $publicIp = [string](Get-DunePublicIpBodyValue -Body $body -Name 'publicIp' -Default '')
         $v = Assert-DuneManualPublicIp -PublicIp $publicIp
         if (-not $v.ok) { Write-DuneError -Response $res -Status ([int]$v.status) -Message $v.message; return }
-        $result = Invoke-DunePublicIpApply -PublicIp $v.publicIp -Mode 'manual'
-        if (-not $result.ok) { Write-DuneJson -Response $res -Status 500 -Body $result; return }
-        Write-DuneJson -Response $res -Body $result
+        $target = $v.publicIp
+        $launch = Start-DunePublicIpApplyAsync -PublicIp $target -Mode 'manual'
+    }
+    else {
+        Write-DuneError -Response $res -Status 400 -Message "Unknown public IP mode: $mode"
         return
     }
 
-    Write-DuneError -Response $res -Status 400 -Message "Unknown public IP mode: $mode"
+    if (-not $launch.ok) {
+        $status = if ($launch.running) { 409 } else { 500 }
+        Write-DuneError -Response $res -Status $status -Message ([string]$launch.error)
+        return
+    }
+    # 202 Accepted: the apply runs in the background; the UI polls
+    # GET /api/public-ip/apply/status for streamed progress.
+    Write-DuneJson -Response $res -Status 202 -Body @{ ok=$true; running=$true; publicIp=$target }
 }

--- a/tests/PublicIp.Tests.ps1
+++ b/tests/PublicIp.Tests.ps1
@@ -84,3 +84,46 @@ Describe 'settings.conf renderer' {
         { New-DuneSettingsConfText -Battlegroup 'sh-test' -Image '{"image":"bad"}' -VmIp '192.168.1.50' -PublicIp '8.8.8.8' } | Should -Throw
     }
 }
+
+Describe 'Public IP apply state file' {
+    BeforeAll {
+        $script:tmpState = Join-Path ([System.IO.Path]::GetTempPath()) ("dst-apply-state-{0}.json" -f ([guid]::NewGuid()))
+        function global:Get-DunePublicIpApplyStatePath { $script:tmpState }
+    }
+    AfterAll {
+        Remove-Item -LiteralPath $script:tmpState -Force -ErrorAction SilentlyContinue
+        Remove-Item Function:\Get-DunePublicIpApplyStatePath -Force -ErrorAction SilentlyContinue
+    }
+    BeforeEach {
+        Remove-Item -LiteralPath $script:tmpState -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'returns an idle state when no file exists' {
+        $st = Read-DunePublicIpApplyState
+        $st.phase | Should -Be 'idle'
+        $st.running | Should -BeFalse
+    }
+
+    It 'round-trips a saved state' {
+        Save-DunePublicIpApplyState -State @{ phase='running'; running=$true; publicIp='8.8.8.8'; steps=@(@{ id='a'; label='A'; status='done' }) }
+        $st = Read-DunePublicIpApplyState
+        $st.phase | Should -Be 'running'
+        $st.publicIp | Should -Be '8.8.8.8'
+        @($st.steps).Count | Should -Be 1
+    }
+
+    It 'self-heals a stale running flag (no progress for >15 min)' {
+        $old = (Get-Date).ToUniversalTime().AddMinutes(-20).ToString('o')
+        Save-DunePublicIpApplyState -State @{ phase='running'; running=$true; publicIp='8.8.8.8'; steps=@(); updated=$old }
+        $st = Get-DunePublicIpApplyStatus
+        $st.running | Should -BeFalse
+        $st.phase | Should -Be 'error'
+    }
+
+    It 'leaves a fresh running state alone' {
+        $fresh = (Get-Date).ToUniversalTime().ToString('o')
+        Save-DunePublicIpApplyState -State @{ phase='running'; running=$true; publicIp='8.8.8.8'; steps=@(); updated=$fresh }
+        $st = Get-DunePublicIpApplyStatus
+        $st.running | Should -BeTrue
+    }
+}

--- a/tools/Run-DevServer.ps1
+++ b/tools/Run-DevServer.ps1
@@ -1,0 +1,89 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Run the DST backend HTTP server directly from source — no PS2EXE build, no
+    installer, no tray/app-window launcher.
+
+.DESCRIPTION
+    Dot-sources the same server files the installed app loads (DuneLog ->
+    Bootstrap -> HttpServer -> lib/*.ps1 -> routes/*.ps1), then starts the HTTP
+    listener on 127.0.0.1:<Port>. Uses the SHARED config at
+    %APPDATA%\DuneServer\dune-server.config, so it talks to the same VM / SSH
+    key the installed app does — you can test real flows (incl. Public IP apply)
+    against your UAT VM without rebuilding the exe each time.
+
+    Fast loop:
+      * Backend change (*.ps1): Ctrl+C this script, re-run it (~2s).
+      * Frontend change (*.tsx): run `npm run dev` in webui/ (vite HMR, proxies
+        /api + /ws to this server). Or `npm run build` and reload.
+
+    NOTE: launch from an **elevated** terminal if you want to test the Public IP
+    apply end to end — its Windows host-route step needs admin. Without admin,
+    everything up to that step still works (good for UI/flow testing).
+
+.PARAMETER Port
+    Preferred listen port (default 47823, matching webui/vite.config.ts proxy).
+
+.PARAMETER Token
+    Per-request token. Default '' (empty) = localhost dev escape hatch: the API
+    is open with no token so `npm run dev` works without juggling a token.
+
+.EXAMPLE
+    pwsh tools\Run-DevServer.ps1
+    # then open http://localhost:5173 (npm run dev) or http://127.0.0.1:47823
+#>
+[CmdletBinding()]
+param(
+    [int]$Port = 47823,
+    [string]$Token = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot  = Split-Path -Parent $PSScriptRoot
+$appDir    = Join-Path $repoRoot 'app'
+$serverDir = Join-Path $appDir 'server'
+$distRoot  = Join-Path $repoRoot 'webui\dist'
+
+if (-not (Test-Path -LiteralPath $serverDir)) { throw "server dir not found: $serverDir" }
+if (-not (Test-Path -LiteralPath $distRoot)) {
+    Write-Warning "webui\dist not found. Run 'npm run build' in webui/ (or use 'npm run dev'). Serving API only."
+}
+
+# Context vars the server + handler pool read (mirrors DuneServer.ps1).
+$script:AppDir          = $appDir
+$script:DuneServerDir   = $serverDir
+$script:MainScript      = Join-Path $repoRoot 'dune-server.ps1'
+$script:PwshExe         = (Get-Process -Id $PID).Path
+$script:DuneIsCompiledExe = $false
+
+# Dot-source order: DuneLog first, then Bootstrap, then HttpServer, then the
+# alphabetical lib loop (skipping those two), then routes.
+. (Join-Path $serverDir 'lib\DuneLog.ps1')
+$script:DuneLogFilePath = Join-Path $env:LOCALAPPDATA 'DuneServer\dune-server-dev.log'
+Initialize-DuneLog -Path $script:DuneLogFilePath
+
+. (Join-Path $serverDir 'lib\Bootstrap.ps1')
+. (Join-Path $serverDir 'HttpServer.ps1')
+$script:DuneServerDir = $serverDir   # re-assert after HttpServer.ps1 dot-source
+Get-ChildItem -Path (Join-Path $serverDir 'lib') -Filter '*.ps1' | Sort-Object Name | ForEach-Object {
+    if ($_.Name -ieq 'DuneLog.ps1' -or $_.Name -ieq 'Bootstrap.ps1') { return }
+    . $_.FullName
+}
+Get-ChildItem -Path (Join-Path $serverDir 'routes') -Filter '*.ps1' | Sort-Object Name | ForEach-Object { . $_.FullName }
+
+$elevated = $false
+try {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $elevated = ([Security.Principal.WindowsPrincipal]::new($id)).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+} catch {}
+
+Write-Host ''
+Write-Host '  DST dev server (from source)' -ForegroundColor Cyan
+Write-Host "  elevated : $elevated $(if (-not $elevated) { '(Public IP apply host-route step will fail without admin)' })" -ForegroundColor $(if ($elevated) { 'Green' } else { 'Yellow' })
+Write-Host "  token    : $(if ($Token) { 'set' } else { 'none (open localhost dev API)' })"
+Write-Host "  webui    : http://localhost:5173  (run 'npm run dev' in webui/ for HMR)" -ForegroundColor Cyan
+Write-Host '  Ctrl+C to stop. Re-run after a .ps1 change.' -ForegroundColor DarkGray
+Write-Host ''
+
+Start-DuneHttpServer -DistRoot $distRoot -PreferredPort $Port -Token $Token

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ApiError, api } from '../../api/client'
 import { Icon } from '../../components/Icon'
 
@@ -47,6 +47,15 @@ type ApplyResponse = {
   steps?: PublicIpStep[]
 }
 
+type ApplyStatus = {
+  phase?: 'idle' | 'starting' | 'running' | 'done' | 'error'
+  running?: boolean
+  publicIp?: string
+  steps?: PublicIpStep[]
+  started?: string
+  error?: string
+}
+
 function stepClass(status: PublicIpStep['status']): string {
   if (status === 'done') return 'text-success'
   if (status === 'failed') return 'text-danger'
@@ -65,6 +74,50 @@ export function PublicIpCard() {
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [steps, setSteps] = useState<PublicIpStep[]>([])
+  const [applyRunning, setApplyRunning] = useState(false)
+  const [applyStarted, setApplyStarted] = useState<number | null>(null)
+  const [now, setNow] = useState(Date.now())
+  const pollRef = useRef<number | null>(null)
+
+  function stopPolling() {
+    if (pollRef.current !== null) { window.clearInterval(pollRef.current); pollRef.current = null }
+  }
+
+  // Pull the latest apply progress from the server. Returns true while the
+  // apply is still running so the caller can keep polling.
+  async function refreshApplyStatus(): Promise<boolean> {
+    try {
+      const s = await api<ApplyStatus>('/api/public-ip/apply/status')
+      if (s.steps && s.steps.length) setSteps(s.steps)
+      if (s.phase === 'done') {
+        setApplyRunning(false); setWorking(null)
+        setError(null)
+        setMessage(`Applied public IP ${s.publicIp ?? targetIp}.`)
+        void loadStatus()
+        return false
+      }
+      if (s.phase === 'error') {
+        setApplyRunning(false); setWorking(null)
+        setError(s.error || 'Public IP change failed.')
+        return false
+      }
+      setApplyRunning(Boolean(s.running))
+      return Boolean(s.running)
+    } catch {
+      // Transient poll failure (server busy mid-restart) — keep polling.
+      return true
+    }
+  }
+
+  function startPolling() {
+    stopPolling()
+    pollRef.current = window.setInterval(() => {
+      void (async () => {
+        const stillRunning = await refreshApplyStatus()
+        if (!stillRunning) stopPolling()
+      })()
+    }, 2000)
+  }
 
   async function loadStatus() {
     setLoading(true)
@@ -83,11 +136,40 @@ export function PublicIpCard() {
 
   useEffect(() => { void loadStatus() }, [])
 
+  // Resume showing live progress if an apply is already running on the server
+  // (e.g. the user reloaded the page or reopened the app mid-change). Also tear
+  // down polling on unmount.
+  useEffect(() => {
+    void (async () => {
+      try {
+        const s = await api<ApplyStatus>('/api/public-ip/apply/status')
+        if (s.running) {
+          setWorking('apply')
+          setApplyRunning(true)
+          if (s.steps && s.steps.length) setSteps(s.steps)
+          setApplyStarted(s.started ? Date.parse(s.started) : Date.now())
+          startPolling()
+        }
+      } catch { /* ignore */ }
+    })()
+    return () => stopPolling()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Tick a clock once per second while an apply runs, for the elapsed timer.
+  useEffect(() => {
+    if (!applyRunning) return
+    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [applyRunning])
+
+  const elapsedSec = applyStarted ? Math.max(0, Math.floor((now - applyStarted) / 1000)) : 0
+
   const currentInput = useMemo(() => (
     mode === 'ddns' ? hostname.trim().toLowerCase() : manualIp.trim()
   ), [mode, hostname, manualIp])
 
-  const canApply = Boolean(targetIp && validatedInput === currentInput && working !== 'apply')
+  const canApply = Boolean(targetIp && validatedInput === currentInput && working !== 'apply' && !applyRunning)
 
   function clearValidation() {
     setTargetIp('')
@@ -162,34 +244,36 @@ export function PublicIpCard() {
     const label = mode === 'ddns' ? `${hostname.trim()} -> ${targetIp}` : targetIp
     if (!window.confirm(
       `Apply public IP change?\n\nTarget: ${label}\n\n`
-      + 'This updates the Windows route, VM public IP alias, Dune settings.conf, K3s ExternalIP, NAT, and restarts affected game pods.',
+      + 'This updates the Windows route, VM public IP alias, Dune settings.conf, K3s ExternalIP, the battlegroup (change-battlegroup-ip), NAT, and restarts the battlegroup. '
+      + 'It can take several minutes and will briefly disconnect connected players. You can safely leave this page — it keeps running on the server.',
     )) return
 
     setWorking('apply')
+    setApplyRunning(true)
     setError(null)
     setMessage(null)
-    setSteps([{ id: 'client', label: 'Apply request sent', status: 'running', detail: 'Waiting for the backend to finish.' }])
+    setApplyStarted(Date.now())
+    setSteps([{ id: 'client', label: 'Apply request sent', status: 'running', detail: 'Starting the public IP change on the server.' }])
     try {
       const body = mode === 'ddns'
         ? { mode, hostname, resolvedIp: targetIp, confirmed: true }
         : { mode, publicIp: targetIp, confirmed: true }
-      const r = await api<ApplyResponse>('/api/public-ip/apply', {
+      await api<ApplyResponse>('/api/public-ip/apply', {
         method: 'POST',
         body: JSON.stringify(body),
       })
-      setSteps(r.steps ?? [])
-      setMessage(`Applied public IP ${r.publicIp}.`)
-      await loadStatus()
+      // 202 Accepted — the apply now runs in the background; poll for progress.
+      startPolling()
     } catch (e) {
+      setApplyRunning(false)
+      setWorking(null)
       if (e instanceof ApiError) {
-        const body = e.body as Partial<ApplyResponse> | undefined
-        if (body?.steps) setSteps(body.steps)
-        setError(body?.error ?? e.message)
+        const eb = e.body as Partial<ApplyResponse> | undefined
+        if (eb?.steps) setSteps(eb.steps)
+        setError(eb?.error ?? e.message)
       } else {
         setError(e instanceof Error ? e.message : String(e))
       }
-    } finally {
-      setWorking(null)
     }
   }
 
@@ -292,6 +376,20 @@ export function PublicIpCard() {
         <p className="mt-3 text-sm text-danger flex items-center gap-1.5">
           <Icon name="AlertCircle" size={14} /> {error}
         </p>
+      )}
+
+      {applyRunning && (
+        <div className="mt-4 rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm flex items-start gap-2">
+          <Icon name="Loader2" size={15} className="animate-spin text-warning mt-0.5" />
+          <div>
+            <div className="text-warning font-medium">
+              Applying public IP change… {Math.floor(elapsedSec / 60)}m {elapsedSec % 60}s
+            </div>
+            <div className="text-xs text-text-dim mt-0.5">
+              This can take several minutes (battlegroup restart). It's safe to leave this page — the change keeps running on the server and progress resumes when you come back.
+            </div>
+          </div>
+        </div>
       )}
 
       {steps.length > 0 && (

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -269,9 +269,10 @@ export function PublicIpCard() {
       setWorking(null)
       if (e instanceof ApiError) {
         const eb = e.body as Partial<ApplyResponse> | undefined
-        if (eb?.steps) setSteps(eb.steps)
+        setSteps(eb?.steps ?? [])
         setError(eb?.error ?? e.message)
       } else {
+        setSteps([])
         setError(e instanceof Error ? e.message : String(e))
       }
     }


### PR DESCRIPTION
## Why

The Settings → Public IP / DDNS **Apply** flow froze DST and left a server half-migrated (blank `settings.conf`, stale director / `HOST_DATACENTER_IP_ADDRESS`), needing a manual SSH repair. This makes the app do — with failsafes — exactly what that manual repair did, and fixes the freeze.

## Root cause of the freeze

The `/api` handler **runspace pool (issue #47) never initialized in the shipped exe**: `$script:DuneServerDir` was set in `DuneServer.ps1` then clobbered to `$null` when `HttpServer.ps1` is dot-sourced, so the server fell back to **single-threaded inline dispatch** and the multi-minute apply head-of-line-blocked the whole UI. (Confirmed in logs: `API handler pool init failed; falling back to inline dispatch` on every launch v12.8.0 → v12.9.0.)

## What changed

**Pool fix**
- Guard the `HttpServer.ps1` declaration so it never overwrites an already-set value, and re-assert `DuneServerDir` after the dot-source in both entrypoints. Log now shows `API handler pool ready (2..16 runspaces)`.

**Apply reworked to async + streamed progress**
- POST returns `202` and starts the apply in a **dedicated background runspace** (keeps all 16 pool workers free); the UI polls `GET /api/public-ip/apply/status` and renders live steps + an elapsed timer. Resumes after reload/force-close; self-heals a stalled run. It can no longer "look hung."

**Hardening / failsafes (mirror the manual golden-path repair)**
- Abort if BG / image / VM-IP can't be discovered (the blank-`settings.conf` brick).
- Assert all 4 `settings.conf` lines are non-blank — not just the line count — and re-verify + repair after the helper runs.
- Patch the legacy `/etc/local.d/dune-network-local-external.start` boot script that hardcodes an old public IP and re-adds it on every reboot.
- Run `change-battlegroup-ip` **non-interactively** (feed choice `1`) so the director / `HOST_DATACENTER_IP_ADDRESS` update, then **reconcile every utility pod's `HOST_DATACENTER_IP_ADDRESS`** (director / serverGateway / textRouter) via `jq` — the gap `change-battlegroup-ip` leaves.
- Canonical `battlegroup restart` + graceful readiness wait (no hard-fail on a slow boot); verify node ExternalIP + `eth0` alias + `TCP :31982`.
- Allow re-applying the **same** IP (it's a repair/re-assert tool); stop the error-path spinner.
- Load `HttpServer.ps1` in the apply runspace (lock helpers live there) and make the named lock optional.

**Dev tooling**
- `tools\Run-DevServer.ps1` runs the backend from source (no installer build) for a fast local loop with `npm run dev`.

## Testing

- 14/14 Pester (`PublicIp.Tests`, incl. new apply-state + self-heal coverage); webui `tsc -b` + eslint clean; all `.ps1` parse + ASCII-safe; both embedded bash scripts pass `sh -n`; runspace smoke test confirms every function the apply calls resolves.
- Pool-ready + new status endpoint verified live from the dev server.
- The real destructive apply needs a VM — to be exercised on UAT before release.

No version bump in this PR (still 12.9.0); cut a release after UAT sign-off.