### PR TITLE
Harden P34 check public-IP detection (release 12.13.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.4] - 2026-06-25
+
+### Fixed
+
+- **P34 connection check no longer dead-ends when the VM can't reach an IP
+  service.** The check read the server's public IP by calling a single endpoint
+  (`api.ipify.org`) from inside the VM. The VMs are BusyBox with no `curl`, so it
+  relied on one `wget` call to one host — if that was blocked, slow, or down, the
+  whole check reported "Could not determine the server's public IP" and gave no
+  verdict. It now (1) tries several IP-echo services (ipify, AWS checkip,
+  ifconfig.me, icanhazip) via both `wget` and `curl`, (2) falls back to the DST
+  host's own detected internet IP (same router/WAN as the VM) and then the
+  last-applied IP from config, and (3) if no live IP can be read at all, still
+  compares what the maps advertise against the K3s ExternalIP to flag a likely
+  stale IP. The summary says where the IP came from so the result stays honest.
+
 ## [12.13.3] - 2026-06-25
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.3'
+$script:DuneToolVersion = '12.13.4'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.3',
+    [string]$Version = '12.13.4',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.3</Version>
+    <Version>12.13.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.3"
+#define MyAppVersion "12.13.4"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -338,6 +338,7 @@ function Get-DuneP34Diagnostic {
         reachable      = $false
         vmIp           = $null
         vmPublicIp     = $null
+        publicIpSource = $null
         k3sExternalIp  = $null
         maps           = @()
         advertisedIps  = @()
