### PR TITLE
Release v12.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.9.2] - 2026-06-19
+
 ### Added
 
 - **Players → Journey: new "Incomplete" filter tab.** Sits between Done and


### PR DESCRIPTION
Dates the CHANGELOG `## [Unreleased]` Incomplete-filter entry into `## [12.9.2] - 2026-06-19` for the v12.9.2 release. All five version stamps were already bumped to 12.9.2 in #301.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>