### PR TITLE
v12.13.14: recover the real gateway from interfaces backups

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.13.13"
+      placeholder: "v12.13.14"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.14] - 2026-06-28
+
+### Fixed
+
+- **Public-IP apply now recovers a network's real gateway instead of guessing.**
+  Building on the wrong-subnet-gateway fix in 12.13.13, when the live default
+  route and current `/etc/network/interfaces` don't yield a gateway on the VM's
+  own subnet (e.g. a VM left with a wrong gateway by an earlier build), the apply
+  now reads the gateway from the `interfaces.bak.*` backups it makes before each
+  rewrite — the oldest backup holds the pristine original — before falling back
+  to the subnet's `.1`. This lets a re-run self-heal a VM previously knocked
+  offline by the bug even when its real gateway isn't `.1` (e.g. `.254`).
+
 ## [12.13.13] - 2026-06-28
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.13'
+$script:DuneToolVersion = '12.13.14'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.13',
+    [string]$Version = '12.13.14',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.13</Version>
+    <Version>12.13.14</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.13"
+#define MyAppVersion "12.13.14"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -743,27 +743,39 @@ fi
 /sbin/ip -4 -o addr show dev eth0
 
 step interfaces
-# Determine the default gateway WITHOUT ever hardcoding a foreign subnet.
-# A wrong gateway (e.g. one on a different /24 than the VM) leaves the VM with
-# no working default route, which silently kills ALL outbound traffic -- the
-# game server can no longer reach Funcom's matchmaker to register, so it drops
-# off the server browser even though it is otherwise healthy. Preference order:
-#   1. the live default route (the gateway that is actually working right now)
-#   2. the existing interfaces 'gateway' line
-#   3. derive .1 of the VM's own /24 as a last resort
-# Then HARD-VALIDATE that the chosen gateway is on the same /24 as the VM; if it
-# is not (e.g. a stale foreign value from a previous run), fall back to the
-# same-subnet .1 rather than write an unreachable gateway.
-GW=$(/sbin/ip route show default 2>/dev/null | awk '/^default/ {print $3; exit}')
-if [ -z "$GW" ]; then
-  GW=$(awk '/^[[:space:]]*gateway[[:space:]]+/ {print $2; exit}' /etc/network/interfaces 2>/dev/null || true)
-fi
-if [ -z "$GW" ]; then
-  GW=$(echo "$VM_IP" | awk -F. '{print $1"."$2"."$3".1"}')
-fi
-GW_PREFIX=$(echo "$GW" | awk -F. '{print $1"."$2"."$3}')
+# Determine the default gateway WITHOUT ever hardcoding a foreign subnet, and
+# recover the user's REAL gateway even if a previous (buggy) run already wrote a
+# wrong one. A gateway on a different /24 than the VM leaves it with no working
+# default route, which silently kills ALL outbound traffic -- the game server
+# can no longer reach Funcom's matchmaker to register, so it drops off the
+# server browser even though it is otherwise healthy.
+#
+# We gather candidate gateways in priority order and pick the FIRST one that
+# sits on the VM's own /24:
+#   1. the live default route (the gateway actually working right now)
+#   2. the current interfaces 'gateway' line
+#   3. the gateway from each interfaces.bak.* we've made -- the oldest backup
+#      holds the pristine ORIGINAL gateway from before any DST rewrite, so this
+#      recovers a network whose real gateway is not .1 (e.g. .254) even after a
+#      prior run wrote a wrong value into the live route and current file.
+# Only if NO candidate is on the VM's subnet do we fall back to the subnet's .1.
+# This lets a re-run self-heal a VM previously broken by a wrong gateway.
 VM_PREFIX=$(echo "$VM_IP" | awk -F. '{print $1"."$2"."$3}')
-if [ "$GW_PREFIX" != "$VM_PREFIX" ]; then
+GW=""
+add_gw_candidate() {
+  cand="$1"
+  if [ -n "$GW" ]; then return 0; fi
+  if [ -z "$cand" ]; then return 0; fi
+  cpfx=$(echo "$cand" | awk -F. '{print $1"."$2"."$3}')
+  if [ "$cpfx" = "$VM_PREFIX" ]; then GW="$cand"; fi
+  return 0
+}
+add_gw_candidate "$(/sbin/ip route show default 2>/dev/null | awk '/^default/ {print $3; exit}')"
+add_gw_candidate "$(awk '/^[[:space:]]*gateway[[:space:]]+/ {print $2; exit}' /etc/network/interfaces 2>/dev/null)"
+for bak in $(ls -1tr /etc/network/interfaces.bak.* 2>/dev/null); do
+  add_gw_candidate "$(awk '/^[[:space:]]*gateway[[:space:]]+/ {print $2; exit}' "$bak" 2>/dev/null)"
+done
+if [ -z "$GW" ]; then
   GW=$(echo "$VM_IP" | awk -F. '{print $1"."$2"."$3".1"}')
 fi
 echo "interfaces gateway -> $GW (VM $VM_IP)"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.13"
+$script:ToolVersion = "12.13.14"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Follow-up refinement to the wrong-subnet-gateway fix shipped in v12.13.13.

## Why
v12.13.13 stopped the apply from ever *writing* a foreign-subnet gateway, and on a fresh apply it correctly preserves the real gateway from the live default route. But its last-resort fallback guessed the subnet's `.1`. For a VM **already** left with a wrong gateway by an earlier build, a re-run sees the bad foreign gateway as the only live default and falls back to `.1` — which is still wrong for networks whose real gateway isn't `.1`.

**Confirmed in the field today:** a second affected host had a `.254` gateway, so the `.1` guess would not have self-healed it.

## What
When neither the live default route nor the current `/etc/network/interfaces` yields a gateway on the VM's own `/24`, the apply now reads the gateway from the `interfaces.bak.*` backups it already makes before each rewrite — the **oldest backup holds the pristine original gateway** — before falling back to `.1`. Candidates are filtered to the VM's own subnet, so a stale foreign value can never win.

Net: a re-run now self-heals a VM previously knocked offline by the bug, regardless of whether its gateway is `.1`, `.254`, etc.

Also bumps the 5 version stamps + bug-report template placeholder to 12.13.14 and adds the CHANGELOG entry.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>