### PR TITLE
feat(updates): return-to-live control + fold +5K spec fix (v12.9.7)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.9.6"
+      placeholder: "v12.9.7"
     validations:
       required: true
 

--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -22,6 +22,12 @@ permissions:
 jobs:
   announce:
     runs-on: ubuntu-latest
+    # Never announce pre-releases. Pre-releases are an occasional, scenario-
+    # specific tool (e.g. handing a targeted test build to a bug reporter for
+    # in-game validation) and must stay silent in the community channels — only
+    # real releases get the "🚀 release" post. workflow_dispatch has no release
+    # context, so this guard is a no-op for manual (re)announcements.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
     steps:
       - name: Post release to Discord
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Return to the live release from a Test build.** A build installed from a
+  pre-release (Test channel) is no longer a dead-end: *Settings &rarr; Dune
+  Server Tool updates* now shows a **"Return to live release"** control whenever
+  the running build is a pre-release. One click switches back to the Stable
+  channel (clearing any pinned pre-release) and installs the live release — even
+  though it isn't strictly "newer" — which also clears the **TEST BUILD**
+  indicator. The Stable install gate is relaxed for pre-release builds so the
+  live release stays installable as a downgrade or same-version reinstall.
+
+### Fixed
+
+- **+5K spec grant not reflecting in-game.** Gameplay Admin &rarr; Players &rarr;
+  Specs "+5K Grant" wrote `xp_amount` directly to `dune.specialization_tracks`
+  and never updated level, so the change did not appear in-game.
+  `Invoke-DunePlayerAwardXp` now routes through the same Funcom stored proc as
+  "Grant Max" (`dune.set_specialization_xp_and_level`): it reads current
+  xp/level, adds the clamped delta, recomputes level without demoting, and writes
+  both. Appears in-game after a full client re-login.
+
 ## [12.9.6] - 2026-06-20
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.9.6'
+$script:DuneToolVersion = '12.9.7'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.9.6',
+    [string]$Version = '12.9.7',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.9.6</Version>
+    <Version>12.9.7</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.9.6"
+#define MyAppVersion "12.9.7"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -183,25 +183,47 @@ function Invoke-DunePlayerRename {
 function Invoke-DunePlayerAwardXp {
     param([string]$Ip, [long]$ControllerId, [string]$TrackType, [int]$Delta)
     $safeTrack = ConvertTo-DuneSqlString $TrackType
-    $cap = 44182
-    $updSql = @"
-UPDATE dune.specialization_tracks
-SET xp_amount = GREATEST(LEAST(xp_amount + ($Delta)::integer, $cap::integer), 0)
+    $cap    = $script:DuneSpecXpMax      # 44182
+    $lvlMax = $script:DuneSpecLevelMax   # 100.0
+
+    # Read the current track so we can add the delta AND recompute level.
+    # Routes through the SAME Funcom stored proc as Grant Max
+    # (dune.set_specialization_xp_and_level), which writes BOTH xp_amount and
+    # level. The old path did a raw UPDATE of xp_amount only, leaving `level`
+    # stale and bypassing the proc, so the grant showed in DST but never
+    # reflected in-game. Level scales 0..cap XP -> 0..100 (anchored by Grant
+    # Max's 44182 -> 100); we never demote a level already earned in-game.
+    # Offline/RAM-authoritative: appears in-game only after a full client
+    # re-login (a BG/zone reboot is not enough).
+    $selSql = @"
+SELECT xp_amount, level FROM dune.specialization_tracks
 WHERE player_id = $ControllerId::bigint AND track_type::text = '$safeTrack';
 "@
-    $upd = Invoke-DuneSqlQuery -Ip $Ip -Sql $updSql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
-    if (-not $upd.ok) { return @{ ok = $false; error = $upd.error } }
-    if (([string]$upd.message) -match 'UPDATE\s+0') {
-        $start = [Math]::Max(0, [Math]::Min($Delta, $cap))
-        $insSql = @"
-INSERT INTO dune.specialization_tracks (player_id, track_type, xp_amount, level)
-VALUES ($ControllerId::bigint, '$safeTrack'::dune.specializationtracktype, $start::integer, 0::real);
-"@
-        $ins = Invoke-DuneSqlQuery -Ip $Ip -Sql $insSql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
-        if (-not $ins.ok) { return @{ ok = $false; error = $ins.error } }
-        return @{ ok = $true; message = "Created '$TrackType' track with $start XP." }
+    $sel = Invoke-DuneSqlQuery -Ip $Ip -Sql $selSql -ReadOnly $true -MaxRows 1 -TimeoutSec 30
+    if (-not $sel.ok) { return @{ ok = $false; error = $sel.error } }
+
+    $curXp = 0; $curLevel = 0.0; $exists = $false
+    $rows = @(ConvertTo-DuneRowMaps -Result $sel)
+    if ($rows.Count -gt 0) {
+        $exists   = $true
+        $curXp    = [int](ConvertTo-DuneInt $rows[0]['xp_amount'])
+        $curLevel = [double]([string]$rows[0]['level'])
     }
-    return @{ ok = $true; message = "Adjusted '$TrackType' XP by $Delta (capped at $cap)." }
+
+    $newXp = [int][Math]::Max(0, [Math]::Min([long]$curXp + $Delta, [long]$cap))
+    $scaledLevel = [Math]::Min($lvlMax, [double]$newXp * $lvlMax / $cap)
+    $newLevel = [Math]::Max($curLevel, $scaledLevel)
+    $newLevelSql = Format-DuneFloatForSql $newLevel
+
+    $sql = "SELECT dune.set_specialization_xp_and_level($ControllerId::bigint, '$safeTrack'::dune.specializationtracktype, $newXp::integer, $newLevelSql::real);"
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+
+    $lvlDisp = [Math]::Round($newLevel, 1)
+    if ($exists) {
+        return @{ ok = $true; message = "Adjusted '$TrackType' XP by $Delta (now $newXp / $cap, level $lvlDisp). Offline edit - appears in-game after a full re-login." }
+    }
+    return @{ ok = $true; message = "Created '$TrackType' track with $newXp XP (level $lvlDisp). Offline edit - appears in-game after a full re-login." }
 }
 
 # Delete item (delete-item): dune.delete_item(id).

--- a/app/server/routes/Update.ps1
+++ b/app/server/routes/Update.ps1
@@ -206,6 +206,43 @@ function Get-DuneSelectedRelease {
     }
 }
 
