### PR TITLE
v12.13.16: fix server rename body parse

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.13.15"
+      placeholder: "v12.13.16"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.16] - 2026-06-28
+
+### Fixed
+
+- **Renaming the server works again.** Game Config → Server name rejected a valid
+  name with "A non-empty name is required" because the route read the request body
+  with a PSObject-only accessor that returned null for hashtable-parsed bodies. It
+  now uses the shared body reader, so the rename + restart applies as expected.
+
 ## [12.13.15] - 2026-06-28
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.15'
+$script:DuneToolVersion = '12.13.16'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.15',
+    [string]$Version = '12.13.16',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.15</Version>
+    <Version>12.13.16</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.15"
+#define MyAppVersion "12.13.16"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/routes/Status.ps1
+++ b/app/server/routes/Status.ps1
@@ -67,8 +67,7 @@ Register-DuneRoute -Method POST -Path '/api/status/refresh' -Handler {
 Register-DuneRoute -Method POST -Path '/api/server/name' -Handler {
     param($req, $res, $routeParams, $body)
     try {
-        $name = $null
-        if ($body -and $body.PSObject.Properties['name']) { $name = [string]$body.name }
+        $name = [string](Get-DuneBodyValue -Body $body -Name 'name')
         if ([string]::IsNullOrWhiteSpace($name)) {
             Write-DuneError -Response $res -Status 400 -Message 'A non-empty "name" is required.'
             return

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.15"
+$script:ToolVersion = "12.13.16"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Fixes Game Config → Server name rejecting a valid name with "A non-empty name is required".

The `POST /api/server/name` route read the body via `$body.PSObject.Properties['name']`, which returns null when the request body is parsed as a hashtable — so a valid name (e.g. "Reaps") was rejected. Switched to the shared `Get-DuneBodyValue` reader used by other routes, so rename + restart applies. Bumps stamps to 12.13.16 + CHANGELOG.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>