### PR TITLE
v12.13.13: P34 private-datacenter detection + public-IP apply fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.13.12"
+      placeholder: "v12.13.13"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ here cover everything those tags shipped.
   battlegroup) never ran, and the server stayed in P34. The host-route step is now
   non-blocking: on conflict it records a warning and the apply continues to fix the
   advertised address.
+- **The apply no longer writes a wrong default gateway (which could knock the VM
+  offline).** When rewriting `/etc/network/interfaces`, the apply previously fell back
+  to a hardcoded gateway if it couldn't find one in the existing file. On any VM whose
+  LAN subnet differed from that hardcoded value, the result was an unreachable gateway
+  and a dead default route — the game server could no longer reach Funcom's matchmaker
+  to register, so it silently dropped off the server browser despite being otherwise
+  healthy. The apply now derives the gateway from the VM's *live default route* (falling
+  back to the existing interfaces line, then the VM subnet's `.1`) and hard-validates
+  that it sits on the VM's own subnet, so a foreign-subnet gateway can never be written.
 
 ## [12.13.12] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.13] - 2026-06-27
+
+### Fixed
+
+- **Re-applying the same (unchanged) public IP now works.** Settings → Public IP /
+  DDNS → Apply was a dead end when the target IP matched the last-applied one: the
+  apply pipeline's internal "Validate target IP" step rejected the unchanged IP
+  ("Target IP is unchanged") and aborted. That blocked the documented repair flow
+  of re-applying your current IP to rewrite the host NAT / K3s ExternalIP after an
+  unclean shutdown or network change. The internal step now allows an unchanged IP
+  (the route-level validation already did), so a deliberate re-apply runs end to
+  end.
+
 ## [12.13.12] - 2026-06-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
-## [12.13.13] - 2026-06-27
+## [12.13.13] - 2026-06-28
 
 ### Added
 
@@ -37,6 +37,15 @@ here cover everything those tags shipped.
   unclean shutdown or network change. The internal step now allows an unchanged IP
   (the route-level validation already did), so a deliberate re-apply runs end to
   end.
+- **A stale Windows host route no longer blocks the public-IP fix.** The Apply flow
+  adds a host-side `/32` route purely as a NAT-loopback convenience (so the host PC
+  can reach the server by its own public IP); outside players never use it. If a
+  conflicting leftover route from a previous IP already existed, that step threw and
+  aborted the *entire* apply — so the critical step it gates (rewriting
+  `HOST_DATACENTER_IP_ADDRESS` off a private/`127.0.0.1` value and restarting the
+  battlegroup) never ran, and the server stayed in P34. The host-route step is now
+  non-blocking: on conflict it records a warning and the apply continues to fix the
+  advertised address.
 
 ## [12.13.12] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ here cover everything those tags shipped.
 
 ## [12.13.13] - 2026-06-27
 
+### Added
+
+- **P34 check now detects a server pinned to advertise a private address.** Choosing
+  "Private" instead of "External" during VM setup pins a private/LAN IP into the
+  server's `HOST_DATACENTER_IP_ADDRESS`, which the director re-advertises to every
+  client on each boot — so players on your own network connect, but anyone outside
+  times out into P34. The Connection check (Settings → Public IP / DDNS → Run check)
+  now reads this value straight from the battlegroup config (so it works even when
+  the servers are down or the game DB is empty) and flags a private — or stale
+  public — datacenter IP with a one-click "Fix it automatically" that re-applies your
+  public IP and restarts the battlegroup.
+
 ### Fixed
 
 - **Re-applying the same (unchanged) public IP now works.** Settings → Public IP /

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.12'
+$script:DuneToolVersion = '12.13.13'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.12',
+    [string]$Version = '12.13.13',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.12</Version>
+    <Version>12.13.13</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.12"
+#define MyAppVersion "12.13.13"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -743,8 +743,30 @@ fi
 /sbin/ip -4 -o addr show dev eth0
 
 step interfaces
