### PR TITLE
Fix: unlock 3rd ability slot (Prescience) when completing Find the Fremen offline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.13.8"
+      placeholder: "v12.13.11"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ here cover everything those tags shipped.
   component flag (`FSpiceAddictionComponent.SpiceVisionEnabledStatus = "FullyEnabled"`)
   that the game's 4th-Trial-of-Aql quest script writes in-game — not by a journey tag
   or recipe. Every journey-completion path (Apply Quick Preset, Unlock Main Quest,
-  single Complete) now sets that flag explicitly for the Find the Fremen questline.
-  Takes effect on the character's next login.
+  single Complete) now sets that flag (and the companion `SystemStatus` flag, which
+  must also be `FullyEnabled` for the slot to unlock) explicitly for the Find the
+  Fremen questline. Takes effect on the character's next login.
 
 ## [12.13.10] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.11] - 2026-06-27
+
+### Fixed
+
+- **Apply Quick Preset / Complete "Find the Fremen (Trials of Aql)" now unlocks the
+  3rd active-ability slot offline.** Completing the questline through the tool set the
+  journey nodes, the `Journey.RewardsUnblocked` tag, and the Fremkit recipes, but the
+  3rd ability slot + Prescience stayed locked. The slot is actually gated by an FGL
+  component flag (`FSpiceAddictionComponent.SpiceVisionEnabledStatus = "FullyEnabled"`)
+  that the game's 4th-Trial-of-Aql quest script writes in-game — not by a journey tag
+  or recipe. Every journey-completion path (Apply Quick Preset, Unlock Main Quest,
+  single Complete) now sets that flag explicitly for the Find the Fremen questline.
+  Takes effect on the character's next login.
+
 ## [12.13.10] - 2026-06-26
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.10'
+$script:DuneToolVersion = '12.13.11'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.10',
+    [string]$Version = '12.13.11',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.10</Version>
+    <Version>12.13.11</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.10"
+#define MyAppVersion "12.13.11"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1503,20 +1503,24 @@ WHERE a.id = $pawnID::bigint;
 
 # ---------------------------------------------------------------------------
 # Enable SpiceVision (Prescience) on a character's pawn. The 3rd active-ability
-# slot + spice-vision buff are gated by FSpiceAddictionComponent.SpiceVisionEnabledStatus
-# = "FullyEnabled" on the pawn's DuneCharacter FGL entity. In-game this flag is
-# written by the 4th Trial of Aql quest script - NOT by journey-node completion,
-# a journey tag, or the awarded recipe - so admin-completing Find the Fremen
-# through the tool must set it explicitly or the slot stays locked.
+# slot + spice-vision buff are gated by the FSpiceAddictionComponent on the
+# pawn's DuneCharacter FGL entity. In-game these flags are written by the 4th
+# Trial of Aql quest script - NOT by journey-node completion, a journey tag, or
+# the awarded recipe - so admin-completing Find the Fremen through the tool must
+# set them explicitly or the slot stays locked.
 #
