### PR TITLE
Service help: clarify "must remain signed in"

### DIFF
--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -383,7 +383,7 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
                   <span className="block">Keep serving while DST is closed</span>
                   <span className="block text-[11px] text-text-dim">
                     {service.enabled
-                      ? 'Installed — backend runs without DST open and loads at sign-in (works while locked)'
+                      ? 'Installed — backend runs without DST open and loads at sign-in (works while locked), must remain signed in'
                       : 'Off — portal and phone need DST open'}
                   </span>
                 </span>


### PR DESCRIPTION
Small copy tweak before cutting v12.11.0: appends ", must remain signed in" to the enabled sub-text of the **Help → "Keep serving while DST is closed"** toggle, so the signed-in requirement is explicit right where the user reads it.

No behavior change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>