### PR TITLE
fix(mobile): calm "Connecting…" state instead of alarming red error banner

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -703,12 +703,16 @@ export default function App() {
             </View>
           </>
         ) : (
-          <View style={[styles.alertBox, { backgroundColor: '#7f1d1d', borderColor: '#991b1b' }]}>
-            <Text style={[styles.alertText, { color: '#fca5a5' }]}>
-              Can&apos;t reach your server right now. It may be starting up or briefly offline — the app will keep retrying and reconnect automatically. You do not need to re-scan.
+          <View style={[styles.alertBox, { backgroundColor: '#1e293b', borderColor: '#f59e0b' }]}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 6 }}>
+              <ActivityIndicator size="small" color="#f59e0b" style={{ marginRight: 8 }} />
+              <Text style={{ color: '#fcd34d', fontSize: 15, fontWeight: '700' }}>Connecting…</Text>
+            </View>
+            <Text style={[styles.alertText, { color: '#cbd5e1' }]}>
+              Waiting for your server — it may be starting up or briefly offline. The app keeps retrying and reconnects automatically, so there&apos;s nothing to do and no need to re-scan.
             </Text>
             {connDiag ? (
-              <Text selectable style={{ color: '#fecaca', fontSize: 11, fontFamily: 'Courier', marginTop: 8 }}>{connDiag}</Text>
+              <Text selectable style={{ color: '#94a3b8', fontSize: 11, fontFamily: 'Courier', marginTop: 8 }}>{connDiag}</Text>
             ) : null}
           </View>
         )}


### PR DESCRIPTION
## Problem

The mobile app's **Server State** card rendered the "can't reach server / warming up" state in **alarming danger red** (`#7f1d1d` bg / `#991b1b` border / `#fca5a5` text — the same red as the **Reboot All** button). So a perfectly normal "still connecting" state looked like a **big error**, even though the copy itself says it's just retrying and there's nothing to do.

(User feedback: "the red banner looks so bad and like a big error, even when it's just waiting to connect.")

## Fix

`mobile/app/index.tsx` — retone the unreachable state into a calm **"Connecting…"** status:
- amber accent (`#f59e0b`) on the neutral slate card background (`#1e293b`) instead of red,
- a small **spinner + "Connecting…"** header so it clearly reads as *in progress*, not broken,
- softened body copy ("Waiting for your server … nothing to do and no need to re-scan").

No logic change — same trigger (`serverState == null`), purely presentation.

## Notes
- Mobile only; ships via EAS, no desktop version bump.
- `npx tsc --noEmit` clean.
- Pairs with #364 (the maps-alert fix) — both will go out in the next app build.