### PR TITLE
P34 check: IPv6 interference caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,10 @@ here cover everything those tags shipped.
   aren't ready/alive, lists the exact per-map UDP port each running map needs
   forwarded (forwarding only 7777 lets players reach one map but P34 on the
   rest), and warns that testing your own public IP from the same network only
-  exercises router NAT loopback (hairpin), not the real external path.
+  exercises router NAT loopback (hairpin), not the real external path. It also
+  notes that IPv6 can cause P34 even when the IPv4 check is green — disabling
+  IPv6 on the server's NIC and re-applying the public IP has resolved it for
+  some hosts.
 
 - **Diagnostic bundle now captures game-server pod logs.** The bundle
   (Help → Create GitHub Issue + Save Logs) previously only collected DST-side

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -471,6 +471,12 @@ export function PublicIpCard() {
                   hairpin poorly. If this check is green but you still get P34, have someone <span className="font-medium">outside
                   your network</span> try to join before assuming the server is broken.
                 </p>
+                <p className="text-xs text-text-dim">
+                  <span className="text-warning font-medium">IPv6 note:</span> if the check is green but players still
+                  get P34, IPv6 can interfere — the server can advertise or route over an IPv6 path that isn’t reachable
+                  while your IPv4 port-forward works. Disabling IPv6 <span className="font-medium">on the server’s network
+                  adapter (NIC)</span> and then re-applying your public IP (below) has fixed P34 for some hosts.
+                </p>
               </div>
             )}
 


### PR DESCRIPTION
Adds an IPv6 caveat to the P34 connection check (Settings -> Public IP / DDNS), same zero-risk guidance pattern as the NAT-loopback note. A reporter confirmed disabling IPv6 + re-applying the public IP resolved their P34 even with a green IPv4 check. Frontend-only; no backend/mutation changes; webui build clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
