### PR TITLE
Recover detached browser portal after restart/update (fix "Failed to fetch")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ here cover everything those tags shipped.
   re-adding — background checks start working within a few seconds. The
   dashboard and setup-wizard warnings now point at this button as the easy fix.
 
+### Fixed
+
+- **Detached browser portal now recovers automatically after a restart or
+  update.** When you hand the portal off to a real browser (Web Portal → open in
+  browser) and the tool then restarts or self-updates, the per-launch auth token
+  rotates and the listener briefly drops — which used to strand the browser tab
+  with dead `TypeError: Failed to fetch` panels (the WebView2 app window
+  reconnects on its own, a browser tab did not). The browser portal now detects
+  the drop, shows a brief **"Reconnecting…"** screen while the tool comes back,
+  and reloads itself to pick up the fresh token — no manual refresh or re-launch
+  needed. Opening `http://127.0.0.1:<port>/` directly (without the `?t=` token in
+  the URL) also works now, because the client trusts the token the backend
+  already injects into the page.
+
 ## [12.9.8] - 2026-06-20
 
 ### Added

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -19,6 +19,7 @@ import { PageStub } from './pages/PageStub'
 import { StatusProvider } from './hooks/useStatus'
 import { isLocalViewer } from './util/viewer'
 import { api } from './api/client'
+import { ReconnectOverlay } from './components/ReconnectOverlay'
 import { PageErrorBoundary } from './components/PageErrorBoundary'
 
 // Wrap every route subtree in an error boundary so an unhandled render
