### PR TITLE
P34 IPv6 note: add the reboot step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ here cover everything those tags shipped.
   rest), and warns that testing your own public IP from the same network only
   exercises router NAT loopback (hairpin), not the real external path. It also
   notes that IPv6 can cause P34 even when the IPv4 check is green — disabling
-  IPv6 on the server's NIC and re-applying the public IP has resolved it for
-  some hosts.
+  IPv6 on the server's NIC, rebooting, and re-applying the public IP has
+  resolved it for some hosts.
 
 - **Diagnostic bundle now captures game-server pod logs.** The bundle
   (Help → Create GitHub Issue + Save Logs) previously only collected DST-side

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -475,7 +475,7 @@ export function PublicIpCard() {
                   <span className="text-warning font-medium">IPv6 note:</span> if the check is green but players still
                   get P34, IPv6 can interfere — the server can advertise or route over an IPv6 path that isn’t reachable
                   while your IPv4 port-forward works. Disabling IPv6 <span className="font-medium">on the server’s network
-                  adapter (NIC)</span> and then re-applying your public IP (below) has fixed P34 for some hosts.
+                  adapter (NIC)</span>, rebooting, then re-applying your public IP (below) has fixed P34 for some hosts.
                 </p>
               </div>
             )}


### PR DESCRIPTION
Reporter clarified the working fix: disable IPv6 on the server host's NIC, **reboot**, then re-apply the public IP in DST. Adds 'rebooting' to the in-app IPv6 note + changelog so the guidance is actionable. Frontend-only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>