### PR TITLE
Announce pre-releases to Discord as test builds

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -22,12 +22,10 @@ permissions:
 jobs:
   announce:
     runs-on: ubuntu-latest
-    # Never announce pre-releases. Pre-releases are an occasional, scenario-
-    # specific tool (e.g. handing a targeted test build to a bug reporter for
-    # in-game validation) and must stay silent in the community channels — only
-    # real releases get the "🚀 release" post. workflow_dispatch has no release
-    # context, so this guard is a no-op for manual (re)announcements.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
+    # Announce every published release. Real releases post as a "🚀 release";
+    # pre-releases post as a "🧪 test build" so bug reporters know to install and
+    # validate them (they are no longer silent). workflow_dispatch has no release
+    # context, so the prerelease flag is derived from the release itself below.
     steps:
       - name: Post release to Discord
         env:
@@ -50,24 +48,37 @@ jobs:
           fi
           echo "Announcing release: $tag"
 
-          rel=$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json name,tagName,body,url)
+          rel=$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json name,tagName,body,url,isPrerelease)
           name=$(printf '%s' "$rel" | jq -r '.name // .tagName')
           url=$(printf '%s' "$rel" | jq -r '.url')
+          prerelease=$(printf '%s' "$rel" | jq -r '.isPrerelease')
           # Discord embed descriptions cap at 4096; keep it readable at ~1500.
           body=$(printf '%s' "$rel" | jq -r '.body // ""' | head -c 1500)
 
+          if [ "$prerelease" = "true" ]; then
+            title_prefix="🧪"
+            color=15105570  # orange — test build
+            footer="Test build — install via the in-app updater: Settings → Dune Server Tool updates → Test channel. Please install and report back."
+          else
+            title_prefix="🚀"
+            color=15844367  # gold — release
+            footer="Download the DuneServerSetup.exe asset from the release page · in-app updater offers it within ~6h"
+          fi
+
           payload=$(jq -n \
-            --arg t "🚀 $name" \
+            --arg t "$title_prefix $name" \
             --arg d "$body" \
             --arg u "$url" \
+            --argjson c "$color" \
+            --arg f "$footer" \
             '{
                username: "DST Releases",
                embeds: [ {
                  title: $t,
                  url: $u,
                  description: $d,
-                 color: 15844367,
-                 footer: { text: "Download the DuneServerSetup.exe asset from the release page · in-app updater offers it within ~6h" }
+                 color: $c,
+                 footer: { text: $f }
                } ]
              }')
 


### PR DESCRIPTION
## Problem

Bug reporters handed a targeted **pre-release** test build had no automatic way to know to install and validate it. The `discord-release.yml` workflow deliberately **skipped pre-releases** (`github.event.release.prerelease == false`), so a test build like `v12.9.7-test2` announced nowhere.

## Change

- **Drop the prerelease guard** — every published release now announces to the Discord #releases webhook.
- **Style by release type** so test builds are visually distinct and actionable:
  - Real release → gold 🚀 post, existing footer.
  - Pre-release → orange 🧪 **test build** post; footer tells the reporter to install via **Settings → Dune Server Tool updates → Test channel** and report back.
- Prerelease state is read from the release JSON (`isPrerelease`), so it works for both the `release: published` event and manual `workflow_dispatch` re-announcements.

Must land on `main` because release-triggered workflows run from the default-branch copy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>