### PR TITLE
Add "Give Package" to storage containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Storage → container detail: "Give Package".** Hand a saved item package to
+  any storage container in one click, alongside the existing "Add Items" picker.
+  Reuses the same shared packages as Players → Give Package (build/import/edit
+  them from either place), so you can drop a whole bundle into a box. Works while
+  the owner is offline — it's a direct database write — and, like all container
+  edits, the items appear in-game after the next battlegroup (server zone)
+  restart.
+
 ## [12.9.2] - 2026-06-19
 
 ### Added

--- a/webui/src/pages/gameplay/StorageTab.tsx
+++ b/webui/src/pages/gameplay/StorageTab.tsx
@@ -5,6 +5,7 @@ import {
   getStorage, getStorageItems, giveItemsToStorage, deleteStorageItem, setStorageItemStack, isValidTemplateId,
   type StorageContainer, type InventoryItem, type DataSource, type StorageGiveItemInput,
 } from '../../api/gameplay'
+import { GivePackageForm } from './players/sections'
 import { fmtNum, SourceBadge, StatCard, DemoNotice, qualityClass } from './shared'
 
 type SortKey = 'id' | 'name' | 'class' | 'owner_name' | 'item_count'
@@ -137,6 +138,7 @@ function ContainerDetail({ container, demo, onClose, onChanged }: {
   const [busy, setBusy] = useState(false)
   const [flash, setFlash] = useState<string | null>(null)
   const [showAdd, setShowAdd] = useState(false)
+  const [showPackage, setShowPackage] = useState(false)
   const [editingId, setEditingId] = useState<number | null>(null)
   const canWrite = !demo
 
@@ -183,6 +185,20 @@ function ContainerDetail({ container, demo, onClose, onChanged }: {
     }
   }
 
+  const handleGivePackage = async (items: StorageGiveItemInput[], pkgName: string) => {
+    setBusy(true); setError(null); setFlash(null)
+    try {
+      const r = await giveItemsToStorage(container.id, items)
+      setShowPackage(false)
+      const n = items.length
+      afterWrite(r.message || `Added package "${pkgName}" — ${n} item${n === 1 ? '' : 's'}.`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const handleSetStack = async (it: InventoryItem, stackSize: number) => {
     setBusy(true); setError(null); setFlash(null)
     try {
@@ -215,8 +231,11 @@ function ContainerDetail({ container, demo, onClose, onChanged }: {
         {canWrite ? (
           <>
             <div className="flex flex-wrap gap-2 mb-2">
-              <button className="btn-primary" disabled={busy} onClick={() => setShowAdd(s => !s)}>
+              <button className="btn-primary" disabled={busy} onClick={() => { setShowAdd(s => !s); setShowPackage(false) }}>
                 <Icon name="PackagePlus" size={14} /> Add Items
+              </button>
+              <button className="btn-secondary" disabled={busy} onClick={() => { setShowPackage(s => !s); setShowAdd(false) }}>
+                <Icon name="PackageCheck" size={14} /> Give Package
               </button>
             </div>
             <div className="mb-3 text-[11px] text-warning border-l-2 border-warning bg-warning/10 rounded px-2.5 py-1.5 flex items-start gap-1.5">
@@ -234,6 +253,20 @@ function ContainerDetail({ container, demo, onClose, onChanged }: {
         )}
 
         {showAdd && <AddItemsForm busy={busy} onSubmit={handleAdd} onCancel={() => setShowAdd(false)} />}
+
+        {showPackage && (
+          <div className="card p-3 mb-3">
+            <GivePackageForm
+              busy={busy}
+              targetLabel={container.name || 'container'}
+              showOverflow={false}
+              onGive={(items, pkgName) => void handleGivePackage(
+                items.map(it => ({ template: it.template, qty: it.qty, quality: it.quality ?? 0 })),
+                pkgName,
+              )}
+            />
+          </div>
+        )}
 
         {flash && <div className="text-sm text-success mb-3 flex items-center gap-2"><Icon name="CheckCircle2" size={15} /> {flash}</div>}
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -1040,10 +1040,14 @@ function OverflowToggle({ checked, disabled, onChange }: {
 // form owns two modes — a give/list view and an inline create/edit editor.
 interface PkgDraftRow { template: string; name: string; qty: string; quality: string }
 
-function GivePackageForm({ busy, playerName, onGive }: {
-  busy: boolean; playerName: string
+export function GivePackageForm({ busy, playerName, targetLabel, showOverflow = true, onGive }: {
+  busy: boolean
+  playerName?: string
+  targetLabel?: string
+  showOverflow?: boolean
   onGive: (items: GiveItemEntry[], pkgName: string, allowOverflow: boolean) => void
 }) {
+  const giveLabel = targetLabel ?? playerName ?? 'player'
   const [packages, setPackages] = useState<ItemPackage[]>([])
   const [loading, setLoading]   = useState(true)
   const [err, setErr]           = useState<string | null>(null)
@@ -1280,11 +1284,11 @@ function GivePackageForm({ busy, playerName, onGive }: {
         </>
       )}
       {err && <div className="text-xs text-error">{err}</div>}
-      {selected && <OverflowToggle checked={overflow} disabled={busy || saving} onChange={setOverflow} />}
+      {showOverflow && selected && <OverflowToggle checked={overflow} disabled={busy || saving} onChange={setOverflow} />}
       {selected && (
         <button className="btn-primary w-full" disabled={busy || saving}
           onClick={() => onGive(selected.items, selected.name, overflow)}>
-          {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} Give to {playerName}
+          {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} Give to {giveLabel}
         </button>
       )}
       <div className="grid grid-cols-4 gap-2">


### PR DESCRIPTION
## What

Adds a **Give Package** action to the Storage → container detail panel, next to the existing "Add Items" picker. Lets you drop a whole saved item package into any storage box in one click.

## Why

Packages could only be handed to a player's backpack (Players → Give Package). This makes the same saved bundles usable for storage containers — which works while the owner is **offline**, since storage gives are a direct DB write keyed by the container (not the player's online state).

## How

- Generalized `GivePackageForm` (in `players/sections.tsx`): added optional `targetLabel` and `showOverflow` props and exported it. Behavior for the Players tab is unchanged (defaults preserve `Give to {playerName}` + overflow toggle).
- `StorageTab.tsx` `ContainerDetail`: new **Give Package** button + panel rendering `GivePackageForm` (overflow hidden — containers have no drop-to-ground), wired to the existing `giveItemsToStorage` batch path. Build/import/edit of packages is shared with the Players flow.
- Reuses the existing battlegroup-restart warning already shown for container edits.

## Validation

- `npm run build` (tsc + vite) ✅
- `npm test` → 51/51 ✅
- `eslint` on changed files ✅

CHANGELOG `## [Unreleased]` updated.