### PR TITLE
fix(mobile): stop "Failed to fetch maps" JSON parse alert when server unreachable

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -201,12 +201,21 @@ export default function App() {
     setLoadingMaps(true);
     try {
       const res = await apiFetch(serverInfo, '/api/map-spinup');
-      const data = await res.json();
-      if (data.ok && data.maps) {
+      // When the server is mid-restart / briefly unreachable the body can be
+      // empty or truncated; res.json() would then throw "Unexpected end of
+      // input" and pop an alarming alert. Parse defensively and just skip on an
+      // empty/non-OK response — the Server State card already tells the user the
+      // server can't be reached, so a maps alert is pure noise.
+      const text = await res.text();
+      if (!res.ok || !text) return;
+      let data: any;
+      try { data = JSON.parse(text); } catch { return; }
+      if (data && data.ok && data.maps) {
         setMaps(data.maps);
       }
     } catch (e) {
-      alert(`Failed to fetch maps: ${e}`);
+      // Network-level failure (server unreachable) — stay quiet; the Server
+      // State banner covers it. Don't alert.
     } finally {
       setLoadingMaps(false);
     }


### PR DESCRIPTION
## Problem

A user set up the **Android mobile app** (Tailscale Funnel) while his server was hit by the post-1.4.10.0 connection issue. The app showed the expected "Can't reach your server right now…" Server State card — **plus** an alarming modal:

> **Alert** — Failed to fetch maps: SyntaxError: JSON Parse error: Unexpected end of input

**Cause:** when the battlegroup is mid-restart / briefly unreachable, `/api/map-spinup` can return an **empty or truncated body**. `fetchMaps` did `await res.json()` directly, so the empty body threw `SyntaxError: Unexpected end of input`, and the `catch` popped `alert("Failed to fetch maps: …")`. It's pure noise stacked on top of the Server State card that already explains the server is unreachable. (The sibling fetches `fetchCatalog` / `fetchVehicleKits` already fail silently — only `fetchMaps` alerted.)

## Fix

`mobile/app/index.tsx` — `fetchMaps` now parses defensively:
- read `res.text()`, skip on empty / non-OK,
- guard `JSON.parse` in a try/catch,
- stay silent on network failure (no alert), matching the other fetches.

No behavior change when the server is reachable; the maps still populate normally.

## Notes
- Mobile app only — ships via EAS (TestFlight / Play), separate from the desktop installer, so no version-stamp bump or CHANGELOG entry.
- `npx tsc --noEmit` passes clean.
- The underlying "can't reach server" is the user's own P34/connection issue (likely Funcom-side post-1.4.10.0) — this PR only removes the misleading parse-error alert.