### PR TITLE
Fix journey writes broken by Funcom journey_story_node schema change (12.13.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.5] - 2026-06-26
+
+### Fixed
+
+- **Gameplay Admin journey writes (Apply Preset, Complete/Reset/Wipe Journey,
+  faction progression) failed after the Funcom 1.4.10.0 patch.** That patch
+  rekeyed the `dune.journey_story_node` table from `account_id` to
+  `character_id`, so DST's writes threw "column account_id does not exist" — the
+  red error box on **Apply Preset** and the other journey actions. DST now
+  resolves the account to its character (`dune.player_state.id`) inline, the same
+  mapping Funcom's own stored functions use, preserving the existing subtree
+  completion and partial-field reset behavior. Verified end-to-end against a
+  live post-patch database.
+
 ## [12.13.4] - 2026-06-25
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.4'
+$script:DuneToolVersion = '12.13.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.4',
+    [string]$Version = '12.13.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.4</Version>
+    <Version>12.13.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.4"
+#define MyAppVersion "12.13.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -986,7 +986,7 @@ function Invoke-DunePlayerProgressionReverse {
     $nodeUpdates = ''
     foreach ($n in $nodes) {
         $safe = ConvertTo-DuneSqlString $n
-        $nodeUpdates += "UPDATE dune.journey_story_node SET complete_condition_state='false'::jsonb, has_pending_reward=false WHERE account_id=$accountID::bigint AND (story_node_id='$safe' OR story_node_id LIKE '$safe.%');`n"
+        $nodeUpdates += "UPDATE dune.journey_story_node SET complete_condition_state='false'::jsonb, has_pending_reward=false WHERE character_id IN (SELECT id FROM dune.player_state WHERE account_id=$accountID::bigint) AND (story_node_id='$safe' OR story_node_id LIKE '$safe.%');`n"
     }
 
     $tx = @"
@@ -1037,11 +1037,17 @@ function Invoke-DunePlayerCompleteJourneyNode {
     if (-not $NodeId) { return @{ ok = $false; error = 'node_id is required.' } }
     $safeNode = ConvertTo-DuneSqlString $NodeId
 
+    # NOTE: the Funcom 1.4.10.0 patch rekeyed dune.journey_story_node from
+    # account_id to character_id (= dune.player_state.id), so writes here resolve
+    # the account to its character via a subquery, exactly as Funcom's own
+    # save_journey_story_node()/delete_journey_story_node() stored functions do
+    # internally. This keeps the existing subtree (story_node_id LIKE 'x.%') and
+    # partial-field semantics that a single-node stored-function upsert can't.
     $upd = @"
 UPDATE dune.journey_story_node
 SET complete_condition_state = 'true'::jsonb,
     reveal_condition_state   = 'true'::jsonb
-WHERE account_id = $AccountId::bigint
+WHERE character_id IN (SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint)
   AND (story_node_id = '$safeNode' OR story_node_id LIKE '$safeNode.%');
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $upd -ReadOnly $false -MaxRows 1 -TimeoutSec 30
@@ -1050,10 +1056,10 @@ WHERE account_id = $AccountId::bigint
     if ($updated -eq 0) {
         $ins = @"
 INSERT INTO dune.journey_story_node
-    (account_id, story_node_id, has_pending_reward,
+    (character_id, story_node_id, has_pending_reward,
      complete_condition_state, reveal_condition_state,
      fail_condition_state, metadata_state, reset_group)
-VALUES ($AccountId::bigint, '$safeNode', false,
+VALUES ((SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint LIMIT 1), '$safeNode', false,
     'true'::jsonb, 'true'::jsonb,
     '{}'::jsonb, '{}'::jsonb,
     'Default'::dune.JourneyStoryResetGroup);
@@ -1103,7 +1109,7 @@ function Invoke-DunePlayerResetJourneyNode {
 UPDATE dune.journey_story_node
 SET complete_condition_state = 'false'::jsonb,
     has_pending_reward       = false
-WHERE account_id = $AccountId::bigint
+WHERE character_id IN (SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint)
   AND (story_node_id = '$safeNode' OR story_node_id LIKE '$safeNode.%');
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $upd -ReadOnly $false -MaxRows 1 -TimeoutSec 30
@@ -1129,7 +1135,7 @@ function Invoke-DunePlayerResetJourneyNodes {
 UPDATE dune.journey_story_node
 SET complete_condition_state = 'false'::jsonb,
     has_pending_reward       = false
-WHERE account_id = $AccountId::bigint;
+WHERE character_id IN (SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint);
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $upd -ReadOnly $false -MaxRows 1 -TimeoutSec 60
     if (-not $r.ok) { return @{ ok = $false; error = "reset journey nodes: $($r.error)" } }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.4"
+$script:ToolVersion = "12.13.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Bug
After the Funcom **1.4.10.0** patch, every **Gameplay Admin → Progression** journey write fails — most visibly the red error box on **Apply Preset** (reported by wulf_au + chumi44, "worked ~5 releases ago").

## Root cause
The patch **rekeyed `dune.journey_story_node` from `account_id` to `character_id`** (= `dune.player_state.id`) and added a `override_reward_block` column. DST's journey writes still referenced `account_id`, so Postgres threw **"column account_id does not exist."** DST didn't change — the schema did. Affected: Apply Preset, single Complete, Reset Journey (node + all), Wipe, and faction progression reverse.

## Fix
Resolve the account to its character **inline** — `(SELECT id FROM dune.player_state WHERE account_id = X)` — the exact mapping Funcom's own `save_journey_story_node()` / `delete_journey_story_node()` stored functions do internally. Chosen over a stored-function rewrite because those are single-node full upserts that would drop DST's existing **subtree completion** (`story_node_id LIKE 'x.%'`) and **partial-field reset** semantics. UPDATEs use `IN (...)` (safe for multi-character accounts); the INSERT uses a `LIMIT 1` scalar subquery and swaps `account_id` → `character_id` (`override_reward_block` takes its default).

## Validation
Verified **end-to-end against the live post-patch DB** via `BEGIN/ROLLBACK`: the inline UPDATE matched an existing node + subtree, the INSERT resolved `character_id` and wrote, reset-all touched the account's 2053 journey rows, and ROLLBACK left zero changes (no game data altered). Parse-checked; UTF-8 BOM preserved. Releases **12.13.5**.

Closes the Apply Preset bug thread (Discord).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
