### PR TITLE
Reset Faction: zero FactionPlayerComponent rep (v12.14.2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.14.1"
+      placeholder: "v12.14.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.14.2] - 2026-06-29
+
+### Fixed
+
+- **Reset Faction now clears the in-game reputation too.** Faction reputation is stored in two places — the `player_faction_reputation` table *and* the pawn's `FactionPlayerComponent` (which the game reads at runtime). Reset Faction was only zeroing the table, so a maxed reputation reappeared on login. It now zeroes both for Atreides and Harkonnen (matching Give Faction Rep / Progression Unlock).
+
 ## [12.14.1] - 2026-06-29
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.14.1'
+$script:DuneToolVersion = '12.14.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.14.1',
+    [string]$Version = '12.14.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.14.1</Version>
+    <Version>12.14.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.14.1"
+#define MyAppVersion "12.14.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1028,9 +1028,15 @@ function Invoke-DunePlayerResetFaction {
 
     $sb = [System.Text.StringBuilder]::new()
     [void]$sb.AppendLine('BEGIN;')
-    # zero rep + reset alignment to None (3) so the recruiter funnel re-triggers
+    # zero rep + reset alignment to None (3) so the recruiter funnel re-triggers.
+    # Faction reputation is dual-written: the player_faction_reputation TABLE *and*
+    # the pawn's FactionPlayerComponent (actors.properties). The game reads the
+    # component at runtime, so zeroing only the table leaves a stale maxed value
+    # that reappears on login — we must zero BOTH (mirrors give-rep / progression).
     [void]$sb.AppendLine("SELECT dune.set_player_faction_reputation($controllerID::bigint, 1::smallint, 0::integer);")
     [void]$sb.AppendLine("SELECT dune.set_player_faction_reputation($controllerID::bigint, 2::smallint, 0::integer);")
+    [void]$sb.AppendLine([string]::Format($script:DuneFactionComponentRepSqlTpl, $controllerID, 'Atreides', 0))
+    [void]$sb.AppendLine([string]::Format($script:DuneFactionComponentRepSqlTpl, $controllerID, 'Harkonnen', 0))
     [void]$sb.AppendLine("SELECT dune.change_player_faction($controllerID::bigint, 3::smallint, 3::smallint, NOW()::timestamp);")
     # remove every faction-related tag (full + abbreviated names, recruitment, alignment)
     $likes = @(
@@ -1053,7 +1059,7 @@ function Invoke-DunePlayerResetFaction {
         Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
         return @{ ok = $false; error = "reset-faction tx: $($r.error)" }
     }
-    return @{ ok = $true; message = "Reset faction for account $AccountId - rep zeroed, alignment cleared, faction tags removed, ClimbTheRanks reset to incomplete. Takes effect on next login."; faction = $fl }
+    return @{ ok = $true; message = "Reset faction for account $AccountId - rep zeroed (table + FactionPlayerComponent), alignment cleared, faction tags removed, ClimbTheRanks reset to incomplete. Takes effect on next login."; faction = $fl }
 }
 
 function Invoke-DunePlayerApplyProgressionPreset {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.14.1"
+$script:ToolVersion = "12.14.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Reset Faction only zeroed player_faction_reputation; the pawn FactionPlayerComponent (read at runtime) kept the maxed value and restored it on login. Confirmed on Hawk (ctrl 227): component Atreides=12474 while table=0. Fix zeroes both factions' component rep in the same tx; dry-run verified. Patch v12.14.2.