### PR TITLE
Add optional role/@everyone mention to the Discord restart alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,11 @@ here cover everything those tags shipped.
   Incoming Webhook URL, and use **Send test message** to verify it. The post is
   a clean embed (server name, minutes-to-restart, scheduled local time, reason)
   and fires at most once per restart, riding the same once-per-day lead window
-  as the in-game broadcast. The webhook URL is stored host-locally, never sent
-  back to the browser, and is redacted from logs and the diagnostics bundle. A
-  Discord outage never blocks or delays the restart (retries on 429/5xx, then
-  logs and moves on).
+  as the in-game broadcast. You can optionally have the alert **@-mention a
+  role** (paste a role ID, or use `everyone`/`here`) so members get pinged. The
+  webhook URL is stored host-locally, never sent back to the browser, and is
+  redacted from logs and the diagnostics bundle. A Discord outage never blocks
+  or delays the restart (retries on 429/5xx, then logs and moves on).
 
 ### Fixed
 

--- a/app/server/lib/RestartSchedule.ps1
+++ b/app/server/lib/RestartSchedule.ps1
@@ -52,6 +52,7 @@ function Get-DuneRestartScheduleDefault {
         broadcastLeadMinutes = 10
         discordEnabled       = $false
         discordWebhookUrl    = ''
+        discordMentionId     = ''
         lastBroadcastDate    = ''
         lastDiscordNoticeDate = ''
         lastRestartDate      = ''
@@ -89,6 +90,7 @@ function Get-DuneRestartSchedule {
     $state.updateAvailable      = [bool]$state.updateAvailable
     $state.discordEnabled       = [bool]$state.discordEnabled
     $state.discordWebhookUrl    = [string]$state.discordWebhookUrl
+    $state.discordMentionId     = [string]$state.discordMentionId
     try { $state.broadcastLeadMinutes = [int]$state.broadcastLeadMinutes } catch { $state.broadcastLeadMinutes = 10 }
     return $state
 }
@@ -109,6 +111,31 @@ function Test-DuneDiscordWebhookUrl {
     return ($Url -match '^https://(?:(?:canary|ptb)\.)?discord(?:app)?\.com/api/webhooks/\d+/[A-Za-z0-9_-]+$')
 }
 
+# Normalize a user-entered "mention on alert" value. Accepts an empty string
+# (no ping), the keywords 'everyone'/'here', a raw role id (17-20 digit
+# snowflake), or a pasted role mention like <@&123...>. Returns the cleaned
+# value to store, or $null when the input is not a valid mention target.
+function Resolve-DuneDiscordMentionInput {
+    param([string]$Mention)
+    if ([string]::IsNullOrWhiteSpace($Mention)) { return '' }
+    $m = $Mention.Trim()
+    if ($m -match '^@?(everyone|here)$') { return $Matches[1].ToLowerInvariant() }
+    if ($m -match '^<@&(\d{17,20})>$')   { return $Matches[1] }
+    if ($m -match '^\d{17,20}$')         { return $m }
+    return $null
+}
+
+# Turn a stored mention value into the Discord payload bits (content prefix +
+# allowed_mentions) so a ping actually fires. Empty -> no ping at all.
+function Get-DuneDiscordMentionPayload {
+    param([string]$Mention)
+    $m = if ($null -eq $Mention) { '' } else { $Mention.Trim() }
+    if ($m -eq 'everyone') { return @{ content = '@everyone'; allowed = @{ parse = @('everyone') } } }
+    if ($m -eq 'here')     { return @{ content = '@here';     allowed = @{ parse = @('everyone') } } }
+    if ($m -match '^\d{17,20}$') { return @{ content = "<@&$m>"; allowed = @{ parse = @(); roles = @($m) } } }
+    return @{ content = ''; allowed = @{ parse = @() } }
+}
+
 # Validate + persist user-facing fields (enable/time/lead + Discord notify).
 # Leaves the run stamps and update-check fields untouched. Returns the full
 # updated state. A $null DiscordWebhookUrl means "leave the stored URL as-is"
@@ -119,7 +146,8 @@ function Set-DuneRestartSchedule {
         [string]$Time,
         [int]$BroadcastLeadMinutes,
         [bool]$DiscordEnabled,
-        [string]$DiscordWebhookUrl
+        [string]$DiscordWebhookUrl,
+        [string]$DiscordMentionId
     )
     if ($Time -notmatch '^([01]\d|2[0-3]):([0-5]\d)$') {
         return @{ ok = $false; status = 400; message = "Invalid time '$Time'. Use 24-hour HH:mm (e.g. 04:00)." }
@@ -139,14 +167,24 @@ function Set-DuneRestartSchedule {
         return @{ ok = $false; status = 400; message = 'Enable Discord notifications requires a webhook URL.' }
     }
 
+    # $null mention means "leave as-is"; anything else is validated then stored.
+    $effectiveMention = if ($null -ne $DiscordMentionId) {
+        $resolved = Resolve-DuneDiscordMentionInput $DiscordMentionId
+        if ($null -eq $resolved) {
+            return @{ ok = $false; status = 400; message = 'Invalid mention. Use a role ID (Discord > right-click role > Copy Role ID), or the keyword everyone or here.' }
+        }
+        $resolved
+    } else { [string]$state.discordMentionId }
+
     $state.enabled              = $Enabled
     $state.time                 = $Time
     $state.broadcastLeadMinutes = $BroadcastLeadMinutes
     $state.discordEnabled       = $DiscordEnabled
     $state.discordWebhookUrl    = $effectiveUrl
+    $state.discordMentionId     = $effectiveMention
     Save-DuneRestartSchedule -State $state
     if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
-        Write-DuneLog "restart schedule saved: enabled=$Enabled time=$Time lead=$BroadcastLeadMinutes discord=$DiscordEnabled discordUrlSet=$([bool]$effectiveUrl)"
+        Write-DuneLog "restart schedule saved: enabled=$Enabled time=$Time lead=$BroadcastLeadMinutes discord=$DiscordEnabled discordUrlSet=$([bool]$effectiveUrl) discordMention=$([bool]$effectiveMention)"
     }
     return @{ ok = $true; schedule = $state }
 }
