### PR TITLE
Add P34 connection-check diagnostic (stale public IP detector)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Connection check (P34 / can't join) in Settings → Public IP / DDNS.** A new
+  one-click diagnostic for the most common "server is visible in the in-game
+  browser but players get *P34 / Connection Request Timed Out*" failure. It
+  compares the server's real current public IP (queried from inside the VM)
+  against the address each map actually advertises to clients
+  (`dune.farm_state`) and the K3s ExternalIP, and flags a **stale public IP** —
+  the usual root cause after an ISP IP change or a game patch/reboot. When a
+  mismatch is found it names the wrong address per map and points to the
+  existing **Apply public IP** action right below, which rewrites the
+  battlegroup + K3s ExternalIP + NAT and restarts the servers so they
+  re-advertise the correct address. Also surfaces servers that aren't
+  ready/alive and reminds you to forward UDP 7777–7810.
+
 ### Fixed
 
 - **Harmless `namespaces "f" not found` noise during Start/Reboot.** An

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.1'
+$script:DuneToolVersion = '12.13.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.1',
+    [string]$Version = '12.13.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.1</Version>
+    <Version>12.13.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.1"
+#define MyAppVersion "12.13.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -1,4 +1,4 @@
-# PublicIp - Settings-driven public IP / DDNS switch.
+﻿# PublicIp - Settings-driven public IP / DDNS switch.
 
 # Server dir captured at lib load time so the async apply runspace (and the API
 # pool runspaces) don't depend on $script:DuneServerDir being set in their
@@ -317,6 +317,150 @@ function Get-DunePublicIpStatus {
         } catch {}
     }
     return $status
