### PR TITLE
Treadwheel kit: 3 tread modules

### DIFF
--- a/app/data/vehicle-kits.json
+++ b/app/data/vehicle-kits.json
@@ -49,7 +49,7 @@
       "templates": ["T4_Passenger", "T5_Inventory", "T6_Boost"],
       "kit": ["TreadwheelChassis_6", "TreadwheelGenerator_6", "TreadwheelHull_6", "TreadwheelInventory_6", "TreadwheelLocomotion_6", "TreadwheelPassenger_6", "TreadwheelScanner_6"],
       "unique": ["TreadwheelEngine_Unique_Speed_6", "TreadwheelBoost_Unique_LessHeat_6"],
-      "qty": {}
+      "qty": {"TreadwheelLocomotion_6": 3}
     },
     {
       "id": "ContainerVehicle",


### PR DESCRIPTION
The Treadwheel mounts 3 Tread (Locomotion) modules per the in-game assembly menu; kit had no qty so it only gave 1. Set TreadwheelLocomotion_6 qty=3. Folds into staged v12.14.1.