### PR TITLE
Fix player tables broken by Funcom 1.4.10.0 account_id→character_id rekey (v12.13.7)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.13.6"
+      placeholder: "v12.13.7"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.7] - 2026-06-26
+
+### Fixed
+
+- **Player Tags panel, the player vehicle list, and Set Respawn broke after the
+  Funcom 1.4.10.0 patch.** That patch rekeyed several per-player tables from
+  `account_id` to `character_id`. The Tags panel reported "the live game database
+  has no `dune.player_tags` table — feature unavailable" and showed no tags (even
+  though all of a character's tags were still there), the Inventory vehicle list
+  could error out, and **Set Respawn** failed. DST now resolves the account to
+  its character (`dune.player_state.id`) when reading/writing `dune.player_tags`,
+  `recovered_vehicles`, `backup_vehicles`, and `player_respawn_locations` — the
+  same approach as the earlier journey-write fix. Tag writes that already go
+  through the game's `update_player_tags` stored procedure were unaffected.
+
 ## [12.13.6] - 2026-06-26
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.6'
+$script:DuneToolVersion = '12.13.7'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.6',
+    [string]$Version = '12.13.7',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.6</Version>
+    <Version>12.13.7</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.6"
+#define MyAppVersion "12.13.7"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -861,13 +861,17 @@ function Invoke-DunePlayerResetAllKeystones {
 }
 
 # ---------------------------------------------------------------------------
-# Player tags (labels like VIP / Verified / Probation). Stored in
-# dune.player_tags(account_id, tag). Read returns string[]; write replaces
-# the full set for an account.
+# Player tags (gameplay tags like Journey.*, Contract.*, Faction.*, plus admin
+# labels). Stored in dune.player_tags(character_id, tag). Funcom rekeyed this
+# table from account_id to character_id in patch 1.4.10.0, so every access
+# resolves the account to its character via dune.player_state.id. Read returns
+# string[]; the overwrite write replaces the full set for the account's
+# character. (Delta writes go through dune.update_player_tags, whose proc
+# signature Funcom kept account_id-based, so those are unaffected.)
 # ---------------------------------------------------------------------------
 function Get-DunePlayerTagsLive {
     param([string]$Ip, [long]$AccountId)
-    $sql = "SELECT tag FROM dune.player_tags WHERE account_id = $AccountId::bigint ORDER BY tag;"
+    $sql = "SELECT tag FROM dune.player_tags WHERE character_id IN (SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint) ORDER BY tag;"
     $soft = Invoke-DuneSqlSoft -Ip $Ip -Sql $sql -MaxRows 200 -TimeoutSec 30
     if (-not $soft.ok) { return @{ ok = $false; error = $soft.error } }
     if ($soft.unsupported) { return @{ ok = $true; tags = @(); unsupported = $true } }
@@ -887,10 +891,12 @@ function Invoke-DunePlayerSetTags {
         if ($s -and $s.Length -le 64) { $clean += $s }
     }
     $values = if ($clean.Count -gt 0) {
-        ($clean | ForEach-Object { "($AccountId::bigint, '" + (ConvertTo-DuneSqlString $_) + "')" }) -join ', '
+        ($clean | ForEach-Object { "('" + (ConvertTo-DuneSqlString $_) + "')" }) -join ', '
     } else { $null }
-    $sqlParts = @("DELETE FROM dune.player_tags WHERE account_id = $AccountId::bigint;")
-    if ($values) { $sqlParts += "INSERT INTO dune.player_tags (account_id, tag) VALUES $values ON CONFLICT DO NOTHING;" }
+    # player_tags is keyed by character_id (Funcom 1.4.10.0 rekey). Resolve the
+    # account to its character inline so the overwrite stays a single round trip.
+    $sqlParts = @("DELETE FROM dune.player_tags WHERE character_id IN (SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint);")
+    if ($values) { $sqlParts += "INSERT INTO dune.player_tags (character_id, tag) SELECT ps.id, v.tag FROM dune.player_state ps CROSS JOIN (VALUES $values) AS v(tag) WHERE ps.account_id = $AccountId::bigint ON CONFLICT DO NOTHING;" }
     $sql = $sqlParts -join "`n"
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }

