### PR TITLE
Fix Journey panel read missed by the v12.13.5 rekey fix (v12.13.8)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.13.7"
+      placeholder: "v12.13.8"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.8] - 2026-06-26
+
+### Fixed
+
+- **The Journey panel showed "No journey nodes recorded for this player yet"
+  even for fully-progressed characters.** The v12.13.5 journey fix updated the
+  journey *write* paths for Funcom's 1.4.10.0 `account_id`→`character_id` rekey
+  but missed the *read*, so the Journey list still queried the old column and
+  came back empty (the nodes were all still there — 2052 on the test character).
+  The read now resolves the account to its character like the write paths do. A
+  full sweep of every per-player table Funcom rekeyed confirms this was the last
+  remaining account_id reference.
+
 ## [12.13.7] - 2026-06-26
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.7'
+$script:DuneToolVersion = '12.13.8'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.7',
+    [string]$Version = '12.13.8',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.7</Version>
+    <Version>12.13.8</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.7"
+#define MyAppVersion "12.13.8"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersRead.ps1
+++ b/app/server/lib/PlayersRead.ps1
@@ -234,13 +234,16 @@ ORDER BY player_id, track_type;
 function Get-DunePlayerJourneyLive {
     param([string]$Ip, [long]$AccountId)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+    # journey_story_node was rekeyed account_id -> character_id in Funcom 1.4.10.0
+    # (character_id = dune.player_state.id). The write paths were updated in
+    # v12.13.5; this read must resolve the account to its character the same way.
     $sql = @"
 SELECT story_node_id AS node_id,
        (complete_condition_state = 'true'::jsonb) AS is_complete,
        (reveal_condition_state   = 'true'::jsonb) AS is_revealed,
        has_pending_reward
 FROM dune.journey_story_node
-WHERE account_id = $AccountId::bigint
+WHERE character_id IN (SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint)
 ORDER BY story_node_id;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 5000 -TimeoutSec 30

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.7"
+$script:ToolVersion = "12.13.8"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## What

Fixes the **Journey** panel showing *"No journey nodes recorded for this player yet"* even for fully-progressed characters.

## Root cause

Funcom's 1.4.10.0 patch rekeyed `dune.journey_story_node` from `account_id` to `character_id`. The v12.13.5 fix updated the journey **write** paths but **missed the read** — `Get-DunePlayerJourneyLive` (`PlayersRead.ps1`) still filtered `WHERE account_id`, so the panel came back empty. The nodes were never gone (2052 on the test character, 1203 done).

## Fix

The read now resolves the account to its character:
```sql
WHERE character_id IN (SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint)
```
matching the write paths.

## Completeness sweep

Re-grepped **all 13** per-player tables Funcom rekeyed to `character_id`. Every DST reference is now correctly keyed (or goes through an account_id-based proc Funcom kept). This was the **last** remaining `account_id` reference on a rekeyed table.

## Validation

Live DB: the new read returns **2052 nodes (1203 done)** for the test character. PS parse-check passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>