### PR TITLE
feat(updates): app-wide Test-channel indicator (v12.9.6)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.9.5"
+      placeholder: "v12.9.6"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.9.6] - 2026-06-20
+
+### Added
+
+- **App-wide Test-channel indicator.** When an install is on the **Test** update
+  channel, a **TEST CHANNEL** badge now appears in the top status bar (visible on
+  every page) and next to the version in the sidebar footer. Both link to
+  *Settings &rarr; Dune Server Tool updates* so it's one click to switch back to
+  *Stable*. This makes it obvious at a glance that an install is running a
+  pre-release verification build.
+
 ## [12.9.5] - 2026-06-20
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.9.5'
+$script:DuneToolVersion = '12.9.6'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.9.5',
+    [string]$Version = '12.9.6',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.9.5</Version>
+    <Version>12.9.6</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.9.5"
+#define MyAppVersion "12.9.6"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.9.5"
+$script:ToolVersion = "12.9.6"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -25,6 +25,7 @@ type Props = {
 export function Sidebar({ collapsed }: Props) {
   const { data: upd } = useUpdateCheck()
   const version = upd?.currentVersion ?? ''
+  const onTestChannel = upd?.channel === 'test'
   const [showPortalConfirm, setShowPortalConfirm] = useState(false)
   const [portalDetaching, setPortalDetaching] = useState(false)
   const [portalError, setPortalError] = useState<string | null>(null)
@@ -258,9 +259,29 @@ export function Sidebar({ collapsed }: Props) {
           <Icon name="Coffee" size={collapsed ? 14 : 11} />
           {!collapsed && <span>Buy Me a Coffee</span>}
         </a>
+        {collapsed && onTestChannel && (
+          <NavLink
+            to="/settings"
+            title="Test update channel — receiving pre-release builds. Click to open Settings."
+            className="w-full flex items-center justify-center h-8 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors"
+          >
+            <Icon name="FlaskConical" size={14} />
+          </NavLink>
+        )}
         {!collapsed && (
           <div className="flex items-center justify-between">
-            <span>{version ? fmtToolVersion(version) : '—'}</span>
+            <span className="flex items-center gap-1.5">
+              {version ? fmtToolVersion(version) : '—'}
+              {onTestChannel && (
+                <NavLink
+                  to="/settings"
+                  title="Test update channel — receiving pre-release builds. Click to open Settings and switch back to Stable."
+                  className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wider border border-warning/40 bg-warning/10 text-warning hover:bg-warning/20 transition-colors"
+                >
+                  <Icon name="FlaskConical" size={9} /> Test
+                </NavLink>
+              )}
+            </span>
             <span className="font-mono">coastal-ms</span>
           </div>
         )}

--- a/webui/src/layout/StatusBar.tsx
+++ b/webui/src/layout/StatusBar.tsx
@@ -1,5 +1,7 @@
+import { Link } from 'react-router-dom'
 import { Icon } from '../components/Icon'
 import { useStatus } from '../hooks/useStatus'
+import { useUpdateCheck } from '../hooks/useUpdateCheck'
 import type { BgState, VmStatus, PortStatus } from '../api/types'
 
 function vmPillClass(vm: VmStatus | undefined | null): string {
@@ -31,6 +33,8 @@ const BG_STYLES: Record<BgState | 'unknown', { cls: string; label: string }> = {
 
 export function StatusBar() {
   const { status, loading, forceRefresh } = useStatus()
+  const { data: upd } = useUpdateCheck()
+  const onTestChannel = upd?.channel === 'test'
   const vm    = status?.vm ?? null
   const ports = status?.ports ?? null
   const bgKey = (status?.bg?.state ?? 'unknown') as BgState | 'unknown'
@@ -57,6 +61,15 @@ export function StatusBar() {
         )}
       </div>
       <div className="flex items-center gap-2 shrink-0">
+        {onTestChannel && (
+          <Link
+            to="/settings"
+            className="pill-warning hover:bg-warning/20 transition-colors"
+            title="This install is on the Test update channel — it receives pre-release builds shared for verification. Click to open Settings and switch back to Stable."
+          >
+            <Icon name="FlaskConical" size={11} /> TEST CHANNEL
+          </Link>
+        )}
         <span className={portPillClass(ports, 7777, 'UDP')} title="Game server ports (forward on your router/firewall)">
           <Icon name="Plug" size={11} /> 7777–7810 UDP
         </span>


### PR DESCRIPTION
## What

Adds an **app-wide Test-channel indicator** so it's obvious at a glance when an install is running a pre-release verification build (Test update channel), not just buried in the Settings card.

- **Top status bar:** a `TEST CHANNEL` amber pill in the right pill cluster, visible on every page, linking to Settings.
- **Sidebar footer:** a `Test` badge next to the version (expanded) and a flask-icon button (collapsed), both linking to Settings.

Both read the channel from the shared `useUpdateCheck` store, so toggling Stable/Test in Settings updates the indicator **live** (no reload).

## Why

Completes the update-channel toggle (v12.9.5). During the Discord-verified test-branch workflow, a reporter on the Test channel now has a constant, unmissable reminder that they're on a pre-release build and a one-click path back to Stable.

## Changes
- `webui/src/layout/StatusBar.tsx`: subscribe to `useUpdateCheck`; render the pill when `channel === 'test'`.
- `webui/src/layout/Sidebar.tsx`: channel badge in the footer (both layout modes).
- Stamp all 5 version files to **12.9.6**; `CHANGELOG.md` entry; `bug_report.yml` version placeholder.

## Verification
- `npm run build` (webui) — clean
- `Build-Installer.ps1` — SUCCESS, version gate passed, artifact at canonical `app/installer/output/DuneServerSetup.exe` (45.94 MB)

## Notes
- Ships live as **v12.9.6**. The reverted +5K spec-grant fix now folds later as **v12.9.7** once confirmed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>