### PR TITLE
Fix Game Servers table mangling long map names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Game Servers table mangled long map names (e.g. dungeon/story maps).** On
+  Server Health, an on-demand map with a long technical name like
+  `CB_Dungeon_Hephaestus` rendered as garbled, column-shifted text
+  ("Hepha | estus Running | t | rue 0"). The `battlegroup status` parser sliced
+  rows by fixed character columns taken from the header's dashes, but the CLI
+  colorizes values with ANSI codes and pads colored cells by byte width, so a
+  long map name overflowed its column and every cell shifted. The Game Servers
+  rows are now parsed by tokens from both ends (map = first token; ready /
+  players / age = last three; phase = everything between), which is immune to
+  column-alignment drift and keeps long map names intact.
+
 ## [12.13.2] - 2026-06-25
 
 ### Added

--- a/app/server/lib/Status.ps1
+++ b/app/server/lib/Status.ps1
@@ -283,12 +283,11 @@ function ConvertFrom-BgStatusText {
             continue
         }
         if ($line -match '^\s*Game Servers\s*$' -and $i + 2 -lt $lines.Length) {
-            $cols = Get-BgColumnSpans -Header $lines[$i + 1] -Dashes $lines[$i + 2]
             $servers = @()
             for ($j = $i + 3; $j -lt $lines.Length; $j++) {
                 $rowLine = $lines[$j]
                 if (-not $rowLine.Trim()) { continue }
-                $values = Get-BgRowValues -Line $rowLine -Cols $cols
+                $values = Get-BgGameServerValues -Line $rowLine
                 if ($values.Count -ge 5 -and $values[0]) {
                     $servers += ,@{
                         map     = $values[0]
@@ -345,9 +344,34 @@ function Get-BgRowValues {
     return $values
 }
 
-# Inspect a `battlegroup status` text blob and return one of:
-#   'running' | 'stopped' | 'starting' | 'stopping' | 'updating' | 'unknown'
-#
+# Parse a Game Servers table row by tokens from BOTH ends, NOT by fixed column
+# offsets. The `battlegroup status` CLI colorizes phase/ready values with ANSI
+# codes; Go's text/tabwriter pads those cells by byte width (counting the
+# invisible escape bytes), so once the ANSI is stripped the visible values no
+# longer line up under the header's dashes and fixed-width slicing cuts a long
+# map name mid-word (e.g. "Hephaestus" -> "Hepha" | "estus Running"). Every
+# column here is a single whitespace-free token EXCEPT Phase, which may contain
+# spaces (e.g. "Reconciling Ready"). So pin map=first, age/players/ready=last
+# three, and treat everything between as the phase. Position-independent, so it
+# is immune to any column-alignment drift.
+function Get-BgGameServerValues {
+    param([string]$Line)
+    if (-not $Line) { return @() }
+    # Strip any residual ANSI just in case, then tokenize on runs of whitespace.
+    $clean = ($Line -replace "`e\[[0-9;]*[A-Za-z]", '').Trim()
+    $tokens = @($clean -split '\s+' | Where-Object { $_ -ne '' })
+    if ($tokens.Count -lt 4) { return @() }
+    $n       = $tokens.Count
+    $map     = $tokens[0]
+    $age     = $tokens[$n - 1]
+    $players = $tokens[$n - 2]
+    $ready   = $tokens[$n - 3]
+    # Phase is whatever remains between the map and the trailing ready/players/age.
+    # When there's no middle token (a 4-token row), phase is empty rather than
+    # accidentally reversing a range.
+    $phase = if ($n -gt 4) { ($tokens[1..($n - 4)] -join ' ') } else { '' }
+    return @($map, $phase, $ready, $players, $age)
+}
 # `battlegroup status` renders a wide kubectl-style table. Relevant signals:
 #
 #   Stopped (any of):


### PR DESCRIPTION
## Bug
On Server Health, the Game Servers table mangled on-demand maps with long technical names. A row for `CB_Dungeon_Hephaestus` rendered as garbled, column-shifted text:

`Hepha | estus Running | t | rue 0 | 22m`  (should be `Dungeon: Hephaestus | Running | true | 0 | 22m`)

## Root cause
`ConvertFrom-BgStatusText` sliced Game Servers rows by **fixed character columns** taken from the header's dashes row. But the `battlegroup status` CLI colorizes values with ANSI codes, and Go's `text/tabwriter` pads colored cells by **byte** width (counting the invisible escape bytes). After DST strips the ANSI (Status.ps1 already does this), the visible values no longer sit under the dashes, and a long map name overflows its column. The old slice produced `CB_Dungeon_Hepha` (16 chars), which the frontend `mapLabel` then prefix-stripped to `Hepha`, with the leftover `estus` spilling into the Phase cell.

## Fix
Parse Game Servers rows by **tokens from both ends** instead of fixed offsets: map = first token, ready/players/age = last three, phase = the (possibly multi-word) middle. Every column except Phase is a single whitespace-free token, so this is position-independent and immune to column-alignment drift. The Battlegroup Info table keeps fixed-width parsing (multiple columns there can legitimately be multi-word).

## Validation
Tested the new parser against four inputs — normal aligned, ANSI-misaligned (reproduces the bug), multi-word phase (`Reconciling Ready`), and 4-token empty-phase — plus the real raw single-token map names (`CB_Dungeon_Hephaestus`, `DeepDesert_1`, `Overmap`, `Survival_1`). All parse correctly. Parse-checked; UTF-8 BOM preserved.

Note: while investigating I also saw the Broadcast panel's "mq-game pod not found" message — that's transient (mq-game still starting right after a battlegroup restart while the header shows BG Running). Left out of this PR; can improve the wording separately if desired.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
