### PR TITLE
Add Brandon M and Daddy STATZY to coffee supporter credits

### DIFF
--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -477,6 +477,14 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <Icon name="Heart" size={14} className="text-ibad shrink-0" />
               <span className="flex-1">Pat (@pat.)</span>
             </div>
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">Brandon M</span>
+            </div>
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">Daddy STATZY (@spiderstatz)</span>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Adds two supporters to the **Thanks for the Coffee** dropdown (`MenuBar.tsx`), after Pat:

- **Brandon M**
- **Daddy STATZY (@spiderstatz)**

Same plain credit-line format as the existing entries (Heart icon + name, not a link). Ships with the next stable release.

webui `tsc -b && vite build` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>