### PR TITLE
Fix harmless namespaces "f" not found noise during Start/Reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Harmless `namespaces "f" not found` noise during Start/Reboot.** An
+  early-boot `kubectl get pods` race could emit a partial line right after the
+  VM IP comes up; the DB-wait step treated that fragment as the namespace and
+  logged `DB wait failed … namespaces "f" not found` (non-fatal — it proceeded
+  anyway). The DB-pod parse now keeps only well-formed `funcom-seabass-* <pod>`
+  lines, so the bogus message no longer appears.
+
 ## [12.13.1] - 2026-06-24
 
 ### Changed

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1445,8 +1445,17 @@ while ($true) {
         $dbPodList = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" `
             "sudo k3s kubectl get pods -A --no-headers 2>/dev/null | awk '`$2 ~ /(-db-|postgres|^pg-|-pg-)/ && `$2 !~ /(dump|backup|fb-|migration|util|mon|pghero)/ && `$4 !~ /(Completed|Succeeded)/ {print `$1, `$2}'"
         $dbPodList = ($dbPodList | Out-String).Trim()
-        if ($dbPodList) {
-            $dbPods = $dbPodList -split "`r?`n" | Where-Object { $_.Trim() }
+        # Keep only well-formed "namespace podname" lines. An early-boot kubectl
+        # race can emit a partial/garbage line (seen in the field as a bare "f"),
+        # which previously became the namespace and produced
+        # "namespaces \"f\" not found". Require a real battlegroup namespace
+        # (funcom-seabass-*) and a non-empty pod name; if none survive, fall
+        # through to the no-DB-pods branch.
+        $dbPods = @($dbPodList -split "`r?`n" | Where-Object {
+            $_p = $_.Trim() -split '\s+', 2
+            $_p.Count -eq 2 -and $_p[0] -like 'funcom-seabass-*' -and $_p[1]
+        })
+        if ($dbPods.Count -gt 0) {
             $dbNs = ($dbPods[0] -split '\s+', 2)[0]
             $podArgs = ($dbPods | ForEach-Object { "pod/$(($_ -split '\s+', 2)[1])" }) -join ' '
             $dbResult = Invoke-WithLiveCounter -Label "Waiting for DB pod(s) Ready..." -EstimateText $estDb `
@@ -1731,8 +1740,17 @@ while ($true) {
         $dbPodList = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" `
             "sudo k3s kubectl get pods -A --no-headers 2>/dev/null | awk '`$2 ~ /(-db-|postgres|^pg-|-pg-)/ && `$2 !~ /(dump|backup|fb-|migration|util|mon|pghero)/ && `$4 !~ /(Completed|Succeeded)/ {print `$1, `$2}'"
         $dbPodList = ($dbPodList | Out-String).Trim()
-        if ($dbPodList) {
-            $dbPods = $dbPodList -split "`r?`n" | Where-Object { $_.Trim() }
+        # Keep only well-formed "namespace podname" lines. An early-boot kubectl
+        # race can emit a partial/garbage line (seen in the field as a bare "f"),
+        # which previously became the namespace and produced
+        # "namespaces \"f\" not found". Require a real battlegroup namespace
+        # (funcom-seabass-*) and a non-empty pod name; if none survive, fall
+        # through to the no-DB-pods branch.
+        $dbPods = @($dbPodList -split "`r?`n" | Where-Object {
+            $_p = $_.Trim() -split '\s+', 2
+            $_p.Count -eq 2 -and $_p[0] -like 'funcom-seabass-*' -and $_p[1]
+        })
+        if ($dbPods.Count -gt 0) {
             $dbNs = ($dbPods[0] -split '\s+', 2)[0]
             $podArgs = ($dbPods | ForEach-Object { "pod/$(($_ -split '\s+', 2)[1])" }) -join ' '
             $dbResult = Invoke-WithLiveCounter -Label "Waiting for DB pod(s) Ready..." -EstimateText $estDb `


### PR DESCRIPTION
## Problem

During a Start/Reboot, a self-hoster's startup output showed:

```
DB wait failed after 00:01 (1 pod in f) - proceeding anyway.
Error from server (NotFound): namespaces "f" not found
```

**Cause:** an early-boot `kubectl get pods` race (right after the VM IP comes up) can emit a partial/garbage line. The DB-wait step splits each line into `namespace podname` and used `$dbPods[0]`'s first token as the namespace — so a stray fragment (`f`) became the namespace, and `kubectl wait -n 'f'` returned `namespaces "f" not found`.

It's **non-fatal** (the step logs "proceeding anyway" and boot continues normally), but it's confusing log noise that looks like a failure — and it surfaced while triaging a Discord can't-connect report, where it was a red herring.

## Fix

The DB-pod parse now keeps only well-formed lines whose namespace matches the battlegroup prefix (`funcom-seabass-*`) **and** has a non-empty pod name. If none survive, it falls through to the existing "No DB pods detected" branch. Applied to **both** DB-wait sites (start path + reboot path, which were identical copies).

Verified:
- A bare `f` line is dropped; the real `funcom-seabass-… db-dbdepl-sts-0` pod is kept → correct namespace + pod args.
- An all-garbage list yields 0 pods → the no-DB-pods fallback (unchanged behavior).
- `dune-server.ps1` parse-checks clean; UTF-8 BOM preserved.

No version bump (log-noise fix; version assigned at next release). CHANGELOG note under `[Unreleased]`.