-GW=$(awk '/^[[:space:]]*gateway[[:space:]]+/ {print $2; exit}' /etc/network/interfaces 2>/dev/null || true)
-if [ -z "$GW" ]; then GW="192.168.23.1"; fi
+# Determine the default gateway WITHOUT ever hardcoding a foreign subnet.
+# A wrong gateway (e.g. one on a different /24 than the VM) leaves the VM with
+# no working default route, which silently kills ALL outbound traffic -- the
+# game server can no longer reach Funcom's matchmaker to register, so it drops
+# off the server browser even though it is otherwise healthy. Preference order:
+#   1. the live default route (the gateway that is actually working right now)
+#   2. the existing interfaces 'gateway' line
+#   3. derive .1 of the VM's own /24 as a last resort
+# Then HARD-VALIDATE that the chosen gateway is on the same /24 as the VM; if it
+# is not (e.g. a stale foreign value from a previous run), fall back to the
+# same-subnet .1 rather than write an unreachable gateway.
+GW=$(/sbin/ip route show default 2>/dev/null | awk '/^default/ {print $3; exit}')
+if [ -z "$GW" ]; then
+  GW=$(awk '/^[[:space:]]*gateway[[:space:]]+/ {print $2; exit}' /etc/network/interfaces 2>/dev/null || true)
+fi
+if [ -z "$GW" ]; then
+  GW=$(echo "$VM_IP" | awk -F. '{print $1"."$2"."$3".1"}')
+fi
+GW_PREFIX=$(echo "$GW" | awk -F. '{print $1"."$2"."$3}')
+VM_PREFIX=$(echo "$VM_IP" | awk -F. '{print $1"."$2"."$3}')
+if [ "$GW_PREFIX" != "$VM_PREFIX" ]; then
+  GW=$(echo "$VM_IP" | awk -F. '{print $1"."$2"."$3".1"}')
+fi
+echo "interfaces gateway -> $GW (VM $VM_IP)"
 sudo cp /etc/network/interfaces "/etc/network/interfaces.bak.$(date -u +%Y%m%d%H%M%S)" 2>/dev/null || true
 cat > /tmp/dst-interfaces <<EOF
 auto lo

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -692,8 +692,19 @@ function Invoke-DunePublicIpApply {
 
             $steps.Add((New-DunePublicIpStepResult 'host-route' 'Update Windows host route' 'running' "Adding route for $target.")) | Out-Null
             & $pub
-            $routeMsg = Invoke-DunePublicIpHostRoute -PublicIp $target -VmIp $vm.ip
-            $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'host-route' 'Update Windows host route' 'done' $routeMsg
+            # The host route is ONLY a NAT-loopback convenience so this Windows host
+            # can reach the server by its public IP; outside players never use it. A
+            # failure here (e.g. a stale conflicting /32 route from a previous IP, or
+            # DST not elevated) must NOT abort the apply -- otherwise the critical step
+            # below (rewriting HOST_DATACENTER_IP_ADDRESS off a private/127.0.0.1 value
+            # and restarting the battlegroup) never runs and the user's P34 stays
+            # broken. So we degrade a host-route failure to a non-blocking warning.
+            try {
+                $routeMsg = Invoke-DunePublicIpHostRoute -PublicIp $target -VmIp $vm.ip
+                $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'host-route' 'Update Windows host route' 'done' $routeMsg
+            } catch {
+                $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'host-route' 'Update Windows host route' 'warning' "Skipped (non-blocking): $($_.Exception.Message) This route only lets this PC reach the server by its own public IP (NAT-loopback testing); outside players are unaffected and the IP change still applied. To enable host-side self-testing, clear the conflicting route and re-apply."
+            }
             & $pub
 
             # --- Phase 1: VM network + persistent files + K3s --------------------

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -598,7 +598,14 @@ function Invoke-DunePublicIpApply {
             $target = ([string]$PublicIp).Trim()
             $steps.Add((New-DunePublicIpStepResult 'validate' 'Validate target IP' 'running' "Checking $target.")) | Out-Null
             & $pub 'running'
-            $valid = Assert-DuneManualPublicIp -PublicIp $target
+            # Re-assert WITH -AllowUnchanged: by the time we're inside the apply
+            # pipeline the user has explicitly confirmed they want to (re)apply,
+            # and a deliberate re-apply of the *same* IP is the whole point of the
+            # repair flow (e.g. rewriting host NAT / K3s ExternalIP after an
+            # unclean shutdown). Without this the internal step rejected an
+            # unchanged IP with "Target IP is unchanged" and aborted the apply,
+            # leaving no way to re-apply the current IP from the UI.
+            $valid = Assert-DuneManualPublicIp -PublicIp $target -AllowUnchanged
             if (-not $valid.ok) { throw $valid.message }
             $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'validate' 'Validate target IP' 'done' "Target $target accepted."
             & $pub

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -340,12 +340,16 @@ function Get-DuneP34Diagnostic {
         vmPublicIp     = $null
         publicIpSource = $null
         k3sExternalIp  = $null
+        datacenterIps      = @()
+        datacenterPrivate  = $false
+        datacenterStale    = $false
         maps           = @()
         advertisedIps  = @()
         igwAddrs       = @()
         igwSuspect     = $false
         staleFarmIp    = $false
         staleK3sIp     = $false
+        vmPublicIpUsable = $false
         serversReady   = $true
         verdict        = 'unknown'
         summary        = $null
@@ -393,6 +397,18 @@ PUB=$(get_ip)
 EXT=$(sudo kubectl get node -o jsonpath='{range .items[0].status.addresses[?(@.type=="ExternalIP")]}{.address}{end}' 2>/dev/null)
 echo "PUB=$PUB"
 echo "EXT=$EXT"
+# HOST_DATACENTER_IP_ADDRESS = the address the director advertises to clients on
+# every boot. It is pinned into the battlegroup CR at setup ("Private" vs
+# "External"); if it is a private/LAN address, outside players are handed an
+# unreachable address and time out into P34. Read every distinct value from the
+# CR so we can flag a pinned-private / stale datacenter IP independently of the
+# game DB (works even when the servers are down or farm_state is empty).
+BG=$(sudo kubectl get battlegroup -A --no-headers -o custom-columns=:metadata.name 2>/dev/null | head -1)
+NS=$(sudo kubectl get battlegroup -A --no-headers -o custom-columns=:metadata.namespace 2>/dev/null | head -1)
+if [ -n "$BG" ] && [ -n "$NS" ] && command -v jq >/dev/null 2>&1; then
+  DC=$(sudo kubectl get battlegroup "$BG" -n "$NS" -o json 2>/dev/null | jq -r '[.. | objects | select(.name=="HOST_DATACENTER_IP_ADDRESS") | .value] | map(select(. != null and . != "")) | unique | join(",")' 2>/dev/null)
+  echo "DC=$DC"
+fi
 '@ -replace "`r", ''
     try {
         $raw = Invoke-V6Ssh -Ip $ctx.ip -Cmd $probe -TimeoutSec 35
@@ -401,6 +417,15 @@ echo "EXT=$EXT"
         if ($mp.Success) { $result.vmPublicIp = $mp.Groups[1].Value.Trim() }
         $me = [regex]::Match($rawText, 'EXT=([0-9.]+)')
         if ($me.Success) { $result.k3sExternalIp = $me.Groups[1].Value.Trim() }
+        $md = [regex]::Match($rawText, 'DC=([0-9.,]+)')
+        if ($md.Success) {
+            $result.datacenterIps = @(
+                $md.Groups[1].Value.Trim() -split ',' |
+                    ForEach-Object { $_.Trim() } |
+                    Where-Object { $_ -match '^\d{1,3}(\.\d{1,3}){3}$' } |
+                    Select-Object -Unique
+            )
+        }
     } catch {
         # Non-fatal: a failed probe just means we lean on the host-side fallback
         # below. Only the farm_state query (next) is essential.
@@ -474,9 +499,28 @@ echo "EXT=$EXT"
 
     $pub = [string]$result.vmPublicIp
     $looksPublic = ($pub -match '^\d{1,3}(\.\d{1,3}){3}$') -and ($pub -notmatch '^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|127\.|0\.)')
+    $result.vmPublicIpUsable = [bool]$looksPublic
     if ($looksPublic) {
         $result.staleFarmIp = [bool](@($advertised | Where-Object { $_ -ne $pub }).Count)
         if ($result.k3sExternalIp) { $result.staleK3sIp = ($result.k3sExternalIp -ne $pub) }
+    }
+
+    # HOST_DATACENTER_IP_ADDRESS sanity (the persistent address the director
+    # advertises to clients on every boot, pinned into the BG CR at setup).
+    # This is read straight from the CR, so it works even when the servers are
+    # down / farm_state is empty — unlike the advertised-IP checks above.
+    #   * datacenterPrivate: a value is an RFC1918 private/LAN address. That is
+    #     the signature of choosing "Private" (not "External") at VM setup — the
+    #     director then hands every outside player an unreachable private address
+    #     and they time out into P34, on every boot.
+    #   * datacenterStale: a value is a real public IP but NOT this server's
+    #     current public IP (a pinned old IP after a network change).
+    $privateRe = '^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|127\.|0\.|169\.254\.)'
+    $result.datacenterPrivate = [bool](@($result.datacenterIps | Where-Object { $_ -match $privateRe }).Count)
+    if ($looksPublic) {
+        $result.datacenterStale = [bool](@($result.datacenterIps | Where-Object {
+            ($_ -notmatch $privateRe) -and ($_ -ne $pub)
+        }).Count)
     }
 
     # IGW (inter-game-world) gateway sanity. During sector handover / map travel
@@ -510,7 +554,24 @@ echo "EXT=$EXT"
     }
 
     # Verdict, most-actionable first.
-    if (@($maps).Count -eq 0) {
+    if ($result.datacenterPrivate) {
+        # The persistent root: the director is pinned to advertise a private/LAN
+        # address to every client. Ranked first because it's actionable even when
+        # the servers look "down" from outside, and it's the explanation behind a
+        # server that's healthy internally but unreachable for outside players.
+        $dcTxt = (@($result.datacenterIps) -join ', ')
+        $result.verdict = 'datacenter-private'
+        $result.summary = "Your server is pinned to advertise a private address ($dcTxt) to players (HOST_DATACENTER_IP_ADDRESS). This is what happens when ""Private"" is chosen instead of ""External"" during VM setup: the server re-announces that private address on every boot, so players on your own network can connect but anyone outside times out into P34. Apply your current public IP ($pub)$srcNote below — that rewrites the advertised address to your public IP and restarts the battlegroup.$igwNote"
+    }
+    elseif ($result.datacenterStale -and -not ($result.staleFarmIp -or $result.staleK3sIp)) {
+        # Public-but-wrong datacenter IP (pinned to an old public IP) that the
+        # farm_state checks didn't already surface (e.g. servers not yet up).
+        $dcTxt = (@($result.datacenterIps) -join ', ')
+        $result.verdict = 'stale-ip'
+        $result.staleFarmIp = $true
+        $result.summary = "Your server advertises $dcTxt to players (HOST_DATACENTER_IP_ADDRESS), but this server's public IP is $pub$srcNote. Players are being sent to the wrong address, which causes P34 / connection timeouts. Apply your current public IP below to fix it.$igwNote"
+    }
+    elseif (@($maps).Count -eq 0) {
         $result.verdict = 'servers-down'
         $result.summary = 'No map servers are registered yet. Start or restart the battlegroup, then re-check.'
     }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.12"
+$script:ToolVersion = "12.13.13"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -73,6 +73,10 @@ type P34Diagnostic = {
   vmIp?: string | null
   vmPublicIp?: string | null
   k3sExternalIp?: string | null
+  datacenterIps?: string[]
+  datacenterPrivate?: boolean
+  datacenterStale?: boolean
+  vmPublicIpUsable?: boolean
   maps?: P34Map[]
   advertisedIps?: string[]
   igwAddrs?: string[]
@@ -80,7 +84,7 @@ type P34Diagnostic = {
   staleFarmIp?: boolean
   staleK3sIp?: boolean
   serversReady?: boolean
-  verdict?: 'healthy' | 'stale-ip' | 'servers-down' | 'servers-not-ready' | 'igw-private' | 'unknown'
+  verdict?: 'healthy' | 'stale-ip' | 'servers-down' | 'servers-not-ready' | 'igw-private' | 'datacenter-private' | 'unknown'
   summary?: string
   error?: string
 }
@@ -412,12 +416,12 @@ export function PublicIpCard() {
             <div className={
               p34.verdict === 'healthy'
                 ? 'rounded-lg border border-success/40 bg-success/10 p-3 text-sm text-success flex items-start gap-2'
-                : p34.verdict === 'stale-ip'
+                : (p34.verdict === 'stale-ip' || p34.verdict === 'datacenter-private')
                   ? 'rounded-lg border border-danger/40 bg-danger/10 p-3 text-sm text-danger flex items-start gap-2'
                   : 'rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm text-warning flex items-start gap-2'
             }>
               <Icon
-                name={p34.verdict === 'healthy' ? 'CheckCircle2' : p34.verdict === 'stale-ip' ? 'AlertTriangle' : 'AlertCircle'}
+                name={p34.verdict === 'healthy' ? 'CheckCircle2' : (p34.verdict === 'stale-ip' || p34.verdict === 'datacenter-private') ? 'AlertTriangle' : 'AlertCircle'}
                 size={15}
                 className="mt-0.5 shrink-0"
               />
@@ -500,7 +504,7 @@ export function PublicIpCard() {
               </div>
             )}
 
-            {p34.verdict === 'stale-ip' && (
+            {(p34.verdict === 'stale-ip' || (p34.verdict === 'datacenter-private' && p34.vmPublicIpUsable)) && (
               <div className="space-y-2">
                 <button
                   type="button"
@@ -512,10 +516,17 @@ export function PublicIpCard() {
                   {applyRunning && fixingP34.current ? 'Fixing…' : `Fix it automatically (set public IP to ${p34.vmPublicIp})`}
                 </button>
                 <p className="text-xs text-text-dim">
-                  This re-applies your current public IP and restarts the servers so they re-advertise the correct
-                  address. Same as setting the IP manually below and clicking Apply — it just fills it in for you.
+                  {p34.verdict === 'datacenter-private'
+                    ? 'This rewrites the address your server advertises (HOST_DATACENTER_IP_ADDRESS) from the private/LAN value to your public IP and restarts the battlegroup, so outside players are routed correctly. Same as setting the IP manually below and clicking Apply.'
+                    : 'This re-applies your current public IP and restarts the servers so they re-advertise the correct address. Same as setting the IP manually below and clicking Apply — it just fills it in for you.'}
                 </p>
               </div>
+            )}
+            {p34.verdict === 'datacenter-private' && !p34.vmPublicIpUsable && (
+              <p className="text-xs text-warning">
+                Your server is advertising a private address to players, but DST couldn’t auto-detect your public IP.
+                Enter your public IPv4 in the field below and click Apply to fix it.
+              </p>
             )}
           </div>
         )}

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -18,7 +18,7 @@ type PublicIpStatus = {
 type PublicIpStep = {
   id: string
   label: string
-  status: 'running' | 'done' | 'failed'
+  status: 'running' | 'done' | 'failed' | 'warning'
   detail?: string
   raw?: string
 }


### PR DESCRIPTION
Ships **v12.13.13**. Targets the post-Funcom-1.4.10.0 P34 / can't-connect wave, plus two field-confirmed bugs in the public-IP apply flow.

## Added
- **P34 check detects a server pinned to advertise a private address.** A "Private" datacenter choice at VM setup pins a private/LAN IP into `HOST_DATACENTER_IP_ADDRESS`, which the director re-advertises every boot — LAN players connect, outside players time out into P34. The Connection check now reads this straight from the battlegroup config (works even when servers are down) and offers one-click "Fix it automatically".

## Fixed
- **Re-applying the same (unchanged) public IP now works.** The internal "Validate target IP" step rejected an unchanged IP and aborted the repair flow; it now allows a deliberate re-apply end to end.
- **A stale Windows host route no longer blocks the fix.** The host-route step (a NAT-loopback convenience) threw on a conflicting leftover route and aborted the *entire* apply — so the critical `HOST_DATACENTER_IP_ADDRESS` rewrite never ran. It's now non-blocking (warning + continue).
- **The apply no longer writes a wrong-subnet default gateway.** It previously fell back to a hardcoded gateway when it couldn't parse one; on a VM whose LAN differed, this wrote an unreachable gateway → dead default route → the server couldn't reach Funcom's matchmaker and silently dropped off the browser. The gateway is now derived from the VM's live default route (then the interfaces line, then the subnet `.1`) and hard-validated to sit on the VM's own subnet, so a foreign-subnet gateway can never be written. Re-running the apply self-heals a VM previously broken this way.

## Field validation
- **ironbeard** (datacenter-private case): both bugs hit live; after the fixes the server re-listed and an **external player joined successfully** from another network.
- **techtonic001** (plain home, non-datacenter): confirmed Test 2 fixed their P34.

Also bumps the 5 version stamps to 12.13.13, rolls the CHANGELOG entry, and bumps the bug-report template version placeholder.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>