### PR TITLE
Add Players "Apply Aql Trial" action (unlocks the ability slot via the recipe award)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ here cover everything those tags shipped.
   the owner is offline — it's a direct database write — and, like all container
   edits, the items appear in-game after the next battlegroup (server zone)
   restart.
+- **Players → Progression: new "Apply Aql Trial" action.** Reproduces the full
+  account diff of completing a Trial of Aql in-game — completes the trial's
+  journey subtree, applies the gameplay tags that flip, and grants the recipe
+  award that unlocks the corresponding ability slot. The slot is gated by recipe
+  knowledge on the character's pawn (TechKnowledge), not a journey tag, so the
+  Tags editor alone never unlocked it — this fixes characters a tag-only edit
+  left stuck. Offline-only (the pawn blob is RAM-authoritative while online) and
+  only the named trial's subtree is completed, so later trials proceed normally.
+  Ships Trial 4 (3rd ability slot / Cryss Knife recipe).
 
 ## [12.9.2] - 2026-06-19
 

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1279,6 +1279,127 @@ function Invoke-DunePlayerUnlockMainQuest {
     return @{ ok = $true; message = "Unlocked main quest $Quest - $($r.nodes) node(s) completed - takes effect on next login"; nodes = $r.nodes }
 }
 
+# ---------------------------------------------------------------------------
+# Recipe knowledge grant. Some progression rewards (e.g. completing an Aql
+# trial) are an awarded crafting recipe stored on the player's pawn, in
+#   TechKnowledgePlayerComponent.m_TechKnowledge.m_TechKnowledgeData[]
+# as { ItemKey, bIsNewEntry, UnlockedState }. The game reads that recipe
+# ownership directly, NOT a journey/player tag, so the Tags editor cannot
+# reproduce the award. Completing the content in-game flips the recipe to
+# "Purchased"; this helper does the same for a character a tag-only edit left
+# stuck. ItemKeys are verified against live pawn TechKnowledge data.
+# ---------------------------------------------------------------------------
+
+# Flip a recipe to "Purchased" (or append it when absent) in a character's pawn
+# TechKnowledge. Offline-only at the route layer (pawn JSON is RAM-authoritative
+# while connected); takes effect on next login.
+function Invoke-DuneGrantRecipe {
+    param([string]$Ip, [long]$AccountId, [string]$RecipeKey)
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+    if (-not $RecipeKey) { return @{ ok = $false; error = 'recipe key is required.' } }
+
+    $pawnID = Get-DunePlayerPawnFromAccount -Ip $Ip -AccountId $AccountId
+    if ($pawnID -le 0) { return @{ ok = $false; error = "no pawn for account $AccountId." } }
+
+    $rk = ConvertTo-DuneSqlString $RecipeKey
+    $path = "'{TechKnowledgePlayerComponent,m_TechKnowledge,m_TechKnowledgeData}'"
+    $sql = @"
+UPDATE dune.actors a
+SET properties = jsonb_set(a.properties, $path,
+  CASE WHEN EXISTS (
+         SELECT 1 FROM jsonb_array_elements(a.properties #> $path) e
+         WHERE e->>'ItemKey' = '$rk')
+       THEN (SELECT jsonb_agg(
+                 CASE WHEN e->>'ItemKey' = '$rk'
+                      THEN jsonb_set(e, '{UnlockedState}', '"Purchased"', true)
+                      ELSE e END)
+             FROM jsonb_array_elements(a.properties #> $path) e)
+       ELSE COALESCE(a.properties #> $path, '[]'::jsonb)
+            || jsonb_build_object('ItemKey', '$rk', 'bIsNewEntry', false, 'UnlockedState', 'Purchased')
+  END, true)
+WHERE a.id = $pawnID::bigint
+  AND a.properties #> $path IS NOT NULL;
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $r.ok) { return @{ ok = $false; error = "grant recipe: $($r.error)" } }
+    $updated = (Get-DuneSqlAffected $r)
+    if ($updated -eq 0) {
+        return @{ ok = $false; error = "pawn $pawnID has no TechKnowledge component yet (character may not have started)." }
+    }
+    return @{ ok = $true; message = "Granted recipe $RecipeKey - takes effect on next login"; recipe = $RecipeKey }
+}
+
+# ---------------------------------------------------------------------------
+# Aql trial completion deltas. Each entry is the FULL set of account changes
+# observed in a before/after snapshot diff when the trial is completed in-game:
+# the journey node to complete, the gameplay tags that flip (including the
+# BigMoments cinematic triggers), and the recipe awarded into pawn TechKnowledge
+# (the award that unlocks the empty ability slot the trial opens). Applying all
+# three reproduces a physical completion for a character that a tag-only edit
+# left stuck, WITHOUT touching later trials - only the named subtree is
+# completed, so the next trial proceeds normally in-game. Only trials with a
+# measured diff are listed; add more as they are snapshotted.
+# ---------------------------------------------------------------------------
+$script:DuneAqlTrialDeltas = [ordered]@{
+    '4' = @{
+        label       = 'Trial 4 of Aql (unlocks 3rd ability slot)'
+        journeyNode = 'DA_MQ_FindTheFremen.FourthTest'
+        tags        = @('BigMoments.Bike.Trigger', 'BigMoments.Stillsuit.Trigger', 'JourneySets.Fremkit.CryssKnife')
+        recipe      = 'RCP_Crysknife_Recipe'
+    }
+}
+
+function Get-DuneAqlTrialCatalog {
+    $list = @()
+    foreach ($k in $script:DuneAqlTrialDeltas.Keys) {
+        $d = $script:DuneAqlTrialDeltas[$k]
+        $list += @{ id = $k; label = [string]$d.label; node = [string]$d.journeyNode; tags = @($d.tags); recipe = [string]$d.recipe }
+    }
+    return $list
+}
+
+# Apply the full snapshot diff for an Aql trial: complete the journey subtree,
+# apply every tag that flips, and grant the awarded recipe. Offline-only at the
+# route layer. Takes effect on next login.
+function Invoke-DuneApplyAqlTrial {
+    param([string]$Ip, [long]$AccountId, [string]$Trial)
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+    if (-not $Trial) { return @{ ok = $false; error = 'trial is required.' } }
+    $key = ([string]$Trial).Trim()
+    if (-not $script:DuneAqlTrialDeltas.Contains($key)) {
+        return @{ ok = $false; error = "unknown Aql trial '$Trial'." }
+    }
+    $delta = $script:DuneAqlTrialDeltas[$key]
+
+    # 1) Complete the journey node subtree (also applies its mapped reward tags).
+    #    Scoped to this trial's subtree only, so later trials are untouched.
+    $jr = Invoke-DunePlayerCompleteJourneyNode -Ip $Ip -AccountId $AccountId -NodeId ([string]$delta.journeyNode)
+    if (-not $jr.ok) { return @{ ok = $false; error = $jr.error } }
+
+    # 2) Apply the remaining diff tags (e.g. the BigMoments cinematic triggers)
+    #    that the node-to-tag map does not cover.
+    $tags = @($delta.tags)
+    if ($tags.Count -gt 0) {
+        $tr = Invoke-DuneApplyTagsWithTierBump -Ip $Ip -AccountId $AccountId -Tags $tags
+        if (-not $tr.ok) { return @{ ok = $false; error = "apply trial tags: $($tr.error)" } }
+    }
+
+    # 3) Grant the awarded recipe into pawn TechKnowledge. This award is what
+    #    unlocks the empty ability slot the trial opens.
+    $recipeName = ''
+    if ($delta.recipe) {
+        $gr = Invoke-DuneGrantRecipe -Ip $Ip -AccountId $AccountId -RecipeKey ([string]$delta.recipe)
+        if (-not $gr.ok) { return @{ ok = $false; error = "grant trial recipe: $($gr.error)" } }
+        $recipeName = [string]$gr.recipe
+    }
+
+    return @{
+        ok      = $true
+        message = "Applied $($delta.label): journey subtree completed, $($tags.Count) tag(s), recipe $recipeName - takes effect on next login"
+        trial   = $key
+    }
+}
+
 function Invoke-DunePlayerSetStarterClass {
     param([string]$Ip, [long]$AccountId, [string]$Job)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -164,6 +164,43 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/journey/complete' -
     }
 }
 
+# GET /api/gameplay/players/aql-trials  (Aql trial unlock catalog for the UI)
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/aql-trials' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $trials = Get-DuneAqlTrialCatalog
+        Write-DuneJson -Response $res -Body @{ trials = $trials; total = $trials.Count; source = 'catalog' }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Aql trials catalog failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/apply-aql-trial  { account_id, trial }
+# Offline-only: writes the pawn TechKnowledge blob, which is RAM-authoritative
+# while the player is online. Reproduces the full snapshot diff of completing an
+# Aql trial - journey subtree + tags + the awarded recipe that unlocks the
+# ability slot - for a character a tag-only edit left stuck. Only the named
+# trial's subtree is completed, so later trials proceed normally in-game.
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/apply-aql-trial' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
+        $trial = [string](Get-DuneBodyValue -Body $body -Name 'trial')
+        if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
+        if (-not $trial) { Write-DuneError -Response $res -Status 400 -Message 'trial is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
+            if (-not $off.ok) {
+                return @{ ok = $false; error = "Player must be offline to apply an Aql trial. $($off.reason)" }
+            }
+            Invoke-DuneApplyAqlTrial -Ip $ip -AccountId $acc -Trial $trial
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Apply Aql trial failed: $($_.Exception.Message)"
+    }
+}
+
 # POST /api/gameplay/players/journey/reset  { account_id, node_id? }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/journey/reset' -Handler {
     param($req, $res, $routeParams, $body)

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -183,3 +183,22 @@ Describe 'Invoke-DunePlayerGiveItemsBulk overflow' -Tag 'Pure' {
         $script:liveArgs.Quantity | Should -Be 500
     }
 }
