### PR TITLE
Settings: isolate each card behind an error boundary (fixes #344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Settings page no longer goes fully blank if one card hits an error.**
+  Each Settings card (Updates, Appearance, Remote Access, Public IP, Mobile App)
+  is now isolated so an unexpected render error in one — for example a stored
+  setting whose shape differs after switching between a test build and a stable
+  build — shows a small inline "couldn't be displayed" notice for just that card
+  while the rest of Settings keeps working, instead of crashing the whole page.
+
 ## [12.11.0] - 2026-06-21
 
 ### Changed

--- a/webui/src/components/SectionErrorBoundary.tsx
+++ b/webui/src/components/SectionErrorBoundary.tsx
@@ -1,0 +1,64 @@
+// SectionErrorBoundary — fine-grained guard for one card/section within a page.
+//
+// PageErrorBoundary protects a whole route subtree: if any child throws during
+// render, the ENTIRE page is replaced by the fallback. That's too coarse for a
+// page like Settings, which stacks several independent cards — a render error
+// in one card (e.g. a settings value whose shape differs between builds, which
+// trips React error #31 "objects are not valid as a React child") would blank
+// the whole Settings route, including unrelated, still-working cards.
+//
+// Wrapping each card in this boundary contains the failure: only the broken
+// card shows a compact inline error (with a Retry), the rest of the page keeps
+// working, and the exception is still logged via console.error so it lands in
+// webview2-debug.log for the diagnostics ZIP.
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+type Props = {
+  // Friendly label for the section/card, shown in the fallback so the user
+  // knows which part failed.
+  name: string
+  children: ReactNode
+}
+
+type State = {
+  error: Error | null
+}
+
+export class SectionErrorBoundary extends Component<Props, State> {
+  state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(`[SectionErrorBoundary:${this.props.name}]`, error, info.componentStack)
+  }
+
+  private handleRetry = (): void => {
+    this.setState({ error: null })
+  }
+
+  render(): ReactNode {
+    const { error } = this.state
+    if (!error) return this.props.children
+
+    return (
+      <div className="card mb-4 p-4 border-danger/40 bg-danger/5">
+        <div className="text-sm font-semibold text-danger mb-1 flex items-center gap-2">
+          {this.props.name} couldn’t be displayed
+        </div>
+        <p className="text-xs text-text-muted mb-2">
+          This section hit an unexpected error and was skipped so the rest of the page keeps working.
+          If it persists, attach the logs ZIP from <strong>Help → Create GitHub Issue + Save Logs</strong>.
+        </p>
+        <pre className="text-[11px] font-mono whitespace-pre-wrap break-words text-text-muted bg-surface-2 border border-border rounded-lg p-2 max-h-32 overflow-auto mb-2">
+          {error.message || String(error)}
+        </pre>
+        <button type="button" className="btn-secondary text-xs" onClick={this.handleRetry}>
+          Retry
+        </button>
+      </div>
+    )
+  }
+}

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -10,6 +10,7 @@ import { AppearanceCard } from './settings/AppearanceCard'
 import { PublicIpCard } from './settings/PublicIpCard'
 import { RemoteAccessCard } from './settings/RemoteAccessCard'
 import { MobileAppCard } from './settings/MobileAppCard'
+import { SectionErrorBoundary } from '../components/SectionErrorBoundary'
 
 const FIELDS: {
   key: string
@@ -491,6 +492,7 @@ export function Settings() {
       )}
 
       {/* --- Update check card (top, collapsible) ------------------------ */}
+      <SectionErrorBoundary name="Dune Server Tool updates">
       <div className="card mb-4">
         <button
           type="button"
@@ -664,7 +666,7 @@ export function Settings() {
                   </span>
                 )}
                 {updCheck.error && (
-                  <span className="text-xs text-danger ml-auto">Check failed: {updCheck.error}</span>
+                  <span className="text-xs text-danger ml-auto">Check failed: {String(updCheck.error)}</span>
                 )}
               </div>
             )}
@@ -682,12 +684,13 @@ export function Settings() {
           </div>
         )}
       </div>
+      </SectionErrorBoundary>
 
-      <AppearanceCard />
+      <SectionErrorBoundary name="Appearance"><AppearanceCard /></SectionErrorBoundary>
 
-      <RemoteAccessCard />
+      <SectionErrorBoundary name="Remote Access"><RemoteAccessCard /></SectionErrorBoundary>
 
-      <PublicIpCard />
+      <SectionErrorBoundary name="Public IP"><PublicIpCard /></SectionErrorBoundary>
 
       {/* --- Database connection (issue #295) --- */}
       <div className="card mb-4 p-6">
@@ -951,7 +954,7 @@ export function Settings() {
         </div>
       </form>
 
-      <MobileAppCard />
+      <SectionErrorBoundary name="Mobile App Pairing"><MobileAppCard /></SectionErrorBoundary>
     </>
   )
 }


### PR DESCRIPTION
## Problem
modoqc reported (Discord #bug-reports) that opening **Settings** crashes the whole page with **React error #31** ("Objects are not valid as a React child", empty `{}`) after switching between a test build (12.11.0 phone-app prerelease) and a stable 12.10.x build. The app still launches; only the Settings route blanks via the page-level error boundary.

Root class: a Settings card renders a backend/settings value whose **persisted shape differs between build lines** after version-switching, tripping React #31. The page-level `PageErrorBoundary` is too coarse — one bad card takes down the entire Settings route, including unrelated, working cards. The exact field needs the reporter's unminified component stack (logs requested in the thread) to name precisely.

## Fix
- New `SectionErrorBoundary` (compact, inline fallback + Retry, logs via `console.error` → `webview2-debug.log`).
- Wrap each Settings card in it: **Updates** (the version-switcher the user was actually using), **Appearance**, **Remote Access**, **Public IP**, **Mobile App**. A render error in one card now degrades to a small inline "couldn't be displayed" notice while the rest of Settings stays usable.
- Belt-and-suspenders: coerce the backend-provided update-check `error` field to a string at its render site (the strongest identified object-as-child candidate).

This directly addresses #344's ask: a settings-shape mismatch degrades gracefully instead of crashing the page. Worth landing before 12.11.0 goes public, since the version-mixing that triggers it is most likely around a release.

## Verification
- `npm run build` (tsc + vite) — passes.
- `eslint` on changed files — clean.

Closes #344.