### PR TITLE
Players: Reset Faction action (rep + tags + journey, offline)

### DIFF
--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1028,36 +1028,24 @@ function Invoke-DunePlayerResetFaction {
 
     $sb = [System.Text.StringBuilder]::new()
     [void]$sb.AppendLine('BEGIN;')
-    foreach ($fn in $factions) {
-        $fid = if ($fn -eq 'Atreides') { 1 } else { 2 }
-        # zero rep + clear alignment for this faction
-        [void]$sb.AppendLine("SELECT dune.set_player_faction_reputation($controllerID::bigint, $fid::smallint, 0::integer);")
-        # remove every faction tag (Faction.<name>.*, contract/storyline/rank tags, recruitment)
-        $likes = @(
-            "tag LIKE 'Faction.$fn.%'",
-            "tag LIKE 'FactionStoryline.$fn%'",
-            "tag LIKE '%Fac_$($fn.Substring(0,4))_Rank%'",
-            "tag LIKE '%$fn%'"
-        ) -join ' OR '
-        [void]$sb.AppendLine("DELETE FROM dune.player_tags WHERE $charScope AND ($likes);")
-        # faction journey subtree (ClimbTheRanks nodes carry the faction in a sub-segment)
-        [void]$sb.AppendLine("DELETE FROM dune.journey_story_node WHERE $charScope AND story_node_id LIKE 'DA_FQ_ClimbTheRanks%' AND story_node_id ILIKE '%$fn%';")
-    }
-    # shared faction tags + climb-the-ranks core only wiped on full 'both' reset
-    if ($fl -eq 'both') {
-        $shared = @(
-            "tag LIKE 'DialogueFlags.Factions.%'",
-            "tag LIKE 'Contract.Faction.%'",
-            "tag LIKE '%Atreides%'", "tag LIKE '%Harkonnen%'",
-            "tag LIKE '%Atre%'", "tag LIKE '%Hark%'",
-            "tag = 'Journey.LandsraadContractsUnlocked'",
-            "tag LIKE 'Contract.Tracking.%FactionUnlocked'",
-            "tag LIKE 'Contract.Tracking.%RecruitmentCompleted'"
-        ) -join ' OR '
-        [void]$sb.AppendLine("DELETE FROM dune.player_tags WHERE $charScope AND ($shared);")
-        [void]$sb.AppendLine("DELETE FROM dune.journey_story_node WHERE $charScope AND story_node_id LIKE 'DA_FQ_ClimbTheRanks%';")
-        [void]$sb.AppendLine("SELECT dune.change_player_faction($controllerID::bigint, 3::smallint, 0::smallint, NOW()::timestamp);")
-    }
+    # zero rep + reset alignment to None (3) so the recruiter funnel re-triggers
+    [void]$sb.AppendLine("SELECT dune.set_player_faction_reputation($controllerID::bigint, 1::smallint, 0::integer);")
+    [void]$sb.AppendLine("SELECT dune.set_player_faction_reputation($controllerID::bigint, 2::smallint, 0::integer);")
+    [void]$sb.AppendLine("SELECT dune.change_player_faction($controllerID::bigint, 3::smallint, 3::smallint, NOW()::timestamp);")
+    # remove every faction-related tag (full + abbreviated names, recruitment, alignment)
+    $likes = @(
+        "tag LIKE 'Faction.%'", "tag LIKE 'FactionStoryline%'",
+        "tag LIKE 'DialogueFlags.Factions.%'", "tag LIKE 'Contract.Faction.%'",
+        "tag LIKE '%Atreides%'", "tag LIKE '%Harkonnen%'",
+        "tag LIKE '%Atre%'", "tag LIKE '%Hark%'",
+        "tag = 'Journey.LandsraadContractsUnlocked'",
+        "tag LIKE 'Contract.Tracking.%FactionUnlocked'",
+        "tag LIKE 'Contract.Tracking.%RecruitmentCompleted'"
+    ) -join ' OR '
+    [void]$sb.AppendLine("DELETE FROM dune.player_tags WHERE $charScope AND ($likes);")
+    # reset ClimbTheRanks journey nodes to incomplete (NOT delete — deleting stops
+    # the game re-offering them, so the recruiter quest can't be replayed)
+    [void]$sb.AppendLine("UPDATE dune.journey_story_node SET complete_condition_state='false'::jsonb, has_pending_reward=false WHERE $charScope AND story_node_id LIKE 'DA_FQ_ClimbTheRanks%';")
     [void]$sb.AppendLine('COMMIT;')
 
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sb.ToString() -ReadOnly $false -MaxRows 1 -TimeoutSec 120
@@ -1065,7 +1053,7 @@ function Invoke-DunePlayerResetFaction {
         Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
         return @{ ok = $false; error = "reset-faction tx: $($r.error)" }
     }
-    return @{ ok = $true; message = "Reset faction ($fl) for account $AccountId - rep zeroed, faction tags + ClimbTheRanks nodes cleared. Takes effect on next login."; faction = $fl }
+    return @{ ok = $true; message = "Reset faction for account $AccountId - rep zeroed, alignment cleared, faction tags removed, ClimbTheRanks reset to incomplete. Takes effect on next login."; faction = $fl }
 }
 
 function Invoke-DunePlayerApplyProgressionPreset {

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1048,6 +1048,8 @@ function Invoke-DunePlayerResetFaction {
         $shared = @(
             "tag LIKE 'DialogueFlags.Factions.%'",
             "tag LIKE 'Contract.Faction.%'",
+            "tag LIKE '%Atreides%'", "tag LIKE '%Harkonnen%'",
+            "tag LIKE '%Atre%'", "tag LIKE '%Hark%'",
             "tag = 'Journey.LandsraadContractsUnlocked'",
             "tag LIKE 'Contract.Tracking.%FactionUnlocked'",
             "tag LIKE 'Contract.Tracking.%RecruitmentCompleted'"

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1008,6 +1008,64 @@ COMMIT;
     }
 }
 
+# Completely wipe a player's faction progression so they can start fresh.
+# Removes ALL Atreides/Harkonnen journey nodes (DA_FQ_ClimbTheRanks*), zeroes
+# faction reputation + alignment, and deletes every faction/rank/recruitment tag
+# for the chosen faction (or both). Offline-only — the game holds this state in
+# RAM while connected. $Faction = 'atreides' | 'harkonnen' | 'both'.
+function Invoke-DunePlayerResetFaction {
+    param([string]$Ip, [long]$AccountId, [string]$Faction)
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+    $fl = ([string]$Faction).ToLowerInvariant()
+    if ($fl -ne 'atreides' -and $fl -ne 'harkonnen' -and $fl -ne 'both') {
+        return @{ ok = $false; error = 'faction must be atreides, harkonnen, or both' }
+    }
+    $controllerID = Get-DunePlayerControllerFromAccount -Ip $Ip -AccountId $AccountId
+    if ($controllerID -le 0) { return @{ ok = $false; error = "no player_controller for account $AccountId." } }
+
+    $factions = if ($fl -eq 'both') { @('Atreides','Harkonnen') } else { @((Get-Culture).TextInfo.ToTitleCase($fl)) }
+    $charScope = "character_id IN (SELECT id FROM dune.player_state WHERE account_id=$AccountId::bigint)"
+
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine('BEGIN;')
+    foreach ($fn in $factions) {
+        $fid = if ($fn -eq 'Atreides') { 1 } else { 2 }
+        # zero rep + clear alignment for this faction
+        [void]$sb.AppendLine("SELECT dune.set_player_faction_reputation($controllerID::bigint, $fid::smallint, 0::integer);")
+        # remove every faction tag (Faction.<name>.*, contract/storyline/rank tags, recruitment)
+        $likes = @(
+            "tag LIKE 'Faction.$fn.%'",
+            "tag LIKE 'FactionStoryline.$fn%'",
+            "tag LIKE '%Fac_$($fn.Substring(0,4))_Rank%'",
+            "tag LIKE '%$fn%'"
+        ) -join ' OR '
+        [void]$sb.AppendLine("DELETE FROM dune.player_tags WHERE $charScope AND ($likes);")
+        # faction journey subtree (ClimbTheRanks nodes carry the faction in a sub-segment)
+        [void]$sb.AppendLine("DELETE FROM dune.journey_story_node WHERE $charScope AND story_node_id LIKE 'DA_FQ_ClimbTheRanks%' AND story_node_id ILIKE '%$fn%';")
+    }
+    # shared faction tags + climb-the-ranks core only wiped on full 'both' reset
+    if ($fl -eq 'both') {
+        $shared = @(
+            "tag LIKE 'DialogueFlags.Factions.%'",
+            "tag LIKE 'Contract.Faction.%'",
+            "tag = 'Journey.LandsraadContractsUnlocked'",
+            "tag LIKE 'Contract.Tracking.%FactionUnlocked'",
+            "tag LIKE 'Contract.Tracking.%RecruitmentCompleted'"
+        ) -join ' OR '
+        [void]$sb.AppendLine("DELETE FROM dune.player_tags WHERE $charScope AND ($shared);")
+        [void]$sb.AppendLine("DELETE FROM dune.journey_story_node WHERE $charScope AND story_node_id LIKE 'DA_FQ_ClimbTheRanks%';")
+        [void]$sb.AppendLine("SELECT dune.change_player_faction($controllerID::bigint, 3::smallint, 0::smallint, NOW()::timestamp);")
+    }
+    [void]$sb.AppendLine('COMMIT;')
+
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sb.ToString() -ReadOnly $false -MaxRows 1 -TimeoutSec 120
+    if (-not $r.ok) {
+        Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
+        return @{ ok = $false; error = "reset-faction tx: $($r.error)" }
+    }
+    return @{ ok = $true; message = "Reset faction ($fl) for account $AccountId - rep zeroed, faction tags + ClimbTheRanks nodes cleared. Takes effect on next login."; faction = $fl }
+}
+
 function Invoke-DunePlayerApplyProgressionPreset {
     param([string]$Ip, [long]$AccountId, [string]$PresetId)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -193,6 +193,25 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/progression-reverse
     }
 }
 
