### PR TITLE
Route pre-release announcements to the bug/testing channel

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -1,8 +1,14 @@
 name: Announce release to Discord
 
-# Posts a formatted message to the DST community Discord #releases channel
-# whenever a GitHub release is published. Uses a Discord webhook URL stored as
-# the repo secret DISCORD_RELEASE_WEBHOOK (the webhook lives in #releases).
+# Posts a formatted message to a DST community Discord channel whenever a GitHub
+# release is published.
+#
+# Routing depends on whether the release is a pre-release:
+#   * Real release  -> #releases channel, via secret DISCORD_RELEASE_WEBHOOK.
+#   * Pre-release    -> the bug/testing channel, via secret DISCORD_TEST_WEBHOOK
+#     (a "🧪 test build" post so the bug reporter knows to install and validate
+#     it). Pre-releases are NOT official, so they never hit the #releases feed.
+# If the channel's webhook secret is missing, the announcement is skipped.
 #
 # Also runnable manually (workflow_dispatch) to (re)announce a specific tag,
 # which is handy for testing without cutting a new release.
@@ -22,25 +28,22 @@ permissions:
 jobs:
   announce:
     runs-on: ubuntu-latest
-    # Announce every published release. Real releases post as a "🚀 release";
-    # pre-releases post as a "🧪 test build" so bug reporters know to install and
-    # validate them (they are no longer silent). workflow_dispatch has no release
-    # context, so the prerelease flag is derived from the release itself below.
+    # Real releases post to #releases; pre-releases post to the bug/testing
+    # channel as a "🧪 test build" so bug reporters know to install and validate
+    # them. Pre-releases are NOT official and never hit the #releases feed.
+    # workflow_dispatch has no release context, so the prerelease flag is derived
+    # from the release itself below.
     steps:
       - name: Post release to Discord
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          TEST_WEBHOOK: ${{ secrets.DISCORD_TEST_WEBHOOK }}
           EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
-
-          if [ -z "${WEBHOOK:-}" ]; then
-            echo "DISCORD_RELEASE_WEBHOOK is not set; skipping Discord announcement."
-            exit 0
-          fi
 
           tag="${EVENT_TAG:-${INPUT_TAG:-}}"
           if [ -z "$tag" ]; then
@@ -56,14 +59,27 @@ jobs:
           body=$(printf '%s' "$rel" | jq -r '.body // ""' | head -c 1500)
 
           if [ "$prerelease" = "true" ]; then
+            webhook="${TEST_WEBHOOK:-}"
+            channel="bug/testing"
             title_prefix="🧪"
             color=15105570  # orange — test build
             footer="Test build — install via the in-app updater: Settings → Dune Server Tool updates → Test channel. Please install and report back."
+            if [ -z "$webhook" ]; then
+              echo "DISCORD_TEST_WEBHOOK is not set; skipping pre-release announcement."
+              exit 0
+            fi
           else
+            webhook="${RELEASE_WEBHOOK:-}"
+            channel="#releases"
             title_prefix="🚀"
             color=15844367  # gold — release
             footer="Download the DuneServerSetup.exe asset from the release page · in-app updater offers it within ~6h"
+            if [ -z "$webhook" ]; then
+              echo "DISCORD_RELEASE_WEBHOOK is not set; skipping release announcement."
+              exit 0
+            fi
           fi
+          echo "Posting to $channel"
 
           payload=$(jq -n \
             --arg t "$title_prefix $name" \
@@ -84,7 +100,7 @@ jobs:
 
           http=$(curl -sS -o /dev/null -w '%{http_code}' \
             -X POST -H "Content-Type: application/json" \
-            -d "$payload" "$WEBHOOK")
+            -d "$payload" "$webhook")
           echo "Discord webhook responded: HTTP $http"
           case "$http" in
             2*) echo "Posted $tag to Discord." ;;


### PR DESCRIPTION
## Problem

The previous change (#315) announced **all** releases — including pre-releases — to the public **#releases** feed. Pre-releases aren't official; a targeted test build for a bug reporter should go to the **bug/testing channel**, not #releases.

## Change

Split the Discord announcer by release type:
- **Real release** → `#releases` via `DISCORD_RELEASE_WEBHOOK` (🚀, unchanged).
- **Pre-release** → bug/testing channel via a **new `DISCORD_TEST_WEBHOOK`** secret (🧪 test build; footer tells the reporter to install via the Test channel and report back).

If the relevant webhook secret is missing, the announcement is **skipped** — a pre-release never falls back to #releases.

## Follow-up required (manual)

- Create the `DISCORD_TEST_WEBHOOK` repo secret pointing at the bug/testing channel, or pre-release announcements will be skipped.
- Delete the stray `v12.9.7-test2` post that #315 sent to #releases.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>