+# Pure decision for "can the in-app updater install the selected release?" Shared
+# by GET /api/update/check (the `installable` flag) and POST /api/update/install
+# (the `blocked` gate) so the two never drift.
+#
+#   Diff                = Compare-DuneSemver(selectedTag, runningVersion)
+#   Channel             = 'stable' | 'test'
+#   HasAsset            = selected release carries DuneServerSetup.exe
+#   RunningIsPrerelease = the build currently running was installed from a pre-release
+#
+# Test channel: install whenever the selected pre-release differs from the
+# running build (forward, sideways, or rollback between -testN candidates).
+# Stable channel: classic "strictly newer" rule, RELAXED when the running build
+# is a pre-release so a tester can always return to the live release even though
+# it is not newer (downgrade to the last Stable or a same-version reinstall that
+# clears the TEST BUILD indicator).
+function Get-DuneInstallDecision {
+    param(
+        [int]$Diff = 0,
+        [string]$Channel = 'stable',
+        [bool]$HasAsset = $false,
+        [bool]$RunningIsPrerelease = $false
+    )
+    $available = ($Diff -gt 0)
+    if ($Channel -eq 'test') {
+        $installable = $HasAsset -and ($Diff -ne 0)
+        $blocked     = ($Diff -eq 0)
+    } else {
+        $installable = $HasAsset -and ($available -or $RunningIsPrerelease)
+        $blocked     = ($Diff -le 0) -and (-not $RunningIsPrerelease)
+    }
+    [pscustomobject]@{
+        available   = $available
+        installable = $installable
+        blocked     = $blocked
+    }
+}
+
 # --- Routes ------------------------------------------------------------------
 
 # GET /api/update/check[?force=1] — compare current vs latest release