+
+Describe 'Get-DuneAqlTrialCatalog' -Tag 'Pure' {
+    It 'includes Trial 4 keyed as "4"' {
+        $cat = Get-DuneAqlTrialCatalog
+        ($cat | Where-Object { $_.id -eq '4' }) | Should -Not -BeNullOrEmpty
+    }
+    It 'maps Trial 4 to the FourthTest journey node' {
+        $t4 = Get-DuneAqlTrialCatalog | Where-Object { $_.id -eq '4' }
+        $t4.node | Should -Be 'DA_MQ_FindTheFremen.FourthTest'
+    }
+    It 'awards the Cryss Knife recipe for Trial 4 (the ability-slot trigger)' {
+        $t4 = Get-DuneAqlTrialCatalog | Where-Object { $_.id -eq '4' }
+        $t4.recipe | Should -Be 'RCP_Crysknife_Recipe'
+    }
+    It 'includes the JourneySets.Fremkit.CryssKnife tag in the Trial 4 delta' {
+        $t4 = Get-DuneAqlTrialCatalog | Where-Object { $_.id -eq '4' }
+        $t4.tags | Should -Contain 'JourneySets.Fremkit.CryssKnife'
+    }
+}

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1734,6 +1734,20 @@ export function unlockMainQuest(accountId: number, quest: string) {
   })
 }
 
