### PR TITLE
12.11.2: show console windows in user session when backend is in Session 0 (service mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.11.2] - 2026-06-24
+
+### Fixed
+
+- **Console windows (server `update`, Funcom `battlegroup.bat`, `edit`) now appear when the "Keep serving while DST is closed" service is active.** That service runs the backend in Windows **Session 0**, where a normal `Start-Process` opened the console on the invisible Session 0 desktop — so clicking update / edit / Open battlegroup.bat looked like it did nothing (no window, no UAC). DST now detects Session 0 and relays these elevated launches into the signed-in user's interactive session via a one-shot Interactive/Highest scheduled task, so the window is visible. Interactive (non-service) launches are unchanged. Regression introduced with service mode in 12.11.0.
+
 ## [12.11.0] - 2026-06-23
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.11.0'
+$script:DuneToolVersion = '12.11.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.11.0',
+    [string]$Version = '12.11.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.11.0</Version>
+    <Version>12.11.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.11.0"
+#define MyAppVersion "12.11.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Commands.ps1
+++ b/app/server/lib/Commands.ps1
@@ -321,6 +321,104 @@ function Get-DuneCommandByName {
     return $null
 }
 
+# ---------------------------------------------------------------------------
+# Visible-window launch that survives Session 0 (service mode).
+#
+# When DST runs as the "Keep serving while DST is closed" service, the backend
+# lives in Windows' non-interactive Session 0. A plain Start-Process there opens
+# its window on the invisible Session 0 desktop, so the operator never sees the
+# update / battlegroup / edit console (a regression introduced with service
+# mode in the 12.11 line). The interactive autostart path is unaffected.
+#
+# Test-DuneCanShowWindowDirectly is true only when this process is in an
+# interactive session (SessionId != 0); there we keep the original
+# Start-Process -Verb RunAs behaviour. Otherwise we relay the launch into the
+# signed-in user's interactive session via a one-shot Interactive/Highest
+# scheduled task (the same principal type the autostart task uses), so the
+# window appears on the user's desktop. The task is removed once it has fired;
+# the spawned window keeps running independently.
+# ---------------------------------------------------------------------------
+function Test-DuneCanShowWindowDirectly {
+    try {
+        return ([System.Diagnostics.Process]::GetCurrentProcess().SessionId -ne 0)
+    } catch {
+        return $true
+    }
+}
+
+function Start-DuneVisibleElevated {
+    param(
+        [Parameter(Mandatory)][string]$FilePath,
+        [string[]]$ArgumentList = @(),
+        [string]$WorkingDirectory
+    )
+
+    # Interactive backend (normal launch / autostart): show the window directly.
+    if (Test-DuneCanShowWindowDirectly) {
+        $sp = @{
+            FilePath    = $FilePath
+            WindowStyle = 'Normal'
+            Verb        = 'RunAs'
+            PassThru    = $true
+            ErrorAction = 'Stop'
+        }
+        if ($ArgumentList.Count -gt 0) { $sp.ArgumentList = $ArgumentList }
+        if ($WorkingDirectory)         { $sp.WorkingDirectory = $WorkingDirectory }
+        $proc = Start-Process @sp
+        return @{ ok = $true; pid = $(if ($proc) { $proc.Id } else { $null }); via = 'direct' }
+    }
+
+    # Session 0 (service mode): relay into the interactive session so the window
+    # is visible. Requires the ScheduledTasks module and a signed-in user.
+    if (-not (Get-Command Register-ScheduledTask -ErrorAction SilentlyContinue) -or
+        -not (Get-Command New-ScheduledTaskAction -ErrorAction SilentlyContinue)) {
+        throw "Running in Session 0 (service mode) and the ScheduledTasks module is unavailable, so the console window cannot be shown in your session. Turn off 'Keep serving while DST is closed' (Help menu) and relaunch DST, or run the command from an elevated PowerShell."
+    }
+
+    $user = if (Get-Command Get-DuneAutostartUserName -ErrorAction SilentlyContinue) {
+        Get-DuneAutostartUserName
+    } else {
+        if ($env:USERDOMAIN -and $env:USERNAME) { "$env:USERDOMAIN\$env:USERNAME" } else { $env:USERNAME }
+    }
+    $folder = if (Get-Command Get-DuneAutostartTaskFolder -ErrorAction SilentlyContinue) {
+        Get-DuneAutostartTaskFolder
+    } else {
+        '\Dune Server\'
+    }
+    $taskName = "DuneVisibleLaunch-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+
+    # Quote only args that contain whitespace and are not already quoted; the
+    # caller may pre-quote paths (e.g. the -File argument).
+    $argString = (@($ArgumentList) | ForEach-Object {
+        $s = [string]$_
+        if ($s -match '\s' -and -not ($s.StartsWith('"') -and $s.EndsWith('"'))) { '"' + $s + '"' } else { $s }
+    }) -join ' '
+
+    $actionParams = @{ Execute = $FilePath }
+    if ($argString)        { $actionParams.Argument = $argString }
+    if ($WorkingDirectory) { $actionParams.WorkingDirectory = $WorkingDirectory }
+
+    $action    = New-ScheduledTaskAction @actionParams
+    $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Highest
+    $settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances Parallel
+
+    # Purge any spent relay tasks from earlier launches BEFORE creating this one,
+    # rather than self-deleting right after Start (which races a cold Task
+    # Scheduler that may not have spawned the action process yet). Each relay
+    # task has no trigger, so a leftover is inert until the next purge.
+    try {
+        Get-ScheduledTask -TaskPath $folder -ErrorAction SilentlyContinue |
+            Where-Object { $_.TaskName -like 'DuneVisibleLaunch-*' } |
+            ForEach-Object {
+                try { Unregister-ScheduledTask -TaskPath $folder -TaskName $_.TaskName -Confirm:$false -ErrorAction SilentlyContinue | Out-Null } catch {}
+            }
+    } catch {}
+
+    Register-ScheduledTask -TaskPath $folder -TaskName $taskName -Action $action -Principal $principal -Settings $settings -Force | Out-Null
+    Start-ScheduledTask -TaskPath $folder -TaskName $taskName -ErrorAction Stop
+    return @{ ok = $true; pid = $null; via = 'scheduled-task' }
+}
+
 # Launch a command in a new visible console window (elevated).
 # Uses pwsh -File <dune-server.ps1> -Cmd <name>, the same entry point the WPF
 # UI used for external commands. Phase 4 will route InApp commands through the
