### PR TITLE
release: v12.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.10.0] - 2026-06-21
+
 ### Added
 
 - **Optional Discord notification when a scheduled restart is imminent.** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ here cover everything those tags shipped.
 
 ### Fixed
 
+- **Saving the restart schedule no longer wipes a stored Discord webhook.**
+  Changing any restart setting (e.g. the time) while leaving the Discord
+  section untouched failed with "Enable Discord notifications requires a
+  webhook URL", because the host couldn't tell "leave the saved URL as-is"
+  apart from "clear it" — the unchanged-URL sentinel was being coerced to an
+  empty value. Saving with the webhook left blank now correctly keeps the
+  stored URL (and any saved mention).
+
 - **Scheduled restart logs are now actually written.** The daily-restart
   scheduler runs on its own background runspace, which dot-sourced the logging
   helper but never pointed it at the active log file — so its per-tick lines

--- a/app/server/lib/RestartSchedule.ps1
+++ b/app/server/lib/RestartSchedule.ps1
@@ -146,8 +146,11 @@ function Set-DuneRestartSchedule {
         [string]$Time,
         [int]$BroadcastLeadMinutes,
         [bool]$DiscordEnabled,
-        [string]$DiscordWebhookUrl,
-        [string]$DiscordMentionId
+        # [object] (not [string]) so a genuine $null survives parameter binding
+        # and means "leave the stored value unchanged". A [string] param coerces
+        # $null to '', which would wrongly read as "clear it".
+        [object]$DiscordWebhookUrl,
+        [object]$DiscordMentionId
     )
     if ($Time -notmatch '^([01]\d|2[0-3]):([0-5]\d)$') {
         return @{ ok = $false; status = 400; message = "Invalid time '$Time'. Use 24-hour HH:mm (e.g. 04:00)." }
@@ -159,7 +162,7 @@ function Set-DuneRestartSchedule {
 
     # Resolve the effective webhook URL: a non-$null value replaces it (empty
     # string clears it); $null keeps the previously-stored URL.
-    $effectiveUrl = if ($null -ne $DiscordWebhookUrl) { $DiscordWebhookUrl.Trim() } else { [string]$state.discordWebhookUrl }
+    $effectiveUrl = if ($null -ne $DiscordWebhookUrl) { ([string]$DiscordWebhookUrl).Trim() } else { [string]$state.discordWebhookUrl }
     if ($effectiveUrl -and -not (Test-DuneDiscordWebhookUrl $effectiveUrl)) {
         return @{ ok = $false; status = 400; message = 'Invalid Discord webhook URL. Expected https://discord.com/api/webhooks/<id>/<token>.' }
     }
@@ -169,7 +172,7 @@ function Set-DuneRestartSchedule {
 
     # $null mention means "leave as-is"; anything else is validated then stored.
     $effectiveMention = if ($null -ne $DiscordMentionId) {
-        $resolved = Resolve-DuneDiscordMentionInput $DiscordMentionId
+        $resolved = Resolve-DuneDiscordMentionInput ([string]$DiscordMentionId)
         if ($null -eq $resolved) {
             return @{ ok = $false; status = 400; message = 'Invalid mention. Use a role ID (Discord > right-click role > Copy Role ID), or the keyword everyone or here.' }
         }


### PR DESCRIPTION
Cuts the public **v12.10.0** stable release.

All 5 version stamps already read `12.10.0` (landed via #327).

### Shipping in 12.10.0
- Optional Discord **restart-imminent webhook** (off by default) — #327
- Optional **role/@everyone mention** on the alert — #331
- Scheduler **runspace-logging fix** — #326
- Pat (@pat.) **coffee credit** — #330

### Also includes a fix found during release testing
- **Saving the schedule no longer wipes a stored Discord webhook.** Changing a restart setting (e.g. the time) with the Discord section untouched failed with "Enable Discord notifications requires a webhook URL". The `$null` "leave-unchanged" sentinel was declared `[string]`, so PowerShell coerced it to `''` (= "clear it"). The sentinel params are now `[object]` so a real `$null` survives binding. Same guard applies to the mention field. Verified against real saved state (`ok=True`, webhook + mention preserved).

This PR therefore contains the CHANGELOG roll **and** the webhook-preservation fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>