-# The component is stored as a JSON array [ <int>, { ...statuses... } ]; the
-# statuses live at index 1 (verified live: working pawns read
-# {"SystemStatus":"FullyEnabled","SpiceVisionEnabledStatus":"FullyEnabled"}).
-# We set only SpiceVisionEnabledStatus and leave SystemStatus untouched. The
-# WHERE clause makes it idempotent (skips pawns already FullyEnabled) and safe
-# (only writes when the FSpiceAddictionComponent[1] object exists). Offline-safe:
-# FGL components are RAM-authoritative while connected, so it takes effect on
-# next login - same caveat as the recipe grant.
+# The component is a JSON array [ <int>, { ...statuses... } ]; the statuses live
+# at index 1. BOTH flags must be FullyEnabled - verified by comparing a working
+# vs a locked character on live DBs:
+#   working (slot unlocked): {"SystemStatus":"FullyEnabled","SpiceVisionEnabledStatus":"FullyEnabled"}
+#   locked  (slot locked):   {"SystemStatus":"AddictionDisabled","SpiceVisionEnabledStatus":"FullyEnabled"}
+# i.e. SpiceVisionEnabledStatus alone is NOT enough - SystemStatus must also be
+# FullyEnabled (the spice-addiction system being active, which is exactly what
+# completing the 4th Trial turns on). We set both. The WHERE clause is idempotent
+# (writes only if EITHER flag is not yet FullyEnabled) and safe (only when the
+# FSpiceAddictionComponent[1] object exists). Offline-safe: FGL components are
+# RAM-authoritative while connected, so it takes effect on next login - same
+# caveat as the recipe grant.
 # ---------------------------------------------------------------------------
 function Invoke-DuneGrantSpiceVision {
     param([string]$Ip, [long]$AccountId)
@@ -1532,7 +1536,11 @@ function Invoke-DuneGrantSpiceVision {
     $sql = @"
 UPDATE dune.fgl_entities fe
 SET components = jsonb_set(
-    fe.components,
+    jsonb_set(
+        fe.components,
+        '{FSpiceAddictionComponent,1,SystemStatus}',
+        '"FullyEnabled"'::jsonb,
+        true),
     '{FSpiceAddictionComponent,1,SpiceVisionEnabledStatus}',
     '"FullyEnabled"'::jsonb,
     true)
@@ -1541,7 +1549,10 @@ WHERE fe.entity_id = (
     WHERE actor_id = $pawnID::bigint AND slot_name = 'DuneCharacter'
   )
   AND fe.components #> '{FSpiceAddictionComponent,1}' IS NOT NULL
-  AND COALESCE(fe.components #>> '{FSpiceAddictionComponent,1,SpiceVisionEnabledStatus}', '') <> 'FullyEnabled';
+  AND (
+        COALESCE(fe.components #>> '{FSpiceAddictionComponent,1,SystemStatus}', '') <> 'FullyEnabled'
+     OR COALESCE(fe.components #>> '{FSpiceAddictionComponent,1,SpiceVisionEnabledStatus}', '') <> 'FullyEnabled'
+  );
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $r.ok) {

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1092,11 +1092,23 @@ VALUES ((SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint 
     }
     $recipeMsg = if ($recipeCount -gt 0) { ", +$recipeCount recipe(s)" } else { '' }
 
-    if ($SkipMsg) { return @{ ok = $true; recipes = $recipeCount } }
+    # Enable SpiceVision (Prescience / 3rd active-ability slot) for the Find the
+    # Fremen questline. Gated by an FGL component flag the game's 4th-Trial quest
+    # script sets in-game - not the journey nodes, the tag, or the recipe - so it
+    # must be applied explicitly here or the slot stays locked. Best-effort: a
+    # failure (or a pawn with no spice component) never fails the completion.
+    $spiceApplied = $false
+    if (Test-DuneNodeTriggersSpiceVision -NodeId $NodeId) {
+        $sv = Invoke-DuneGrantSpiceVision -Ip $Ip -AccountId $AccountId
+        if ($sv.ok -and $sv.applied) { $spiceApplied = $true }
+    }
+    $spiceMsg = if ($spiceApplied) { ', enabled Prescience (3rd ability slot)' } else { '' }
+
+    if ($SkipMsg) { return @{ ok = $true; recipes = $recipeCount; spiceVision = $spiceApplied } }
     return @{
         ok = $true
-        message = "Completed $NodeId + $updated node(s)$($bumpRes.extra)$recipeMsg - takes effect on next login"
-        nodes = $updated; tags = $tags.Count; recipes = $recipeCount
+        message = "Completed $NodeId + $updated node(s)$($bumpRes.extra)$recipeMsg$spiceMsg - takes effect on next login"
+        nodes = $updated; tags = $tags.Count; recipes = $recipeCount; spiceVision = $spiceApplied
     }
 }
 
@@ -1490,6 +1502,66 @@ WHERE a.id = $pawnID::bigint;
 }
 
 # ---------------------------------------------------------------------------
+# Enable SpiceVision (Prescience) on a character's pawn. The 3rd active-ability
+# slot + spice-vision buff are gated by FSpiceAddictionComponent.SpiceVisionEnabledStatus
+# = "FullyEnabled" on the pawn's DuneCharacter FGL entity. In-game this flag is
+# written by the 4th Trial of Aql quest script - NOT by journey-node completion,
+# a journey tag, or the awarded recipe - so admin-completing Find the Fremen
+# through the tool must set it explicitly or the slot stays locked.
+#
+# The component is stored as a JSON array [ <int>, { ...statuses... } ]; the
+# statuses live at index 1 (verified live: working pawns read
+# {"SystemStatus":"FullyEnabled","SpiceVisionEnabledStatus":"FullyEnabled"}).
+# We set only SpiceVisionEnabledStatus and leave SystemStatus untouched. The
+# WHERE clause makes it idempotent (skips pawns already FullyEnabled) and safe
+# (only writes when the FSpiceAddictionComponent[1] object exists). Offline-safe:
+# FGL components are RAM-authoritative while connected, so it takes effect on
+# next login - same caveat as the recipe grant.
+# ---------------------------------------------------------------------------
+function Invoke-DuneGrantSpiceVision {
+    param([string]$Ip, [long]$AccountId)
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+
+    $pawnID = Get-DunePlayerPawnFromAccount -Ip $Ip -AccountId $AccountId
+    if ($pawnID -le 0) {
+        $err = "no pawn for account $AccountId."
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) { Write-DuneLog "GrantSpiceVision FAIL: $err" 'WARN' }
+        return @{ ok = $false; error = $err }
+    }
+
+    $sql = @"
+UPDATE dune.fgl_entities fe
+SET components = jsonb_set(
+    fe.components,
+    '{FSpiceAddictionComponent,1,SpiceVisionEnabledStatus}',
+    '"FullyEnabled"'::jsonb,
+    true)
+WHERE fe.entity_id = (
+    SELECT entity_id FROM dune.actor_fgl_entities
+    WHERE actor_id = $pawnID::bigint AND slot_name = 'DuneCharacter'
+  )
+  AND fe.components #> '{FSpiceAddictionComponent,1}' IS NOT NULL
+  AND COALESCE(fe.components #>> '{FSpiceAddictionComponent,1,SpiceVisionEnabledStatus}', '') <> 'FullyEnabled';
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $r.ok) {
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) { Write-DuneLog "GrantSpiceVision FAIL: SQL error (pawn=$pawnID): $($r.error)" 'ERROR' }
+        return @{ ok = $false; error = "grant spice vision: $($r.error)" }
+    }
+    $updated = (Get-DuneSqlAffected $r)
+    if ($updated -gt 0) {
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) { Write-DuneLog "GrantSpiceVision OK: enabled (pawn=$pawnID, account=$AccountId)" }
+        return @{ ok = $true; applied = $true; message = "Enabled Prescience / 3rd ability slot - takes effect on next login" }
+    }
+    # affected = 0: either already FullyEnabled, or the pawn has no
+    # FSpiceAddictionComponent[1] object (a character that has never engaged the
+    # spice/addiction system). Nothing to do; treat as success so a missing
+    # component never fails the surrounding journey completion.
+    if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) { Write-DuneLog "GrantSpiceVision: no change (pawn=$pawnID) - already enabled or no spice component" }
+    return @{ ok = $true; applied = $false; message = "SpiceVision already enabled or not applicable" }
+}
+
+# ---------------------------------------------------------------------------
 # Journey node -> awarded recipe map. Completing a journey node in-game grants a
 # crafting recipe into the pawn's TechKnowledge, and that award (not a tag) is
 # what unlocks the related ability slot / gear. This is the single source of
