### PR TITLE
P34 check: per-map UDP ports + NAT-loopback caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ here cover everything those tags shipped.
   restarts the battlegroup so the servers re-advertise the correct address (the
   same repair as setting the IP manually and clicking Apply, filled in for you).
   After the fix it re-runs the check to confirm. Also surfaces servers that
-  aren't ready/alive and reminds you to forward UDP 7777–7810.
+  aren't ready/alive, lists the exact per-map UDP port each running map needs
+  forwarded (forwarding only 7777 lets players reach one map but P34 on the
+  rest), and warns that testing your own public IP from the same network only
+  exercises router NAT loopback (hairpin), not the real external path.
 
 - **Diagnostic bundle now captures game-server pod logs.** The bundle
   (Help → Create GitHub Issue + Save Logs) previously only collected DST-side

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -448,6 +448,32 @@ export function PublicIpCard() {
               </div>
             )}
 
+            {p34.maps && p34.maps.length > 0 && (
+              <div className="rounded-lg border border-border bg-surface-2/40 p-3 text-sm space-y-2">
+                <div className="flex items-center gap-2 font-medium">
+                  <Icon name="Network" size={14} className="text-text-muted" />
+                  Port forwarding (UDP)
+                </div>
+                <p className="text-xs text-text-dim">
+                  Each map uses its own UDP port. Forward the whole <span className="font-medium">UDP 7777–7810</span>
+                  range to this server — maps can also start on demand on other ports in that range, and forwarding only
+                  7777 lets players reach one map but P34 on the rest. Currently active maps:
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {p34.maps.map(m => (
+                    <span key={`port-${m.map}-${m.serverId}`} className="pill-muted font-mono">{m.map} → UDP {m.port}</span>
+                  ))}
+                </div>
+                <p className="text-xs text-text-dim">
+                  <span className="text-warning font-medium">NAT loopback note:</span> testing your own server by its
+                  public IP from a device on the <span className="font-medium">same network</span> exercises your
+                  router’s NAT loopback (hairpin), not the real outside path — many routers (Asus among them) handle UDP
+                  hairpin poorly. If this check is green but you still get P34, have someone <span className="font-medium">outside
+                  your network</span> try to join before assuming the server is broken.
+                </p>
+              </div>
+            )}
+
             {p34.verdict === 'stale-ip' && (
               <div className="space-y-2">
                 <button


### PR DESCRIPTION
## What
Refines the P34 connection check (Settings -> Public IP / DDNS) with guidance for the **host public-path** class of P34 (NAT loopback / incomplete per-map port forwarding) seen in the official-Discord reports (e.g. "local IP works, public IP P34s, NAT loopback on an Asus router").

Adds, below the per-map address table:
- A **Port forwarding (UDP)** block: recommends forwarding the whole **UDP 7777-7810** range (maps can start on demand on other ports in that range), and lists each **currently active** map -> its UDP port as helpful detail.
- A **NAT-loopback caveat**: testing your own public IP from the same LAN exercises router hairpin NAT, not the real external path, so a green check can still P34 for same-network self-tests; have an outside player verify.

## Safety (no-regression review)
- **Frontend-only.** No backend, route, or .ps1 changes. The diagnostic stays read-only (queries farm_state / ipify / k3s ExternalIP; no mutations). Nothing here can alter server/connectivity state.
- No new API calls or actions; the existing "Fix it automatically" flow is untouched.
- The map list reuses the same `p34.maps && p34.maps.length > 0` guard as the existing table (backend `@()`-wraps maps), so no new crash surface.
- Wording recommends the **full port range** (not just the active maps) so users can't under-forward and miss on-demand maps.
- webui `tsc -b && vite build` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
