### PR TITLE
fix(public-ip): retry DDNS resolve + public-resolver fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Public IP / DDNS: "did not resolve to a usable public IPv4 address" on the
+  first attempt.** Right after a network or public-IP change, the first DDNS
+  lookup could hit a brief empty answer that Windows then negative-cached,
+  making every retry keep failing until the cache expired (the "click off, wait,
+  then it resolves" symptom). DST now retries the lookup a few times and falls
+  back to querying public resolvers (1.1.1.1 / 8.8.8.8) directly, which bypasses
+  a poisoned local DNS cache, so a hostname that genuinely resolves succeeds on
+  the first click.
+
 ## [12.9.3] - 2026-06-20
 
 ### Added

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -162,24 +162,51 @@ function Test-DuneDdnsHostname {
     return @{ ok=$true; hostname=$h }
 }
 
+# Gather A records for a hostname using whichever method first yields an
+# answer. The system resolver is tried first, then direct queries to public
+# resolvers (1.1.1.1 / 8.8.8.8). Querying a specific -Server bypasses the
+# Windows DNS Client cache, so a momentary negative answer cached right after
+# a network/IP change (DDNS providers like No-IP use very low TTLs and lag a
+# few seconds to propagate) cannot keep poisoning subsequent lookups. A final
+# .NET GetHostAddresses pass covers hosts-file / odd-resolver setups.
+function Get-DuneHostnameIPv4Records {
+    param([string]$Name)
+    $sources = @(
+        { Resolve-DnsName -Name $Name -Type A -DnsOnly -NoHostsFile -ErrorAction Stop }
+        { Resolve-DnsName -Name $Name -Type A -Server '1.1.1.1' -DnsOnly -NoHostsFile -ErrorAction Stop }
+        { Resolve-DnsName -Name $Name -Type A -Server '8.8.8.8' -DnsOnly -NoHostsFile -ErrorAction Stop }
+    )
+    foreach ($src in $sources) {
+        try {
+            $ips = @(& $src |
+                Where-Object { $_.IPAddress } |
+                Select-Object -ExpandProperty IPAddress -Unique)
+            if ($ips.Count -gt 0) { return $ips }
+        } catch { }
+    }
+    try {
+        return @([System.Net.Dns]::GetHostAddresses($Name) |
+            Where-Object { $_.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork } |
+            ForEach-Object { $_.ToString() } |
+            Select-Object -Unique)
+    } catch { return @() }
+}
+
 function Resolve-DunePublicIpHostname {
     param([string]$Hostname)
     $hv = Test-DuneDdnsHostname -Hostname $Hostname
     if (-not $hv.ok) { return $hv }
+    # Retry a few times: a lookup fired immediately after an IP/network change
+    # can briefly return nothing before the DDNS record propagates. Without the
+    # retry the user sees a spurious "did not resolve" until the answer settles.
     $records = @()
-    try {
-        $records = @(Resolve-DnsName -Name $hv.hostname -Type A -ErrorAction Stop |
-            Where-Object { $_.IPAddress } |
-            Select-Object -ExpandProperty IPAddress -Unique)
-    } catch {
-        try {
-            $records = @([System.Net.Dns]::GetHostAddresses($hv.hostname) |
-                Where-Object { $_.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork } |
-                ForEach-Object { $_.ToString() } |
-                Select-Object -Unique)
-        } catch {
-            return @{ ok=$false; status=400; message="Could not resolve hostname '$($hv.hostname)' to an IPv4 address." }
-        }
+    for ($attempt = 1; $attempt -le 4; $attempt++) {
+        $records = @(Get-DuneHostnameIPv4Records -Name $hv.hostname)
+        if ($records.Count -gt 0) { break }
+        if ($attempt -lt 4) { Start-Sleep -Milliseconds 1200 }
+    }
+    if ($records.Count -lt 1) {
+        return @{ ok=$false; status=400; message="Could not resolve hostname '$($hv.hostname)' to an IPv4 address." }
     }
     $public = @()
     foreach ($r in $records) {

--- a/tests/PublicIp.Tests.ps1
+++ b/tests/PublicIp.Tests.ps1
@@ -68,6 +68,36 @@ Describe 'DDNS hostname validation' {
     }
 }
 
+Describe 'DDNS hostname resolution resilience' {
+    It 'retries when the first lookup returns nothing (transient negative cache)' {
+        $script:resolveCalls = 0
+        Mock -CommandName Get-DuneHostnameIPv4Records -MockWith {
+            $script:resolveCalls++
+            if ($script:resolveCalls -lt 2) { return @() }
+            return @('50.123.76.96')
+        }
+        $r = Resolve-DunePublicIpHostname -Hostname 'dunecoastal.myvnc.com'
+        $r.ok | Should -BeTrue
+        $r.publicIp | Should -Be '50.123.76.96'
+        $script:resolveCalls | Should -BeGreaterThan 1
+    }
+
+    It 'fails cleanly after exhausting retries when nothing resolves' {
+        Mock -CommandName Get-DuneHostnameIPv4Records -MockWith { @() }
+        $r = Resolve-DunePublicIpHostname -Hostname 'dunecoastal.myvnc.com'
+        $r.ok | Should -BeFalse
+        $r.status | Should -Be 400
+        $r.message | Should -Match 'Could not resolve'
+    }
+
+    It 'ignores private answers and reports no usable public IP' {
+        Mock -CommandName Get-DuneHostnameIPv4Records -MockWith { @('192.168.23.219') }
+        $r = Resolve-DunePublicIpHostname -Hostname 'dunecoastal.myvnc.com'
+        $r.ok | Should -BeFalse
+        $r.message | Should -Match 'usable public IPv4'
+    }
+}
+
 Describe 'settings.conf renderer' {
     It 'renders exactly four lines' {
         $text = New-DuneSettingsConfText -Battlegroup 'sh-test' -Image 'registry.funcom.com/funcom/self-hosting/seabass-server:1988751-0-shipping' -VmIp '192.168.1.50' -PublicIp '8.8.8.8'


### PR DESCRIPTION
## Problem

On the Settings → Public IP / DDNS card, clicking **Resolve hostname** right after a network or public-IP change (e.g. swapping the VM) failed the **first** time with:

> Hostname 'dunecoastal.myvnc.com' did not resolve to a usable public IPv4 address.

…even though the hostname resolves perfectly (`dunecoastal.myvnc.com → 50.123.76.96`, the real public IP). The workaround was to "click off, wait, then resolve again" — a classic transient-failure pattern.

## Root cause

Not DNS or the hostname value. DDNS providers (No-IP / myvnc) use very low TTLs and lag a few seconds to propagate after an IP change. The first lookup in DST's long-lived elevated server process can hit a momentary empty answer, which Windows then **negative-caches**. `Resolve-DunePublicIpHostname` did a single attempt with no retry, and its fallback (`[System.Net.Dns]::GetHostAddresses`) used the **same poisoned OS cache** — so every retry kept failing until the negative entry expired.

## Fix

- New `Get-DuneHostnameIPv4Records` helper gathers A records via the system resolver first, then queries public resolvers (**1.1.1.1 / 8.8.8.8**) directly with `-Server`, which **bypasses the Windows DNS Client cache** (so a poisoned local negative entry can't block a name that genuinely resolves). Final `.NET GetHostAddresses` pass for hosts-file / odd setups.
- `Resolve-DunePublicIpHostname` now **retries up to 4 times** (~1.2s apart) to ride out brief propagation gaps.
- ASCII-only edit (no BOM needed; verified 0 non-ASCII bytes, parse clean).

## Tests

- Added 3 Pester cases in `tests/PublicIp.Tests.ps1`: retry recovers from a first-attempt miss, clean failure after exhausting retries, and private answers reported as "no usable public IPv4."
- Full `PublicIp.Tests.ps1` suite green: **17/17**.
- Verified live against the real hostname (cold-cache flush + resolve) and a bogus hostname (graceful failure).

Backend-only PowerShell change; no webui changes.