@@ -367,27 +368,65 @@ function Get-DuneP34Diagnostic {
     $result.reachable = $true
     $result.vmIp = [string]$ctx.ip
 
+    $cfg = $null
+    try { $cfg = Read-DuneConfig } catch {}
+
     # 1) VM-side real public IP (what clients must reach) + K3s ExternalIP, one
-    #    SSH round trip. ipify is queried from INSIDE the VM so it reflects the
-    #    server's actual egress/WAN IP, which is what port-forwarding maps to.
+    #    SSH round trip. Query the public IP from INSIDE the VM so it reflects
+    #    the server's actual egress/WAN IP, which is what port-forwarding maps
+    #    to. The VM is BusyBox and often has no curl, so try several IP-echo
+    #    endpoints via both wget and curl and take the first that answers — a
+    #    single endpoint being down/blocked must not blank the whole diagnostic.
     $probe = @'
-PUB=$(curl -fsS --max-time 8 https://api.ipify.org 2>/dev/null)
-[ -z "$PUB" ] && PUB=$(wget -qO- --timeout=8 https://api.ipify.org 2>/dev/null)
+get_ip() {
+  for url in https://api.ipify.org https://checkip.amazonaws.com https://ifconfig.me https://icanhazip.com; do
+    ip=$(wget -qO- --timeout=6 "$url" 2>/dev/null | tr -d "[:space:]")
+    [ -z "$ip" ] && ip=$(curl -fsS --max-time 6 "$url" 2>/dev/null | tr -d "[:space:]")
+    case "$ip" in
+      [0-9]*.[0-9]*.[0-9]*.[0-9]*) echo "$ip"; return 0 ;;
+    esac
+  done
+}
+PUB=$(get_ip)
 EXT=$(sudo kubectl get node -o jsonpath='{range .items[0].status.addresses[?(@.type=="ExternalIP")]}{.address}{end}' 2>/dev/null)
 echo "PUB=$PUB"
 echo "EXT=$EXT"
 '@ -replace "`r", ''
     try {
-        $raw = Invoke-V6Ssh -Ip $ctx.ip -Cmd $probe -TimeoutSec 25
+        $raw = Invoke-V6Ssh -Ip $ctx.ip -Cmd $probe -TimeoutSec 35
         $rawText = ($raw -join "`n")
         $mp = [regex]::Match($rawText, 'PUB=([0-9.]+)')
         if ($mp.Success) { $result.vmPublicIp = $mp.Groups[1].Value.Trim() }
         $me = [regex]::Match($rawText, 'EXT=([0-9.]+)')
         if ($me.Success) { $result.k3sExternalIp = $me.Groups[1].Value.Trim() }
     } catch {
-        $result.error = "Public IP probe failed: $($_.Exception.Message)"
-        $result.summary = $result.error
-        return $result
+        # Non-fatal: a failed probe just means we lean on the host-side fallback
+        # below. Only the farm_state query (next) is essential.
+    }
+
+    # Fallback chain for the public IP: the VM-side egress IP is best, but if the
+    # VM can't reach any IP-echo service (no curl, blocked egress, flaky DNS), use
+    # the DST host's own detected internet IP — it sits behind the same router/WAN
+    # so it resolves to the same public address — then the last-applied IP from
+    # config. Record where it came from so the summary can be honest.
+    if ($result.vmPublicIp) {
+        $result.publicIpSource = 'vm'
+    } else {
+        $hostIp = $null
+        if (Get-Command Get-DunePublicIp -ErrorAction SilentlyContinue) {
+            try { $hostIp = Get-DunePublicIp } catch {}
+        }
+        if ($hostIp) {
+            $result.vmPublicIp = [string]$hostIp
+            $result.publicIpSource = 'host'
+        } else {
+            $lastApplied = $null
+            try { $lastApplied = [string]$cfg.LastAppliedPublicIp } catch {}
+            if ($lastApplied) {
+                $result.vmPublicIp = $lastApplied
+                $result.publicIpSource = 'last-applied'
+            }
+        }
     }
 
     # 2) farm_state — the address/port each map advertises to clients, plus its
@@ -433,6 +472,15 @@ echo "EXT=$EXT"
         if ($result.k3sExternalIp) { $result.staleK3sIp = ($result.k3sExternalIp -ne $pub) }
     }
 
+    # Where the public IP came from, for an honest summary. The host-detected IP
+    # is behind the same router/WAN as the VM so it's a reliable stand-in, but we
+    # say so rather than implying we read it from the server itself.
+    $srcNote = switch ($result.publicIpSource) {
+        'host'         { ' (detected from the DST host, since the VM could not reach an IP-check service)' }
+        'last-applied' { ' (your last-applied public IP, since neither the VM nor the DST host could detect a current one)' }
+        default        { '' }
+    }
+
     # Verdict, most-actionable first.
     if (@($maps).Count -eq 0) {
         $result.verdict = 'servers-down'
@@ -444,19 +492,30 @@ echo "EXT=$EXT"
         $parts = @()
         if ($result.staleFarmIp) { $parts += "your maps advertise $advTxt to players" }
         if ($result.staleK3sIp)  { $parts += "the K3s ExternalIP is $($result.k3sExternalIp)" }
-        $result.summary = "Stale public IP detected: $($parts -join ' and '), but this server's real public IP is $pub. Players are being sent to the wrong address, which causes P34 / connection timeouts. Apply your current public IP below to fix it."
+        $result.summary = "Stale public IP detected: $($parts -join ' and '), but this server's public IP is $pub$srcNote. Players are being sent to the wrong address, which causes P34 / connection timeouts. Apply your current public IP below to fix it."
     }
     elseif (-not $result.serversReady) {
         $result.verdict = 'servers-not-ready'
         $result.summary = 'Public IP looks correct, but one or more map servers are not ready/alive yet. Wait for them to finish booting, or restart the battlegroup.'
     }
     elseif (-not $looksPublic) {
-        $result.verdict = 'unknown'
-        $result.summary = if ($pub) { "Could not classify the detected public IP ($pub). Verify your port forwarding (UDP 7777-7810) manually." } else { 'Could not determine the server''s public IP from inside the VM. Check the VM''s internet access.' }
+        # No usable public IP from the VM, the DST host, or config. We can still
+        # compare what the maps advertise against the K3s ExternalIP — if those
+        # two disagree, the IP is almost certainly stale even without an egress
+        # reading; if they agree, fall back to honest guidance.
+        if ($result.k3sExternalIp -and @($advertised | Where-Object { $_ -ne $result.k3sExternalIp }).Count) {
+            $result.verdict = 'stale-ip'
+            $result.staleFarmIp = $true
+            $advTxt = (@($advertised) -join ', ')
+            $result.summary = "Your maps advertise $advTxt to players, but the K3s ExternalIP is $($result.k3sExternalIp) — they don't match, which causes P34 / connection timeouts. (Couldn't read this server's live public IP to confirm which is current.) Apply your current public IP below to reconcile them."
+        } else {
+            $result.verdict = 'unknown'
+            $result.summary = 'Could not determine this server''s public IP from the VM or the DST host, and your maps/K3s agree on one address, so nothing looks stale. If players still get P34, verify the VM has internet access and that UDP 7777-7810 is port-forwarded to this server.'
+        }
     }
     else {
         $result.verdict = 'healthy'
-        $result.summary = "All $(@($maps).Count) map server(s) advertise the correct public IP ($pub) and are ready. If players still get P34, check that UDP 7777-7810 is port-forwarded to this server."
+        $result.summary = "All $(@($maps).Count) map server(s) advertise the correct public IP ($pub$srcNote) and are ready. If players still get P34, check that UDP 7777-7810 is port-forwarded to this server."
     }
 
     $result.ok = $true

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.3"
+$script:ToolVersion = "12.13.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
The P34 connection check read the public IP from a single endpoint (api.ipify.org) inside the VM. VMs are BusyBox with no curl, so it relied on one wget call to one host — if blocked/slow/down, the whole check reported 'Could not determine the server's public IP' with no verdict (hit by a reporter whose Validate-IP was green).

Now: (1) try several IP-echo services (ipify, AWS checkip, ifconfig.me, icanhazip) via wget and curl; (2) fall back to the DST host's own detected internet IP (same router/WAN as the VM), then the last-applied config IP; (3) if no live IP at all, still compare farm_state advertised IPs vs the K3s ExternalIP to flag a likely stale IP. Summary records where the IP came from. Bumps the five version stamps to 12.13.4.

Verified the new multi-endpoint probe returns the correct IP on a live VM. Parse-checked; BOM preserved.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>