### PR TITLE
Fix Players → Specs "+5K Grant" not reflecting in-game (write xp + level via stored proc)

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -22,6 +22,12 @@ permissions:
 jobs:
   announce:
     runs-on: ubuntu-latest
+    # Never announce pre-releases. Pre-releases are an occasional, scenario-
+    # specific tool (e.g. handing a targeted test build to a bug reporter for
+    # in-game validation) and must stay silent in the community channels — only
+    # real releases get the "🚀 release" post. workflow_dispatch has no release
+    # context, so this guard is a no-op for manual (re)announcements.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
     steps:
       - name: Post release to Discord
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.9.5] - 2026-06-20
+
+### Fixed
+
+- **Gameplay Admin -> Players -> Specs: "+5K Grant" applied in DST but did not
+  show in-game.** The +5K grant wrote `xp_amount` directly to
+  `dune.specialization_tracks` and never touched `level`, so the server's
+  in-memory progression state was never refreshed the way the working "Grant
+  Max" action does. The grant now goes through the same Funcom stored procedure
+  (`dune.set_specialization_xp_and_level`) used by Grant Max: it reads the
+  current xp/level, adds the delta (clamped to the track cap), recomputes the
+  matching level without ever demoting the player, and writes both values. As
+  with other offline progression edits, the change appears in-game after a full
+  client re-login.
+
 ## [12.9.4] - 2026-06-20
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.9.4'
+$script:DuneToolVersion = '12.9.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.9.4',
+    [string]$Version = '12.9.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.9.4</Version>
+    <Version>12.9.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.9.4"
+#define MyAppVersion "12.9.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -183,25 +183,47 @@ function Invoke-DunePlayerRename {
 function Invoke-DunePlayerAwardXp {
     param([string]$Ip, [long]$ControllerId, [string]$TrackType, [int]$Delta)
     $safeTrack = ConvertTo-DuneSqlString $TrackType
-    $cap = 44182
-    $updSql = @"
-UPDATE dune.specialization_tracks
-SET xp_amount = GREATEST(LEAST(xp_amount + ($Delta)::integer, $cap::integer), 0)
+    $cap    = $script:DuneSpecXpMax      # 44182
+    $lvlMax = $script:DuneSpecLevelMax   # 100.0
+
+    # Read the current track so we can add the delta AND recompute level.
+    # Routes through the SAME Funcom stored proc as Grant Max
+    # (dune.set_specialization_xp_and_level), which writes BOTH xp_amount and
+    # level. The old path did a raw UPDATE of xp_amount only, leaving `level`
+    # stale and bypassing the proc, so the grant showed in DST but never
+    # reflected in-game. Level scales 0..cap XP -> 0..100 (anchored by Grant
+    # Max's 44182 -> 100); we never demote a level already earned in-game.
+    # Offline/RAM-authoritative: appears in-game only after a full client
+    # re-login (a BG/zone reboot is not enough).
+    $selSql = @"
+SELECT xp_amount, level FROM dune.specialization_tracks
 WHERE player_id = $ControllerId::bigint AND track_type::text = '$safeTrack';
 "@
-    $upd = Invoke-DuneSqlQuery -Ip $Ip -Sql $updSql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
-    if (-not $upd.ok) { return @{ ok = $false; error = $upd.error } }
-    if (([string]$upd.message) -match 'UPDATE\s+0') {
-        $start = [Math]::Max(0, [Math]::Min($Delta, $cap))
-        $insSql = @"
-INSERT INTO dune.specialization_tracks (player_id, track_type, xp_amount, level)
-VALUES ($ControllerId::bigint, '$safeTrack'::dune.specializationtracktype, $start::integer, 0::real);
-"@
-        $ins = Invoke-DuneSqlQuery -Ip $Ip -Sql $insSql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
-        if (-not $ins.ok) { return @{ ok = $false; error = $ins.error } }
-        return @{ ok = $true; message = "Created '$TrackType' track with $start XP." }
+    $sel = Invoke-DuneSqlQuery -Ip $Ip -Sql $selSql -ReadOnly $true -MaxRows 1 -TimeoutSec 30
+    if (-not $sel.ok) { return @{ ok = $false; error = $sel.error } }
+
+    $curXp = 0; $curLevel = 0.0; $exists = $false
+    $rows = @(ConvertTo-DuneRowMaps -Result $sel)
+    if ($rows.Count -gt 0) {
+        $exists   = $true
+        $curXp    = [int](ConvertTo-DuneInt $rows[0]['xp_amount'])
+        $curLevel = [double]([string]$rows[0]['level'])
     }
-    return @{ ok = $true; message = "Adjusted '$TrackType' XP by $Delta (capped at $cap)." }
+
+    $newXp = [int][Math]::Max(0, [Math]::Min([long]$curXp + $Delta, [long]$cap))
+    $scaledLevel = [Math]::Min($lvlMax, [double]$newXp * $lvlMax / $cap)
+    $newLevel = [Math]::Max($curLevel, $scaledLevel)
+    $newLevelSql = Format-DuneFloatForSql $newLevel
+
+    $sql = "SELECT dune.set_specialization_xp_and_level($ControllerId::bigint, '$safeTrack'::dune.specializationtracktype, $newXp::integer, $newLevelSql::real);"
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+
+    $lvlDisp = [Math]::Round($newLevel, 1)
+    if ($exists) {
+        return @{ ok = $true; message = "Adjusted '$TrackType' XP by $Delta (now $newXp / $cap, level $lvlDisp). Offline edit - appears in-game after a full re-login." }
+    }
+    return @{ ok = $true; message = "Created '$TrackType' track with $newXp XP (level $lvlDisp). Offline edit - appears in-game after a full re-login." }
 }
 
 # Delete item (delete-item): dune.delete_item(id).

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.9.4"
+$script:ToolVersion = "12.9.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/AwardSpecXp.Tests.ps1
+++ b/tests/AwardSpecXp.Tests.ps1
@@ -1,0 +1,110 @@
+# Tests the offline specialization-XP grant (the "+5000 XP" button on
+# Players -> Specs): Invoke-DunePlayerAwardXp in lib/GameplayPlayers.ps1.
+#
+# Regression guard for the Discord-reported bug "Specs +5K Grant shows applied
+# in DST but not in-game": the old code did a raw `UPDATE ... SET xp_amount`
+# only, leaving `level` stale and bypassing the Funcom stored proc, so the
+# grant never reflected in-game. The fix routes through
+# dune.set_specialization_xp_and_level (writes BOTH xp_amount and level),
+# caps XP at the max, recomputes level on the 0..max -> 0..100 scale, and
+# never demotes a level already earned in-game.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+
+    $script:curRow       = $null
+    $script:lastWriteSql = $null
+    $script:lastSelectSql = $null
+    $script:writeCount   = 0
+
+    function global:Invoke-DuneSqlQuery {
+        param([string] $Ip, [string] $Sql, [bool] $ReadOnly, [int] $MaxRows, [int] $TimeoutSec)
+        if ($ReadOnly -and $Sql -match 'SELECT xp_amount, level') {
+            $script:lastSelectSql = $Sql
+            if ($null -eq $script:curRow) { return @{ ok = $true; maps = @() } }
+            return @{ ok = $true; maps = @(@{ xp_amount = $script:curRow.xp; level = $script:curRow.level }) }
+        }
+        $script:lastWriteSql = $Sql
+        $script:writeCount   = $script:writeCount + 1
+        return @{ ok = $true; maps = @(); message = 'SELECT 1' }
+    }
+    function global:ConvertTo-DuneRowMaps {
+        param($Result)
+        if ($Result -and $Result.maps) { return $Result.maps }
+        return @()
+    }
+    function global:ConvertTo-DuneInt {
+        param($Value)
+        if ($null -eq $Value) { return 0 }
+        return [int]$Value
+    }
+
+    Import-DstLib 'GameplayPlayers.ps1'
+}
+
+AfterAll {
+    Remove-Item function:global:Invoke-DuneSqlQuery   -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneInt     -ErrorAction SilentlyContinue
+}
+
+Describe 'Invoke-DunePlayerAwardXp (offline spec XP grant)' -Tag 'Players' {
+    BeforeEach {
+        $script:curRow        = $null
+        $script:lastWriteSql  = $null
+        $script:lastSelectSql = $null
+        $script:writeCount    = 0
+    }
+
+    It 'routes through the stored proc and never does a raw xp_amount-only UPDATE' {
+        $script:curRow = @{ xp = 10000; level = 22.6 }
+        $r = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 555 -TrackType 'Combat' -Delta 5000
+        $r.ok | Should -BeTrue
+
+        $script:lastWriteSql | Should -Match 'dune\.set_specialization_xp_and_level'
+        $script:lastWriteSql | Should -Not -Match 'UPDATE\s+dune\.specialization_tracks'
+        # current + delta, applied to the same track
+        $script:lastWriteSql | Should -Match '15000::integer'
+        $script:lastWriteSql | Should -Match "'Combat'::dune\.specializationtracktype"
+    }
+
+    It 'caps XP at the track maximum (44182)' {
+        $script:curRow = @{ xp = 43000; level = 97.3 }
+        $r = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 555 -TrackType 'Combat' -Delta 5000
+        $r.ok | Should -BeTrue
+        $script:lastWriteSql | Should -Match '44182::integer'
+        $script:lastWriteSql | Should -Match '100::real'   # capped level
+    }
+
+    It 'never demotes a level already earned in-game' {
+        # Player leveled past the linear scale: 1000 XP but level 90 in-game.
+        $script:curRow = @{ xp = 1000; level = 90 }
+        $r = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 555 -TrackType 'Gathering' -Delta 5000
+        $r.ok | Should -BeTrue
+        $script:lastWriteSql | Should -Match '6000::integer'
+        $script:lastWriteSql | Should -Match '90::real'    # level preserved, not lowered
+    }
+
+    It 'creates the track via the stored proc when none exists yet' {
+        $script:curRow = $null
+        $r = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 555 -TrackType 'Crafting' -Delta 5000
+        $r.ok | Should -BeTrue
+        $r.message | Should -Match 'Created'
+        $script:lastWriteSql | Should -Match 'dune\.set_specialization_xp_and_level'
+        $script:lastWriteSql | Should -Match '5000::integer'
+    }
+
+    It 'reads the current track before writing (so it can recompute level)' {
+        $script:curRow = @{ xp = 10000; level = 22.6 }
+        $null = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 777 -TrackType 'Combat' -Delta 100
+        $script:lastSelectSql | Should -Match 'SELECT xp_amount, level'
+        $script:lastSelectSql | Should -Match 'player_id = 777'
+    }
+
+    It 'clamps a negative delta at zero XP' {
+        $script:curRow = @{ xp = 1000; level = 2.3 }
+        $r = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 555 -TrackType 'Combat' -Delta -5000
+        $r.ok | Should -BeTrue
+        $script:lastWriteSql | Should -Match '0::integer'
+    }
+}


