### PR TITLE
Diagnostics: scrub connection-string passwords (DB/AMQP URIs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,10 @@ here cover everything those tags shipped.
   server gateway, battlegroup director, text router, game message queue) into
   `game-pods.txt` and `game-server-logs.txt`, so the actual join-rejection
   reason is captured. Dump/backup pods are excluded. The sanitizer now also
-  scrubs JWTs (e.g. the FLS `ServiceAuthToken` printed in gateway logs) and
-  known FLS secret fields, so the token can never leave the machine.
+  scrubs JWTs (e.g. the FLS `ServiceAuthToken` printed in gateway logs), known
+  FLS secret fields, and passwords embedded in connection-string URIs (e.g. the
+  `postgresql://user:<password>@…` string the director/gateway print), so no
+  token or credential can leave the machine.
 
 ### Fixed
 

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -42,6 +42,13 @@ function Invoke-DstRedaction {
     #     JSON "<Name>": "value" form, as a safety net for any non-JWT token.
     $out = [regex]::Replace($out, '(?i)\b(ServiceAuthToken|ServiceAuthKey|ServiceAuthSecret|ServiceAuthKeyId)\b(["'']?\s*[:=]\s*["'']?)[A-Za-z0-9._/+\-]{6,}', '${1}${2}<redacted>')
 
+    # 1e) Credentials embedded in connection-string URIs, e.g. the Postgres
+    #     connection string the battlegroup director / gateway print:
+    #       db=postgresql://dune:<password>@host:5432/...
+    #     Also covers amqp:// (RabbitMQ), redis://, mongodb://, etc. Keep the
+    #     scheme + username for readability; scrub only the password.
+    $out = [regex]::Replace($out, '(?i)([a-z][a-z0-9+.\-]*://[^:/?#\s@]+:)[^@/?#\s]+(@)', '${1}<redacted>${2}')
+
     # 2) IPv4 addresses (but leave 127.0.0.1 / 0.0.0.0 / 255.255.255.255 alone —
     #    those carry no identifying info and matter for log readability).
     $out = [regex]::Replace($out, '\b(?!(?:127\.0\.0\.1|0\.0\.0\.0|255\.255\.255\.255)\b)(?:\d{1,3}\.){3}\d{1,3}\b', '<ip>')


### PR DESCRIPTION
## What
Follow-up to #369. The new game-server pod-log capture pulls the battlegroup-director and gateway logs, which print the Postgres connection string **with the password in cleartext** (`db=postgresql://dune:<password>@...-db-dbdepl-svc:15432/dune`). The JWT/secret-field redaction from #369 didn't catch it, so a saved bundle leaked the DB password (confirmed live on a real reporter's bundle).

## Fix
`Invoke-DstRedaction` now scrubs the password in any `scheme://user:password@host` URI (postgresql, amqp/RabbitMQ, redis, mongodb, ...), keeping the scheme + username for readability.

## Validation
- Parses clean; BOM intact.
- Verified on the real leaked string: `postgresql://dune:UlF...@host` -> `postgresql://dune:<redacted>@host`; `amqp://user:pass@` -> `amqp://user:<redacted>@`; a plain `https://example.com/path?x=1` with no creds is left untouched (no false positive).
- The earlier JWT redaction held on the same bundle (no token leaked).

Note: the exposed bundle was already removed from Discord and the reporter notified.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