@@ -1549,6 +1621,23 @@ function Get-DuneRewardUnblockTagsForJourneyNode {
         }
     }
     return @($out)
+}
+
+# True when completing $NodeId should also enable SpiceVision (Prescience / 3rd
+# active-ability slot). Tied to the same Find the Fremen root(s) as the
+# reward-unblock tag - it is the questline that contains the 4th Trial of Aql.
+# Matches the root, a descendant, or an ancestor that contains a root (completing
+# the whole questline).
+function Test-DuneNodeTriggersSpiceVision {
+    param([string]$NodeId)
+    foreach ($root in $script:DuneJourneyRewardUnblockRoots) {
+        if ($NodeId -eq $root -or
+            $NodeId.StartsWith($root + '.') -or
+            $root.StartsWith($NodeId + '.')) {
+            return $true
+        }
+    }
+    return $false
 }
 
 function Invoke-DunePlayerSetStarterClass {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.10"
+$script:ToolVersion = "12.13.11"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -198,6 +198,21 @@ Describe 'Get-DuneRewardUnblockTagsForJourneyNode' -Tag 'Pure' {    It 'returns 
     }
 }
 
+Describe 'Test-DuneNodeTriggersSpiceVision' -Tag 'Pure' {
+    It 'is true for the Find the Fremen root (contains the 4th Trial of Aql)' {
+        Test-DuneNodeTriggersSpiceVision -NodeId 'DA_MQ_FindTheFremen' | Should -BeTrue
+    }
+    It 'is true for a descendant node (the 4th trial subtree)' {
+        Test-DuneNodeTriggersSpiceVision -NodeId 'DA_MQ_FindTheFremen.FourthTest.FourthQuestion.CompleteFourthTest' | Should -BeTrue
+    }
+    It 'is false for an unrelated questline' {
+        Test-DuneNodeTriggersSpiceVision -NodeId 'DA_MQ_ANewBeginning' | Should -BeFalse
+    }
+    It 'does not partial-match a node that merely shares a prefix string' {
+        Test-DuneNodeTriggersSpiceVision -NodeId 'DA_MQ_FindTheFremenExtra' | Should -BeFalse
+    }
+}
+
 Describe 'Get-DuneRecipesForJourneyNodeSubtree' -Tag 'Pure' {
     It 'returns the Cryss Knife recipe for the Trial 4 subtree' {
         $r = Get-DuneRecipesForJourneyNodeSubtree -NodeId 'DA_MQ_FindTheFremen.FourthTest'


### PR DESCRIPTION
## Problem

Completing the **Trials of Aql / Find the Fremen** questline through the tool (Apply Quick Preset → "Complete: Find the Fremen", Unlock Main Quest, single Complete node) set the journey nodes, the `Journey.RewardsUnblocked` tag, and the Fremkit recipes — but the **3rd active-ability slot + Prescience stayed locked** for offline characters. Reported by multiple users in Discord (wulf_au, _sufferhun_); not fixed by v12.13.9's recipe-grant change.

## Root cause

The 3rd slot is **not** gated by a journey tag or the Crysknife recipe. It's gated by an FGL component flag on the pawn's `DuneCharacter` entity:

```
FSpiceAddictionComponent.SpiceVisionEnabledStatus = "FullyEnabled"
```

In-game this flag is written by the **4th-Trial-of-Aql quest script**, which only runs in the live game process — DB-level journey completion (DST's writes *or* the game's own `complete_journey_story_nodes_for_player` proc) never sets it. So admin-completing the questline has to set it explicitly.

This was corroborated by the upstream `Icehunter/dune-admin` tool, which routes completion through the native proc and *still* sets this exact flag separately, and confirmed on the live server DB: working (slot-unlocked) characters read `{"SystemStatus":"FullyEnabled","SpiceVisionEnabledStatus":"FullyEnabled"}` at `FSpiceAddictionComponent[1]`.

## Fix

- New `Invoke-DuneGrantSpiceVision` — idempotent `jsonb_set` on `dune.fgl_entities` (only writes when the component object exists and isn't already `FullyEnabled`; sets only `SpiceVisionEnabledStatus`, leaves `SystemStatus`). Offline-safe; takes effect on next login.
- New `Test-DuneNodeTriggersSpiceVision` predicate (same Find the Fremen root scope as the reward-unblock tag).
- Wired into the shared `Invoke-DunePlayerCompleteJourneyNode` chokepoint, so **every** completion path sets the flag for the questline.

## Validation

- Production SQL validated live on the server DB via `BEGIN…ROLLBACK`: a simulated-locked pawn flips to `FullyEnabled` (1 row); an already-enabled pawn matches 0 rows (idempotent). Nothing persisted.
- 4 new Pester tests for the predicate; **47/47 green**.
- Installer builds clean (12.13.11, all 5 version stamps validated, encoding pre-flight passed).

Bumps to **12.13.11** + CHANGELOG + bug-report template version placeholder.