### PR TITLE
v12.13.17: cross-server restore character disclaimer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.13.16"
+      placeholder: "v12.13.17"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.13.17] - 2026-06-28
+
+### Changed
+
+- **Restore now warns that cross-server restores don't reliably restore characters.**
+  Characters are bound to Funcom accounts in the cloud, so restoring a backup onto a
+  different VM/battlegroup recovers the world and bases but may not restore character
+  logins (they can fail to load or get cleared on boot). The Restore card and its
+  confirmation prompt now say so — restore is intended for the same server.
+
 ## [12.13.16] - 2026-06-28
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.13.16'
+$script:DuneToolVersion = '12.13.17'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.13.16',
+    [string]$Version = '12.13.17',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.13.16</Version>
+    <Version>12.13.17</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.13.16"
+#define MyAppVersion "12.13.17"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.13.16"
+$script:ToolVersion = "12.13.17"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -87,6 +87,7 @@ export function Database() {
         'ALL players, bases, inventories, storage, blueprints, and the market will be rolled back to that snapshot. ' +
         'Everything created since the backup is permanently lost. This cannot be undone.\n\n' +
         'Take a fresh backup first if you have not. The battlegroup must be stopped.\n\n' +
+        'NOTE: restoring a backup onto a DIFFERENT server/battlegroup than it was taken on does NOT reliably restore characters — they are bound to your Funcom account in the cloud, so they may fail to load or get cleared on boot. Cross-server restores recover the world/bases, not character logins. Restore is intended for the SAME server.\n\n' +
         'Type RESTORE to continue:',
       )
       if (typed == null) return
@@ -287,7 +288,7 @@ export function Database() {
           title="Restore Backup"
           icon="Upload"
           tone="ibad"
-          description="Full destructive restore — REPLACES the entire BG database with a previously taken backup. All players, bases, inventories, storage, blueprints, and the market roll back to that snapshot; everything since is permanently lost. The battlegroup must be stopped, and this cannot be undone."
+          description="Full destructive restore — REPLACES the entire BG database with a previously taken backup. All players, bases, inventories, storage, blueprints, and the market roll back to that snapshot; everything since is permanently lost. The battlegroup must be stopped, and this cannot be undone. Restoring onto a different server/BG than it came from won't reliably restore characters (they're cloud-bound to Funcom accounts) — world/bases come back, character logins may not."
           hint={
             !vmRunning ? 'VM must be running to restore a backup.'
             : bgState === 'running' ? 'Stop the battlegroup first to avoid database corruption.'


### PR DESCRIPTION
Adds an honest cross-server-restore disclaimer to the Database → Restore card and its confirmation prompt: characters are cloud-bound to Funcom accounts, so restoring a backup onto a different VM/battlegroup recovers the world and bases but may not restore character logins (they can fail to load or get cleared on boot). Restore is intended for the same server. Bumps stamps to 12.13.17 + CHANGELOG. Surfaced from a live recovery case where a cross-server restore brought back bases but characters wouldn't persist.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>