### PR TITLE
Suppress transient red error banner on mobile/remote portal load (grace after >2 failures)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **No more transient red error banner when opening the mobile apps / remote
+  portal.** The remote Dashboard and Maps views fired their first data request
+  the instant they mounted; over a remote tunnel that first request often fails
+  while the connection is still warming up, flashing a red error banner that
+  cleared a couple seconds later on the next poll. They now retry quietly and
+  only surface the banner after **more than 2 consecutive failures**, so a real
+  outage still shows within a couple seconds but a warmup blip never flashes.
+
 ## [12.13.0] - 2026-06-24
 
 ### Added

--- a/webui/src/pages/remote/Dashboard.tsx
+++ b/webui/src/pages/remote/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import {
   getRemoteStatus,
@@ -40,26 +40,50 @@ export function RemoteDashboard() {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
+  // Suppress the transient error banner on load: over a remote tunnel the first
+  // request often fails while the connection warms up. Retry quietly and only
+  // surface the red banner after more than 2 consecutive failures, so a genuine
+  // outage still shows (within a couple seconds) but a warmup blip never flashes.
+  const failRef = useRef(0)
+  const retryRef = useRef<number | null>(null)
 
   const load = useCallback(async (showSpinner: boolean) => {
     if (showSpinner) setLoading(true); else setRefreshing(true)
-    setError(null)
+    let scheduledRetry = false
+    const scheduleRetry = () => {
+      scheduledRetry = true
+      if (retryRef.current !== null) window.clearTimeout(retryRef.current)
+      retryRef.current = window.setTimeout(() => { void load(showSpinner) }, 1800)
+    }
     try {
       const [s, b] = await Promise.allSettled([getRemoteStatus(), getRemoteBackups()])
-      if (s.status === 'fulfilled') setStatus(s.value)
-      else if (s.reason instanceof RemoteApiError && s.reason.status === 401) {
+      if (s.status === 'fulfilled') {
+        setStatus(s.value)
+        failRef.current = 0
+        setError(null)
+      } else if (s.reason instanceof RemoteApiError && s.reason.status === 401) {
         window.location.href = '/remote/login-required'; return
-      } else setError(s.reason instanceof Error ? s.reason.message : String(s.reason))
+      } else {
+        failRef.current += 1
+        if (failRef.current > 2) setError(s.reason instanceof Error ? s.reason.message : String(s.reason))
+        else scheduleRetry()
+      }
       if (b.status === 'fulfilled') setBackups(b.value)
       // Backups failing is non-fatal — VM may be down. Show what we have.
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
+      failRef.current += 1
+      if (failRef.current > 2) setError(e instanceof Error ? e.message : String(e))
+      else scheduleRetry()
     } finally {
-      setLoading(false); setRefreshing(false)
+      setRefreshing(false)
+      if (!scheduledRetry) setLoading(false)
     }
   }, [])
 
   useEffect(() => { void load(true) }, [load])
+
+  // Clear any pending grace-retry timer on unmount.
+  useEffect(() => () => { if (retryRef.current !== null) window.clearTimeout(retryRef.current) }, [])
 
   // Auto-refresh every 30 s while the page is visible. Cheap because the
   // backend caches port-status results for 5 minutes.

--- a/webui/src/pages/remote/Maps.tsx
+++ b/webui/src/pages/remote/Maps.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import {
   getRemoteMaps,
@@ -42,24 +42,44 @@ export function RemoteMaps() {
   const [refreshing, setRefreshing] = useState(false)
   const [actions, setActions] = useState<Record<string, ActionState>>({})
   const [globalAction, setGlobalAction] = useState<ActionState>({ busy: null, message: null, isError: false })
+  // Grace for the transient load error (see load()): only surface the banner
+  // after more than 2 consecutive failures.
+  const failRef = useRef(0)
+  const retryRef = useRef<number | null>(null)
 
   const load = useCallback(async (showSpinner: boolean) => {
     if (showSpinner) setLoading(true); else setRefreshing(true)
-    setError(null)
+    let scheduledRetry = false
+    const scheduleRetry = () => {
+      scheduledRetry = true
+      if (retryRef.current !== null) window.clearTimeout(retryRef.current)
+      retryRef.current = window.setTimeout(() => { void load(showSpinner) }, 1800)
+    }
     try {
       const r = await getRemoteMaps()
       setData(r)
+      failRef.current = 0
+      setError(null)
     } catch (e) {
       if (e instanceof RemoteApiError && e.status === 401) {
         window.location.href = '/remote/login-required'; return
       }
-      setError(e instanceof Error ? e.message : String(e))
+      // Suppress the transient error banner on load: over a remote tunnel the
+      // first request often fails while the connection warms up. Retry quietly
+      // and only surface the banner after more than 2 consecutive failures.
+      failRef.current += 1
+      if (failRef.current > 2) setError(e instanceof Error ? e.message : String(e))
+      else scheduleRetry()
     } finally {
-      setLoading(false); setRefreshing(false)
+      setRefreshing(false)
+      if (!scheduledRetry) setLoading(false)
     }
   }, [])
 
   useEffect(() => { void load(true) }, [load])
+
+  // Clear any pending grace-retry timer on unmount.
+  useEffect(() => () => { if (retryRef.current !== null) window.clearTimeout(retryRef.current) }, [])
 
   // Refresh after every successful write so the user sees the new state.
   const refreshSilently = useCallback(() => { void load(false) }, [load])


### PR DESCRIPTION
## Problem

When opening the **mobile apps / remote portal**, a red error banner flashes for a couple seconds, then clears on its own.

**Cause:** the remote `Dashboard` and `Maps` views set their `error` state on the **very first** failed request — and that request fires the instant the page mounts (`useEffect(() => void load(true), [])`). Over a remote tunnel (mobile via Tailscale Funnel), that first request often fails or times out while the connection is still warming up, so the banner shows; the 30s auto-refresh then succeeds and clears it.

## Fix

Both remote views now retry quietly (~1.8s) on a failed load and only surface the banner after **more than 2 consecutive failures**. Any success resets the counter and clears the error; the loading spinner is kept during grace retries (no empty flash); the retry timer is cleared on unmount.

Net: a genuine outage still surfaces within a couple seconds; a warmup blip on open never flashes red.

## Files
- `webui/src/pages/remote/Dashboard.tsx`
- `webui/src/pages/remote/Maps.tsx`

## Coordination
- **No version bump / installer rebuild** here, deliberately: avoids a stamp collision with the parallel UDP PR #359 and does not clobber its test build in the shared installer output. CHANGELOG note is under `[Unreleased]`; version assigned at release.
- Off `main` (12.13.0); does not include #359. `[Unreleased]` merges cleanly.

## Checks
- webui build + typecheck clean; lint clean on both changed files.