### PR TITLE
site: resync remote guide to v12.11.0 (Tailscale Funnel default)

### DIFF
--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -99,8 +99,9 @@ import DownloadButton from "../components/DownloadButton.astro";
           class="underline decoration-dotted hover:text-dune-text"
           >Remote portal</a
         >
-        — phone-friendly view of status + map spin-up/down behind a
-        Cloudflare Tunnel + Access policy. Setup is BYO Cloudflare account.
+        — phone-friendly view of status + map spin-up/down. Recommended
+        setup is a free Tailscale Funnel (no domain); a bring-your-own
+        Cloudflare domain is supported as an advanced option.
       </li>
     </ul>
 
@@ -114,6 +115,17 @@ import DownloadButton from "../components/DownloadButton.astro";
       effect at the next launch. The toggle is loopback-only — remote
       viewers can't enable it on your host. The uninstaller cleans up the
       scheduled task automatically.
+    </p>
+
+    <h2 class="text-2xl font-semibold mb-4">Optional: keep serving while DST is closed</h2>
+    <p class="text-dune-muted leading-relaxed mb-4">
+      Off by default. Open <strong class="text-dune-text">Help → Keep serving
+      while DST is closed</strong> to install a background service so the
+      portal, phone apps, scheduled restarts, and Discord notifications keep
+      running while the DST window is closed — including while your PC is
+      locked — and load at sign-in. You must stay signed in to Windows; a full
+      sign-out stops remote access. Host-only (remote viewers can't enable it),
+      and the uninstaller removes the service.
     </p>
 
     <h2 class="text-2xl font-semibold mb-4">Where things live</h2>

--- a/site/src/pages/remote.astro
+++ b/site/src/pages/remote.astro
@@ -5,12 +5,12 @@ import PageHeader from "../components/PageHeader.astro";
 
 <Base
   title="Remote access guide — DST"
-  description="A friendly, step-by-step walkthrough for exposing the DST portal to your phone over a Cloudflare Tunnel + Cloudflare Access, including the prerequisites no other guide tells you about."
+  description="Reach the DST portal and the mobile app from anywhere. The recommended path is a free Tailscale Funnel — no domain, no port-forward, no account beyond Tailscale itself. A bring-your-own Cloudflare domain is supported as an advanced option."
 >
   <PageHeader
     eyebrow="Remote portal"
     title="Remote access: the complete guide"
-    intro="DST is local-only by default. If you want to check status and spin maps up/down from your phone, you can expose a small, read-mostly subset of the portal through a Cloudflare Tunnel gated by Cloudflare Access. This page is the full walkthrough — including the prerequisite step that trips most first-timers."
+    intro="DST is local-only by default. To check status and spin maps up/down from your phone, expose a small, read-mostly subset of the portal over the internet. The recommended, zero-domain path is a free Tailscale Funnel. If you'd rather use a permanent custom hostname, you can bring your own Cloudflare domain instead."
   />
 
   <section class="mx-auto max-w-3xl px-6 pb-16 space-y-12 text-dune-text">
@@ -20,9 +20,9 @@ import PageHeader from "../components/PageHeader.astro";
       <ol class="list-decimal list-inside text-sm space-y-1 text-dune-muted">
         <li><a class="text-dune-text hover:underline" href="#what">What the remote portal does</a></li>
         <li><a class="text-dune-text hover:underline" href="#how-it-works">How it works (security model)</a></li>
-        <li><a class="text-dune-text hover:underline" href="#prereqs">Prerequisites — a Cloudflare zone</a></li>
-        <li><a class="text-dune-text hover:underline" href="#setup">Setup (8 steps, ~15 min)</a></li>
-        <li><a class="text-dune-text hover:underline" href="#verify">Verify it works</a></li>
+        <li><a class="text-dune-text hover:underline" href="#funnel">Recommended: Tailscale Funnel</a></li>
+        <li><a class="text-dune-text hover:underline" href="#pair">Open the portal on your phone</a></li>
+        <li><a class="text-dune-text hover:underline" href="#domain">Advanced: bring your own Cloudflare domain</a></li>
         <li><a class="text-dune-text hover:underline" href="#trouble">Troubleshooting</a></li>
         <li><a class="text-dune-text hover:underline" href="#faq">FAQ</a></li>
         <li><a class="text-dune-text hover:underline" href="#revoke">Disabling or revoking access</a></li>
@@ -35,6 +35,7 @@ import PageHeader from "../components/PageHeader.astro";
       <ul class="space-y-2 text-dune-muted leading-relaxed">
         <li><strong class="text-dune-text">Dashboard</strong> — VM up/down, battlegroup state, public IP, port-forward summary, last few backups.</li>
         <li><strong class="text-dune-text">Maps</strong> — spin a configured map up or down, run a one-click <em>fix partitions</em> if a worker pin drifts.</li>
+        <li><strong class="text-dune-text">Mobile app</strong> — the iOS / Android apps (in testing — access via the <a class="underline text-dune-text" href="https://discord.gg/tj2x7cywSC" rel="noopener" target="_blank">DST Discord</a>) talk to the same remote endpoint for a native dashboard + maps surface.</li>
         <li>That's it. No initial-setup wizard, no <span class="font-mono">.ini</span> editor, no SSH/shell, no DB import or restore, no Settings. The remote route module physically cannot reach those handlers.</li>
       </ul>
     </div>
@@ -43,196 +44,98 @@ import PageHeader from "../components/PageHeader.astro";
     <div id="how-it-works">
       <h2 class="text-2xl font-semibold mb-4">2 · How it works (security model)</h2>
       <p class="text-dune-muted leading-relaxed mb-3">
-        Three layers, all of which must pass for any remote request:
+        Whichever transport you pick, the chain is the same shape: a public HTTPS
+        endpoint forwards into a <strong class="text-dune-text">loopback bridge</strong>
+        on <span class="font-mono">127.0.0.1:47900</span>, which proxies to the
+        locally-running DST. The bridge binds loopback only — no inbound
+        port-forward, no public IP, no Windows Firewall rule, no admin rights.
       </p>
+      <p class="text-dune-muted leading-relaxed mb-3">Every remote request is gated:</p>
       <ol class="list-decimal list-inside space-y-2 text-dune-muted leading-relaxed">
-        <li><strong class="text-dune-text">Cloudflare Tunnel</strong> — outbound-only TCP from your PC to Cloudflare's edge. No inbound port-forward, no public IP. <span class="font-mono">cloudflared</span> sees your DST listener at <span class="font-mono">http://127.0.0.1:&lt;port&gt;</span> and proxies it to a hostname like <span class="font-mono">dune.example.com</span>.</li>
-        <li><strong class="text-dune-text">Cloudflare Access</strong> — a per-hostname policy that requires a verified identity (Google / GitHub / one-time PIN). The request arrives at DST with a <span class="font-mono">Cf-Access-Authenticated-User-Email</span> header that only Cloudflare can sign.</li>
-        <li><strong class="text-dune-text">DST allow-list</strong> — DST reads that email and looks it up in <span class="font-mono">%APPDATA%\DuneServer\remote-acl.json</span>. Owner + 0–3 admins, all explicitly added by you in <strong>Settings → Remote Access</strong>. Anything else is a 401/403.</li>
+        <li><strong class="text-dune-text">Permanent remote token</strong> — the QR you scan carries an unguessable per-host token. The phone app (and the magic-link browser portal, <span class="font-mono">https://…/?key=&lt;token&gt;</span>) send it on every request; without it DST answers 401. This is what protects a Tailscale Funnel, whose URL is otherwise public.</li>
+        <li><strong class="text-dune-text">DST allow-list</strong> — the dashboard + maps surface is the only thing <span class="font-mono">/remote/*</span> exposes; the module can't reach Settings, SSH, or the DB. Owner + 0–3 admins are managed in <strong>Settings → Remote Access</strong>.</li>
+        <li><strong class="text-dune-text">(Cloudflare path only) email identity</strong> — if you bring your own Cloudflare domain, Cloudflare Access adds a verified-email gate in front, and the browser co-admin portal authenticates by email instead of the token.</li>
       </ol>
       <p class="text-dune-muted leading-relaxed mt-3">
-        DST's per-launch GUID token (<span class="font-mono">DuneToken</span>) is still enforced on every request as defense-in-depth, so even an attacker on your Windows box who forges the Cloudflare header without going through the tunnel can't reach the remote API.
-      </p>
-      <p class="text-dune-muted leading-relaxed mt-3">
-        Every successful write (spin up / spin down / fix partitions) appends a line to <span class="font-mono">%APPDATA%\DuneServer\.logs\remote-audit.log</span> with timestamp, role, email, path, and status.
+        Every successful write (spin up / spin down / fix partitions) appends a line to <span class="font-mono">%APPDATA%\DuneServer\.logs\remote-audit.log</span> with timestamp, role, path, and status.
       </p>
     </div>
 
-    <!-- Prereqs ----------------------------------------------------------- -->
-    <div id="prereqs">
-      <h2 class="text-2xl font-semibold mb-4">3 · Prerequisites — a Cloudflare zone</h2>
+    <!-- Tailscale Funnel (recommended) ----------------------------------- -->
+    <div id="funnel">
+      <h2 class="text-2xl font-semibold mb-4">3 · Recommended: Tailscale Funnel <span class="text-dune-muted text-base font-normal">— no domain, ~5 min</span></h2>
       <p class="text-dune-muted leading-relaxed mb-4">
-        The biggest snag people hit on first run is step 4 below — <span class="font-mono">cloudflared tunnel login</span> opens a browser tab that shows a list of <strong>zones</strong>. A "zone" is just Cloudflare's word for a domain that's been added to your account. If your account is empty, the page is empty and there's nothing to pick. That's not a bug; it's the prerequisite.
+        Tailscale Funnel gives you a stable public HTTPS address like
+        <span class="font-mono">https://&lt;name&gt;.ts.net</span> with no domain to buy,
+        no router port-forward, and no public IP — it works behind CGNAT. DST ships
+        only the local bridge and detects the Funnel automatically; it does not
+        bundle or manage Tailscale, so you keep ownership of it.
       </p>
+      <div class="space-y-5">
+        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">Step 1 · Install Tailscale on your DST machine</h3>
+          <p class="text-dune-muted text-sm">Download it from <a class="underline text-dune-text" href="https://tailscale.com/download" rel="noopener" target="_blank">tailscale.com/download</a> and sign in to create your free tailnet. (A personal account is plenty for one host.)</p>
+        </div>
 
-      <div class="rounded-md border border-amber-500/40 bg-amber-500/10 p-4 text-sm leading-relaxed">
-        <p class="mb-2"><strong>You need a domain on Cloudflare before you start.</strong> If you already see your domain listed under <em>Websites</em> in the Cloudflare dashboard with a green <strong>Active</strong> badge, skip ahead to step 4 — you're ready.</p>
-        <p class="mb-2">Otherwise, do this once (free):</p>
-        <ol class="list-decimal list-inside space-y-2">
-          <li>
-            <strong>Get a domain.</strong> Register one anywhere — Cloudflare Registrar, Namecheap, Porkbun, GoDaddy, etc. all work. You'll only ever use a subdomain (e.g. <span class="font-mono">dune.yourdomain.xyz</span>), so a cheap <span class="font-mono">.xyz</span> / <span class="font-mono">.click</span> / <span class="font-mono">.fun</span> is fine — many are $1–$5/yr. The domain itself never needs to host a website.
-          </li>
-          <li>
-            <strong>Add the domain to Cloudflare.</strong> Sign in to <a class="underline text-dune-text" href="https://dash.cloudflare.com/" rel="noopener" target="_blank">dash.cloudflare.com</a>, click <strong>+ Add a domain</strong>, paste the domain name, and pick the <strong>Free</strong> plan when prompted. Cloudflare scans the existing DNS records and shows you what it found.
-          </li>
-          <li>
-            <strong>Point your registrar at Cloudflare's nameservers.</strong> Cloudflare shows you two nameservers, e.g. <span class="font-mono">amy.ns.cloudflare.com</span> and <span class="font-mono">bob.ns.cloudflare.com</span>. Go to your registrar's control panel → <em>Nameservers</em> (sometimes called <em>DNS</em> or <em>Custom DNS</em>) and replace whatever's there with those two. Save.
-          </li>
-          <li>
-            <strong>Wait for the zone to go Active.</strong> Back in the Cloudflare dashboard the domain starts as <span class="font-mono">Pending</span>. Once DNS propagates and Cloudflare confirms you're now authoritative, it flips to <span class="font-mono">Active</span>. Usually 5–30 minutes; sometimes a few hours. You'll get an email when it's done. <strong>Until it's Active, <span class="font-mono">cloudflared tunnel login</span> will not show the domain.</strong>
-          </li>
-        </ol>
-        <p class="mt-3 text-xs">No, you do not need to build a website. You're using Cloudflare purely as a DNS host plus tunnel terminator. The Free plan is fine — there are no usage charges for the tunnel or for Cloudflare Access at the size of one or two admins.</p>
+        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">Step 2 · Enable a Funnel on the bridge port</h3>
+          <p class="text-dune-muted text-sm mb-2">In a terminal on the DST host:</p>
+          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">tailscale funnel --bg http://127.0.0.1:47900</pre>
+          <p class="text-dune-muted text-xs mt-2">The first time, Tailscale may prompt you to enable HTTPS certificates and the Funnel feature for your tailnet — follow the link it prints. <span class="font-mono">--bg</span> runs it in the background so it survives the terminal closing.</p>
+        </div>
+
+        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">Step 3 · Confirm DST picked it up</h3>
+          <p class="text-dune-muted text-sm">Open <strong>Settings → Mobile App</strong> in DST. Once the Funnel is active, the stable <span class="font-mono">…ts.net</span> address appears there automatically with a <em>Tailscale Funnel</em> badge. That's your remote endpoint — no further config.</p>
+        </div>
       </div>
     </div>
 
-    <!-- Setup ------------------------------------------------------------- -->
-    <div id="setup">
-      <h2 class="text-2xl font-semibold mb-4">4 · Setup (8 steps, ~15 min)</h2>
-      <p class="text-dune-muted leading-relaxed mb-6">
-        Everything below assumes the prerequisite above is done — your domain shows <strong>Active</strong> in the Cloudflare dashboard.
+    <!-- Open the portal on your phone ------------------------------------ -->
+    <div id="pair">
+      <h2 class="text-2xl font-semibold mb-4">4 · Open the portal on your phone</h2>
+      <p class="text-dune-muted leading-relaxed mb-3">
+        The mobile portal runs in any browser — no app required. In DST, open
+        <strong class="text-dune-text">Settings → Mobile App</strong> and click
+        <strong>Generate QR Code</strong>, then open the magic link it produces
+        (<span class="font-mono">https://&lt;name&gt;.ts.net/?key=&lt;token&gt;</span>)
+        on your phone. The link carries your remote URL plus the permanent token,
+        so it keeps working across restarts.
       </p>
-
-      <ol class="space-y-6">
-        <!-- Step 1 -->
-        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 1 · Install <span class="font-mono">cloudflared</span> on your DST machine</h3>
-          <p class="text-dune-muted text-sm mb-3">Open an <strong>admin</strong> PowerShell window (right-click → Run as administrator) and run:</p>
-          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">winget install --id Cloudflare.cloudflared</pre>
-          <p class="text-dune-muted text-xs mt-2">No <span class="font-mono">winget</span>? Download the <span class="font-mono">.msi</span> from <a class="underline text-dune-text" href="https://github.com/cloudflare/cloudflared/releases/latest" rel="noopener" target="_blank">github.com/cloudflare/cloudflared/releases/latest</a> and double-click.</p>
-          <p class="text-dune-muted text-xs mt-2"><strong>Verify:</strong> close that PowerShell window, open a new one, and run <span class="font-mono">cloudflared --version</span>. You should see a version like <span class="font-mono">cloudflared version 2024.x.x</span>. If it says "not recognized", restart the PowerShell window again — <span class="font-mono">PATH</span> only refreshes for new sessions.</p>
-          <p class="text-dune-muted text-xs mt-2">DST itself doesn't install or run <span class="font-mono">cloudflared</span> for you — you keep ownership of the tunnel. DST only detects whether <span class="font-mono">cloudflared.exe</span> is on <span class="font-mono">PATH</span> and surfaces that in the Settings card.</p>
-        </li>
-
-        <!-- Step 2 -->
-        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 2 · Decide on your hostname</h3>
-          <p class="text-dune-muted text-sm mb-2">Pick a subdomain on the zone you set up. A clear, single-purpose name is best. Examples:</p>
-          <ul class="list-disc list-inside text-dune-muted text-sm space-y-1 mb-2">
-            <li><span class="font-mono">dune.yourdomain.xyz</span></li>
-            <li><span class="font-mono">portal.yourdomain.click</span></li>
-            <li><span class="font-mono">server.dune.yourdomain.fun</span></li>
-          </ul>
-          <p class="text-dune-muted text-xs">Don't use your root <span class="font-mono">yourdomain.xyz</span> if you ever plan to host anything else there. Use a subdomain. You don't need to create it ahead of time — <span class="font-mono">cloudflared</span> creates the DNS record for you in step 5.</p>
-        </li>
-
-        <!-- Step 3 -->
-        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 3 · Authenticate <span class="font-mono">cloudflared</span> with your Cloudflare account</h3>
-          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">cloudflared tunnel login</pre>
-          <p class="text-dune-muted text-sm mt-2">
-            A browser tab opens to the Cloudflare dashboard and shows every <strong>zone</strong> (domain) on your account. Click the domain you want to use (e.g. <span class="font-mono">yourdomain.xyz</span>) → <strong>Authorize</strong>.
-          </p>
-          <p class="text-dune-muted text-sm mt-2">
-            You should see <strong>You have successfully logged in</strong> in the browser and the terminal prints something like <em>Successfully fetched cert.pem</em>. A cert is now saved to <span class="font-mono">%USERPROFILE%\.cloudflared\cert.pem</span>. This cert is your bridge between <span class="font-mono">cloudflared</span> and your CF account — guard it like a password (it's per-zone, not per-tunnel).
-          </p>
-          <div class="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs leading-relaxed">
-            <strong>No zones listed?</strong> Your Cloudflare account has no domains on it yet, or the one you added is still <span class="font-mono">Pending</span>. Go back to <a class="underline" href="#prereqs">Prerequisites</a>.
-          </div>
-        </li>
-
-        <!-- Step 4 -->
-        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 4 · Create a tunnel</h3>
-          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">cloudflared tunnel create dune-portal</pre>
-          <p class="text-dune-muted text-sm mt-2">
-            <span class="font-mono">dune-portal</span> is just a friendly name — you can call it whatever you like. The command prints a <strong>tunnel UUID</strong> (a long string of hex) and writes a credentials JSON file at <span class="font-mono">%USERPROFILE%\.cloudflared\&lt;UUID&gt;.json</span>.
-          </p>
-          <p class="text-dune-muted text-xs mt-2"><strong>Save that UUID</strong> — you'll paste it into a config file in step 6. If you lose it, run <span class="font-mono">cloudflared tunnel list</span> to print it again.</p>
-        </li>
-
-        <!-- Step 5 -->
-        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 5 · Point your hostname at the tunnel</h3>
-          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">cloudflared tunnel route dns dune-portal dune.yourdomain.xyz</pre>
-          <p class="text-dune-muted text-sm mt-2">
-            Replace <span class="font-mono">dune.yourdomain.xyz</span> with the hostname you chose in step 2. This creates a <strong>proxied CNAME</strong> record in Cloudflare DNS — your subdomain now resolves to <span class="font-mono">&lt;UUID&gt;.cfargotunnel.com</span>, but visitors never see that.
-          </p>
-          <p class="text-dune-muted text-xs mt-2"><strong>Verify in the dashboard:</strong> Cloudflare → your domain → <strong>DNS → Records</strong>. You'll see a new CNAME for <span class="font-mono">dune</span> with the orange "proxied" cloud icon.</p>
-        </li>
-
-        <!-- Step 6 -->
-        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 6 · Tell <span class="font-mono">cloudflared</span> where to send traffic (ingress)</h3>
-          <p class="text-dune-muted text-sm mb-3">
-            Create or edit <span class="font-mono">%USERPROFILE%\.cloudflared\config.yml</span> with the snippet below. Replace <span class="font-mono">&lt;UUID&gt;</span> with the tunnel UUID from step 4, and <span class="font-mono">dune.yourdomain.xyz</span> with your hostname:
-          </p>
-          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">tunnel: dune-portal
-credentials-file: C:\Users\You\.cloudflared\&lt;UUID&gt;.json
-
-ingress:
-  - hostname: dune.yourdomain.xyz
-    service: http://127.0.0.1:47823
-  - service: http_status:404</pre>
-          <p class="text-dune-muted text-xs mt-2">
-            That last <span class="font-mono">http_status:404</span> line is the catch-all — anything that arrives without a matching <span class="font-mono">hostname:</span> entry gets a 404 instead of being silently forwarded somewhere.
-          </p>
-          <div class="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs leading-relaxed">
-            <strong>Port caveat:</strong> DST prefers port <span class="font-mono">47823</span> but roams to <span class="font-mono">47824–47872</span> if it's in use. If you suspect a port collision, free 47823 (so DST always takes it) or read the actual port from <span class="font-mono">%LOCALAPPDATA%\DuneServer\last-url.txt</span> and update the <span class="font-mono">service:</span> line to match. The Settings page status bar also shows the current port.
-          </div>
-        </li>
-
-        <!-- Step 7 -->
-        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 7 · Lock the hostname down with Cloudflare Access</h3>
-          <p class="text-dune-muted text-sm mb-3">
-            Without Access, anyone who guesses your hostname could hit DST. Access puts a Cloudflare login screen in front. In the Cloudflare Zero Trust dashboard:
-          </p>
-          <ol class="list-decimal list-inside text-dune-muted text-sm space-y-1 mb-3">
-            <li>Open <a class="underline text-dune-text" href="https://one.dash.cloudflare.com/" rel="noopener" target="_blank">one.dash.cloudflare.com</a> → <strong>Access → Applications → Add an application</strong>.</li>
-            <li>Pick <strong>Self-hosted</strong>.</li>
-            <li><strong>Application name:</strong> anything (e.g. <em>DST portal</em>).</li>
-            <li><strong>Session duration:</strong> 24 h is reasonable; pick what feels right.</li>
-            <li><strong>Application domain:</strong> select your zone and type <span class="font-mono">dune</span> as the subdomain (i.e. it builds <span class="font-mono">dune.yourdomain.xyz</span>).</li>
-            <li>Continue → on the policies page, <strong>Add a policy</strong>:
-              <ul class="list-disc list-inside ml-4 mt-1">
-                <li>Name: <em>Owner + admins</em></li>
-                <li>Action: <strong>Allow</strong></li>
-                <li>Include: <strong>Emails</strong> → list yourself and each trusted admin (one email per line). One-time-PIN identity provider is enabled by default, so admins don't need a Cloudflare account — they just enter their email and get a 6-digit code.</li>
-              </ul>
-            </li>
-            <li>Save / Done.</li>
-          </ol>
-          <p class="text-dune-muted text-xs">
-            Cloudflare now intercepts every request to your hostname, requires the visitor to prove they own one of those emails, and injects <span class="font-mono">Cf-Access-Authenticated-User-Email</span> on the way through. DST compares that to its own allow-list — the Access list and DST's allow-list are independent, so the principle of least privilege applies twice.
-          </p>
-        </li>
-
-        <!-- Step 8 -->
-        <li class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 8 · Run the tunnel + enable in DST</h3>
-          <p class="text-dune-muted text-sm mb-2">Start the tunnel from PowerShell:</p>
-          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">cloudflared tunnel run dune-portal</pre>
-          <div class="rounded-md border border-dune-border bg-dune-bg p-3 mt-3">
-            <p class="text-dune-muted text-sm"><strong class="text-dune-text">Expected output — this is success, not a hang.</strong> <span class="font-mono">cloudflared tunnel run</span> is a long-running process: it does <em>not</em> finish and hand your prompt back. It prints a few <span class="font-mono">Registered tunnel connection</span> lines with <span class="font-mono">connIndex=0</span> through <span class="font-mono">connIndex=3</span> — those are the four redundant connections it opens to Cloudflare's edge. Once you reach <span class="font-mono">connIndex=3</span> the tunnel is <strong>live</strong> and the window will simply sit there with no further output. That is the healthy, running state — it is not frozen or stuck. Leave the window open and move on to the next step.</p>
-          </div>
-          <p class="text-dune-muted text-sm mt-3">Or install it as a Windows service so it survives reboots (run admin PowerShell):</p>
-          <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">cloudflared service install
-Start-Service cloudflared</pre>
-          <p class="text-dune-muted text-sm mt-4">Then in DST: open <strong>Settings → Remote Access</strong>:</p>
-          <ul class="list-disc list-inside text-dune-muted text-sm space-y-1 mt-1">
-            <li>Tick <strong>Enable remote portal</strong>.</li>
-            <li>Set <strong>Owner email</strong> to whatever you put in the Access policy.</li>
-            <li>Add any admin emails you also listed in Access (max 3).</li>
-            <li>Save.</li>
-          </ul>
-          <p class="text-dune-muted text-sm mt-3">
-            On your phone, browse to <span class="font-mono">https://dune.yourdomain.xyz/remote/</span>. You'll see the Cloudflare login first, then the mobile portal. Done.
-          </p>
-        </li>
-      </ol>
+      <p class="text-dune-muted text-sm">
+        On the same LAN you can also reach the portal directly at <span class="font-mono">http://&lt;lan-ip&gt;:47900</span> without any tunnel.
+      </p>
+      <div class="rounded-xl border border-dune-border bg-dune-surface p-5 mt-4">
+        <h3 class="font-semibold mb-1">Native iOS / Android apps</h3>
+        <p class="text-dune-muted text-sm">The DST mobile apps are in active testing. To get access and take part, <a class="underline text-dune-text" href="https://discord.gg/tj2x7cywSC" rel="noopener" target="_blank">join the DST Discord</a> — TestFlight invites, the Android build, and testing are coordinated there.</p>
+      </div>
     </div>
 
-    <!-- Verify ----------------------------------------------------------- -->
-    <div id="verify">
-      <h2 class="text-2xl font-semibold mb-4">5 · Verify it works</h2>
-      <p class="text-dune-muted leading-relaxed mb-3">Quick checklist before you trust it:</p>
-      <ol class="list-decimal list-inside space-y-2 text-dune-muted leading-relaxed">
-        <li><strong class="text-dune-text">From your PC's browser:</strong> visit <span class="font-mono">https://dune.yourdomain.xyz/remote/</span>. You should see the Cloudflare Access login first, sign in with the owner email, then land on the DST mobile dashboard.</li>
-        <li><strong class="text-dune-text">From a different network</strong> (your phone on cellular, not WiFi): same hostname, same login. Confirms the tunnel is actually carrying traffic from the public internet.</li>
-        <li><strong class="text-dune-text">From a different email</strong> (a friend or a secondary inbox you control): you should be <em>blocked at the Access screen</em>. If it lets them in and DST returns 403, only the Access policy was missed; if it lets them in fully, the Access policy isn't applied to that hostname — re-check step 7.</li>
-        <li><strong class="text-dune-text">Audit log:</strong> in DST, <strong>Settings → Remote Access → View audit log</strong> should show your spin-up / spin-down clicks with your email, timestamp, and HTTP 200.</li>
-      </ol>
+    <!-- Cloudflare custom domain (advanced, trimmed) --------------------- -->
+    <div id="domain">
+      <h2 class="text-2xl font-semibold mb-4">5 · Advanced: bring your own Cloudflare domain <span class="text-dune-muted text-base font-normal">— optional</span></h2>
+      <p class="text-dune-muted leading-relaxed mb-3">
+        Most hosts don't need this — the Tailscale Funnel above already gives you a
+        stable HTTPS address. But if you want a <strong class="text-dune-text">permanent
+        custom hostname</strong> (e.g. <span class="font-mono">dune.yourdomain.xyz</span>)
+        with email-identity gating, DST supports a Cloudflare
+        <strong>named tunnel + Access</strong> setup that you own end to end.
+      </p>
+      <p class="text-dune-muted leading-relaxed mb-3">The shape of it:</p>
+      <ul class="list-disc list-inside space-y-2 text-dune-muted leading-relaxed text-sm">
+        <li>Add a domain to a free Cloudflare account and wait for the zone to go <strong>Active</strong>.</li>
+        <li>Install <span class="font-mono">cloudflared</span>, then <span class="font-mono">cloudflared tunnel login</span> → <span class="font-mono">create</span> → <span class="font-mono">route dns</span> for your subdomain.</li>
+        <li>Point the tunnel's <span class="font-mono">config.yml</span> ingress at the DST bridge — <span class="font-mono">service: http://127.0.0.1:47900</span> — not a roaming backend port.</li>
+        <li>Add a Cloudflare <strong>Access</strong> policy on the hostname (email allow-list / one-time PIN), then list the same owner + admin emails in <strong>Settings → Remote Access</strong>.</li>
+        <li>For the phone app over a custom domain, create a Cloudflare <em>Service Token</em> and paste the Client ID + Secret into <strong>Settings → Remote Access</strong> so the app can pass Access.</li>
+      </ul>
+      <p class="text-dune-muted leading-relaxed mt-3 text-sm">
+        Cloudflare's own docs are the source of truth for the tunnel + Access steps:
+        <a class="underline text-dune-text" href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/" rel="noopener" target="_blank">Connect networks (Tunnels)</a>
+        and
+        <a class="underline text-dune-text" href="https://developers.cloudflare.com/cloudflare-one/policies/access/" rel="noopener" target="_blank">Access policies</a>.
+        Pairing prefers a Tailscale Funnel when one is active, then falls back to this custom domain.
+      </p>
     </div>
 
     <!-- Troubleshooting -------------------------------------------------- -->
@@ -240,48 +143,23 @@ Start-Service cloudflared</pre>
       <h2 class="text-2xl font-semibold mb-4">6 · Troubleshooting</h2>
       <div class="space-y-5">
         <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2"><span class="font-mono">cloudflared tunnel login</span> shows no zones</h3>
-          <p class="text-dune-muted text-sm">Either no domain is on your Cloudflare account, or it's still <span class="font-mono">Pending</span>. Back to <a class="underline text-dune-text" href="#prereqs">Prerequisites</a> — wait for <strong>Active</strong> before retrying.</p>
+          <h3 class="font-semibold mb-2">No remote address shows in Settings → Mobile App</h3>
+          <p class="text-dune-muted text-sm">DST hasn't detected a Funnel. Confirm <span class="font-mono">tailscale funnel status</span> lists <span class="font-mono">/ proxy http://127.0.0.1:47900</span>. If it's empty, re-run <span class="font-mono">tailscale funnel --bg http://127.0.0.1:47900</span> and complete any HTTPS/Funnel enablement link Tailscale prints.</p>
         </div>
 
         <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2"><span class="font-mono">cloudflared tunnel run</span> looks frozen / stuck at <span class="font-mono">connIndex=3</span></h3>
-          <p class="text-dune-muted text-sm">It isn't stuck — that's the tunnel <strong>working</strong>. <span class="font-mono">cloudflared tunnel run</span> is a foreground daemon, not a one-shot command, so it never returns you to the prompt. The <span class="font-mono">connIndex=0</span>–<span class="font-mono">connIndex=3</span> lines are its four edge connections registering; once all four are up the window goes quiet and stays running. Leave it open and browse to <span class="font-mono">https://dune.yourdomain.xyz/remote/</span> — if you only see a 502 or 1033 <em>after</em> the page loads, that's a separate issue covered below. If the page loads fine, you're done; to keep the tunnel up after closing the window or rebooting, install it as a service (Step 8).</p>
+          <h3 class="font-semibold mb-2">Phone shows "Cannot reach server"</h3>
+          <p class="text-dune-muted text-sm">Make sure DST is running on the host (the bridge proxies to it). Re-scan the QR if you switched transports or hostnames — a stale paired URL is the usual cause. On the host, probe the bridge: <span class="font-mono">curl http://127.0.0.1:47900/_dst/health</span>.</p>
         </div>
 
         <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2">Error 1033: Argo Tunnel error</h3>
-          <p class="text-dune-muted text-sm">Cloudflare reached your hostname but the tunnel isn't connected. Check <span class="font-mono">cloudflared tunnel run dune-portal</span> is still going (or the <span class="font-mono">cloudflared</span> Windows service is <em>Running</em>). Restart it.</p>
+          <h3 class="font-semibold mb-2">401 / "Authentication required"</h3>
+          <p class="text-dune-muted text-sm">The request reached DST without a valid token. Re-pair from <strong>Settings → Mobile App → Generate QR Code</strong> so the app picks up the current token, and confirm <strong>Enable remote portal</strong> is on in <strong>Settings → Remote Access</strong>.</p>
         </div>
 
         <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2">Error 502: Bad Gateway (after Cloudflare login)</h3>
-          <p class="text-dune-muted text-sm">The tunnel is up but <span class="font-mono">cloudflared</span> can't reach DST on the configured local port. Most common causes:</p>
-          <ul class="list-disc list-inside text-dune-muted text-sm mt-1 space-y-1">
-            <li>DST isn't running. Launch DST first.</li>
-            <li>DST grabbed a different port — check <span class="font-mono">%LOCALAPPDATA%\DuneServer\last-url.txt</span> or the Settings page status bar and update the <span class="font-mono">service:</span> line in <span class="font-mono">config.yml</span> to match. Restart <span class="font-mono">cloudflared</span>.</li>
-            <li>Windows Firewall is blocking <span class="font-mono">cloudflared</span> talking to <span class="font-mono">127.0.0.1</span>. Allow it.</li>
-          </ul>
-        </div>
-
-        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2">Cloudflare login succeeds but DST returns 401 / 403</h3>
-          <p class="text-dune-muted text-sm">Access let you in but DST's own allow-list didn't recognise the email. The two lists are independent — open <strong>Settings → Remote Access</strong> in DST and confirm the exact email matches the one Cloudflare showed you (no typos, no different domain). Save.</p>
-        </div>
-
-        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2">Loop: Cloudflare login keeps re-asking</h3>
-          <p class="text-dune-muted text-sm">Usually a cookie/HTTPS issue. Make sure you're hitting <span class="font-mono">https://</span> (not <span class="font-mono">http://</span>) and the Access app's <em>Application domain</em> matches the exact hostname you're visiting (including any subdomain). On iOS Safari with strict tracking prevention you may need to enable cross-site cookies for <span class="font-mono">cloudflareaccess.com</span>.</p>
-        </div>
-
-        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2">DNS doesn't resolve / "site can't be reached"</h3>
-          <p class="text-dune-muted text-sm">Confirm step 5 actually created a DNS record: Cloudflare dashboard → your domain → <strong>DNS → Records</strong>. Look for a proxied CNAME on your subdomain pointing at <span class="font-mono">&lt;UUID&gt;.cfargotunnel.com</span>. If missing, re-run <span class="font-mono">cloudflared tunnel route dns dune-portal dune.yourdomain.xyz</span>.</p>
-        </div>
-
-        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2"><span class="font-mono">cloudflared</span> service won't start after reboot</h3>
-          <p class="text-dune-muted text-sm">From admin PowerShell: <span class="font-mono">Get-Service cloudflared</span> shows status; <span class="font-mono">Start-Service cloudflared</span> starts it; check logs at <span class="font-mono">%PROGRAMDATA%\Cloudflare\cloudflared\cloudflared.log</span>. The most common reason is the service can't find <span class="font-mono">config.yml</span> at the path it expects — see <a class="underline text-dune-text" href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/" rel="noopener" target="_blank">Cloudflare's config-file docs</a>.</p>
+          <h3 class="font-semibold mb-2">Custom-domain (Cloudflare) returns 502 after login</h3>
+          <p class="text-dune-muted text-sm">The tunnel is up but <span class="font-mono">cloudflared</span> can't reach the bridge. Confirm the ingress <span class="font-mono">service:</span> line points at <span class="font-mono">http://127.0.0.1:47900</span> (the bridge), that DST is running, and that Windows Firewall isn't blocking <span class="font-mono">cloudflared</span> talking to <span class="font-mono">127.0.0.1</span>.</p>
         </div>
       </div>
     </div>
@@ -291,28 +169,24 @@ Start-Service cloudflared</pre>
       <h2 class="text-2xl font-semibold mb-4">7 · FAQ</h2>
       <div class="space-y-5">
         <div>
-          <h3 class="font-semibold mb-1">Do I have to use Cloudflare? Can I just port-forward?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">You <em>can</em>, but DST doesn't help you with that and the remote portal middleware assumes the Cloudflare Access header. A bare port-forward would expose DST to the entire internet with no identity gate — not recommended.</p>
+          <h3 class="font-semibold mb-1">Do I need a domain or a Cloudflare account?</h3>
+          <p class="text-dune-muted text-sm leading-relaxed">No. The recommended Tailscale Funnel path needs neither — just a free Tailscale account on the host. A Cloudflare domain is only for the optional permanent-hostname setup.</p>
         </div>
         <div>
-          <h3 class="font-semibold mb-1">Does this cost anything?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">No, at this scale. Cloudflare's Free plan includes the tunnel and up to 50 Cloudflare Access users for free. The only spend is the domain registration itself, which can be under $5/yr.</p>
+          <h3 class="font-semibold mb-1">If the Funnel URL is public, what stops a stranger?</h3>
+          <p class="text-dune-muted text-sm leading-relaxed">The per-host remote token. The URL is reachable, but every request needs the unguessable token from your QR / magic link, or DST returns 401. The remote surface is also limited to dashboard + maps and is audit-logged.</p>
         </div>
         <div>
-          <h3 class="font-semibold mb-1">Can I share the URL with my whole Discord?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">You can share the URL, but each visitor still needs an email on the Access allow-list AND in DST's allow-list to get in. The owner + 3 admins cap in DST is intentional — this isn't a public dashboard.</p>
+          <h3 class="font-semibold mb-1">Should I keep it running when DST is closed?</h3>
+          <p class="text-dune-muted text-sm leading-relaxed">By default the portal is up only while DST is open. <strong>Help → Keep serving while DST is closed</strong> installs a background service so the portal, phone apps, scheduled restarts, and Discord notifications keep running while DST is closed and while the PC is locked — you just have to stay signed in to Windows.</p>
         </div>
         <div>
           <h3 class="font-semibold mb-1">Does the remote portal expose my SSH key or DB credentials?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">No. The remote route module physically cannot reach the Settings, SSH, or DB handlers — those routes are not registered for <span class="font-mono">/remote/*</span> at all, by design. Even an authenticated admin can't escalate beyond the dashboard + maps surface.</p>
-        </div>
-        <div>
-          <h3 class="font-semibold mb-1">My PC reboots — does the tunnel come back automatically?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">Only if you ran <span class="font-mono">cloudflared service install</span> in step 8. If you just ran <span class="font-mono">cloudflared tunnel run …</span> in a PowerShell window, that dies with the window. Install the service.</p>
+          <p class="text-dune-muted text-sm leading-relaxed">No. The remote route module physically cannot reach the Settings, SSH, or DB handlers — those routes are not registered for <span class="font-mono">/remote/*</span> at all, by design. Even a paired admin can't escalate beyond the dashboard + maps surface.</p>
         </div>
         <div>
           <h3 class="font-semibold mb-1">My ISP gave me a new public IP. Do I have to redo anything?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">No. Cloudflare Tunnels are outbound from your PC — there's no inbound public IP involved. ISP IP changes are invisible to the tunnel.</p>
+          <p class="text-dune-muted text-sm leading-relaxed">No. Both Tailscale Funnel and Cloudflare Tunnel are outbound from your PC — there's no inbound public IP involved, so ISP IP changes are invisible.</p>
         </div>
       </div>
     </div>
@@ -322,10 +196,10 @@ Start-Service cloudflared</pre>
       <h2 class="text-2xl font-semibold mb-4">8 · Disabling or revoking access</h2>
       <ul class="space-y-2 text-dune-muted leading-relaxed">
         <li><strong class="text-dune-text">Pause everything:</strong> untick <strong>Enable remote portal</strong> in DST Settings. Every <span class="font-mono">/remote/*</span> request is refused immediately (the owner field is cleared, so DST fails closed).</li>
-        <li><strong class="text-dune-text">Revoke an admin:</strong> remove their email from the DST allow-list and save. The next request they make returns 403 and gets logged. Also remove them from the Cloudflare Access policy so they can't reach DST at all.</li>
-        <li><strong class="text-dune-text">Kill the tunnel:</strong> <span class="font-mono">Stop-Service cloudflared</span> (or close the <span class="font-mono">cloudflared</span> window). Hostname goes dark immediately.</li>
-        <li><strong class="text-dune-text">Nuke the cert:</strong> delete <span class="font-mono">%USERPROFILE%\.cloudflared\cert.pem</span>. Re-run <span class="font-mono">cloudflared tunnel login</span> to issue a new one.</li>
-        <li><strong class="text-dune-text">Audit:</strong> Settings → Remote Access → <strong>View audit log</strong> shows the last 50 mutating actions with timestamp, role, email, path, and HTTP status.</li>
+        <li><strong class="text-dune-text">Kill the Funnel:</strong> <span class="font-mono">tailscale funnel --https=443 off</span> (or <span class="font-mono">tailscale serve reset</span>). The <span class="font-mono">…ts.net</span> endpoint goes dark immediately.</li>
+        <li><strong class="text-dune-text">Re-pair:</strong> a fresh QR rotates nothing by itself, but disabling and re-enabling the remote portal forces every paired device to re-authenticate.</li>
+        <li><strong class="text-dune-text">Custom domain:</strong> stop the <span class="font-mono">cloudflared</span> tunnel and remove the email from both the Cloudflare Access policy and DST's allow-list.</li>
+        <li><strong class="text-dune-text">Audit:</strong> Settings → Remote Access → <strong>View audit log</strong> shows the last 50 mutating actions with timestamp, role, path, and HTTP status.</li>
       </ul>
     </div>
   </section>


### PR DESCRIPTION
Resyncs the marketing site to the shipped **v12.11.0** remote model. The site still described the pre-pivot story (Cloudflare quick tunnel as *the* way) and had a real port bug.

## `remote.astro` (rewritten)
- **Leads with Tailscale Funnel** as the recommended, zero-domain default (`tailscale funnel --bg http://127.0.0.1:47900` → stable `…ts.net`).
- **Accurate security model**: loopback bridge on `47900` + the permanent **remote token** gating every request (what protects an otherwise-public Funnel URL). Cloudflare Access email identity is noted as a custom-domain-only extra (it gates the `/remote/*` browser co-admin portal).
- **Trims** the full Cloudflare walkthrough to a short bring-your-own-domain summary + links to Cloudflare's own docs (the named-tunnel path we *kept*).
- **Fixes a real bug**: the Cloudflare ingress `service:` port `47823 → 47900` (must route through the bridge, or it 502s).
- **Phone-app testing → Discord**: native iOS/Android app access + testing is deferred to the DST Discord; the browser magic-link portal stays documented since it needs no app.

## `install.astro`
- Remote-portal blurb now leads with Tailscale Funnel (Cloudflare optional).
- Documents the new **Help → Keep serving while DST is closed** service.

Version/download blocks auto-sync from the latest GitHub release at build time, so no manual version edits were needed. Site builds clean (`npm run build`, 9 pages).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>