### PR TITLE
Add "Remove passphrase" action for SSH keys (no rotation needed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Remove passphrase from your SSH key — without rotating it.** When a key is
+  passphrase-protected, DST's background checks (battlegroup status, server
+  health, game data) can't use it: they run non-interactively and can't answer a
+  passphrase prompt, so the dashboard shows **Unknown** even though an
+  interactive SSH terminal still works. Previously the only in-app fix was
+  **Rotate SSH Key**, which generates a *brand-new* key that then has to be
+  re-authorized on the VM. There's now a **Remove passphrase** button on the
+  Settings → SSH key field: enter the key's current passphrase and DST strips it
+  off the existing key in place (`POST /api/config/strip-ssh-passphrase`). The
+  key pair is unchanged, so it stays authorized on the VM and nothing needs
+  re-adding — background checks start working within a few seconds. The
+  dashboard and setup-wizard warnings now point at this button as the easy fix.
+
 ## [12.9.8] - 2026-06-20
 
 ### Added

--- a/app/server/lib/Setup.ps1
+++ b/app/server/lib/Setup.ps1
@@ -168,7 +168,7 @@ function Get-DuneSetupPreflight {
                     if ((Test-DuneSshKeyEncrypted -KeyPath $keyPath) -eq $true) {
                         $checks.Add(@{
                             key = 'sshkey'; label = 'SSH key authorized on VM'; ok = $false; severity = 'warning'
-                            detail = "This SSH key is passphrase-protected, so the tool can't use it for background checks (battlegroup status, server health, game data) — those run non-interactively and can't answer a passphrase prompt. An interactive SSH terminal still works because it can prompt you, which is why the VM looks reachable while the dashboard shows Unknown. Fix it with the Rotate SSH Key action (VM menu, key 'g') to generate a passphrase-less key, or strip the passphrase from this one."
+                            detail = "This SSH key is passphrase-protected, so the tool can't use it for background checks (battlegroup status, server health, game data) — those run non-interactively and can't answer a passphrase prompt. An interactive SSH terminal still works because it can prompt you, which is why the VM looks reachable while the dashboard shows Unknown. Fix it in Settings - SSH key with the 'Remove passphrase' button (keeps this same key, no VM changes), or rotate to a passphrase-less key with the Rotate SSH Key action (VM menu, key 'g')."
                             fix    = "Remove the passphrase from the existing key (press Enter when asked for the new passphrase to leave it empty):`nssh-keygen -p -f `"$keyPath`""
                         }) | Out-Null
                     }

--- a/app/server/lib/Status.ps1
+++ b/app/server/lib/Status.ps1
@@ -36,7 +36,7 @@ function Get-DuneSshFailureReason {
     # is the classic "interactive SSH works but the dashboard shows Unknown" trap.
     if ($err -match '(?im)Permission denied|no supported authentication|authentication fail|publickey') {
         if ((Test-DuneSshKeyEncrypted -KeyPath $KeyPath) -eq $true) {
-            return "SSH key is passphrase-protected, so background checks (battlegroup status, server health, game data) can't use it — they run non-interactively and can't answer a passphrase prompt. An interactive SSH terminal still works because it can prompt you. Fix it with the Rotate SSH Key action (VM menu, key 'g'), or strip the passphrase: ssh-keygen -p -f `"$KeyPath`""
+            return "SSH key is passphrase-protected, so background checks (battlegroup status, server health, game data) can't use it — they run non-interactively and can't answer a passphrase prompt. An interactive SSH terminal still works because it can prompt you. Fix it in Settings - SSH key with the 'Remove passphrase' button (keeps this same key, no VM changes), or strip it manually: ssh-keygen -p -f `"$KeyPath`""
         }
         return "VM rejected the SSH key (its public half isn't in dune@VM:~/.ssh/authorized_keys). Run the Rotate SSH Key action (VM menu, key 'g') to generate and authorize a fresh key."
     }

--- a/app/server/routes/Config.ps1
+++ b/app/server/routes/Config.ps1
@@ -106,6 +106,77 @@ Register-DuneRoute -Method POST -Path '/api/config/rotate-ssh-key' -Handler {
     }
 }
 
+# POST /api/config/strip-ssh-passphrase — remove the passphrase from the EXISTING
+# SSH key in place. Unlike rotation, this keeps the same key pair, so its public
+# half stays in dune@VM:~/.ssh/authorized_keys and nothing has to be re-authorized
+# on the VM. Background checks (battlegroup status, server health, game data) run
+# non-interactively and can't answer a passphrase prompt, so an unencrypted private
+# key is what lets them work. Body: { passphrase: "<current passphrase>" }.
+Register-DuneRoute -Method POST -Path '/api/config/strip-ssh-passphrase' -Handler {
+    param($req, $res, $routeParams, $body)
+
+    $cfg     = Read-DuneConfig
+    $keyPath = if ($cfg) { [string]$cfg.SshKey } else { '' }
+    if (-not $keyPath) {
+        Write-DuneError -Response $res -Status 400 -Message 'No SSH key is configured. Set the SSH key path in Settings first.'
+        return
+    }
+    if (-not (Test-Path -LiteralPath $keyPath)) {
+        Write-DuneError -Response $res -Status 404 -Message "Configured SSH key file not found: $keyPath"
+        return
+    }
+
+    $passphrase = ''
+    if ($body -is [hashtable] -and $body.Contains('passphrase')) { $passphrase = [string]$body['passphrase'] }
+    elseif ($body -and $body.passphrase)                        { $passphrase = [string]$body.passphrase }
+
+    # Already unencrypted? Nothing to do — keep it idempotent so the button is safe
+    # to click on a key that's already fine.
+    if ((Test-DuneSshKeyEncrypted -KeyPath $keyPath) -eq $false) {
+        Write-DuneJson -Response $res -Body @{
+            ok        = $true
+            stripped  = $false
+            encrypted = $false
+            message   = 'This SSH key already has no passphrase — background checks can use it as-is.'
+        }
+        return
+    }
+
+    if (-not $passphrase) {
+        Write-DuneError -Response $res -Status 400 -Message "Enter the key's current passphrase so it can be removed."
+        return
+    }
+
+    try {
+        # `ssh-keygen -p` changes the passphrase in place: -P is the old passphrase,
+        # -N '' sets an empty new one. Fully non-interactive, so it runs without a
+        # console prompt. Only the private key file is rewritten; the .pub (and thus
+        # the key authorized on the VM) is unchanged.
+        $out  = & ssh-keygen -p -P $passphrase -N '' -f $keyPath 2>&1
+        $code = $LASTEXITCODE
+        $text = ($out | Out-String).Trim()
+
+        if ($code -ne 0 -or (Test-DuneSshKeyEncrypted -KeyPath $keyPath) -eq $true) {
+            if ($text -match '(?im)incorrect passphrase|failed to load|invalid format|bad passphrase|unable to load') {
+                Write-DuneError -Response $res -Status 400 -Message 'That passphrase is incorrect — the key was not changed. Try again with the key''s current passphrase.'
+            } else {
+                $detail = if ($text) { $text } else { "ssh-keygen exited $code" }
+                Write-DuneError -Response $res -Status 500 -Message "Could not remove the passphrase: $detail"
+            }
+            return
+        }
+
+        Write-DuneJson -Response $res -Body @{
+            ok        = $true
+            stripped  = $true
+            encrypted = $false
+            message   = 'Passphrase removed. The key is otherwise unchanged, so it stays authorized on the VM — background checks will start working within a few seconds.'
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Could not remove the SSH key passphrase: $($_.Exception.Message)"
+    }
+}
+
 # POST /api/config/open-battlegroup-bat — open Funcom's original battlegroup.bat
 # (located in the root of the Steam install folder) in an elevated window. The
 # .bat launches battlegroup.ps1 and pauses on exit. The API server already runs

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -52,6 +52,14 @@ export function Settings() {
   // finish, then propagates the fresh key everywhere DST uses it.
   const [sshRotating, setSshRotating] = useState(false)
   const [sshRotateMsg, setSshRotateMsg] = useState<string | null>(null)
+  // "Remove passphrase (keep same key)" — strips the passphrase off the existing
+  // key in place (no rotation, nothing to re-authorize on the VM), so background
+  // checks that run non-interactively can use it.
+  const [sshStripOpen, setSshStripOpen] = useState(false)
+  const [sshStripPass, setSshStripPass] = useState('')
+  const [sshStripping, setSshStripping] = useState(false)
+  const [sshStripMsg, setSshStripMsg] = useState<string | null>(null)
+  const [sshStripOk, setSshStripOk] = useState<boolean | null>(null)
   const [openingBat, setOpeningBat] = useState(false)
   const [batMsg, setBatMsg] = useState<string | null>(null)
   // Database connection test (issue #295): verify the configured in-pod
@@ -173,6 +181,30 @@ export function Settings() {
       setError(e instanceof Error ? e.message : String(e))
     } finally {
       setSshRotating(false)
+    }
+  }
+
+  async function onStripSshPassphrase() {
+    setSshStripping(true)
+    setSshStripMsg(null)
+    setSshStripOk(null)
+    setError(null)
+    try {
+      const r = await api<{ ok: boolean; stripped: boolean; message?: string }>(
+        '/api/config/strip-ssh-passphrase',
+        { method: 'POST', body: JSON.stringify({ passphrase: sshStripPass }) },
+      )
+      setSshStripOk(r.ok)
+      setSshStripMsg(r.message ?? (r.ok ? 'Passphrase removed.' : 'Could not remove the passphrase.'))
+      if (r.ok) {
+        setSshStripPass('')
+        setSshStripOpen(false)
+      }
+    } catch (e) {
+      setSshStripOk(false)
+      setSshStripMsg(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSshStripping(false)
     }
   }
 
@@ -834,6 +866,17 @@ export function Settings() {
                     {sshRotating ? 'Rotating…' : 'Generate new'}
                   </button>
                 )}
+                {f.key === 'SshKey' && (
+                  <button
+                    type="button"
+                    onClick={() => { setSshStripOpen(o => !o); setSshStripMsg(null) }}
+                    title="Strip the passphrase off this key without rotating it (keeps the same key, no VM changes)"
+                    className="btn-secondary shrink-0"
+                  >
+                    <Icon name="KeyRound" size={15} />
+                    Remove passphrase
+                  </button>
+                )}
                 </div>
               </>
             ) : (
@@ -847,6 +890,42 @@ export function Settings() {
               />
             )}
             {f.help && <p className="mt-1 text-xs text-text-dim">{f.help}</p>}
+            {f.key === 'SshKey' && sshStripOpen && (
+              <div className="mt-2 rounded-lg border border-border bg-surface-2 p-3 space-y-2">
+                <p className="text-xs text-text-dim">
+                  Removes the passphrase from this key <span className="text-text">without rotating it</span> — the key pair
+                  stays the same, so it remains authorized on the VM and nothing needs re-adding. Background checks run
+                  non-interactively and can't answer a passphrase prompt, which is why a passphrase-protected key shows the
+                  dashboard as Unknown. Enter the key's current passphrase:
+                </p>
+                <div className="flex items-stretch gap-2">
+                  <input
+                    type="password"
+                    autoComplete="off"
+                    value={sshStripPass}
+                    placeholder="Current passphrase"
+                    onChange={e => setSshStripPass(e.target.value)}
+                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); void onStripSshPassphrase() } }}
+                    className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-surface border border-border text-text text-sm
+                               placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void onStripSshPassphrase()}
+                    disabled={sshStripping}
+                    className="btn-secondary shrink-0"
+                  >
+                    <Icon name={sshStripping ? 'Loader2' : 'KeyRound'} size={15} className={sshStripping ? 'animate-spin' : ''} />
+                    {sshStripping ? 'Removing…' : 'Remove passphrase'}
+                  </button>
+                </div>
+              </div>
+            )}
+            {f.key === 'SshKey' && sshStripMsg && (
+              <p className={`mt-1 text-xs flex items-center gap-1.5 ${sshStripOk ? 'text-success' : 'text-danger'}`}>
+                <Icon name={sshStripOk ? 'CheckCircle2' : 'AlertTriangle'} size={13} /> {sshStripMsg}
+              </p>
+            )}
             {f.key === 'SshKey' && sshRotateMsg && (
               <p className="mt-1 text-xs text-success flex items-center gap-1.5">
                 <Icon name="CheckCircle2" size={13} /> {sshRotateMsg}


### PR DESCRIPTION
## Why

A Discord user (and the in-app warning) hit this: a **passphrase-protected SSH key** breaks DST's background checks (battlegroup status, server health, game data) because they run **non-interactively** and can't answer a passphrase prompt — so the dashboard shows **Unknown** even though an interactive SSH terminal still works (it *can* prompt).

The only in-app fix was **Rotate SSH Key**, which generates a **brand-new** key that then has to be re-authorized on the VM. Users who just want to keep their existing key had to drop to the command line (`ssh-keygen -p -f …`).

## What

- **New backend route** `POST /api/config/strip-ssh-passphrase` — strips the passphrase off the **configured** key in place via `ssh-keygen -p -P <old> -N ''` (fully non-interactive). Idempotent (no-ops on an already-unencrypted key), and returns a clear error on a wrong passphrase. Only the private key file is rewritten — the `.pub` (and thus the key authorized on the VM) is unchanged, so nothing needs re-adding on the server.
- **Settings → SSH key**: new **Remove passphrase** button next to *Generate new*, with a reveal panel that takes the key's current passphrase and applies the strip. Success/error feedback inline.
- **Guidance copy** in the dashboard SSH-failure reason (`Status.ps1`) and the setup-wizard preflight (`Setup.ps1`) now point at this button as the easy fix (keeps the same key, no VM changes), with the manual `ssh-keygen` command retained as the fallback.
- CHANGELOG `[Unreleased]` entry.

## Verification

- PowerShell parse-check passes on all three edited `.ps1` files; all retain UTF-8 BOM, no mojibake.
- `webui` `tsc -b && vite build` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>