### PR TITLE
Catalog: Treadwheel Hull giveable + populate Treadwheel kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ here cover everything those tags shipped.
 - **Reset Faction** (Players → Progression). One offline action wipes a player's faction so they can start fresh: zeroes Atreides + Harkonnen reputation, clears faction alignment, removes all faction tags, and resets the `DA_FQ_ClimbTheRanks` journey nodes to incomplete (so faction quests — including meeting the recruiters — can be replayed). Double-acknowledged.
 - **Grant Cosmetic / Variant** (Players → Items). Browsable, searchable picker for ~269 cosmetic unlockables — appearance set variants, colour swatches, and vehicle skins — that aren't in the standard Give Item catalog. Delivers the unlock via the existing give-item path.
 
+### Fixed
+
+- **Treadwheel Hull is now giveable**, and the **Treadwheel vehicle kit is populated.** The Treadwheel Hull modules (Mk1–Mk6) were missing from the Give Item catalog, and the Give Vehicle Kit entry for the Treadwheel had no parts. The kit now grants all nine modules at Mk6 (Swift Engine + Steady Boost uniques, plus standard Chassis, Generator, Hull, Inventory, Tread, Passenger, Scanner).
+
 ## [12.14.0] - 2026-06-28
 
 ### Added

--- a/app/data/item-catalog.json
+++ b/app/data/item-catalog.json
@@ -6619,6 +6619,34 @@
       "name": "Treadwheel Chassis Mk6",
       "category": "Vehicle Modules"
     },
+    "TreadwheelHull_0": {
+      "name": "Scrap Treadwheel Hull",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelHull_1": {
+      "name": "Treadwheel Hull Mk1",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelHull_2": {
+      "name": "Treadwheel Hull Mk2",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelHull_3": {
+      "name": "Treadwheel Hull Mk3",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelHull_4": {
+      "name": "Treadwheel Hull Mk4",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelHull_5": {
+      "name": "Treadwheel Hull Mk5",
+      "category": "Vehicle Modules"
+    },
+    "TreadwheelHull_6": {
+      "name": "Treadwheel Hull Mk6",
+      "category": "Vehicle Modules"
+    },
     "TreadwheelEngine_0": {
       "name": "Scrap Treadwheel Engine",
       "category": "Vehicle Modules"

--- a/app/data/vehicle-kits.json
+++ b/app/data/vehicle-kits.json
@@ -47,8 +47,8 @@
       "label": "Treadwheel",
       "className": "/Game/Dune/Systems/Vehicles/Blueprints/GroundVehicles/BP_TreadWheel.BP_TreadWheel_C",
       "templates": ["T4_Passenger", "T5_Inventory", "T6_Boost"],
-      "kit": [],
-      "unique": [],
+      "kit": ["TreadwheelChassis_6", "TreadwheelGenerator_6", "TreadwheelHull_6", "TreadwheelInventory_6", "TreadwheelLocomotion_6", "TreadwheelPassenger_6", "TreadwheelScanner_6"],
+      "unique": ["TreadwheelEngine_Unique_Speed_6", "TreadwheelBoost_Unique_LessHeat_6"],
       "qty": {}
     },
     {


### PR DESCRIPTION
TreadwheelHull_0-6 missing from the Give Item catalog (present in gameplay-item-data); added as Vehicle Modules. Treadwheel vehicle kit was empty; populated with all 9 Mk6 modules (Swift Engine + Steady Boost uniques + Chassis/Generator/Hull/Inventory/Tread/Passenger/Scanner). Folds into the staged v12.15.0.