+// Apply Aql Trial — reproduces the full snapshot diff of completing an Aql
+// trial (journey subtree + tags + the awarded recipe that unlocks the ability
+// slot). Offline-only on the server side.
+export interface AqlTrialInfo { id: string; label: string; node: string; tags: string[]; recipe: string }
+export function getAqlTrials() {
+  return api<{ ok: boolean; trials: AqlTrialInfo[]; total: number; source: DataSource }>(
+    '/api/gameplay/players/aql-trials')
+}
+export function applyAqlTrial(accountId: number, trial: string) {
+  return api<WriteResult>('/api/gameplay/players/apply-aql-trial', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId, trial }),
+  })
+}
+
 export function completeContract(accountId: number, contractId: string) {
   return api<WriteResult>('/api/gameplay/players/contract/complete', {
     method: 'POST', body: JSON.stringify({ account_id: accountId, contract_id: contractId }),

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -32,11 +32,11 @@ import {
   getLandsraadOverview, getLandsraadPlayerContributions, setLandsraadContribution,
   getPlayerJourneyNodes, completeJourneyNode, resetJourneyNode,
   getTrainerCatalog, getTrainerStatus, unlockTrainer, resetTrainerSkills,
-  getMainQuestCatalog, unlockMainQuest,
+  getMainQuestCatalog, unlockMainQuest, getAqlTrials, applyAqlTrial,
   type Player, type PlayerEvent, type PlayerStats, type ProgressionPreset, type SpecTrackFull,
   type CatalogItem, type ItemPackage, type GiveItemEntry,
   type LandsraadHouse, type LandsraadIniSetting,
-  type JourneyNode, type TrainerInfo, type TrainerStatus, type MainQuestInfo,
+  type JourneyNode, type TrainerInfo, type TrainerStatus, type MainQuestInfo, type AqlTrialInfo,
   type PlayerVehicleRow,
 } from '../../../api/gameplay'
 import { VEHICLE_CATALOG, VEHICLE_KIT_FUEL_TEMPLATE, VEHICLE_KIT_TORCH_TEMPLATE, type VehicleTemplate } from '../../../data/vehicles'
@@ -473,7 +473,7 @@ interface ActionDef {
   liveOnly?: boolean      // requires player to be online (RMQ path)
   offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   fields?: ActionField[]
-  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'update-tags'
+  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'update-tags' | 'aql-trial'
   balance?: 'solari' | 'scrip' | 'intel'  // show the player's current balance read-only above the form
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
@@ -532,6 +532,9 @@ const ACTIONS: ActionDef[] = [
     run: () => Promise.resolve({ message: '' }) },
   { id: 'unlock-main-quest', group: 'Progression', label: 'Unlock Main Quest', icon: 'Flag', custom: 'unlock-mainquest',
     rowNote: 'Complete an entire main-quest story line',
+    run: () => Promise.resolve({ message: '' }) },
+  { id: 'apply-aql-trial', group: 'Progression', label: 'Apply Aql Trial', icon: 'Sparkles', custom: 'aql-trial',
+    rowNote: 'Reproduces an Aql trial completion — journey + tags + the recipe award that unlocks the ability slot',
     run: () => Promise.resolve({ message: '' }) },
   { id: 'reset-progression', group: 'Progression', label: 'Reset Progression (live)', icon: 'RotateCcw', liveOnly: true,
     rowNote: 'Single confirmation required',
@@ -881,6 +884,12 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
               onSubmit={(quest, name) => runAction(def, async () => {
                 const r = await unlockMainQuest(player.account_id, quest)
                 return { message: r.message || `Unlocked main quest "${name}" for ${player.name}.` }
+              })} />
+          ) : def.custom === 'aql-trial' ? (
+            <AqlTrialForm busy={busy}
+              onSubmit={(trial, label) => runAction(def, async () => {
+                const r = await applyAqlTrial(player.account_id, trial)
+                return { message: r.message || `Applied ${label} for ${player.name}.` }
               })} />
           ) : def.custom === 'progression-unlock' ? (
             <ProgressionUnlockForm busy={busy}
@@ -1710,6 +1719,58 @@ function UnlockMainQuestForm({ busy, onSubmit }: { busy: boolean; onSubmit: (que
       <button className="btn-primary w-full" disabled={busy || !sel}
         onClick={() => onSubmit(sel, chosen?.name || sel)}>
         {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Flag" size={13} />} Unlock Main Quest
+      </button>
+    </div>
+  )
+}
+
+// Apply Aql Trial — reproduces the full before/after snapshot diff of completing
+// an Aql trial: completes the journey subtree, applies the tags that flip, and
+// grants the recipe award that unlocks the ability slot. The recipe lives on the
+// pawn (RAM-authoritative while online), so this is offline-only and takes
+// effect on next login. Use it for a character a tag-only edit left stuck.
+function AqlTrialForm({ busy, onSubmit }: { busy: boolean; onSubmit: (trial: string, label: string) => void }) {
+  const [trials, setTrials] = useState<AqlTrialInfo[]>([])
+  const [sel, setSel] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState('')
+
+  useEffect(() => {
+    let alive = true
+    setLoading(true)
+    getAqlTrials()
+      .then(r => {
+        if (!alive) return
+        const list = r.trials || []
+        setTrials(list)
+        setSel(list[0]?.id || '')
+      })
+      .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
+      .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [])
+
+  const chosen = trials.find(t => t.id === sel)
+  const selectCls = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50'
+
+  if (loading) return <div className="text-sm text-text-dim flex items-center gap-2"><Icon name="Loader2" size={13} className="animate-spin" /> Loading Aql trials…</div>
+  if (err) return <div className="text-sm text-danger">{err}</div>
+  if (trials.length === 0) return <div className="text-sm text-text-dim">No Aql trials available.</div>
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Aql trial</label>
+        <select value={sel} disabled={busy} className={selectCls} onChange={e => setSel(e.target.value)}>
+          {trials.map(t => (<option key={t.id} value={t.id}>{t.label}</option>))}
+        </select>
+      </div>
+      <div className="text-[11px] text-text-muted">
+        Completes the trial's journey subtree, applies its tags, and grants the recipe award that unlocks the ability slot. Player must be offline; takes effect on next login. Later trials are untouched.
+      </div>
+      <button className="btn-primary w-full" disabled={busy || !sel}
+        onClick={() => onSubmit(sel, chosen?.label || sel)}>
+        {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Sparkles" size={13} />} Apply Aql Trial
       </button>
     </div>
   )


### PR DESCRIPTION
## Why

Completing a **Trial of Aql** (Find the Fremen) unlocks an **ability slot** on the wheel. Several players reported that "completing" the trial by editing tags in DST left the slot locked.

Root cause, confirmed by a before/after live snapshot diff on a real character: the slot is gated by a **recipe award** stored on the character's **pawn** (`TechKnowledgePlayerComponent.m_TechKnowledge.m_TechKnowledgeData`, e.g. `RCP_Crysknife_Recipe` → `Purchased`), **not** a journey/player tag. The Tags editor only writes `dune.player_tags`, so a tag-only edit marks the quest done without ever granting the recipe → slot stays locked. Finishing the trial in-game flips the recipe and the slot opens.

## What

New **Players → Progression → "Apply Aql Trial"** action that reproduces the *full* snapshot diff of a physical trial completion:

1. Completes the trial's **journey subtree** (`Invoke-DunePlayerCompleteJourneyNode`) — scoped to the named subtree only, so **later trials proceed normally** in-game.
2. Applies the **tags that flip** (incl. the `BigMoments.*` cinematic triggers + `JourneySets.Fremkit.CryssKnife`).
3. Grants the **awarded recipe** into pawn TechKnowledge (`Invoke-DuneGrantRecipe`) — the actual ability-slot trigger.

**Offline-only** (the pawn blob is RAM-authoritative while the player is connected); takes effect on next login. Ships **Trial 4** (3rd ability slot / Cryss Knife recipe); the catalog (`$script:DuneAqlTrialDeltas`) is data-driven so more trials can be added once snapshotted.

## Changes

- `app/server/lib/PlayersWrites.ps1` — `Invoke-DuneGrantRecipe`, `$script:DuneAqlTrialDeltas`, `Get-DuneAqlTrialCatalog`, `Invoke-DuneApplyAqlTrial`.
- `app/server/routes/PlayersWrites.ps1` — `GET /api/gameplay/players/aql-trials`, `POST /api/gameplay/players/apply-aql-trial` (offline-gated).
- `webui` — `getAqlTrials`/`applyAqlTrial` API + `AqlTrialForm` dropdown wired into the Progression actions.
- `tests/PlayersWrites.Tests.ps1` — 4 catalog guards.
- `CHANGELOG.md` — Unreleased entry.

## Verification

- `webui` build (tsc + vite): green.
- Pester `PlayersWrites.Tests.ps1`: **34/34** pass.
- PS parse-check on both edited `.ps1` files: clean; BOMs intact.
- Rebased onto current `main` (incl. #303); CHANGELOG conflict resolved keeping both entries.

A matching #faq thread with the repair SQL has been posted to the community Discord for admins who need to fix already-stuck characters.