### PR TITLE
Add Vosper (@vosper61) to Thanks for the Coffee credits

### DIFF
--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -485,6 +485,10 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <Icon name="Heart" size={14} className="text-ibad shrink-0" />
               <span className="flex-1">Daddy STATZY (@spiderstatz)</span>
             </div>
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">Vosper (@vosper61)</span>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Adds **Vosper (@vosper61)** to the "Thanks for the Coffee" supporter credits dropdown in `MenuBar.tsx`, after Daddy STATZY.

Per Coastal: queue for the **next** release — do **not** cut a release for this alone. No version bump, no CHANGELOG entry; it'll ride along with the next release's other changes.

webui build verified clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>