--- a/app/server/lib/PlayersRead.ps1
+++ b/app/server/lib/PlayersRead.ps1
@@ -299,12 +299,18 @@ function Get-DunePlayerKeystonesLive {
 function Get-DunePlayerVehiclesLive {
     param([string]$Ip, [long]$ControllerId)
     if ($ControllerId -le 0) { return @{ ok = $false; error = 'controller_id is required.' } }
-    $accSql = "SELECT account_id::text AS aid FROM dune.player_state WHERE player_controller_id = $ControllerId::bigint LIMIT 1;"
+    # Resolve both the account_id and the character_id (player_state.id). Funcom's
+    # 1.4.10.0 rekey moved recovered_vehicles/backup_vehicles to character_id.
+    $accSql = "SELECT account_id::text AS aid, id::text AS cid FROM dune.player_state WHERE player_controller_id = $ControllerId::bigint LIMIT 1;"
     $acc = Invoke-DuneSqlQuery -Ip $Ip -Sql $accSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
     $accountId = 0L
+    $characterId = 0L
     if ($acc.ok) {
         $maps = ConvertTo-DuneRowMaps -Result $acc
-        if ($maps.Count -ge 1) { $accountId = [int64](ConvertTo-DuneInt $maps[0]['aid']) }
+        if ($maps.Count -ge 1) {
+            $accountId = [int64](ConvertTo-DuneInt $maps[0]['aid'])
+            $characterId = [int64](ConvertTo-DuneInt $maps[0]['cid'])
+        }
     }
     $sql = @"
 SELECT pa.actor_id::text AS vid, a.class AS class, COALESCE(a.map, '') AS map,
@@ -315,14 +321,14 @@ SELECT pa.actor_id::text AS vid, a.class AS class, COALESCE(a.map, '') AS map,
 FROM dune.permission_actor pa
 JOIN dune.permission_actor_rank par ON par.permission_actor_id = pa.actor_id
 JOIN dune.actors a ON a.id = pa.actor_id
-LEFT JOIN dune.recovered_vehicles rv ON rv.vehicle_id = pa.actor_id AND rv.account_id = $accountId::bigint
+LEFT JOIN dune.recovered_vehicles rv ON rv.vehicle_id = pa.actor_id AND rv.character_id = $characterId::bigint
 WHERE par.player_id = $ControllerId::bigint AND pa.actor_type = 2
 UNION ALL
 SELECT a.id::text AS vid, a.class AS class, '' AS map,
        1.0 AS dur, '' AS vname, false AS recovered, true AS backup
 FROM dune.backup_vehicles bv
 JOIN dune.actors a ON a.id = bv.vehicle_id
-WHERE bv.account_id = $accountId::bigint
+WHERE bv.character_id = $characterId::bigint
 ORDER BY class;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1000 -TimeoutSec 20

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -817,9 +817,9 @@ function Invoke-DunePlayerSetRespawn {
 
     $sql = @"
 INSERT INTO dune.player_respawn_locations
-    (id, account_id, "group", locator_transform, locator_actor_id, locator_name, locator_name_index, map, dimension, last_used_timestamp)
+    (id, character_id, "group", locator_transform, locator_actor_id, locator_name, locator_name_index, map, dimension, last_used_timestamp)
 VALUES (
-    gen_random_uuid(), $AccountId::bigint, '$safeGroup',
+    gen_random_uuid(), (SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint LIMIT 1), '$safeGroup',
     ROW(ROW($x::float8, $y::float8, $z::float8)::dune.vector, ROW(0,0,0,1)::dune.quaternion)::dune.transform,
     NULL, NULL, 0, '$safeMap', 0,
     (extract(epoch from now()) * 1000)::bigint

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.6"
+$script:ToolVersion = "12.13.7"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## What

Funcom's 1.4.10.0 patch rekeyed several per-player tables from `account_id` to `character_id` (`character_id` = `dune.player_state.id`) — the same change that previously broke `journey_story_node`. DST still queried four of them by `account_id`, so they errored or returned nothing.

## Symptoms fixed

- **Player Tags panel** reported *"the live game database has no `dune.player_tags` table — feature unavailable"* and showed no tags — even though every tag was still present (404 on the test character).
- **Inventory vehicle list** could error (joins on `recovered_vehicles` / `backup_vehicles`).
- **Set Respawn** failed (insert into `player_respawn_locations`).

## Fix

Resolve the account to its character (`dune.player_state.id`) for:
- `dune.player_tags` read (`Get-DunePlayerTagsLive`) + overwrite write (`Invoke-DunePlayerSetTags`).
- `recovered_vehicles` + `backup_vehicles` joins (vehicle list read).
- `player_respawn_locations` insert (`Invoke-DunePlayerSetRespawn`).

Delta tag writes go through `dune.update_player_tags`, whose proc signature Funcom **kept** account_id-based, so those (Apply Preset, journey completes, tier bumps) were already correct and are untouched.

## Full audit

Inventoried all `dune` tables: **13 are now keyed by `character_id`**. Of those, DST touches only the four fixed here directly; the rest are either not queried by DST or accessed via account_id-based procs Funcom retained (`update_player_tags`, `delete_mnemonic_recall_lesson_all`). `journey_story_node` was already fixed in v12.13.5.

## Validation

Every new query run against the **live DB** (writes wrapped in `BEGIN…ROLLBACK`, nothing persisted):

| Check | Result |
|---|---|
| Tag read | 404 rows |
| Tag overwrite | DELETE 404 → INSERT 2 → rollback → 404 intact |
| Set Respawn insert | INSERT 1 ok, rolled back |
| Vehicles read | 13 rows, no error |

PS parse-check passes on all three lib files.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>