+# POST /api/gameplay/players/faction/reset  { account_id, faction }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/faction/reset' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
+        $fac = [string](Get-DuneBodyValue -Body $body -Name 'faction')
+        if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
+        if (-not $fac) { Write-DuneError -Response $res -Status 400 -Message 'faction is required (atreides|harkonnen|both).'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
+            if (-not $off.ok) { return @{ ok = $false; error = "Player must be offline to reset faction. $($off.reason)" } }
+            Invoke-DunePlayerResetFaction -Ip $ip -AccountId $acc -Faction $fac
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Reset faction failed: $($_.Exception.Message)"
+    }
+}
+
 # POST /api/gameplay/players/progression/apply-preset  { account_id, preset_id }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/progression/apply-preset' -Handler {
     param($req, $res, $routeParams, $body)

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1755,6 +1755,12 @@ export function wipeJourney(accountId: number) {
   })
 }
 
+export function resetFaction(accountId: number, faction: 'atreides' | 'harkonnen' | 'both') {
+  return api<WriteResult>('/api/gameplay/players/faction/reset', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId, faction }),
+  })
+}
+
 // Journey Nodes browser — reads every journey_story_node row for the account.
 export interface JourneyNode {
   node_id: string

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -25,7 +25,7 @@ import {
   resetAllKeystones, resetAllSpecs, resetJourney, resetProgressionLive, resetSpec,
   restoreDestroyed,
   setFactionTier, setPlayerTags, setSkillPoints,
-  setStarterClass, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, wipeJourney,
+  setStarterClass, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, wipeJourney, resetFaction,
   chatWhisper, isValidTemplateId, getItemCatalog,
   parseTcnoPackageText,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
@@ -563,7 +563,7 @@ interface ActionDef {
   liveOnly?: boolean      // requires player to be online (RMQ path)
   offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   fields?: ActionField[]
-  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'update-tags' | 'teleport-player' | 'teleport-location' | 'set-respawn'
+  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'update-tags' | 'teleport-player' | 'teleport-location' | 'set-respawn' | 'reset-faction'
   balance?: 'solari' | 'scrip' | 'intel'  // show the player's current balance read-only above the form
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
@@ -649,6 +649,9 @@ const ACTIONS: ActionDef[] = [
       }
       return wipeJourney(p.account_id)
     } },
+  { id: 'reset-faction', group: 'Progression', label: 'Reset Faction', icon: 'Swords', custom: 'reset-faction', offlineOnly: true,
+    rowNote: 'Wipe faction rep + tags + ClimbTheRanks nodes to start fresh. Player must be offline.',
+    run: () => Promise.resolve({ message: '' }) },
 
   // ----- Items -----
   { id: 'give-item',      group: 'Items', label: 'Give Item', icon: 'PackagePlus', custom: 'give-item',
@@ -986,6 +989,12 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
               onReverse={(faction, preset, presetName) => runAction(def, async () => {
                 const r = await progressionReverse(player.id, faction, preset)
                 return { message: r.message || `Progression unlock (${presetName}) reversed for ${player.name}.` }
+              })} />
+          ) : def.custom === 'reset-faction' ? (
+            <ResetFactionForm busy={busy} playerName={player.name}
+              onReset={faction => runAction(def, async () => {
+                const r = await resetFaction(player.account_id, faction)
+                return { message: r.message || `Reset ${faction} faction for ${player.name}.` }
               })} />
           ) : def.custom === 'give-package' ? (
             <GivePackageForm busy={busy} playerName={player.name}
@@ -1946,8 +1955,41 @@ function UnlockMainQuestForm({ busy, onSubmit }: { busy: boolean; onSubmit: (que
   )
 }
 
-// Progression Unlock — faction + stage picker that drives the existing
-// progression-unlock / progression-reverse routes. Completes the
+// Reset Faction — wipe a player's faction progression (rep, tags, ClimbTheRanks
+// nodes) so they can start fresh. Offline-only; double-acknowledged. 'Both'
+// clears all faction state + alignment.
+function ResetFactionForm({ busy, playerName, onReset }: {
+  busy: boolean
+  playerName: string
+  onReset: (faction: 'atreides' | 'harkonnen' | 'both') => void
+}) {
+  const [faction, setFaction] = useState<'atreides' | 'harkonnen' | 'both'>('atreides')
+  const selectCls = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50'
+  const go = () => {
+    const typed = window.prompt(
+      `Reset ${faction} faction for ${playerName} — zeroes rep, removes faction tags, and resets ClimbTheRanks journey nodes. Cannot be undone.\n\nType  reset faction  to proceed:`
+    ) || ''
+    if (typed.trim().toLowerCase() !== 'reset faction') return
+    onReset(faction)
+  }
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Faction</label>
+        <select value={faction} disabled={busy} className={selectCls} onChange={e => setFaction(e.target.value as 'atreides' | 'harkonnen' | 'both')}>
+          <option value="atreides">Atreides</option>
+          <option value="harkonnen">Harkonnen</option>
+          <option value="both">Both (full reset)</option>
+        </select>
+      </div>
+      <button className="btn-danger w-full" disabled={busy} onClick={go}>
+        <Icon name="Swords" size={13} /> Reset Faction
+      </button>
+    </div>
+  )
+}
+
+// Progression Unlock — faction + stage picker that drives the existing// progression-unlock / progression-reverse routes. Completes the
 // DA_FQ_ClimbTheRanks journey nodes for the chosen faction and writes the
 // faction tier tags + reputation. 'Ch3 Start' = tier 5 (start of chapter 3);
 // 'Rank 19 Eligible' = tier 19 + the Landsraad onboarding nodes. Works for both

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -650,7 +650,7 @@ const ACTIONS: ActionDef[] = [
       return wipeJourney(p.account_id)
     } },
   { id: 'reset-faction', group: 'Progression', label: 'Reset Faction', icon: 'Swords', custom: 'reset-faction', offlineOnly: true,
-    rowNote: 'Wipe faction rep + tags + ClimbTheRanks nodes to start fresh. Player must be offline.',
+    rowNote: 'Wipe ALL faction rep + tags + ClimbTheRanks nodes to start fresh. Player must be offline.',
     run: () => Promise.resolve({ message: '' }) },
 
   // ----- Items -----
@@ -992,9 +992,9 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
               })} />
           ) : def.custom === 'reset-faction' ? (
             <ResetFactionForm busy={busy} playerName={player.name}
-              onReset={faction => runAction(def, async () => {
-                const r = await resetFaction(player.account_id, faction)
-                return { message: r.message || `Reset ${faction} faction for ${player.name}.` }
+              onReset={() => runAction(def, async () => {
+                const r = await resetFaction(player.account_id, 'both')
+                return { message: r.message || `Reset faction for ${player.name}.` }
               })} />
           ) : def.custom === 'give-package' ? (
             <GivePackageForm busy={busy} playerName={player.name}
@@ -1955,33 +1955,24 @@ function UnlockMainQuestForm({ busy, onSubmit }: { busy: boolean; onSubmit: (que
   )
 }
 
-// Reset Faction — wipe a player's faction progression (rep, tags, ClimbTheRanks
-// nodes) so they can start fresh. Offline-only; double-acknowledged. 'Both'
-// clears all faction state + alignment.
+// Reset Faction — one button that wipes ALL faction progression (rep, tags,
+// ClimbTheRanks nodes, alignment) so a player starts fresh. Offline-only;
+// double-acknowledged.
 function ResetFactionForm({ busy, playerName, onReset }: {
   busy: boolean
   playerName: string
-  onReset: (faction: 'atreides' | 'harkonnen' | 'both') => void
+  onReset: () => void
 }) {
-  const [faction, setFaction] = useState<'atreides' | 'harkonnen' | 'both'>('atreides')
-  const selectCls = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50'
   const go = () => {
     const typed = window.prompt(
-      `Reset ${faction} faction for ${playerName} — zeroes rep, removes faction tags, and resets ClimbTheRanks journey nodes. Cannot be undone.\n\nType  reset faction  to proceed:`
+      `Reset ALL faction progression for ${playerName} — zeroes rep, removes every faction tag, and resets ClimbTheRanks journey nodes for both factions. Cannot be undone.\n\nType  reset faction  to proceed:`
     ) || ''
     if (typed.trim().toLowerCase() !== 'reset faction') return
-    onReset(faction)
+    onReset()
   }
   return (
-    <div className="space-y-3">
-      <div>
-        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Faction</label>
-        <select value={faction} disabled={busy} className={selectCls} onChange={e => setFaction(e.target.value as 'atreides' | 'harkonnen' | 'both')}>
-          <option value="atreides">Atreides</option>
-          <option value="harkonnen">Harkonnen</option>
-          <option value="both">Both (full reset)</option>
-        </select>
-      </div>
+    <div className="space-y-2">
+      <p className="text-[11px] text-text-dim">Removes Atreides + Harkonnen rep, tags, and faction journey nodes. Player must be offline; takes effect on next login.</p>
       <button className="btn-danger w-full" disabled={busy} onClick={go}>
         <Icon name="Swords" size={13} /> Reset Faction
       </button>


### PR DESCRIPTION
## What
New **Reset Faction** action in Gameplay Admin → Players → Progression. Completely wipes a player's faction so they can start fresh — directly addresses the case where the Tags editor can't reliably remove faction journey tags.

Per faction (Atreides / Harkonnen) or **Both**:
- Zeroes faction reputation (`set_player_faction_reputation`)
- Deletes all faction tags (`Faction.<name>.*`, `FactionStoryline.<name>*`, `Fac_<f>_Rank*`, any `%<name>%`)
- Deletes the faction's `DA_FQ_ClimbTheRanks` journey nodes
- **Both** also clears shared `DialogueFlags.Factions.*` / `Contract.Faction.*`, Landsraad unlock, and resets alignment to none

Offline-gated (RAM-authoritative while connected) + double-acknowledged ("type reset faction").

## Verify
- PS parse OK; webui build clean
- Dry-run against Hawk (acct 19, maxed Atreides) with ROLLBACK: rep proc OK, 38 faction tags + 31 ClimbTheRanks nodes matched

## Backend
- `Invoke-DunePlayerResetFaction` (PlayersWrites.ps1) + `POST /api/gameplay/players/faction/reset`