@@ -53,6 +54,7 @@ export default function App() {
 
   return (
     <StatusProvider>
+      <ReconnectOverlay />
       <AppShell>
         <Routes>
           <Route path="/"           element={<Boundary name="Dashboard"><Dashboard /></Boundary>} />

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -1,7 +1,12 @@
+import { reportNetworkError, reportResponse } from './connection'
+
 const API_BASE = ''  // same-origin
 const TOKEN_KEY = 'dune.token'
 
 function getToken(): string {
+  // 1. Explicit handoff from the app/portal via ?t= on the launch URL. Highest
+  //    priority because it's the freshest signal and only present right after a
+  //    navigation; we stash it and strip it from the address bar.
   const url = new URL(window.location.href)
   const fromUrl = url.searchParams.get('t')
   if (fromUrl) {
@@ -10,6 +15,19 @@ function getToken(): string {
     window.history.replaceState({}, '', url.toString())
     return fromUrl
   }
+  // 2. The backend injects the CURRENT per-launch token into index.html as
+  //    window.__duneRemoteToken on every page load (HttpServer.ps1). Since the
+  //    token rotates on every server restart, this injected value is
+  //    authoritative — trust it over a possibly-stale sessionStorage copy so a
+  //    plain reload recovers an orphaned browser tab after a restart/update.
+  const injected = (typeof window !== 'undefined' && window.__duneRemoteToken) || ''
+  if (injected) {
+    if (sessionStorage.getItem(TOKEN_KEY) !== injected) {
+      sessionStorage.setItem(TOKEN_KEY, injected)
+    }
+    return injected
+  }
+  // 3. Fall back to whatever we last stored.
   return sessionStorage.getItem(TOKEN_KEY) ?? ''
 }
 
@@ -35,7 +53,19 @@ export async function api<T = unknown>(
   }
   if (token) headers.set('X-Dune-Token', token)
 
-  const res = await fetch(`${API_BASE}${path}`, { ...init, headers })
+  let res: Response
+  try {
+    res = await fetch(`${API_BASE}${path}`, { ...init, headers })
+  } catch (e) {
+    // Network-level failure (server restarting / listener down). Flag it so the
+    // reconnect overlay can take over and recover, then surface the error.
+    reportNetworkError()
+    throw e
+  }
+  // Got an HTTP response — the listener is up. A 401 with a token we sent means
+  // the per-launch token rotated (server restarted): connection.ts turns that
+  // into a recovery too.
+  reportResponse(res.status, !!token)
   const text = await res.text()
   let body: unknown = undefined
   if (text) {

--- a/webui/src/api/connection.ts
+++ b/webui/src/api/connection.ts
@@ -1,0 +1,55 @@
+// Live connectivity tracker for the local DST backend.
+//
+// The backend's auth token is a per-launch GUID that ROTATES on every restart,
+// and the HTTP listener briefly drops while the tool restarts or self-updates.
+// The WebView2 app survives this because it re-navigates to the fresh URL (with
+// the new token); a detached browser tab does not, so it ends up stranded with
+// "Failed to fetch" panels and a token the server no longer accepts.
+//
+// This tiny store lets the API client report fetch outcomes so <ReconnectOverlay>
+// can detect the drop, wait for the server to come back, and reload — at which
+// point the backend re-injects the current token (window.__duneRemoteToken) and
+// the session recovers automatically.
+
+export type ConnState = 'connected' | 'recovering'
+
+let state: ConnState = 'connected'
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const l of listeners) l()
+}
+
+function set(next: ConnState): void {
+  if (next === state) return
+  state = next
+  emit()
+}
+
+/** A fetch() rejected (network-level failure) — the listener is unreachable. */
+export function reportNetworkError(): void {
+  set('recovering')
+}
+
+/**
+ * The backend returned an HTTP response. Any status code means the listener is
+ * up. A 401 when we DID send a token means the per-launch token rotated (the
+ * server restarted), so we recover the same way as a hard drop: reload to pick
+ * up the freshly-injected token.
+ */
+export function reportResponse(status: number, sentToken: boolean): void {
+  if (status === 401 && sentToken) {
+    set('recovering')
+    return
+  }
+  set('connected')
+}
+
+export function getConnState(): ConnState {
+  return state
+}
+
+export function subscribeConn(cb: () => void): () => void {
+  listeners.add(cb)
+  return () => { listeners.delete(cb) }
+}

--- a/webui/src/components/ReconnectOverlay.tsx
+++ b/webui/src/components/ReconnectOverlay.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { subscribeConn, getConnState } from '../api/connection'
+import { Icon } from './Icon'
+
+// How long the backend must stay unreachable before we surface the overlay, so
+// a single transient blip doesn't flash a full-screen takeover.
+const SHOW_DELAY_MS = 1200
+// How often to probe the static index while waiting for the server to return.
+const POLL_MS = 1500
+// Loop guard: if we auto-reload this many times inside the window, stop and
+// offer a manual button instead of thrashing.
+const RELOAD_WINDOW_MS = 30_000
+const MAX_RELOADS = 3
+const RELOAD_LOG_KEY = 'dune.reconnect.reloads'
+
+function recentReloadCount(): number {
+  try {
+    const raw = sessionStorage.getItem(RELOAD_LOG_KEY)
+    const arr = raw ? (JSON.parse(raw) as number[]) : []
+    const cutoff = Date.now() - RELOAD_WINDOW_MS
+    return arr.filter((t) => t > cutoff).length
+  } catch {
+    return 0
+  }
+}
+
+function logReload(): void {
+  try {
+    const raw = sessionStorage.getItem(RELOAD_LOG_KEY)
+    const arr = raw ? (JSON.parse(raw) as number[]) : []
+    arr.push(Date.now())
+    sessionStorage.setItem(RELOAD_LOG_KEY, JSON.stringify(arr.slice(-10)))
+  } catch {
+    /* ignore */
+  }
+}
+
+// True while THIS tab is deliberately running the in-app updater. The
+// UpdateBanner's full-screen <UpdatingPage> owns that flow, so we stand down and
+// let it manage the reload/close messaging instead of reloading underneath it.
+function isUpdatingHere(): boolean {
+  return !!(window as unknown as { __duneUpdating?: boolean }).__duneUpdating
+}
+
+// Recovers a stranded browser tab after the backend restarts or self-updates.
+// The per-launch token rotates on restart and the listener briefly drops, so a
+// detached tab is left with dead "Failed to fetch" panels. We wait for the
+// server to answer again, then reload — the fresh index.html re-injects the
+// current token and the session heals.
+export function ReconnectOverlay() {
+  const state = useSyncExternalStore(subscribeConn, getConnState, getConnState)
+  const recovering = state === 'recovering'
+  const [visible, setVisible] = useState(false)
+  const [giveUp, setGiveUp] = useState(false)
+  const pollRef = useRef<number | null>(null)
+
+  // Debounced show.
+  useEffect(() => {
+    if (!recovering) {
+      setVisible(false)
+      setGiveUp(false)
+      return
+    }
+    const id = window.setTimeout(() => setVisible(true), SHOW_DELAY_MS)
+    return () => window.clearTimeout(id)
+  }, [recovering])
+
+  // While shown, probe the static index until the server answers, then reload.
+  useEffect(() => {
+    if (!visible || giveUp) return
+    let cancelled = false
+
+    const probe = async () => {
+      if (isUpdatingHere()) return
+      try {
+        await fetch(`${window.location.origin}/?_=${Date.now()}`, {
+          method: 'HEAD',
+          cache: 'no-store',
+        })
+      } catch {
+        return // still down — keep waiting
+      }
+      if (cancelled) return
+      if (recentReloadCount() >= MAX_RELOADS) {
+        setGiveUp(true)
+        return
+      }
+      logReload()
+      window.location.reload()
+    }
+
+    pollRef.current = window.setInterval(() => { void probe() }, POLL_MS)
+    void probe()
+    return () => {
+      cancelled = true
+      if (pollRef.current) window.clearInterval(pollRef.current)
+    }
+  }, [visible, giveUp])
+
+  if (!visible || isUpdatingHere()) return null
+
+  return (
+    <div className="fixed inset-0 z-[9998] flex items-center justify-center bg-slate-950/95 p-6">
+      <div className="max-w-md w-full text-center">
+        <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-amber-400/15">
+          <Icon
+            name="RefreshCw"
+            size={28}
+            className={`text-amber-300 ${giveUp ? '' : 'animate-spin'}`}
+          />
+        </div>
+        <h1 className="text-xl font-semibold text-amber-100">
+          {giveUp ? 'Still trying to reconnect…' : 'Reconnecting to Dune Server Tool…'}
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-slate-300">
+          {giveUp
+            ? 'The tool is taking a while to come back. It may still be updating or restarting.'
+            : 'The tool restarted or updated and is coming back. This page reconnects automatically.'}
+        </p>
+        {giveUp && (
+          <button
+            type="button"
+            className="mt-5 px-4 py-1.5 rounded-md bg-amber-400 text-amber-950 font-semibold text-sm hover:bg-amber-300"
+            onClick={() => window.location.reload()}
+          >
+            Reload now
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/webui/src/components/UpdateBanner.tsx
+++ b/webui/src/components/UpdateBanner.tsx
@@ -134,6 +134,9 @@ export function UpdateBanner() {
   const onInstall = async () => {
     setInstalling(true)
     setInstallErr(null)
+    // Signal the reconnect overlay to stand down for this tab: the updater
+    // intentionally takes the server down, and <UpdatingPage> owns that UX.
+    ;(window as unknown as { __duneUpdating?: boolean }).__duneUpdating = true
     try {
       const res = await installUpdate()
       if (res.launched) {
@@ -141,9 +144,11 @@ export function UpdateBanner() {
         setLaunched(true)
       } else {
         setInstallErr(res.reason ?? 'Installer did not launch.')
+        ;(window as unknown as { __duneUpdating?: boolean }).__duneUpdating = false
       }
     } catch (e) {
       setInstallErr(e instanceof Error ? e.message : String(e))
+      ;(window as unknown as { __duneUpdating?: boolean }).__duneUpdating = false
     } finally {
       setInstalling(false)
     }


### PR DESCRIPTION
## Problem

When the portal is handed off to a real browser (**Web Portal → open in browser**) and DST then restarts or self-updates, the browser tab is left stranded with `TypeError: Failed to fetch` panels (Server Health VM/BG "Unknown", Web Interfaces error, update banner error) — exactly what the attached screenshot showed.

Root cause:
- The backend auth token is a **per-launch GUID that rotates on every restart**, and the HTTP listener briefly drops during a restart/update.
- The **WebView2 app window** owns the server lifecycle and re-navigates to the fresh URL (new token), so it self-heals.
- A **detached browser tab** never re-navigates. Worse, even pressing F5 didn't recover because `client.ts getToken()` preferred the stale `sessionStorage['dune.token']` over the **fresh token the backend already injects** into `index.html` as `window.__duneRemoteToken`.

## Fix

- **Token recovery** — `client.ts getToken()` now trusts the backend-injected `window.__duneRemoteToken` (the live per-launch token, written on every index load) over a possibly-stale stored copy. A plain reload — or opening `http://127.0.0.1:<port>/` with no `?t=` — now recovers the session.
- **Auto-reconnect overlay** — new `api/connection.ts` store + `ReconnectOverlay` component. The API client reports network failures and `401`-with-token (token rotated) to the store; the overlay shows a brief **"Reconnecting…"** screen, polls the static index until the server answers, then reloads to pick up the fresh token. It stands down for the tab that deliberately launched the in-app updater (that flow's existing `UpdatingPage` keeps owning it).

## Verification

- `npm run build` (tsc + vite) ✓
- `npm run lint` — 0 errors (2 pre-existing warnings, unrelated files) ✓
- `npm test` — 51/51 pass ✓
- Live-tested the running instance: every `/api/*` returns `200` with the token, `401` without — confirming the screenshot was the restart window.
- Installer rebuilt to the canonical `app/installer/output/DuneServerSetup.exe`.

Folded into the existing **v12.9.9** CHANGELOG entry (this re-cuts v12.9.9 per request).