### PR TITLE
Release v12.9.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.9.0"
+      placeholder: "v12.9.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.9.1] - 2026-06-19
+
+### Fixed
+
+- **Public IP / DDNS apply no longer freezes the whole app.** The `/api` handler
+  runspace pool (added so a slow request can't block the UI) was silently failing
+  to initialize in the shipped build, so DST ran single-threaded and the
+  multi-minute Public IP apply locked up the entire interface. The pool now
+  initializes correctly.
+- **The apply is now resilient and can't half-brick the server.** It runs in the
+  background with live, streamed step-by-step progress and an elapsed timer (so it
+  never looks hung, and you can leave the page and come back). New safeguards
+  mirror the manual recovery procedure: it aborts before writing if the
+  battlegroup/image/VM details can't be read (the cause of a blank `settings.conf`),
+  verifies `settings.conf` is intact (and repairs it if the Funcom helper corrupts
+  it), fixes a legacy boot script that re-applied an old IP on every reboot,
+  propagates the new IP to the battlegroup **and its utility services** (director /
+  gateway / text router) — not just the game servers — and verifies the external
+  IP and RabbitMQ port at the end.
+- **Re-applying the current IP is now allowed** — the apply is a repair/re-assert
+  tool, so re-running it (e.g. after the VM config drifts) no longer errors with
+  "Target IP is unchanged," and an apply error no longer leaves the UI spinning.
+
+### Added
+
+- `tools/Run-DevServer.ps1` to run the backend from source for local development
+  without building the installer.
+
 ## [12.9.0] - 2026-06-19
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.9.0'
+$script:DuneToolVersion = '12.9.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.9.0',
+    [string]$Version = '12.9.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.9.0</Version>
+    <Version>12.9.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.9.0"
+#define MyAppVersion "12.9.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.9.0"
+$script:ToolVersion = "12.9.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Bumps all 5 version stamps to 12.9.1, rolls the CHANGELOG `[Unreleased]` into `[12.9.1]`, and updates the `bug_report.yml` `tool_version` placeholder.

Stamp-only follow-up to #299 (the version bump landed after that PR's squash captured its state). Source content is otherwise identical to what's already on main from #299.