### PR DESCRIPTION
## Bug
Reported in Discord #bug-reports: **Gameplay Admin → Player → Specs → "+5K Grant"** shows applied in DST but does not change the value in-game.

## Root cause
`Invoke-DunePlayerAwardXp` wrote only `xp_amount` to `dune.specialization_tracks` via a raw `UPDATE` and never touched `level`. The working "Grant Max" action instead calls the Funcom stored procedure `dune.set_specialization_xp_and_level`, which sets **both** xp and level.

## Change
`Invoke-DunePlayerAwardXp` now:
- SELECTs current `xp_amount`/`level`,
- adds the delta clamped to the track cap (`$script:DuneSpecXpMax` = 44182),
- recomputes `level` on the 0..cap → 0..100 scale, never demoting (`max(curLevel, scaled)`),
- writes both values through `dune.set_specialization_xp_and_level` — the same path as Grant Max.

As with other offline progression edits, the change is expected to surface in-game only after a **full client re-login**.

## Tests
- New `tests/AwardSpecXp.Tests.ps1` (6 cases). Full suite: **300 pass**.

## Also in this PR
- `discord-release.yml` guarded so it stays silent on GitHub pre-releases (used for targeted Discord test builds).
- Version stamped to **v12.9.5** across the 5 files; CHANGELOG rolled.

## Validation status
Delivered to the reporter as pre-release `v12.9.5-test1` (Discord test branch). **Pending in-game confirmation** — the level-curve scaling is unverified against the live DB, which is exactly what the test build validates. Fold to live on reporter confirmation.