### PR TITLE
Fix: scheduler runspace silently dropped all restart/broadcast logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Scheduled restart logs are now actually written.** The daily-restart
+  scheduler runs on its own background runspace, which dot-sourced the logging
+  helper but never pointed it at the active log file — so its per-tick lines
+  (pre-restart broadcast sent/failed, "scheduled restart firing", and the
+  restart result) were silently dropped and never reached
+  `%LOCALAPPDATA%\DuneServer\dune-server.log`. Only the one-time "restart
+  scheduler started" line (written from the main thread) ever showed up, which
+  made it impossible to confirm afterwards whether the in-game maintenance
+  broadcast had fired. The scheduler (and the concurrent post-restart
+  update-check) runspaces now inherit the main process's log path, so these
+  events are recorded and auditable.
+
 ## [12.9.9] - 2026-06-20
 
 ### Added

--- a/app/server/lib/DuneLog.ps1
+++ b/app/server/lib/DuneLog.ps1
@@ -29,6 +29,17 @@ function Initialize-DuneLog {
     } catch { }
 }
 
+# Point logging at an existing log file WITHOUT rolling it or writing a header.
+# Used by background runspaces (e.g. the restart scheduler) that dot-source this
+# file fresh: they would otherwise have $script:DuneLogPath = $null and silently
+# drop every Write-DuneLog. They must share the main process's log file, so a
+# header/roll here would be wrong and could race the main thread's appends.
+function Set-DuneLogPath {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Path)
+    $script:DuneLogPath = $Path
+}
+
 function Write-DuneLog {
     [CmdletBinding()]
     param(

--- a/app/server/lib/RestartSchedule.ps1
+++ b/app/server/lib/RestartSchedule.ps1
@@ -416,6 +416,20 @@ function New-DuneSchedulerInitialSessionState {
             [void]$iss.StartupScripts.Add($f.FullName)
         }
     }
+
+    # Propagate the active log file into the runspace so Write-DuneLog actually
+    # writes there. The runspace dot-sources DuneLog.ps1 but never runs
+    # Initialize-DuneLog, so without this its $script:DuneLogPath stays $null and
+    # every scheduler/broadcast/restart line is silently dropped. The runspace
+    # scripts call Set-DuneLogPath (header-less, no roll) with this value.
+    $logPath = $script:DuneLogPath
+    if (-not $logPath) { $logPath = Join-Path $env:LOCALAPPDATA 'DuneServer\dune-server.log' }
+    if ($logPath) {
+        [void]$iss.Variables.Add(
+            [System.Management.Automation.Runspaces.SessionStateVariableEntry]::new(
+                'DuneSchedulerLogPath', $logPath, 'Active Dune log file for runspace logging'))
+    }
+
     return $iss
 }
 
@@ -442,6 +456,9 @@ function Start-DuneFuncomUpdateCheckAsync {
         $ps = [powershell]::Create()
         $ps.Runspace = $rs
         [void]$ps.AddScript({
+            if ($DuneSchedulerLogPath -and (Get-Command Set-DuneLogPath -ErrorAction SilentlyContinue)) {
+                try { Set-DuneLogPath -Path $DuneSchedulerLogPath } catch {}
+            }
             try { [void](Get-DuneFuncomServerUpdateStatus -Persist) } catch {
                 if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
                     try { Write-DuneLog "async update check error: $($_.Exception.Message)" 'WARN' } catch {}
@@ -478,6 +495,9 @@ function Start-DuneRestartScheduler {
         $ps = [powershell]::Create()
         $ps.Runspace = $rs
         [void]$ps.AddScript({
+            if ($DuneSchedulerLogPath -and (Get-Command Set-DuneLogPath -ErrorAction SilentlyContinue)) {
+                try { Set-DuneLogPath -Path $DuneSchedulerLogPath } catch {}
+            }
             while ($true) {
                 try { Invoke-DuneRestartScheduleTick } catch {
                     if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
## Problem

While checking whether last night's 23:00 scheduled restart broadcast fired, I found the backend log (`%LOCALAPPDATA%\DuneServer\dune-server.log`) contains **no** scheduler tick lines — not just last night, but across the entire multi-day log. The only restart-related line that ever appears is the one-time `restart scheduler started (30s tick)`.

## Root cause

The restart scheduler — and the concurrent post-restart Funcom update-check — run on their own background runspaces built by `New-DuneSchedulerInitialSessionState`. Those runspaces dot-source `DuneLog.ps1` (so `Write-DuneLog` exists) but **never call `Initialize-DuneLog`**, so inside the runspace `$script:DuneLogPath` stays `$null` and every `Write-DuneLog` silently no-ops (guarded by `if ($script:DuneLogPath)`).

The `restart scheduler started` line survives only because it's logged from the **main thread**, where the log path was initialized. Everything inside the tick — `scheduled restart broadcast sent/failed`, `scheduled restart firing`, `scheduled restart result`, `post-restart update check error` — went nowhere.

Net effect: you can't confirm after the fact whether the daily in-game maintenance broadcast actually fired. (`restart-schedule.json`'s `lastBroadcastDate` is no help — the code sets it in both the success and `catch` branches.)

## Fix

- Add a header-less `Set-DuneLogPath` to `DuneLog.ps1` that only sets `$script:DuneLogPath` — no roll, no header. The runspace shares the **same** physical log file as the main process, so rolling or writing a header there would be wrong and could race the main thread's appends.
- `New-DuneSchedulerInitialSessionState` now injects the active log path as the `DuneSchedulerLogPath` ISS session variable (falls back to the default `%LOCALAPPDATA%\DuneServer\dune-server.log` if unset).
- Both runspace scripts (scheduler loop + async update check) call `Set-DuneLogPath -Path $DuneSchedulerLogPath` before doing any work.

## Verification

- `pwsh` parse-check clean on both edited scripts; UTF-8 BOM preserved on both (both contain non-ASCII).
- End-to-end runspace test: built an ISS that dot-sources `DuneLog.ps1` + injects `DuneSchedulerLogPath`, ran a runspace doing `Set-DuneLogPath` then `Write-DuneLog 'scheduled restart broadcast sent'` / `'scheduled restart firing (time=23:00)'` — both lines correctly appended to the target log file. Without the fix, nothing was written.

No version bump; logged under `## [Unreleased]` to fold into the next release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>