### PR TITLE
discord-release: clarify updater timing in announcement footer (~6h → on next launch)

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -67,7 +67,7 @@ jobs:
                  url: $u,
                  description: $d,
                  color: 15844367,
-                 footer: { text: "Download the DuneServerSetup.exe asset from the release page · in-app updater offers it within ~6h" }
+                 footer: { text: "Download the DuneServerSetup.exe asset from the release page · the in-app updater offers it on your next launch (or within ~6h if DST is left running)" }
                } ]
              }')
 


### PR DESCRIPTION
## What
The Discord release-announcement footer (`.github/workflows/discord-release.yml`) claimed the in-app updater offers a new build **"within ~6h"**. That's only the **background re-poll interval** (`useUpdateCheck.ts`: `POLL_MS = 6 * 60 * 60 * 1000`). The updater **also checks on app launch** (and via the **Check now** button + Settings), so in practice a new release is offered **immediately on the next launch** — usually instant, not 6h.

## Change
Reword the footer so the ~6h is framed as the *left-running fallback*, not the norm:

> Download the DuneServerSetup.exe asset from the release page · the in-app updater offers it on your next launch (or within ~6h if DST is left running)

## Why on main
`discord-release.yml` triggers on `release: published`; GitHub runs release-triggered workflows from the **default branch (main)**, so this footer fix only takes effect once merged to main. One-line, workflow-only change — no app code touched.