@@ -346,20 +444,21 @@ function Invoke-DuneCommandExternal {
     # or error) stays readable instead of the window closing instantly. InApp
     # commands capture stdout and must never pause, so they don't get the flag.
     if ($cmd.Mode -eq 'Console') { $argList += '-PauseOnExit' }
-    $startArgs = @{
-        FilePath         = $script:PwshExe
-        ArgumentList     = $argList
-        WorkingDirectory = (Split-Path -Parent $script:MainScript)
-        WindowStyle      = 'Normal'
-        Verb             = 'RunAs'   # dune-server.ps1 requires admin
-        PassThru         = $true
-    }
-    $proc = Start-Process @startArgs
+    # Launch so the window is VISIBLE to the signed-in user even when this
+    # backend runs in Session 0 ("Keep serving while DST is closed" service
+    # mode). A plain Start-Process there opens the console on the invisible
+    # Session 0 desktop; Start-DuneVisibleElevated relays it into the
+    # interactive session when needed. dune-server.ps1 requires admin.
+    $launch = Start-DuneVisibleElevated `
+        -FilePath $script:PwshExe `
+        -ArgumentList $argList `
+        -WorkingDirectory (Split-Path -Parent $script:MainScript)
     return @{
         ok      = $true
         name    = $cmd.Name
         mode    = $cmd.Mode
-        pid     = if ($proc) { $proc.Id } else { $null }
+        pid     = $launch.pid
+        via     = $launch.via
         started = (Get-Date).ToString('o')
     }
 }

--- a/app/server/routes/Config.ps1
+++ b/app/server/routes/Config.ps1
@@ -200,11 +200,15 @@ Register-DuneRoute -Method POST -Path '/api/config/open-battlegroup-bat' -Handle
     }
 
     try {
-        $proc = Start-Process -FilePath $bat -WorkingDirectory $steam -Verb RunAs -PassThru -ErrorAction Stop
+        # Use the session-aware launcher so the window is visible even when the
+        # backend runs in Session 0 (service mode) instead of landing on the
+        # invisible Session 0 desktop.
+        $launch = Start-DuneVisibleElevated -FilePath $bat -WorkingDirectory $steam
         Write-DuneJson -Response $res -Body @{
             ok      = $true
             path    = $bat
-            pid     = if ($proc) { $proc.Id } else { $null }
+            pid     = $launch.pid
+            via     = $launch.via
             message = 'Opened Funcom battlegroup.bat in an elevated window.'
         }
     } catch {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.11.0"
+$script:ToolVersion = "12.11.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Fixes the service-mode (Session 0) console-visibility regression introduced in 12.11.0.

## Problem
"Keep serving while DST is closed" runs the backend in Windows **Session 0**. A plain `Start-Process` there opens its window on the invisible Session 0 desktop, so server `update`, the Funcom `battlegroup.bat`, and `edit` launched but never appeared for the operator (no window, no UAC).

## Fix
`Start-DuneVisibleElevated` detects Session 0 and relays the elevated launch into the signed-in user's interactive session via a one-shot Interactive/Highest scheduled task (the same principal autostart uses). Interactive (non-service) launches keep the original `Start-Process -Verb RunAs` path. Wires `Invoke-DuneCommandExternal` + the `open-battlegroup-bat` route through it.

## Validation
Built `DuneServerSetup.exe`, installed it, enabled service mode (backend confirmed in Session 0), clicked Open battlegroup.bat -> the relay scheduled task fired and the console window appeared in the interactive session. Confirmed on a live host.

Bumps the five version stamps 12.11.0 -> 12.11.2 and rolls the CHANGELOG.