### PR TITLE
release: v12.9.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.9.3"
+      placeholder: "v12.9.4"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.9.4] - 2026-06-20
+
 ### Fixed
 
 - **Public IP / DDNS: "did not resolve to a usable public IPv4 address" on the

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.9.3'
+$script:DuneToolVersion = '12.9.4'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.9.3',
+    [string]$Version = '12.9.4',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.9.3</Version>
+    <Version>12.9.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.9.3"
+#define MyAppVersion "12.9.4"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.9.3"
+$script:ToolVersion = "12.9.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Release v12.9.4

Patch release rolling up the DDNS resolve-retry fix (PR #306, already merged to main).

### Changes
- Bumped all **5 version stamps** 12.9.3 → 12.9.4 (`dune-server.ps1`, `app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/installer/DuneServer.iss`).
- Rolled `CHANGELOG.md` `[Unreleased]` → `[12.9.4] - 2026-06-20`.
- Bumped `bug_report.yml` `tool_version` placeholder to v12.9.4. (The "Resolve hostname" surface is already listed in the page/button placeholder.)

### What's in 12.9.4
- **Fixed:** Public IP / DDNS "did not resolve to a usable public IPv4 address" on the first attempt after a network/IP change — now retries + queries public resolvers (1.1.1.1 / 8.8.8.8) directly, bypassing a poisoned local DNS negative cache.

### Build
- Installer built and verified: `DuneServerSetup.exe` **45.93 MB**, FileVersion **12.9.4.0**, at the canonical `app/installer/output/` path.

Held for review — no merge/tag/publish without explicit go-ahead.