@@ -249,11 +286,16 @@ Register-DuneRoute -Method GET -Path '/api/update/check' -Handler {
         # a specific pre-release, so installing it is allowed whenever it
         # differs from the running build (sideways re-install or rollback to an
         # earlier -testN build are both intentional). On Stable the classic
-        # "strictly newer" rule applies.
-        $isTest       = ($channel -eq 'test')
-        $available    = ($diff -gt 0)
+        # "strictly newer" rule applies - EXCEPT when the running build is a
+        # pre-release (Test build). In that case Stable must stay installable
+        # even when not strictly newer so a tester can always return to the live
+        # release (a downgrade to the last Stable, or a same-version reinstall
+        # to clear the TEST BUILD indicator). Without this a Test build is a
+        # dead-end: the live release is never "newer", so the button stays off.
         $hasAsset     = -not [string]::IsNullOrEmpty($rel.assetUrl)
-        $installable  = if ($isTest) { $hasAsset -and ($diff -ne 0) } else { $available -and $hasAsset }
+        $decision     = Get-DuneInstallDecision -Diff $diff -Channel $channel -HasAsset $hasAsset -RunningIsPrerelease $runningIsPrerelease
+        $available    = $decision.available
+        $installable  = $decision.installable
         Write-DuneJson -Response $res -Body @{
             available       = $available
             installable     = $installable
@@ -409,13 +451,19 @@ Register-DuneRoute -Method POST -Path '/api/update/install' -Handler {
             Write-DuneError -Response $res -Status 503 -Message 'No installer asset available on the selected release.'
             return
         }
-        # Channel-aware gate. Stable blocks anything not strictly newer. Test
-        # only blocks re-installing the exact same build (diff == 0); a
-        # deliberate sideways install or rollback to an earlier -testN build is
-        # allowed so a tester can move between candidate builds at will.
+        # Channel-aware gate. Stable blocks anything not strictly newer, UNLESS
+        # the running build is a pre-release (Test build) - then a stable install
+        # is always allowed so the tester can return to the live release even
+        # though it is not "newer" (downgrade to last Stable, or same-version
+        # reinstall to clear the TEST BUILD indicator). Test only blocks
+        # re-installing the exact same build (diff == 0); a deliberate sideways
+        # install or rollback to an earlier -testN build is allowed so a tester
+        # can move between candidate builds at will.
         $channel = Get-DuneUpdateChannel
+        $runningIsPrerelease = Get-DuneUpdateInstalledPrerelease
         $diff = Compare-DuneSemver -A $rel.tag -B ([string]$script:DuneToolVersion)
-        $blocked = if ($channel -eq 'test') { $diff -eq 0 } else { $diff -le 0 }
+        $hasAsset = -not [string]::IsNullOrEmpty($rel.assetUrl)
+        $blocked = (Get-DuneInstallDecision -Diff $diff -Channel $channel -HasAsset $hasAsset -RunningIsPrerelease $runningIsPrerelease).blocked
         if ($blocked) {
             Write-DuneJson -Response $res -Body @{
                 launched = $false

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.9.6"
+$script:ToolVersion = "12.9.7"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/AwardSpecXp.Tests.ps1
+++ b/tests/AwardSpecXp.Tests.ps1
@@ -1,0 +1,110 @@
+# Tests the offline specialization-XP grant (the "+5000 XP" button on
+# Players -> Specs): Invoke-DunePlayerAwardXp in lib/GameplayPlayers.ps1.
+#
+# Regression guard for the Discord-reported bug "Specs +5K Grant shows applied
+# in DST but not in-game": the old code did a raw `UPDATE ... SET xp_amount`
+# only, leaving `level` stale and bypassing the Funcom stored proc, so the
+# grant never reflected in-game. The fix routes through
+# dune.set_specialization_xp_and_level (writes BOTH xp_amount and level),
+# caps XP at the max, recomputes level on the 0..max -> 0..100 scale, and
+# never demotes a level already earned in-game.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+
+    $script:curRow       = $null
+    $script:lastWriteSql = $null
+    $script:lastSelectSql = $null
+    $script:writeCount   = 0
+
+    function global:Invoke-DuneSqlQuery {
+        param([string] $Ip, [string] $Sql, [bool] $ReadOnly, [int] $MaxRows, [int] $TimeoutSec)
+        if ($ReadOnly -and $Sql -match 'SELECT xp_amount, level') {
+            $script:lastSelectSql = $Sql
+            if ($null -eq $script:curRow) { return @{ ok = $true; maps = @() } }
+            return @{ ok = $true; maps = @(@{ xp_amount = $script:curRow.xp; level = $script:curRow.level }) }
+        }
+        $script:lastWriteSql = $Sql
+        $script:writeCount   = $script:writeCount + 1
+        return @{ ok = $true; maps = @(); message = 'SELECT 1' }
+    }
+    function global:ConvertTo-DuneRowMaps {
+        param($Result)
+        if ($Result -and $Result.maps) { return $Result.maps }
+        return @()
+    }
+    function global:ConvertTo-DuneInt {
+        param($Value)
+        if ($null -eq $Value) { return 0 }
+        return [int]$Value
+    }
+
+    Import-DstLib 'GameplayPlayers.ps1'
+}
+
+AfterAll {
+    Remove-Item function:global:Invoke-DuneSqlQuery   -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneInt     -ErrorAction SilentlyContinue
+}
+
+Describe 'Invoke-DunePlayerAwardXp (offline spec XP grant)' -Tag 'Players' {
+    BeforeEach {
+        $script:curRow        = $null
+        $script:lastWriteSql  = $null
+        $script:lastSelectSql = $null
+        $script:writeCount    = 0
+    }
+
+    It 'routes through the stored proc and never does a raw xp_amount-only UPDATE' {
+        $script:curRow = @{ xp = 10000; level = 22.6 }
+        $r = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 555 -TrackType 'Combat' -Delta 5000
+        $r.ok | Should -BeTrue
+
+        $script:lastWriteSql | Should -Match 'dune\.set_specialization_xp_and_level'
+        $script:lastWriteSql | Should -Not -Match 'UPDATE\s+dune\.specialization_tracks'
+        # current + delta, applied to the same track
+        $script:lastWriteSql | Should -Match '15000::integer'
+        $script:lastWriteSql | Should -Match "'Combat'::dune\.specializationtracktype"
+    }
+
+    It 'caps XP at the track maximum (44182)' {
+        $script:curRow = @{ xp = 43000; level = 97.3 }
+        $r = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 555 -TrackType 'Combat' -Delta 5000
+        $r.ok | Should -BeTrue
+        $script:lastWriteSql | Should -Match '44182::integer'
+        $script:lastWriteSql | Should -Match '100::real'   # capped level
+    }
+
+    It 'never demotes a level already earned in-game' {
+        # Player leveled past the linear scale: 1000 XP but level 90 in-game.
+        $script:curRow = @{ xp = 1000; level = 90 }
+        $r = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 555 -TrackType 'Gathering' -Delta 5000
+        $r.ok | Should -BeTrue
+        $script:lastWriteSql | Should -Match '6000::integer'
+        $script:lastWriteSql | Should -Match '90::real'    # level preserved, not lowered
+    }
+
+    It 'creates the track via the stored proc when none exists yet' {
+        $script:curRow = $null
+        $r = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 555 -TrackType 'Crafting' -Delta 5000
+        $r.ok | Should -BeTrue
+        $r.message | Should -Match 'Created'
+        $script:lastWriteSql | Should -Match 'dune\.set_specialization_xp_and_level'
+        $script:lastWriteSql | Should -Match '5000::integer'
+    }
+
+    It 'reads the current track before writing (so it can recompute level)' {
+        $script:curRow = @{ xp = 10000; level = 22.6 }
+        $null = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 777 -TrackType 'Combat' -Delta 100
+        $script:lastSelectSql | Should -Match 'SELECT xp_amount, level'
+        $script:lastSelectSql | Should -Match 'player_id = 777'
+    }
+
+    It 'clamps a negative delta at zero XP' {
+        $script:curRow = @{ xp = 1000; level = 2.3 }
+        $r = Invoke-DunePlayerAwardXp -Ip '1.2.3.4' -ControllerId 555 -TrackType 'Combat' -Delta -5000
+        $r.ok | Should -BeTrue
+        $script:lastWriteSql | Should -Match '0::integer'
+    }
+}

--- a/tests/UpdateChannel.Tests.ps1
+++ b/tests/UpdateChannel.Tests.ps1
@@ -134,3 +134,56 @@ Describe 'Get-DuneUpdateInstalledPrerelease (running-build marker)' {
         Get-DuneUpdateInstalledPrerelease | Should -BeFalse
     }
 }
+
+Describe 'Get-DuneInstallDecision (install/blocked gate)' {
+    Context 'Stable channel, running a normal (non-prerelease) build' {
+        It 'installs a strictly newer release' {
+            $d = Get-DuneInstallDecision -Diff 1 -Channel 'stable' -HasAsset $true -RunningIsPrerelease $false
+            $d.installable | Should -BeTrue
+            $d.blocked     | Should -BeFalse
+        }
+        It 'blocks a same-version reinstall' {
+            $d = Get-DuneInstallDecision -Diff 0 -Channel 'stable' -HasAsset $true -RunningIsPrerelease $false
+            $d.installable | Should -BeFalse
+            $d.blocked     | Should -BeTrue
+        }
+        It 'blocks a downgrade' {
+            $d = Get-DuneInstallDecision -Diff -1 -Channel 'stable' -HasAsset $true -RunningIsPrerelease $false
+            $d.installable | Should -BeFalse
+            $d.blocked     | Should -BeTrue
+        }
+        It 'never installs without an asset even when newer' {
+            (Get-DuneInstallDecision -Diff 1 -Channel 'stable' -HasAsset $false -RunningIsPrerelease $false).installable | Should -BeFalse
+        }
+    }
+
+    Context 'Stable channel, running a pre-release (Test) build - return-to-live' {
+        It 'allows returning to the live release as a downgrade' {
+            # running 12.9.7-test1 (reports 12.9.7); live stable is 12.9.6 => diff < 0
+            $d = Get-DuneInstallDecision -Diff -1 -Channel 'stable' -HasAsset $true -RunningIsPrerelease $true
+            $d.installable | Should -BeTrue
+            $d.blocked     | Should -BeFalse
+        }
+        It 'allows a same-version live reinstall (clears the TEST BUILD indicator)' {
+            # after fold: live stable == 12.9.7, running 12.9.7-test1 => diff == 0
+            $d = Get-DuneInstallDecision -Diff 0 -Channel 'stable' -HasAsset $true -RunningIsPrerelease $true
+            $d.installable | Should -BeTrue
+            $d.blocked     | Should -BeFalse
+        }
+        It 'still requires an installer asset' {
+            (Get-DuneInstallDecision -Diff -1 -Channel 'stable' -HasAsset $false -RunningIsPrerelease $true).installable | Should -BeFalse
+        }
+    }
+
+    Context 'Test channel' {
+        It 'installs any pre-release that differs from the running build' {
+            (Get-DuneInstallDecision -Diff 1  -Channel 'test' -HasAsset $true -RunningIsPrerelease $true).installable | Should -BeTrue
+            (Get-DuneInstallDecision -Diff -1 -Channel 'test' -HasAsset $true -RunningIsPrerelease $true).installable | Should -BeTrue
+        }
+        It 'blocks reinstalling the exact same pre-release build' {
+            $d = Get-DuneInstallDecision -Diff 0 -Channel 'test' -HasAsset $true -RunningIsPrerelease $true
+            $d.installable | Should -BeFalse
+            $d.blocked     | Should -BeTrue
+        }
+    }
+}

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -309,6 +309,42 @@ export function Settings() {
     }
   }
 
+  // Return-to-live: a tester on a pre-release (Test) build gets back onto the
+  // live release in one click. Force the Stable channel (clearing any pinned
+  // pre-release) so the check resolves the live release, then install it. The
+  // backend stable gate is relaxed for pre-release builds, so this works even
+  // though the live release is not strictly "newer" (it's a downgrade or a
+  // same-version reinstall that also clears the TEST BUILD indicator).
+  async function onReturnToLive() {
+    setUpdInstalling(true)
+    setUpdErr(null)
+    setUpdMsg(null)
+    try {
+      if (updChannel !== 'stable') {
+        await setUpdateChannel('stable', '')
+        setUpdChannel('stable')
+        setSelectedTag('')
+      }
+      const res = await checkForUpdate({ force: true })
+      setUpdCheck(res)
+      publishUpdateCheck(res)
+      if (!(res.installable ?? res.available)) {
+        setUpdErr(res.error ?? 'The live release is not installable right now.')
+        return
+      }
+      const r = await installUpdate()
+      if (r.launched) {
+        setUpdMsg(`Installer launched — returning to the live release ${fmtToolVersion(r.toVersion)}. The portal will go offline briefly, then relaunch.`)
+      } else {
+        setUpdErr(r.reason ?? 'Installer did not launch.')
+      }
+    } catch (e) {
+      setUpdErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setUpdInstalling(false)
+    }
+  }
+
   useEffect(() => {
     void (async () => {
       try {
@@ -456,6 +492,24 @@ export function Settings() {
 
         {updExpanded && (
           <div className="px-6 pb-5 space-y-3">
+            {updCheck?.runningIsPrerelease && (
+              <div className="rounded-md border border-warning/40 bg-warning/10 px-3 py-2.5 flex items-center gap-3 flex-wrap">
+                <Icon name="FlaskConical" size={15} className="text-warning shrink-0" />
+                <span className="text-sm">
+                  You're running a <span className="font-semibold text-warning">TEST build</span>
+                  {updCheck.currentVersion ? ` (${fmtToolVersion(updCheck.currentVersion)})` : ''}. Done testing? Return to the live release.
+                </span>
+                <button
+                  type="button"
+                  onClick={onReturnToLive}
+                  disabled={updInstalling}
+                  className="btn-secondary ml-auto shrink-0"
+                >
+                  <Icon name={updInstalling ? 'Loader2' : 'Undo2'} size={15} className={updInstalling ? 'animate-spin' : ''} />
+                  {updInstalling ? 'Working…' : 'Return to live release'}
+                </button>
+              </div>
+            )}
             <div className="flex items-center justify-between">
               <p className="text-sm text-text-dim">
                 Checks GitHub releases for newer versions. Installs silently — Start Menu icon keeps working, your config in <span className="font-mono">%APPDATA%\DuneServer</span> is preserved.
@@ -539,7 +593,7 @@ export function Settings() {
                     release notes
                   </a>
                 )}
-                {(updCheck.installable ?? updCheck.available) && (
+                {(updCheck.installable ?? updCheck.available) && !(updCheck.channel !== 'test' && updCheck.runningIsPrerelease === true && !updCheck.available) && (
                   <button
                     type="button"
                     onClick={onInstallUpdate}


### PR DESCRIPTION
Destined for **live v12.9.7**, but held until verified on the Test channel via the **v12.9.7-test1** pre-release.

## What's in here

**1. Return to the live release from a Test build**
A build installed from a pre-release (Test channel) was a dead-end: the live release is never "newer", so the install button stayed disabled with no way back to Stable.

- *Settings → Dune Server Tool updates* now shows a **"Return to live release"** control whenever the running build is a pre-release. One click forces the Stable channel (clearing any pinned pre-release), then installs the live release even though it isn't strictly newer — which also clears the **TEST BUILD** indicator.
- Backend stable install gate is relaxed for pre-release builds (downgrade to last Stable, or same-version reinstall to clear the flag).
- Gate logic centralized in a pure `Get-DuneInstallDecision` shared by `/api/update/check` (`installable`) and `/api/update/install` (`blocked`) so the two never drift. **+9 tests.**

**2. Re-apply the reverted +5K spec-grant fix**
`Invoke-DunePlayerAwardXp` now routes through `dune.set_specialization_xp_and_level` (same proc as "Grant Max") so the +5K grant reflects in-game after a client re-login. Restores `tests/AwardSpecXp.Tests.ps1` and the `discord-release.yml` pre-release guard (keeps pre-releases silent on Discord).

## Release mechanics
- Stamped **v12.9.7** across the 5 version files; rolled CHANGELOG; bumped `bug_report.yml` placeholder.
- Full suite **326 pass**.
- A **v12.9.7-test1** pre-release is cut from this branch for the reporter to verify. **Do not merge until test-1 is confirmed** — merging folds this to live v12.9.7.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>