### PR TITLE
MobileAppCard: show one-time token, keep remote KEY local-only

### DIFF
--- a/webui/src/pages/settings/MobileAppCard.tsx
+++ b/webui/src/pages/settings/MobileAppCard.tsx
@@ -327,7 +327,7 @@ export function MobileAppCard() {
                   <h4 style={{ margin: '0 0 0.5rem 0', fontSize: '14px', color: '#0369a1' }}>Manual Entry Details</h4>
                   <div style={{ fontSize: '13px', fontFamily: 'monospace', color: '#334155' }}>
                     <div style={{ marginBottom: '4px', wordBreak: 'break-all' }}><strong>URL:</strong> {pairUrl}</div>
-                    {localViewer && <div style={{ wordBreak: 'break-all' }}><strong>Token:</strong> {data.remoteToken || data.token}</div>}
+                    <div style={{ wordBreak: 'break-all' }}><strong>Token:</strong> {data.token}</div>
                   </div>
                   <div className="help-text" style={{ marginTop: '0.5rem' }}>
                     On the same network you can also use <code>http://&lt;this-pc-lan-ip&gt;:{bridgePort}</code>.


### PR DESCRIPTION
Follow-up to #340. Manual Entry now shows the safe-to-show one-time (per-launch) token instead of hiding the page token behind a local-only gate; the permanent remote KEY stays local-only in the browser-portal link.

- Mirrors what the DST desktop app uses (per-launch token).
- Verified: pairing/QR works end-to-end; webui builds clean; installer re-bundled.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>