### PR TITLE
v12.13.15: fix partition-clear bundled-script path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.13.14"
+      placeholder: "v12.13.15"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.15] - 2026-06-28
+
+### Fixed
+
+- **Auto-clear of on-demand map partitions at battlegroup start works again.** The
+  launcher's post-restart hook looked for a bundled script named
+  `dune-clear-partitions.start`, which no longer exists (it was consolidated into
+  `dune-clear-partitions-install.sh`), so it logged "exited -1 / not found" and
+  skipped the clear — on-demand maps (DeepDesert/Arrakeen/Harko) could be slow to
+  spawn after a restart. The hook now points at the bundled installer, which also
+  (re)installs the boot hook + cron, so the partition heal runs and self-repairs.
+  Manual **fix-on-demand-maps** / Map SpinUp "Fix partitions" were unaffected.
+
 ## [12.13.14] - 2026-06-28
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.14'
+$script:DuneToolVersion = '12.13.15'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.14',
+    [string]$Version = '12.13.15',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.14</Version>
+    <Version>12.13.15</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.14"
+#define MyAppVersion "12.13.15"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.14"
+$script:ToolVersion = "12.13.15"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a
@@ -825,8 +825,8 @@ function Wait-MapPodReady {
 
 function Get-DuneRemotePartitionScriptPath {
     $candidates = @(
-        (Join-Path $scriptDir 'resources\remote-scripts\dune-clear-partitions.start')
-        (Join-Path $scriptDir 'app\resources\remote-scripts\dune-clear-partitions.start')
+        (Join-Path $scriptDir 'resources\remote-scripts\dune-clear-partitions-install.sh')
+        (Join-Path $scriptDir 'app\resources\remote-scripts\dune-clear-partitions-install.sh')
     )
     foreach ($p in $candidates) {
         if (Test-Path -LiteralPath $p) { return $p }
@@ -845,7 +845,7 @@ function Invoke-DuneRemotePartitionScript {
     )
     $local = Get-DuneRemotePartitionScriptPath
     if (-not $local) {
-        return @{ ok = $false; rc = -1; output = @('Bundled dune-clear-partitions.start not found in install dir.') }
+        return @{ ok = $false; rc = -1; output = @('Bundled dune-clear-partitions-install.sh not found in install dir.') }
     }
 
     $stamp     = [Guid]::NewGuid().ToString('N').Substring(0, 12)


### PR DESCRIPTION
Fixes the v12.13.15 partition-clear regression seen on a live BG restart: the launcher's post-restart hook logged `partition-clear script exited -1 — Bundled dune-clear-partitions.start not found in install dir`.

**Cause:** `Get-DuneRemotePartitionScriptPath` looked for `dune-clear-partitions.start`, which no longer ships — it was consolidated into `dune-clear-partitions-install.sh`. So the auto-clear of on-demand map partitions silently no-op'd after a restart (DeepDesert/Arrakeen/Harko slow to spawn). Manual fix-on-demand-maps / Map SpinUp "Fix partitions" were unaffected (they use the correct path).

**Fix:** point the hook at `dune-clear-partitions-install.sh`. Running it not only heals but also reinstalls the boot hook + cron, so the heal self-repairs. Low severity (BG still comes up), but worth shipping.

Bumps the 5 stamps + bug-report placeholder to 12.13.15, adds CHANGELOG entry.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>