### PR TITLE
Add "Incomplete" filter to Players → Journey (v12.9.2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.9.1"
+      placeholder: "v12.9.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Players → Journey: new "Incomplete" filter tab.** Sits between Done and
+  Revealed and lists only nodes that haven't been completed yet, so you can see
+  at a glance what's left for a player (and Complete them) instead of scrolling
+  past the finished ones.
+
 ## [12.9.1] - 2026-06-19
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.9.1'
+$script:DuneToolVersion = '12.9.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.9.1',
+    [string]$Version = '12.9.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.9.1</Version>
+    <Version>12.9.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.9.1"
+#define MyAppVersion "12.9.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.9.1"
+$script:ToolVersion = "12.9.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -2627,12 +2627,12 @@ function LandsraadSection({ player, canWrite, demo, refreshKey, flash, onChanged
 
 // ---------------------------------------------------------------------------
 // Journey — full browser over every journey_story_node row for the account.
-// Filter tabs (All / Done / Revealed / Reward), node-id search, client-side
+// Filter tabs (All / Done / Incomplete / Revealed / Reward), node-id search, client-side
 // pagination, per-row Complete/Reset, and a Wipe-All control. All writes work
 // online or offline (DB writes); they take effect on the player's next login.
 // ---------------------------------------------------------------------------
 const JOURNEY_PAGE_SIZE = 50
-type JourneyFilter = 'all' | 'done' | 'revealed' | 'reward'
+type JourneyFilter = 'all' | 'done' | 'incomplete' | 'revealed' | 'reward'
 
 export function JourneySection({ player, canWrite, demo, refreshKey, flash, onChanged }: SectionProps) {
   const [nodes, setNodes] = useState<JourneyNode[]>([])
@@ -2657,6 +2657,7 @@ export function JourneySection({ player, canWrite, demo, refreshKey, flash, onCh
   const counts = useMemo(() => ({
     all: nodes.length,
     done: nodes.filter(n => n.is_complete).length,
+    incomplete: nodes.filter(n => !n.is_complete).length,
     revealed: nodes.filter(n => n.is_revealed).length,
     reward: nodes.filter(n => n.has_pending_reward).length,
   }), [nodes])
@@ -2665,6 +2666,7 @@ export function JourneySection({ player, canWrite, demo, refreshKey, flash, onCh
     const q = search.trim().toLowerCase()
     return nodes.filter(n => {
       if (filter === 'done' && !n.is_complete) return false
+      if (filter === 'incomplete' && n.is_complete) return false
       if (filter === 'revealed' && !n.is_revealed) return false
       if (filter === 'reward' && !n.has_pending_reward) return false
       if (q && !n.node_id.toLowerCase().includes(q)) return false
@@ -2714,6 +2716,7 @@ export function JourneySection({ player, canWrite, demo, refreshKey, flash, onCh
   const tabs: Array<{ id: JourneyFilter; label: string; n: number }> = [
     { id: 'all', label: 'All', n: counts.all },
     { id: 'done', label: 'Done', n: counts.done },
+    { id: 'incomplete', label: 'Incomplete', n: counts.incomplete },
     { id: 'revealed', label: 'Revealed', n: counts.revealed },
     { id: 'reward', label: 'Reward', n: counts.reward },
   ]


### PR DESCRIPTION
## What

Adds an **Incomplete** filter tab to the Players → Journey section, sitting between **Done** and **Revealed**. It lists only journey nodes where `is_complete` is `false`, so you can see at a glance what a player still has left (and Complete them) instead of scrolling past the finished ones.

Previously the only filters were All / Done / Revealed / Reward — there was no way to isolate *not-yet-completed* nodes.

## Changes

- `webui/src/pages/gameplay/players/sections.tsx`
  - New `'incomplete'` value on `JourneyFilter`
  - `counts.incomplete` (`!n.is_complete`)
  - Filter predicate: `filter === 'incomplete' && n.is_complete` → excluded
  - New **Incomplete** tab + updated section comment
- Version bump to **12.9.2** across all five stamps
- `CHANGELOG.md` Unreleased entry
- `bug_report.yml` `tool_version` placeholder → `v12.9.2`

## Test

- `npm run build` (tsc -b + vite) green
- Installer build to follow for live test

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>