@@ -186,7 +224,8 @@ function Send-DuneDiscordWebhook {
         [string]$ServerName,
         [int]$MinutesToRestart,
         [datetime]$RestartAt,
-        [string]$Reason
+        [string]$Reason,
+        [string]$MentionId
     )
     if (-not (Test-DuneDiscordWebhookUrl $Url)) {
         return @{ ok = $false; status = 400; message = 'Invalid Discord webhook URL.' }
@@ -215,9 +254,11 @@ function Send-DuneDiscordWebhook {
     $payload = [ordered]@{
         username = 'DST Server'
         embeds   = @($embed)
-        # No @everyone/@here pings in the MVP.
-        allowed_mentions = @{ parse = @() }
     }
+    # Optional role/@everyone/@here ping. Empty mention => no ping (parse: []).
+    $mp = Get-DuneDiscordMentionPayload $MentionId
+    if ($mp.content) { $payload.content = $mp.content }
+    $payload.allowed_mentions = $mp.allowed
     $json = $payload | ConvertTo-Json -Depth 6
 
     $attempts = 0
@@ -473,7 +514,7 @@ function Invoke-DuneRestartScheduleTick {
                     }
                     $reason = if ($state.updateAvailable) { 'Scheduled daily BG maintenance (Funcom server update available)' } else { 'Scheduled daily BG maintenance' }
                     $d = Send-DuneDiscordWebhook -Url $state.discordWebhookUrl -ServerName $serverName `
-                        -MinutesToRestart $lead -RestartAt $restartAt -Reason $reason
+                        -MinutesToRestart $lead -RestartAt $restartAt -Reason $reason -MentionId $state.discordMentionId
                     if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
                         $dm = if ($d -and $d.ok) { "sent (HTTP $($d.status))" } else { "failed: $($d.message)" }
                         Write-DuneLog "scheduled restart discord notice $dm [$(Get-DuneRedactedWebhookUrl $state.discordWebhookUrl)]"

--- a/app/server/routes/RestartSchedule.ps1
+++ b/app/server/routes/RestartSchedule.ps1
@@ -18,6 +18,7 @@ Register-DuneRoute -Method GET -Path '/api/restart-schedule' -Handler {
             broadcastLeadMinutes = [int]$state.broadcastLeadMinutes
             discordEnabled       = [bool]$state.discordEnabled
             discordWebhookSet    = [bool]([string]$state.discordWebhookUrl)
+            discordMentionId     = [string]$state.discordMentionId
             lastRestartDate      = [string]$state.lastRestartDate
             lastResult           = [string]$state.lastResult
             updateAvailable      = [bool]$state.updateAvailable
@@ -39,18 +40,21 @@ Register-DuneRoute -Method PUT -Path '/api/restart-schedule' -Handler {
     # $null webhook means "leave the stored URL unchanged" so the secret never
     # has to round-trip through the browser. Only a present key updates it.
     $discordWebhookUrl = $null
+    $discordMentionId = $null
     if ($body -is [hashtable]) {
         if ($body.ContainsKey('enabled'))              { $enabled = [bool]$body.enabled }
         if ($body.ContainsKey('time'))                 { $time = [string]$body.time }
         if ($body.ContainsKey('broadcastLeadMinutes')) { try { $lead = [int]$body.broadcastLeadMinutes } catch { $lead = -1 } }
         if ($body.ContainsKey('discordEnabled'))       { $discordEnabled = [bool]$body.discordEnabled }
         if ($body.ContainsKey('discordWebhookUrl'))    { $discordWebhookUrl = [string]$body.discordWebhookUrl }
+        if ($body.ContainsKey('discordMentionId'))     { $discordMentionId = [string]$body.discordMentionId }
     } elseif ($body) {
         if ($null -ne $body.enabled)              { $enabled = [bool]$body.enabled }
         if ($body.time)                           { $time = [string]$body.time }
         if ($null -ne $body.broadcastLeadMinutes) { try { $lead = [int]$body.broadcastLeadMinutes } catch { $lead = -1 } }
         if ($null -ne $body.discordEnabled)       { $discordEnabled = [bool]$body.discordEnabled }
         if ($body.PSObject.Properties['discordWebhookUrl']) { $discordWebhookUrl = [string]$body.discordWebhookUrl }
+        if ($body.PSObject.Properties['discordMentionId'])  { $discordMentionId = [string]$body.discordMentionId }
     }
     if (-not $time) {
         Write-DuneError -Response $res -Status 400 -Message 'Body must include "time" (HH:mm).'
@@ -58,7 +62,7 @@ Register-DuneRoute -Method PUT -Path '/api/restart-schedule' -Handler {
     }
     try {
         $r = Set-DuneRestartSchedule -Enabled $enabled -Time $time -BroadcastLeadMinutes $lead `
-            -DiscordEnabled $discordEnabled -DiscordWebhookUrl $discordWebhookUrl
+            -DiscordEnabled $discordEnabled -DiscordWebhookUrl $discordWebhookUrl -DiscordMentionId $discordMentionId
         if (-not $r.ok) {
             Write-DuneError -Response $res -Status ([int]$r.status) -Message $r.message
             return
@@ -70,6 +74,7 @@ Register-DuneRoute -Method PUT -Path '/api/restart-schedule' -Handler {
             broadcastLeadMinutes = [int]$state.broadcastLeadMinutes
             discordEnabled       = [bool]$state.discordEnabled
             discordWebhookSet    = [bool]([string]$state.discordWebhookUrl)
+            discordMentionId     = [string]$state.discordMentionId
             lastRestartDate      = [string]$state.lastRestartDate
             lastResult           = [string]$state.lastResult
             updateAvailable      = [bool]$state.updateAvailable
@@ -105,7 +110,7 @@ Register-DuneRoute -Method POST -Path '/api/restart-schedule/test-discord' -Hand
         $lead = [int]$state.broadcastLeadMinutes
         if ($lead -le 0) { $lead = 10 }
         $r = Send-DuneDiscordWebhook -Url $url -ServerName $serverName -MinutesToRestart $lead `
-            -RestartAt ((Get-Date).AddMinutes($lead)) -Reason 'Test notification from Dune Server Tool'
+            -RestartAt ((Get-Date).AddMinutes($lead)) -Reason 'Test notification from Dune Server Tool' -MentionId $state.discordMentionId
         if (-not $r.ok) {
             Write-DuneError -Response $res -Status 502 -Message $r.message
             return

--- a/webui/src/api/restartSchedule.ts
+++ b/webui/src/api/restartSchedule.ts
@@ -8,6 +8,7 @@ export interface RestartSchedule {
   broadcastLeadMinutes: number // 0 = no broadcast
   discordEnabled: boolean
   discordWebhookSet: boolean   // whether a webhook URL is stored (URL is write-only)
+  discordMentionId: string     // role id or 'everyone'/'here' to ping; '' = no ping
   lastRestartDate: string
   lastResult: string
   updateAvailable: boolean
@@ -35,6 +36,7 @@ export function saveRestartSchedule(body: {
   broadcastLeadMinutes: number
   discordEnabled: boolean
   discordWebhookUrl?: string   // omit to leave the stored URL unchanged
+  discordMentionId?: string    // omit to leave the stored mention unchanged
 }) {
   return api<RestartSchedule>('/api/restart-schedule', {
     method: 'PUT',

--- a/webui/src/pages/dashboard/ScheduledRestarts.tsx
+++ b/webui/src/pages/dashboard/ScheduledRestarts.tsx
@@ -12,6 +12,9 @@ import {
 // Client-side sanity check for a Discord incoming-webhook URL. The server
 // re-validates; this just gives fast inline feedback.
 const WEBHOOK_RE = /^https:\/\/(?:(?:canary|ptb)\.)?discord(?:app)?\.com\/api\/webhooks\/\d+\/[\w-]+$/
+// Optional "mention on alert" target: empty, the keyword everyone/here, a raw
+// role id (17-20 digit snowflake), or a pasted <@&id> role mention.
+const MENTION_RE = /^(?:@?(?:everyone|here)|<@&\d{17,20}>|\d{17,20})$/
 
 // Spell the lead minutes the same way the in-game broadcast does, so the
 // preview line matches what players will see.
@@ -48,6 +51,7 @@ export function ScheduledRestarts() {
   const [webhookInput, setWebhookInput] = useState('')
   const [webhookSet, setWebhookSet] = useState(false)
   const [clearWebhook, setClearWebhook] = useState(false)
+  const [mention, setMention] = useState('')
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [checking, setChecking] = useState(false)
@@ -66,6 +70,7 @@ export function ScheduledRestarts() {
       setWebhookSet(s.discordWebhookSet)
       setWebhookInput('')
       setClearWebhook(false)
+      setMention(s.discordMentionId || '')
     } catch (e) {
       setMsg({ kind: 'err', text: e instanceof ApiError ? e.message : 'Failed to load schedule.' })
     } finally {
@@ -76,6 +81,7 @@ export function ScheduledRestarts() {
   useEffect(() => { void load() }, [load])
 
   const webhookInputValid = webhookInput.trim() === '' || WEBHOOK_RE.test(webhookInput.trim())
+  const mentionValid = mention.trim() === '' || MENTION_RE.test(mention.trim())
   // Will a webhook be stored after this save?
   const effectiveWebhookSet = clearWebhook ? false : (webhookSet || webhookInput.trim() !== '')
 
@@ -85,8 +91,8 @@ export function ScheduledRestarts() {
     try {
       const body: {
         enabled: boolean; time: string; broadcastLeadMinutes: number
-        discordEnabled: boolean; discordWebhookUrl?: string
-      } = { enabled, time, broadcastLeadMinutes: lead, discordEnabled }
+        discordEnabled: boolean; discordWebhookUrl?: string; discordMentionId?: string
+      } = { enabled, time, broadcastLeadMinutes: lead, discordEnabled, discordMentionId: mention.trim() }
       if (clearWebhook) body.discordWebhookUrl = ''
       else if (webhookInput.trim() !== '') body.discordWebhookUrl = webhookInput.trim()
       const s = await saveRestartSchedule(body)
@@ -95,13 +101,14 @@ export function ScheduledRestarts() {
       setWebhookSet(s.discordWebhookSet)
       setWebhookInput('')
       setClearWebhook(false)
+      setMention(s.discordMentionId || '')
       setMsg({ kind: 'ok', text: 'Schedule saved.' })
     } catch (e) {
       setMsg({ kind: 'err', text: e instanceof ApiError ? e.message : 'Save failed.' })
     } finally {
       setSaving(false)
     }
-  }, [enabled, time, lead, discordEnabled, webhookInput, clearWebhook])
+  }, [enabled, time, lead, discordEnabled, webhookInput, clearWebhook, mention])
 
   const runCheck = useCallback(async () => {
     setChecking(true)
@@ -130,9 +137,9 @@ export function ScheduledRestarts() {
     }
   }, [])
 
-  const discordDirty = !!sched && (sched.discordEnabled !== discordEnabled || webhookInput.trim() !== '' || clearWebhook)
+  const discordDirty = !!sched && (sched.discordEnabled !== discordEnabled || webhookInput.trim() !== '' || clearWebhook || (sched.discordMentionId || '') !== mention.trim())
   const dirty = !!sched && (sched.enabled !== enabled || sched.time !== time || sched.broadcastLeadMinutes !== lead || discordDirty)
-  const canSave = dirty && webhookInputValid && !(discordEnabled && !effectiveWebhookSet)
+  const canSave = dirty && webhookInputValid && mentionValid && !(discordEnabled && !effectiveWebhookSet)
 
   return (
     <div className="card p-5">
@@ -267,6 +274,27 @@ export function ScheduledRestarts() {
                     </div>
                     {!webhookInputValid && (
                       <p className="text-[11px] text-danger mt-1">That doesn't look like a Discord webhook URL.</p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label className="block text-xs uppercase tracking-wider text-text-dim mb-1">
+                      Mention on alert <span className="normal-case text-text-dim">(optional)</span>
+                    </label>
+                    <input
+                      type="text"
+                      value={mention}
+                      onChange={e => setMention(e.target.value)}
+                      placeholder="Role ID, or everyone / here"
+                      autoComplete="off"
+                      aria-label="Discord mention on alert"
+                      className={FIELD_CLASS}
+                    />
+                    <p className="text-[11px] text-text-dim mt-1">
+                      Pings a role when the alert posts. Paste a role ID (Discord → enable Developer Mode → right-click the role → Copy Role ID), or type <code>everyone</code> or <code>here</code>. Leave blank for no ping.
+                    </p>
+                    {!mentionValid && (
+                      <p className="text-[11px] text-danger mt-1">Enter a role ID (17–20 digits), or the keyword everyone or here.</p>
                     )}
                   </div>
 


### PR DESCRIPTION
Follow-up to #327. Adds an optional **Mention on alert** field to the Scheduled Restarts → Discord section so the restart-imminent post can ping a role.

## What
- New `discordMentionId` setting (persisted in `restart-schedule.json`). Accepts a **role ID** (17–20 digit snowflake), a pasted `<@&id>` role mention, or the keywords `everyone` / `here`. Empty = no ping (unchanged default).
- Validated both client-side (`MENTION_RE`) and server-side (`Resolve-DuneDiscordMentionInput`); the webhook payload sets `content` + `allowed_mentions` so the ping actually fires.
- Carried through both the scheduled notice and the **Send test message** path.

## Why a separate PR
The mention commit was authored on the #327 branch but its push was rejected moments before #327 merged, so it didn't make the squash. This re-lands just that change on top of current `main`.

## Notes
- A webhook cannot resolve a role *by name* (no permission to read the role list), so the UI asks for a role ID or everyone/here — documented inline in the field help.
- Role IDs are not secrets, so they are not redacted (only `discordWebhookUrl` is).

## Validation
- `pwsh` parse-check + BOM verified on both edited `.ps1` (ParseErrors=0, BOM=True).
- webui `npm run build` (typecheck) clean, `lint` 0 errors, `test` 51/51.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>