### PR TITLE
fix(updates): Test indicator reflects installed build, not channel toggle (v12.9.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@ here cover everything those tags shipped.
 
 ### Added
 
-- **App-wide Test-channel indicator.** When an install is on the **Test** update
-  channel, a **TEST CHANNEL** badge now appears in the top status bar (visible on
-  every page) and next to the version in the sidebar footer. Both link to
-  *Settings &rarr; Dune Server Tool updates* so it's one click to switch back to
-  *Stable*. This makes it obvious at a glance that an install is running a
-  pre-release verification build.
+- **App-wide "test build" indicator.** When the **currently running build** was
+  installed from a pre-release (a targeted Test-channel verification build), a
+  **TEST BUILD** badge appears in the top status bar (visible on every page) and
+  next to the version in the sidebar footer. Both link to *Settings &rarr; Dune
+  Server Tool updates*. The indicator keys off what was actually **installed**
+  (recorded by the updater at install time), not the channel preference — so
+  toggling the Stable/Test switch alone never lights it; only installing a
+  pre-release build does, and a later Stable install clears it.
 
 ## [12.9.5] - 2026-06-20
 

--- a/app/server/lib/Config.ps1
+++ b/app/server/lib/Config.ps1
@@ -23,7 +23,9 @@ $script:DuneConfigKeys = @(
     'ClientConfigPath',
     'DbPort',
     'UpdateChannel',
-    'UpdatePreReleaseTag'
+    'UpdatePreReleaseTag',
+    'UpdateInstalledPrerelease',
+    'UpdateInstalledTag'
 )
 
 # Default in-pod PostgreSQL port. All DST DB access runs as
@@ -131,6 +133,23 @@ function Get-DuneUpdatePreReleaseTag {
         return $v.Trim()
     } catch {}
     return ''
+}
+
+# Whether the build currently installed was itself a GitHub pre-release (a
+# targeted Discord test build), as recorded by the in-app updater at the moment
+# it launched that install. This is the truth source for the app-wide "running a
+# test build" indicator — NOT the UpdateChannel preference. Merely toggling the
+# channel to Test (a preference that takes effect on the NEXT install) must not
+# light the indicator; only actually installing a pre-release build does. A
+# subsequent stable install writes 'false' and clears it. Absent/blank => false
+# (a normal stable install never wrote it).
+function Get-DuneUpdateInstalledPrerelease {
+    try {
+        $raw = Read-DuneConfigRaw
+        $v = if ($raw.Contains('UpdateInstalledPrerelease')) { [string]$raw['UpdateInstalledPrerelease'] } else { '' }
+        return ($v -match '^(?i:true|1|yes)$')
+    } catch {}
+    return $false
 }
 
 function Save-DuneConfig {

--- a/app/server/routes/Update.ps1
+++ b/app/server/routes/Update.ps1
@@ -219,13 +219,15 @@ Register-DuneRoute -Method GET -Path '/api/update/check' -Handler {
         $rel     = Get-DuneSelectedRelease -Force:$force
         $current = [string]$script:DuneToolVersion
         $channel = Get-DuneUpdateChannel
+        $runningIsPrerelease = Get-DuneUpdateInstalledPrerelease
         if (-not $rel -or $rel.error) {
             Write-DuneJson -Response $res -Body @{
-                available       = $false
-                channel         = $channel
-                currentVersion  = $current
-                checkedAt       = (Get-Date).ToString('o')
-                error           = $rel.error
+                available           = $false
+                channel             = $channel
+                runningIsPrerelease = $runningIsPrerelease
+                currentVersion      = $current
+                checkedAt           = (Get-Date).ToString('o')
+                error               = $rel.error
             }
             return
         }
@@ -257,6 +259,7 @@ Register-DuneRoute -Method GET -Path '/api/update/check' -Handler {
             installable     = $installable
             assetMissing    = ($available -and -not $hasAsset)
             channel         = $channel
+            runningIsPrerelease = $runningIsPrerelease
             isPrerelease    = [bool]$rel.isPrerelease
             selectedTag     = $rel.tag
             currentVersion  = $current
@@ -444,6 +447,22 @@ Register-DuneRoute -Method POST -Path '/api/update/install' -Handler {
             Write-DuneError -Response $res -Status 500 -Message "Download failed: $dest not present after fetch."
             return
         }
+
+        # Record the truth source for the app-wide "running a test build"
+        # indicator at the moment we commit to launching this install: was the
+        # build we're about to install a GitHub pre-release? The new build reads
+        # this from config on startup. We deliberately key the indicator off
+        # what was actually INSTALLED, not the UpdateChannel preference, so that
+        # merely toggling the channel (which only affects the next install)
+        # never lights the indicator. A later stable install writes 'false'.
+        try {
+            Invoke-WithDuneLock -Name 'config' -Script {
+                Save-DuneConfig @{
+                    UpdateInstalledPrerelease = if ([bool]$rel.isPrerelease) { 'true' } else { 'false' }
+                    UpdateInstalledTag        = [string]$rel.tag
+                }
+            } | Out-Null
+        } catch {}
 
         # Respond to the client FIRST so the browser sees confirmation
         # before we tear ourselves down. The relauncher below kills this

--- a/tests/UpdateChannel.Tests.ps1
+++ b/tests/UpdateChannel.Tests.ps1
@@ -114,3 +114,23 @@ Describe 'Get-DuneSelectedRelease channel resolution' {
         $r.isPrerelease | Should -BeFalse
     }
 }
+
+Describe 'Get-DuneUpdateInstalledPrerelease (running-build marker)' {
+    It 'is false when the marker key is absent (normal stable install)' {
+        function global:Read-DuneConfigRaw { @{ UpdateChannel = 'stable' } }
+        Get-DuneUpdateInstalledPrerelease | Should -BeFalse
+    }
+    It 'is true only after a pre-release build was installed' {
+        function global:Read-DuneConfigRaw { @{ UpdateInstalledPrerelease = 'true' } }
+        Get-DuneUpdateInstalledPrerelease | Should -BeTrue
+    }
+    It 'is false when a later stable install wrote false' {
+        function global:Read-DuneConfigRaw { @{ UpdateInstalledPrerelease = 'false' } }
+        Get-DuneUpdateInstalledPrerelease | Should -BeFalse
+    }
+    It 'does not key off the channel preference (toggling Test alone stays false)' {
+        # User toggled to Test (preference set) but never installed a pre-release.
+        function global:Read-DuneConfigRaw { @{ UpdateChannel = 'test' } }
+        Get-DuneUpdateInstalledPrerelease | Should -BeFalse
+    }
+}

--- a/webui/src/api/update.ts
+++ b/webui/src/api/update.ts
@@ -28,6 +28,14 @@ export interface UpdateCheck {
   error?: string
   /** Update channel this check resolved against: 'stable' (default) or 'test'. */
   channel?: 'stable' | 'test'
+  /**
+   * True when the build CURRENTLY RUNNING was installed from a GitHub
+   * pre-release (a targeted test build), as recorded by the updater at install
+   * time. This — not `channel` — drives the app-wide "running a test build"
+   * indicator, so merely toggling the channel preference (which only affects
+   * the next install) does not light it up.
+   */
+  runningIsPrerelease?: boolean
   /** True when the resolved release is a GitHub pre-release (test channel). */
   isPrerelease?: boolean
   /** The exact tag the updater resolved to act on (stable latest or pinned pre-release). */

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -25,7 +25,7 @@ type Props = {
 export function Sidebar({ collapsed }: Props) {
   const { data: upd } = useUpdateCheck()
   const version = upd?.currentVersion ?? ''
-  const onTestChannel = upd?.channel === 'test'
+  const onTestChannel = upd?.runningIsPrerelease === true
   const [showPortalConfirm, setShowPortalConfirm] = useState(false)
   const [portalDetaching, setPortalDetaching] = useState(false)
   const [portalError, setPortalError] = useState<string | null>(null)
@@ -262,7 +262,7 @@ export function Sidebar({ collapsed }: Props) {
         {collapsed && onTestChannel && (
           <NavLink
             to="/settings"
-            title="Test update channel — receiving pre-release builds. Click to open Settings."
+            title="Running a pre-release Test build. Click to open Settings."
             className="w-full flex items-center justify-center h-8 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors"
           >
             <Icon name="FlaskConical" size={14} />
@@ -275,7 +275,7 @@ export function Sidebar({ collapsed }: Props) {
               {onTestChannel && (
                 <NavLink
                   to="/settings"
-                  title="Test update channel — receiving pre-release builds. Click to open Settings and switch back to Stable."
+                  title="Running a pre-release Test build. Click to open Settings, switch to Stable, and install the released build."
                   className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wider border border-warning/40 bg-warning/10 text-warning hover:bg-warning/20 transition-colors"
                 >
                   <Icon name="FlaskConical" size={9} /> Test

--- a/webui/src/layout/StatusBar.tsx
+++ b/webui/src/layout/StatusBar.tsx
@@ -34,7 +34,7 @@ const BG_STYLES: Record<BgState | 'unknown', { cls: string; label: string }> = {
 export function StatusBar() {
   const { status, loading, forceRefresh } = useStatus()
   const { data: upd } = useUpdateCheck()
-  const onTestChannel = upd?.channel === 'test'
+  const onTestChannel = upd?.runningIsPrerelease === true
   const vm    = status?.vm ?? null
   const ports = status?.ports ?? null
   const bgKey = (status?.bg?.state ?? 'unknown') as BgState | 'unknown'
@@ -65,9 +65,9 @@ export function StatusBar() {
           <Link
             to="/settings"
             className="pill-warning hover:bg-warning/20 transition-colors"
-            title="This install is on the Test update channel — it receives pre-release builds shared for verification. Click to open Settings and switch back to Stable."
+            title="This install is running a pre-release TEST build (installed from the Test channel for verification before it goes live). Click to open Settings, switch to Stable, and install the released build."
           >
-            <Icon name="FlaskConical" size={11} /> TEST CHANNEL
+            <Icon name="FlaskConical" size={11} /> TEST BUILD
           </Link>
         )}
         <span className={portPillClass(ports, 7777, 'UDP')} title="Game server ports (forward on your router/firewall)">


### PR DESCRIPTION
## Problem

The app-wide Test indicator (shipped in v12.9.6) keyed off the `UpdateChannel` **preference**, which is saved the instant the Stable/Test switch is toggled. So toggling to Test and navigating away — **without installing anything** — wrongly lit the indicator, even though the running build was still a stable release.

## Fix

Drive the indicator off **what is actually running**, recorded at install time:

- The updater now writes `UpdateInstalledPrerelease` (+ `UpdateInstalledTag`) into config at the moment it launches an install, based on whether the selected release is a GitHub pre-release. A later **stable** install writes `false`, clearing it. Absent ⇒ false (a normal stable install never wrote it).
- `GET /api/update/check` returns `runningIsPrerelease` (from config).
- `StatusBar` + `Sidebar` indicators read `runningIsPrerelease` instead of `channel === 'test'`; relabelled to **TEST BUILD** with accurate tooltips.

Result: toggling the channel (a preference that only affects the *next* install) no longer lights the indicator — only actually installing a pre-release build does.

## Changes
- `app/server/lib/Config.ps1`: allowlist `UpdateInstalledPrerelease` / `UpdateInstalledTag`; add `Get-DuneUpdateInstalledPrerelease`.
- `app/server/routes/Update.ps1`: persist the marker at install launch; expose `runningIsPrerelease` in `/check`.
- `webui/src/api/update.ts`, `StatusBar.tsx`, `Sidebar.tsx`: indicator reads `runningIsPrerelease`.
- `tests/UpdateChannel.Tests.ps1`: +4 tests (suite **311 passing**).
- `CHANGELOG.md` [12.9.6] entry updated to describe the corrected behavior.

## Verification
- `npm run build` (webui) — clean
- PowerShell suite — **311 passing, 0 failing**
- `Build-Installer.ps1` — SUCCESS, version gate passed (still 12.9.6), artifact at canonical `app/installer/output/DuneServerSetup.exe` (45.94 MB)

## Release
Re-release under **v12.9.6** (no version bump) to replace the buggy artifact.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>