+}
+
+# ----------------------------------------------------------------------------
+# P34 connectivity diagnostic.
+#
+# "P34 / Connection Request Timed Out" AFTER the server is visible in the
+# in-game browser (FLS auth fine, no 403002) is, on self-hosted servers, almost
+# always a STALE PUBLIC IP: the game servers advertise an old external IPv4 to
+# clients in dune.farm_state.game_addr, so clients dial the wrong address and
+# time out. This compares the VM's real current public IP (ipify, from inside
+# the VM) against what the maps actually advertise (farm_state) and the K3s
+# ExternalIP, and names the mismatch. The fix is the Public IP apply flow in
+# this same Settings card, which rewrites the battlegroup CR + K3s ExternalIP
+# and restarts the servers so they re-register farm_state with the right IP.
+# ----------------------------------------------------------------------------
+function Get-DuneP34Diagnostic {
+    $result = [ordered]@{
+        ok             = $false
+        reachable      = $false
+        vmIp           = $null
+        vmPublicIp     = $null
+        k3sExternalIp  = $null
+        maps           = @()
+        advertisedIps  = @()
+        staleFarmIp    = $false
+        staleK3sIp     = $false
+        serversReady   = $true
+        verdict        = 'unknown'
+        summary        = $null
+        error          = $null
+    }
+
+    if (-not (Get-Command Get-DuneDbContext -ErrorAction SilentlyContinue) -or
+        -not (Get-Command Invoke-DuneSqlRaw -ErrorAction SilentlyContinue) -or
+        -not (Get-Command Invoke-V6Ssh -ErrorAction SilentlyContinue)) {
+        $result.error = 'Server/DB helpers unavailable.'
+        $result.summary = $result.error
+        return $result
+    }
+
+    $ctx = $null
+    try { $ctx = Get-DuneDbContext } catch { $result.error = $_.Exception.Message; $result.summary = $result.error; return $result }
+    if (-not $ctx.ok) {
+        $result.error = $ctx.message
+        $result.summary = $ctx.message
+        return $result
+    }
+    $result.reachable = $true
+    $result.vmIp = [string]$ctx.ip
+
+    # 1) VM-side real public IP (what clients must reach) + K3s ExternalIP, one
+    #    SSH round trip. ipify is queried from INSIDE the VM so it reflects the
+    #    server's actual egress/WAN IP, which is what port-forwarding maps to.
+    $probe = @'
+PUB=$(curl -fsS --max-time 8 https://api.ipify.org 2>/dev/null)
+[ -z "$PUB" ] && PUB=$(wget -qO- --timeout=8 https://api.ipify.org 2>/dev/null)
+EXT=$(sudo kubectl get node -o jsonpath='{range .items[0].status.addresses[?(@.type=="ExternalIP")]}{.address}{end}' 2>/dev/null)
+echo "PUB=$PUB"
+echo "EXT=$EXT"
+'@ -replace "`r", ''
+    try {
+        $raw = Invoke-V6Ssh -Ip $ctx.ip -Cmd $probe -TimeoutSec 25
+        $rawText = ($raw -join "`n")
+        $mp = [regex]::Match($rawText, 'PUB=([0-9.]+)')
+        if ($mp.Success) { $result.vmPublicIp = $mp.Groups[1].Value.Trim() }
+        $me = [regex]::Match($rawText, 'EXT=([0-9.]+)')
+        if ($me.Success) { $result.k3sExternalIp = $me.Groups[1].Value.Trim() }
+    } catch {
+        $result.error = "Public IP probe failed: $($_.Exception.Message)"
+        $result.summary = $result.error
+        return $result
+    }
+
+    # 2) farm_state — the address/port each map advertises to clients, plus its
+    #    readiness. game_addr is stored as "1.2.3.4/0"; strip the suffix.
+    $sql = "SELECT map, server_id, split_part(game_addr::text,'/',1) AS ip, game_port, ready, alive FROM dune.farm_state ORDER BY map;"
+    $maps = @()
+    try {
+        $csv = Invoke-DuneSqlRaw -Ip $ctx.ip -Sql $sql -Csv -TimeoutSec 30
+        if (Test-DunePsqlError -Output $csv) {
+            $result.error = "farm_state query failed: $(Get-DunePsqlErrorMessage -Output $csv)"
+            $result.summary = $result.error
+            return $result
+        }
+        $lines = @(($csv -split "`r?`n") | Where-Object { $_ -ne '' })
+        if ($lines.Count -ge 2) {
+            $rows = $lines | ConvertFrom-Csv
+            foreach ($r in $rows) {
+                $maps += [ordered]@{
+                    map      = [string]$r.map
+                    serverId = [string]$r.server_id
+                    ip       = ([string]$r.ip).Trim()
+                    port     = [string]$r.game_port
+                    ready    = ([string]$r.ready -eq 't')
+                    alive    = ([string]$r.alive -eq 't')
+                }
+            }
+        }
+    } catch {
+        $result.error = "farm_state query failed: $($_.Exception.Message)"
+        $result.summary = $result.error
+        return $result
+    }
+
+    $result.maps = @($maps)
+    $advertised = @($maps | ForEach-Object { $_.ip } | Where-Object { $_ } | Select-Object -Unique)
+    $result.advertisedIps = @($advertised)
+    $result.serversReady = -not [bool](@($maps | Where-Object { -not $_.ready -or -not $_.alive }).Count)
+
+    $pub = [string]$result.vmPublicIp
+    $looksPublic = ($pub -match '^\d{1,3}(\.\d{1,3}){3}$') -and ($pub -notmatch '^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|127\.|0\.)')
+    if ($looksPublic) {
+        $result.staleFarmIp = [bool](@($advertised | Where-Object { $_ -ne $pub }).Count)
+        if ($result.k3sExternalIp) { $result.staleK3sIp = ($result.k3sExternalIp -ne $pub) }
+    }
+
+    # Verdict, most-actionable first.
+    if (@($maps).Count -eq 0) {
+        $result.verdict = 'servers-down'
+        $result.summary = 'No map servers are registered yet. Start or restart the battlegroup, then re-check.'
+    }
+    elseif ($result.staleFarmIp -or $result.staleK3sIp) {
+        $result.verdict = 'stale-ip'
+        $advTxt = (@($advertised) -join ', ')
+        $parts = @()
+        if ($result.staleFarmIp) { $parts += "your maps advertise $advTxt to players" }
+        if ($result.staleK3sIp)  { $parts += "the K3s ExternalIP is $($result.k3sExternalIp)" }
+        $result.summary = "Stale public IP detected: $($parts -join ' and '), but this server's real public IP is $pub. Players are being sent to the wrong address, which causes P34 / connection timeouts. Apply your current public IP below to fix it."
+    }
+    elseif (-not $result.serversReady) {
+        $result.verdict = 'servers-not-ready'
+        $result.summary = 'Public IP looks correct, but one or more map servers are not ready/alive yet. Wait for them to finish booting, or restart the battlegroup.'
+    }
+    elseif (-not $looksPublic) {
+        $result.verdict = 'unknown'
+        $result.summary = if ($pub) { "Could not classify the detected public IP ($pub). Verify your port forwarding (UDP 7777-7810) manually." } else { 'Could not determine the server''s public IP from inside the VM. Check the VM''s internet access.' }
+    }
+    else {
+        $result.verdict = 'healthy'
+        $result.summary = "All $(@($maps).Count) map server(s) advertise the correct public IP ($pub) and are ready. If players still get P34, check that UDP 7777-7810 is port-forwarded to this server."
+    }
+
+    $result.ok = $true
+    return $result
 }
 
 function Invoke-DunePublicIpHostRoute {

--- a/app/server/routes/PublicIp.ps1
+++ b/app/server/routes/PublicIp.ps1
@@ -17,6 +17,15 @@ Register-DuneRoute -Method GET -Path '/api/public-ip/status' -Handler {
     }
 }
 
+Register-DuneRoute -Method GET -Path '/api/public-ip/p34' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Write-DuneJson -Response $res -Body (Get-DuneP34Diagnostic)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
 Register-DuneRoute -Method POST -Path '/api/public-ip/resolve' -Handler {
     param($req, $res, $routeParams, $body)
     $hostname = [string](Get-DunePublicIpBodyValue -Body $body -Name 'hostname' -Default '')

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.1"
+$script:ToolVersion = "12.13.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -56,6 +56,31 @@ type ApplyStatus = {
   error?: string
 }
 
+type P34Map = {
+  map?: string
+  serverId?: string
+  ip?: string
+  port?: string
+  ready?: boolean
+  alive?: boolean
+}
+
+type P34Diagnostic = {
+  ok?: boolean
+  reachable?: boolean
+  vmIp?: string | null
+  vmPublicIp?: string | null
+  k3sExternalIp?: string | null
+  maps?: P34Map[]
+  advertisedIps?: string[]
+  staleFarmIp?: boolean
+  staleK3sIp?: boolean
+  serversReady?: boolean
+  verdict?: 'healthy' | 'stale-ip' | 'servers-down' | 'servers-not-ready' | 'unknown'
+  summary?: string
+  error?: string
+}
+
 function stepClass(status: PublicIpStep['status']): string {
   if (status === 'done') return 'text-success'
   if (status === 'failed') return 'text-danger'
@@ -78,6 +103,9 @@ export function PublicIpCard() {
   const [applyStarted, setApplyStarted] = useState<number | null>(null)
   const [now, setNow] = useState(Date.now())
   const pollRef = useRef<number | null>(null)
+  const [p34, setP34] = useState<P34Diagnostic | null>(null)
+  const [p34Loading, setP34Loading] = useState(false)
+  const [p34Error, setP34Error] = useState<string | null>(null)
 
   function stopPolling() {
     if (pollRef.current !== null) { window.clearInterval(pollRef.current); pollRef.current = null }
@@ -117,6 +145,19 @@ export function PublicIpCard() {
         if (!stillRunning) stopPolling()
       })()
     }, 2000)
+  }
+
+  async function runP34Check() {
+    setP34Loading(true)
+    setP34Error(null)
+    try {
+      const r = await api<P34Diagnostic>('/api/public-ip/p34')
+      setP34(r)
+    } catch (e) {
+      setP34Error(e instanceof Error ? e.message : String(e))
+    } finally {
+      setP34Loading(false)
+    }
   }
 
   async function loadStatus() {
@@ -300,6 +341,92 @@ export function PublicIpCard() {
           <Icon name={loading ? 'Loader2' : 'RefreshCw'} size={15} className={loading ? 'animate-spin' : ''} />
           Refresh
         </button>
+      </div>
+
+      <div className="mb-5 rounded-lg border border-border bg-surface-2/40 p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            <Icon name="Activity" size={16} className="text-text-muted shrink-0" />
+            <span className="font-medium text-sm">Connection check (P34 / can't join)</span>
+          </div>
+          <button type="button" onClick={() => void runP34Check()} disabled={p34Loading} className="btn-secondary shrink-0">
+            <Icon name={p34Loading ? 'Loader2' : 'Stethoscope'} size={15} className={p34Loading ? 'animate-spin' : ''} />
+            {p34Loading ? 'Checking…' : 'Run check'}
+          </button>
+        </div>
+        <p className="text-xs text-text-dim mt-1.5">
+          Checks whether your map servers advertise your current public IP. A mismatch is the usual cause of
+          “P34 / Connection Request Timed Out” when the server is visible in the browser but players can’t join.
+        </p>
+
+        {p34Error && (
+          <p className="mt-3 text-sm text-danger flex items-center gap-1.5">
+            <Icon name="AlertCircle" size={14} /> {p34Error}
+          </p>
+        )}
+
+        {p34 && (
+          <div className="mt-3 space-y-3">
+            <div className={
+              p34.verdict === 'healthy'
+                ? 'rounded-lg border border-success/40 bg-success/10 p-3 text-sm text-success flex items-start gap-2'
+                : p34.verdict === 'stale-ip'
+                  ? 'rounded-lg border border-danger/40 bg-danger/10 p-3 text-sm text-danger flex items-start gap-2'
+                  : 'rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm text-warning flex items-start gap-2'
+            }>
+              <Icon
+                name={p34.verdict === 'healthy' ? 'CheckCircle2' : p34.verdict === 'stale-ip' ? 'AlertTriangle' : 'AlertCircle'}
+                size={15}
+                className="mt-0.5 shrink-0"
+              />
+              <span>{p34.summary}</span>
+            </div>
+
+            {p34.reachable && (
+              <div className="flex flex-wrap gap-2 text-xs">
+                {p34.vmPublicIp && <span className="pill-muted">this server’s public IP · {p34.vmPublicIp}</span>}
+                {p34.k3sExternalIp && (
+                  <span className={p34.staleK3sIp ? 'pill-danger' : 'pill-muted'}>K3s ExternalIP · {p34.k3sExternalIp}</span>
+                )}
+              </div>
+            )}
+
+            {p34.maps && p34.maps.length > 0 && (
+              <div className="border border-border rounded-lg overflow-hidden text-sm">
+                <div className="grid grid-cols-[1fr_auto_auto] gap-x-3 px-3 py-1.5 bg-surface-2 text-xs uppercase tracking-wide text-text-dim">
+                  <span>Map</span>
+                  <span>Advertised address</span>
+                  <span>State</span>
+                </div>
+                {p34.maps.map(m => {
+                  const mismatch = Boolean(p34.vmPublicIp && m.ip && m.ip !== p34.vmPublicIp)
+                  return (
+                    <div key={`${m.map}-${m.serverId}`} className="grid grid-cols-[1fr_auto_auto] gap-x-3 px-3 py-1.5 border-t border-border items-center">
+                      <span className="font-medium truncate">{m.map}</span>
+                      <span className={`font-mono ${mismatch ? 'text-danger' : 'text-text'}`}>{m.ip}:{m.port}</span>
+                      <span className="flex items-center gap-1 text-xs">
+                        <Icon
+                          name={m.ready && m.alive ? 'CheckCircle2' : 'AlertCircle'}
+                          size={13}
+                          className={m.ready && m.alive ? 'text-success' : 'text-warning'}
+                        />
+                        {m.ready && m.alive ? 'ready' : 'not ready'}
+                      </span>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+
+            {p34.verdict === 'stale-ip' && (
+              <p className="text-xs text-text-dim">
+                Fix: set your current public IP below (Resolve a DDNS hostname or enter it manually), then click
+                <span className="font-medium"> Apply public IP</span>. That rewrites the battlegroup, K3s ExternalIP and NAT, and
+                restarts the servers so they re-advertise the correct address.
+              </p>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="flex flex-wrap gap-2 mb-4">


### PR DESCRIPTION
## What

Adds a **Connection check (P34 / can't join)** diagnostic to **Settings → Public IP / DDNS**.

The most common post-patch / post-ISP-change failure is: the server is **visible in the in-game browser** (FLS auth fine, no 403002) but players get **"P34 / Connection Request Timed Out"** on join. On self-hosted servers this is almost always a **stale public IP** — the game servers advertise an old external IPv4 to clients in `dune.farm_state.game_addr`, so clients dial the wrong address and time out.

## How it works

One click runs `GET /api/public-ip/p34` → `Get-DuneP34Diagnostic`, which:

1. Reads the server's **real current public IP** via ipify **from inside the VM** (so it reflects the actual WAN/egress IP that port-forwarding maps to).
2. Reads what each map **advertises to clients** from `dune.farm_state` (address + port + ready/alive).
3. Reads the **K3s ExternalIP**.
4. Returns a verdict:
   - **stale-ip** (red) — names the wrong advertised address per map, points to the existing **Apply public IP** action right below as the fix.
   - **healthy** (green) — all maps advertise the correct public IP and are ready.
   - **servers-down / servers-not-ready / unknown** — warning with guidance + a UDP 7777–7810 port-forward reminder.

The **cure already exists**: the Apply public IP flow rewrites the battlegroup CR + K3s ExternalIP + NAT and restarts the servers so they re-register `farm_state` with the right address. This change adds the **alarm** that tells a confused user *why* they're stuck and which button fixes it.

## Changes

- `app/server/lib/PublicIp.ps1` — new `Get-DuneP34Diagnostic`.
- `app/server/routes/PublicIp.ps1` — new `GET /api/public-ip/p34`.
- `webui/src/pages/settings/PublicIpCard.tsx` — P34 check section (button, verdict banner, IP pills, per-map advertised-address table).
- Version bump to **12.13.2** across the 5 stamps; CHANGELOG entry under `[Unreleased]`.

## Validation

- webui `tsc -b && vite build` clean.
- Both edited `.ps1` files parse clean; `PublicIp.ps1` re-saved UTF-8-with-BOM (installer preflight passes; all 5 version stamps match).
- Installer built: `app/installer/output/DuneServerSetup.exe` (v12.13.2, 46 MB).
- Mechanism verified against a **healthy** live DB: all 3 maps advertise `50.123.76.96`, VM ipify = `50.123.76.96` → green. A **broken** server's `farm_state` is still needed to watch it flag red in the wild.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>