### PR TITLE
Minimize to tray now defaults off (v12.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.10.2] - 2026-06-21
+
+### Changed
+
+- **Minimize to tray is now off by default.** Minimizing the Dune Server Tool
+  window keeps its normal taskbar button unless you opt in. Turn it on any time
+  via the tray icon's right-click **Minimize to tray** toggle (the choice is
+  still remembered across launches).
+
 ## [12.10.1] - 2026-06-21
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.10.1'
+$script:DuneToolVersion = '12.10.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.10.1',
+    [string]$Version = '12.10.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.10.1</Version>
+    <Version>12.10.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -28,7 +28,7 @@ internal sealed class MainForm : Form
     // tray's "Quit (stops server)" is the explicit shutdown from the tray.
     private NotifyIcon? _tray;
     private ToolStripMenuItem? _trayMinItem;
-    private bool _minimizeToTray = true;
+    private bool _minimizeToTray;
     private bool _trayBalloonShown;
     private FormWindowState _restoreState = FormWindowState.Normal;
 
@@ -626,7 +626,7 @@ internal sealed class MainForm : Form
     private void ToggleMinimizeToTray()
     {
         // CheckOnClick has already flipped the menu item before this fires.
-        _minimizeToTray = _trayMinItem?.Checked ?? true;
+        _minimizeToTray = _trayMinItem?.Checked ?? false;
         SaveWindowState();
     }
 
@@ -656,7 +656,7 @@ internal sealed class MainForm : Form
         public int W { get; set; }
         public int H { get; set; }
         public bool Max { get; set; }
-        // Nullable so pre-12.10.1 state files (no field) default to enabled.
+        // Nullable so pre-12.10.1 state files (no field) default to disabled.
         public bool? MinTray { get; set; }
     }
 
@@ -669,7 +669,7 @@ internal sealed class MainForm : Form
         var def = new Size(2000, 1300);
         var saved = LoadWindowState();
 
-        _minimizeToTray = saved?.MinTray ?? true;
+        _minimizeToTray = saved?.MinTray ?? false;
 
         Rectangle bounds;
         if (saved != null && saved.W >= MinimumSize.Width && saved.H >= MinimumSize.Height)

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.10.1"
+#define MyAppVersion "12.10.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.10.1"
+$script:ToolVersion = "12.10.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## What

Minimize-to-tray (shipped in #335) defaulted to **on**, so minimizing silently tucked DST into the system tray. This flips the default to **off** — minimizing keeps the normal taskbar button unless the user opts in via the tray icon's right-click **Minimize to tray** toggle. The toggle still persists across launches.

## Changes

- `app/desktop/DuneShell/MainForm.cs` — three default fallbacks (`_minimizeToTray` field init, `ToggleMinimizeToTray`, `ApplyStartupBounds`) flipped `true` → `false`; comment updated.
- Bumped all 5 version stamps `12.10.1` → `12.10.2`.
- Rolled `CHANGELOG.md` into `[12.10.2]`.

## Verification

- `dotnet build -c Release` on DuneShell: succeeded, 0 warnings/errors.
- Installer built: `DuneServerSetup.exe` (45.95 MB).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>