### PR TITLE
Add Pat (@pat.) to Thanks for the Coffee supporter credits

### DIFF
--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -395,6 +395,10 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <Icon name="Heart" size={14} className="text-ibad shrink-0" />
               <span className="flex-1">Ken (@krazy2168)</span>
             </div>
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">Pat (@pat.)</span>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Re-adds the supporter credit for Pat (@pat.) in the MenuBar "Thanks for the Coffee" list. Originally added in #328, reverted in #329 to hold; this re-applies it for the v12.10.0 release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>