### PR TITLE
Revert "Add Pat (@pat.) to Thanks for the Coffee" — hold for next stable

### DIFF
--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -395,10 +395,6 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <Icon name="Heart" size={14} className="text-ibad shrink-0" />
               <span className="flex-1">Ken (@krazy2168)</span>
             </div>
-            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
-              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
-              <span className="flex-1">Pat (@pat.)</span>
-            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Reverts #328 (`05e0307`) off `main` so the Pat (@pat.) coffee credit does **not** ship in any interim/hotfix release. The change will be re-landed for the next **official stable** release.

Original change is preserved on branch `coastal-ms/coffee-credit-pat` for easy re-application.