### PR TITLE
Add Pat (@pat.) to Thanks for the Coffee supporter credits

### DIFF
--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -395,6 +395,10 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <Icon name="Heart" size={14} className="text-ibad shrink-0" />
               <span className="flex-1">Ken (@krazy2168)</span>
             </div>
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">Pat (@pat.)</span>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Adds **Pat (@pat.)** to the "Thanks for the Coffee" supporter dropdown in the menu bar, matching the existing entries (Decker, Ogmosis, boosterfuel, Techtonic, Ken).

- `webui/src/layout/MenuBar.tsx`: one new credit row.
- webui `npm run build` (tsc + vite) passes clean.