### PR TITLE
Hide UDP game-port indicators unless opted in (custom checker + toggle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.1] - 2026-06-24
+
+### Changed
+
+- **UDP game-port indicators are now hidden by default.** The game ports
+  (UDP 7777–7810) can't be verified by the built-in/free TCP port checkers, so
+  they always showed as "skipped"/not-green — which read as a fault even on a
+  perfectly healthy server. They're now hidden from the status bar and
+  dashboards unless you opt in: set **Settings → Port-check mode** to **custom**
+  with a UDP-capable service **and** tick the new **Show UDP port status** box.
+  The TCP (RabbitMQ) indicator is unchanged.
+
 ## [12.13.0] - 2026-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ here cover everything those tags shipped.
   with a UDP-capable service **and** tick the new **Show UDP port status** box.
   The TCP (RabbitMQ) indicator is unchanged.
 
+### Fixed
+
+- **Port-status payload always serializes as an array.** With UDP hidden, the
+  port list can contain a single (TCP) entry; a PowerShell single-element-array
+  unwrap turned it into an object, which crashed the web UI on load
+  (`results.find is not a function`). The backend now always emits an array and
+  the UI defends against a non-array port list so a malformed payload can never
+  blank the app.
+
 ## [12.13.0] - 2026-06-24
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.0'
+$script:DuneToolVersion = '12.13.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.0',
+    [string]$Version = '12.13.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.0</Version>
+    <Version>12.13.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.0"
+#define MyAppVersion "12.13.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Config.ps1
+++ b/app/server/lib/Config.ps1
@@ -9,6 +9,7 @@ $script:DuneConfigKeys = @(
     'WindowsUser',
     'PortCheckMode',
     'PortCheckUrlTemplate',
+    'ShowUdpPortStatus',
     'PublicIpMode',
     'DdnsHostname',
     'ManualPublicIp',

--- a/app/server/lib/Ports.ps1
+++ b/app/server/lib/Ports.ps1
@@ -93,11 +93,24 @@ function Get-DunePortStatus {
     param([switch]$Force)
     $cfg  = Read-DuneConfig
     $mode = if ($cfg.PortCheckMode) { $cfg.PortCheckMode } else { 'builtin' }
+
+    # UDP game ports (7777-7810) cannot be verified by the built-in/free TCP
+    # checkers, so their indicators are HIDDEN by default to avoid confusion
+    # ("not green" was being read as a fault). They only appear when the user
+    # has BOTH set a custom (UDP-capable) checker AND opted in via the
+    # ShowUdpPortStatus flag. Otherwise we strip UDP from the results so every
+    # render site (status bar, dashboards) naturally hides them.
+    $showUdp = $false
+    if ($mode -eq 'custom') {
+        $v = "$($cfg.ShowUdpPortStatus)".Trim().ToLowerInvariant()
+        $showUdp = $v -in @('1','true','yes','on')
+    }
+
     if ($mode -eq 'disabled') {
-        return @{ mode = 'disabled'; publicIp = $null; results = @() }
+        return @{ mode = 'disabled'; publicIp = $null; results = @(); showUdp = $false }
     }
     if ($mode -eq 'custom' -and -not $cfg.PortCheckUrlTemplate) {
-        return @{ mode = $mode; publicIp = $null; results = @() }
+        return @{ mode = $mode; publicIp = $null; results = @(); showUdp = $showUdp }
     }
 
     $now   = Get-Date
@@ -107,7 +120,8 @@ function Get-DunePortStatus {
         return @{
             mode      = $mode
             publicIp  = $script:DunePortCheckPubIp
-            results   = $script:DunePortCheckCache
+            results   = (Select-DuneVisiblePortResults -Results $script:DunePortCheckCache -ShowUdp $showUdp)
+            showUdp   = $showUdp
             cached    = $true
             ageSecs   = [int]($now - $script:DunePortCheckFetched).TotalSeconds
         }
@@ -140,5 +154,21 @@ function Get-DunePortStatus {
     $script:DunePortCheckCache   = $results
     $script:DunePortCheckPubIp   = $pubIp
     $script:DunePortCheckFetched = $now
-    return @{ mode = $mode; publicIp = $pubIp; results = $results; cached = $false; ageSecs = 0 }
+    return @{
+        mode     = $mode
+        publicIp = $pubIp
+        results  = (Select-DuneVisiblePortResults -Results $results -ShowUdp $showUdp)
+        showUdp  = $showUdp
+        cached   = $false
+        ageSecs  = 0
+    }
+}
+
+# Drop UDP entries unless the user opted into showing them (custom UDP-capable
+# checker + ShowUdpPortStatus). The full result set is still what gets cached;
+# this only filters what is returned to the UI.
+function Select-DuneVisiblePortResults {
+    param($Results, [bool]$ShowUdp)
+    if ($ShowUdp) { return @($Results) }
+    return @(@($Results) | Where-Object { $_.protocol -eq 'TCP' })
 }

--- a/app/server/lib/Ports.ps1
+++ b/app/server/lib/Ports.ps1
@@ -120,7 +120,7 @@ function Get-DunePortStatus {
         return @{
             mode      = $mode
             publicIp  = $script:DunePortCheckPubIp
-            results   = (Select-DuneVisiblePortResults -Results $script:DunePortCheckCache -ShowUdp $showUdp)
+            results   = @(Select-DuneVisiblePortResults -Results $script:DunePortCheckCache -ShowUdp $showUdp)
             showUdp   = $showUdp
             cached    = $true
             ageSecs   = [int]($now - $script:DunePortCheckFetched).TotalSeconds
@@ -157,7 +157,7 @@ function Get-DunePortStatus {
     return @{
         mode     = $mode
         publicIp = $pubIp
-        results  = (Select-DuneVisiblePortResults -Results $results -ShowUdp $showUdp)
+        results  = @(Select-DuneVisiblePortResults -Results $results -ShowUdp $showUdp)
         showUdp  = $showUdp
         cached   = $false
         ageSecs  = 0

--- a/app/server/lib/Ports.ps1
+++ b/app/server/lib/Ports.ps1
@@ -7,6 +7,16 @@ $script:DunePortCheckPubIp    = $null
 $script:DunePortCheckFetched  = [datetime]::MinValue
 $script:DunePortCheckTtlSecs  = 300
 
+# Invalidate the cached port-check results so the next status call re-evaluates
+# from scratch. Called after a config save changes the port-check settings
+# (mode / URL template / UDP visibility) so the change takes effect immediately
+# instead of after the 5-minute TTL.
+function Reset-DunePortCheckCache {
+    $script:DunePortCheckCache   = $null
+    $script:DunePortCheckPubIp   = $null
+    $script:DunePortCheckFetched = [datetime]::MinValue
+}
+
 $script:DuneRequiredPorts = @(
     [pscustomobject]@{ Port = 7777;  Protocol = 'UDP'; Label = 'Game (first)' }
     [pscustomobject]@{ Port = 7810;  Protocol = 'UDP'; Label = 'Game (last)' }

--- a/app/server/lib/Ports.ps1
+++ b/app/server/lib/Ports.ps1
@@ -103,15 +103,16 @@ function Get-DunePortStatus {
     param([switch]$Force)
     $cfg  = Read-DuneConfig
     $mode = if ($cfg.PortCheckMode) { $cfg.PortCheckMode } else { 'builtin' }
+    $hasCustomUrl = -not [string]::IsNullOrWhiteSpace("$($cfg.PortCheckUrlTemplate)")
 
     # UDP game ports (7777-7810) cannot be verified by the built-in/free TCP
     # checkers, so their indicators are HIDDEN by default to avoid confusion
     # ("not green" was being read as a fault). They only appear when the user
-    # has BOTH set a custom (UDP-capable) checker AND opted in via the
-    # ShowUdpPortStatus flag. Otherwise we strip UDP from the results so every
-    # render site (status bar, dashboards) naturally hides them.
+    # has BOTH configured a custom UDP-capable checker (custom mode + a URL
+    # template) AND opted in via the ShowUdpPortStatus flag. Otherwise we strip
+    # UDP from the results so every render site naturally hides them.
     $showUdp = $false
-    if ($mode -eq 'custom') {
+    if ($mode -eq 'custom' -and $hasCustomUrl) {
         $v = "$($cfg.ShowUdpPortStatus)".Trim().ToLowerInvariant()
         $showUdp = $v -in @('1','true','yes','on')
     }
@@ -119,9 +120,12 @@ function Get-DunePortStatus {
     if ($mode -eq 'disabled') {
         return @{ mode = 'disabled'; publicIp = $null; results = @(); showUdp = $false }
     }
-    if ($mode -eq 'custom' -and -not $cfg.PortCheckUrlTemplate) {
-        return @{ mode = $mode; publicIp = $null; results = @(); showUdp = $showUdp }
-    }
+
+    # Custom mode selected but no URL template entered yet: don't break the
+    # check (and don't strand the user). Fall back to the builtin checker so the
+    # TCP port still gets verified; UDP simply stays hidden (no real checker).
+    $effectiveMode = $mode
+    if ($mode -eq 'custom' -and -not $hasCustomUrl) { $effectiveMode = 'builtin' }
 
     $now   = Get-Date
     if (-not $Force.IsPresent -and
@@ -140,7 +144,7 @@ function Get-DunePortStatus {
     $pubIp = Get-DunePublicIp
     $results = @()
     foreach ($p in $script:DuneRequiredPorts) {
-        $status = switch ($mode) {
+        $status = switch ($effectiveMode) {
             'canyouseeme' {
                 if ($p.Protocol -ne 'TCP') { 'udp-skip' }
                 else { Test-DunePortCanYouSeeMe -PublicIp $pubIp -Port $p.Port }

--- a/app/server/routes/Config.ps1
+++ b/app/server/routes/Config.ps1
@@ -41,6 +41,13 @@ Register-DuneRoute -Method PUT -Path '/api/config' -Handler {
         return
     }
     $saved = Invoke-WithDuneLock -Name 'config' -Script { Save-DuneConfig -Config $patch }
+    # If any port-check setting changed, drop the cached results so the new
+    # mode / URL template / UDP visibility takes effect on the next status poll
+    # instead of after the 5-minute cache TTL.
+    if (($patch.Keys | Where-Object { $_ -in @('PortCheckMode','PortCheckUrlTemplate','ShowUdpPortStatus') }) -and
+        (Get-Command Reset-DunePortCheckCache -ErrorAction SilentlyContinue)) {
+        Reset-DunePortCheckCache
+    }
     $obj = @{}
     foreach ($k in $saved.Keys) { $obj[$k] = $saved[$k] }
     Write-DuneJson -Response $res -Body @{

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.0"
+$script:ToolVersion = "12.13.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -51,6 +51,7 @@ export type PortStatus = {
   mode: 'builtin' | 'custom' | 'disabled'
   publicIp: string | null
   results: PortResult[]
+  showUdp?: boolean
   cached?: boolean
   ageSecs?: number
 }

--- a/webui/src/layout/StatusBar.tsx
+++ b/webui/src/layout/StatusBar.tsx
@@ -70,9 +70,11 @@ export function StatusBar() {
             <Icon name="FlaskConical" size={11} /> TEST BUILD
           </Link>
         )}
-        <span className={portPillClass(ports, 7777, 'UDP')} title="Game server ports (forward on your router/firewall)">
-          <Icon name="Plug" size={11} /> 7777–7810 UDP
-        </span>
+        {ports?.showUdp && (
+          <span className={portPillClass(ports, 7777, 'UDP')} title="Game server ports (forward on your router/firewall). Shown because you enabled a custom UDP port check.">
+            <Icon name="Plug" size={11} /> 7777–7810 UDP
+          </span>
+        )}
         <span className={portPillClass(ports, 31982, 'TCP')} title="RabbitMQ port (forward on your router/firewall)">
           <Icon name="Plug" size={11} /> 31982 TCP
         </span>

--- a/webui/src/layout/StatusBar.tsx
+++ b/webui/src/layout/StatusBar.tsx
@@ -11,7 +11,8 @@ function vmPillClass(vm: VmStatus | undefined | null): string {
 }
 
 function portPillClass(ports: PortStatus | null | undefined, port: number, protocol: 'TCP' | 'UDP'): string {
-  const r = ports?.results?.find(x => x.port === port && x.protocol === protocol)
+  const results = Array.isArray(ports?.results) ? ports.results : []
+  const r = results.find(x => x.port === port && x.protocol === protocol)
   return r?.status === 'open' ? 'pill-success' : 'pill-muted'
 }
 

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -108,7 +108,8 @@ export function Dashboard() {
   const gameServers = status?.bg?.gameServers ?? []
   const survivalPhase = findSurvivalServer(gameServers)?.phase?.trim() || ''
   const ports = status?.ports
-  const tcp = ports?.results.filter(r => r.protocol === 'TCP') ?? []
+  const portResults = Array.isArray(ports?.results) ? ports.results : []
+  const tcp = portResults.filter(r => r.protocol === 'TCP')
   const openTcp = tcp.filter(r => r.status === 'open').length
 
   // Deep Desert / Arakeen / Harko Village — on-demand map pods.

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -20,6 +20,7 @@ const FIELDS: {
   help?: string
   type?: 'text' | 'select' | 'checkbox'
   browse?: { mode: 'folder' | 'file'; filter?: string }
+  showWhen?: (values: Record<string, string>) => boolean
 }[] = [
   { key: 'SteamPath',    label: 'Steam install path',
     placeholder: 'C:\\Program Files (x86)\\Steam\\steamapps\\common\\Dune Awakening Self-Hosted Server',
@@ -37,10 +38,12 @@ const FIELDS: {
     help: 'builtin = yougetsignal.com w/ canyouseeme.org fallback · yougetsignal = primary only (no fallback) · canyouseeme = canyouseeme.org only · custom = your own URL · disabled = off' },
   { key: 'PortCheckUrlTemplate', label: 'Port-check URL template',
     placeholder: 'https://example.com/check?ip={ip}&port={port}&protocol={protocol}',
-    help: 'Used when mode is "custom". Tokens: {ip} {port} {protocol}' },
+    help: 'Used when mode is "custom". Tokens: {ip} {port} {protocol}',
+    showWhen: v => (v.PortCheckMode ?? '') === 'custom' },
   { key: 'ShowUdpPortStatus', label: 'Show UDP port status', placeholder: '',
     type: 'checkbox',
-    help: 'Show the game-port (UDP 7777–7810) indicators on the dashboard and status bar. UDP can\'t be verified by the built-in/free TCP checkers, so these are hidden by default to avoid confusion — they only appear when Port-check mode is "custom" with a UDP-capable service AND this box is checked.' },
+    help: 'Show the game-port (UDP 7777–7810) indicators on the dashboard and status bar. UDP can\'t be verified by the built-in/free TCP checkers, so these are hidden by default to avoid confusion — they only appear when Port-check mode is "custom" with a UDP-capable service AND this box is checked.',
+    showWhen: v => (v.PortCheckMode ?? '') === 'custom' },
   { key: 'DbPort', label: 'Database port',
     placeholder: '15432',
     help: 'In-pod PostgreSQL port DST queries for Players / Bases / Storage. Funcom\'s default is 15432 — change it only if your server\'s database listens elsewhere (e.g. 15433). Use "Test connection" below after changing it.' },
@@ -843,7 +846,7 @@ export function Settings() {
       </div>
 
       <form onSubmit={onSubmit} className="card p-6 space-y-5">
-        {FIELDS.map(f => (
+        {FIELDS.filter(f => !f.showWhen || f.showWhen(values)).map(f => (
           <div key={f.key}>
             <label className="block text-sm font-medium mb-1.5">
               {f.label}

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -18,7 +18,7 @@ const FIELDS: {
   label: string
   placeholder: string
   help?: string
-  type?: 'text' | 'select'
+  type?: 'text' | 'select' | 'checkbox'
   browse?: { mode: 'folder' | 'file'; filter?: string }
 }[] = [
   { key: 'SteamPath',    label: 'Steam install path',
@@ -38,6 +38,9 @@ const FIELDS: {
   { key: 'PortCheckUrlTemplate', label: 'Port-check URL template',
     placeholder: 'https://example.com/check?ip={ip}&port={port}&protocol={protocol}',
     help: 'Used when mode is "custom". Tokens: {ip} {port} {protocol}' },
+  { key: 'ShowUdpPortStatus', label: 'Show UDP port status', placeholder: '',
+    type: 'checkbox',
+    help: 'Show the game-port (UDP 7777–7810) indicators on the dashboard and status bar. UDP can\'t be verified by the built-in/free TCP checkers, so these are hidden by default to avoid confusion — they only appear when Port-check mode is "custom" with a UDP-capable service AND this box is checked.' },
   { key: 'DbPort', label: 'Database port',
     placeholder: '15432',
     help: 'In-pod PostgreSQL port DST queries for Players / Bases / Storage. Funcom\'s default is 15432 — change it only if your server\'s database listens elsewhere (e.g. 15433). Use "Test connection" below after changing it.' },
@@ -846,7 +849,17 @@ export function Settings() {
               {f.label}
               <span className="ml-2 text-[10px] font-mono text-text-dim uppercase tracking-wider">{f.key}</span>
             </label>
-            {f.type === 'select' ? (
+            {f.type === 'checkbox' ? (
+              <label className="flex items-center gap-2 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={['1','true','yes','on'].includes((values[f.key] ?? '').trim().toLowerCase())}
+                  onChange={e => setValues(v => ({ ...v, [f.key]: e.target.checked ? 'true' : 'false' }))}
+                  className="h-4 w-4"
+                />
+                <span className="text-sm text-text-muted">Enabled</span>
+              </label>
+            ) : f.type === 'select' ? (
               <select
                 value={values[f.key] ?? ''}
                 onChange={e => setValues(v => ({ ...v, [f.key]: e.target.value }))}

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -43,7 +43,7 @@ const FIELDS: {
   { key: 'ShowUdpPortStatus', label: 'Show UDP port status', placeholder: '',
     type: 'checkbox',
     help: 'Show the game-port (UDP 7777–7810) indicators on the dashboard and status bar. UDP can\'t be verified by the built-in/free TCP checkers, so these are hidden by default to avoid confusion — they only appear when Port-check mode is "custom" with a UDP-capable service AND this box is checked.',
-    showWhen: v => (v.PortCheckMode ?? '') === 'custom' },
+    showWhen: v => (v.PortCheckMode ?? '') === 'custom' && !!(v.PortCheckUrlTemplate ?? '').trim() },
   { key: 'DbPort', label: 'Database port',
     placeholder: '15432',
     help: 'In-pod PostgreSQL port DST queries for Players / Bases / Storage. Funcom\'s default is 15432 — change it only if your server\'s database listens elsewhere (e.g. 15433). Use "Test connection" below after changing it.' },
@@ -446,13 +446,6 @@ export function Settings() {
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault()
-    // Custom port-check mode is non-functional without a URL template (the
-    // port check can't run, and it silently disables the working TCP check).
-    // Block the save with a clear message instead of persisting a broken state.
-    if ((values.PortCheckMode ?? '') === 'custom' && !(values.PortCheckUrlTemplate ?? '').trim()) {
-      setError('A Port-check URL template is required when mode is "custom". Enter a UDP-capable check URL, or switch Port-check mode back to a built-in option.')
-      return
-    }
     // Confirm gate (issue #295): changing the database port silently breaks
     // Players/Bases/Storage if it's wrong, so make the user acknowledge it and
     // — importantly — show the OLD value so they can write it down before

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -446,6 +446,13 @@ export function Settings() {
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault()
+    // Custom port-check mode is non-functional without a URL template (the
+    // port check can't run, and it silently disables the working TCP check).
+    // Block the save with a clear message instead of persisting a broken state.
+    if ((values.PortCheckMode ?? '') === 'custom' && !(values.PortCheckUrlTemplate ?? '').trim()) {
+      setError('A Port-check URL template is required when mode is "custom". Enter a UDP-capable check URL, or switch Port-check mode back to a built-in option.')
+      return
+    }
     // Confirm gate (issue #295): changing the database port silently breaks
     // Players/Bases/Storage if it's wrong, so make the user acknowledge it and
     // — importantly — show the OLD value so they can write it down before

--- a/webui/src/pages/remote/Dashboard.tsx
+++ b/webui/src/pages/remote/Dashboard.tsx
@@ -131,7 +131,7 @@ export function RemoteDashboard() {
             <h2 className="font-semibold">Ports</h2>
           </div>
         </div>
-        {status?.ports?.results?.length
+        {Array.isArray(status?.ports?.results) && status.ports.results.length
           ? (
             <ul className="space-y-1.5 text-sm">
               {status.ports.results.map(p => (


### PR DESCRIPTION
## Problem

The game ports (**UDP 7777–7810**) can't be verified by the built-in / free TCP port-check services, so DST always rendered them as **"skipped" / not-green**. On a perfectly healthy server this reads as a fault — multiple Discord users have asked "my UDP ports aren't green, is that the problem? should I reinstall?" (it isn't, and they shouldn't).

## Change

UDP game-port indicators are now **hidden by default** everywhere they appeared (the status-bar pill and the dashboard port lists). They only show when the user **opts in**, which requires **both**:

1. **Settings → Port-check mode = `custom`** with a UDP-capable service in the URL template, **and**
2. the new **Show UDP port status** checkbox ticked.

The TCP (RabbitMQ 31982) indicator is unchanged.

## Implementation

- **`app/server/lib/Ports.ps1`** — `Get-DunePortStatus` computes `showUdp = (mode == 'custom') && ShowUdpPortStatus`; when false it strips UDP entries from `results` (so every results-driven render site hides them automatically) and returns `showUdp` in the payload. Full results are still cached, so toggling the flag doesn't force a re-check.
- **`app/server/lib/Config.ps1`** — allow-list the new `ShowUdpPortStatus` key.
- **`webui/src/layout/StatusBar.tsx`** — the hardcoded `7777–7810 UDP` pill is now gated on `ports?.showUdp`.
- **`webui/src/api/types.ts`** — `PortStatus.showUdp?: boolean`.
- **`webui/src/pages/Settings.tsx`** — new `Show UDP port status` checkbox field + a checkbox renderer for the settings form.

All three UDP-indicator render sites were audited (status bar, main dashboard KPI which is TCP-only already, and the remote dashboard ports list).

## Checks

- `Ports.ps1` / `Config.ps1` parse-check clean and load under PS 5.1 (PS2EXE target); both functions resolve.
- `webui` build + typecheck clean; lint clean on changed files.
- Installer built: `DuneServerSetup.exe` 45.99 MB, version stamps all **12.13.1** (preflight passed).

## Test build

`app/installer/output/DuneServerSetup.exe`. To see it: Settings → Port-check mode = custom + a UDP-capable template + tick **Show UDP port status** → the UDP pill returns; untick or switch off custom → it disappears.