### PR TITLE
v12.14.3 — Set Faction Tier / Give Faction Rep establish membership for unaligned players

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.14.2"
+      placeholder: "v12.14.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.14.3] - 2026-06-29
+
+### Fixed
+
+- **Set Faction Tier / Give Faction Rep now actually establish faction membership for unaligned players.** On a character that hadn't joined a faction, these actions only wrote a reputation row the game ignores — the `FactionPlayerComponent` patch silently no-op'd (no array entry to update) and nothing joined the faction or ran recruitment, so in-game the trader stayed locked, standing read 0, and the recruiter kept offering the initial quest. For an **offline, unaligned** character they now establish full membership in one transaction: join the faction, complete the `DA_FQ_ClimbTheRanks` recruitment journey nodes, apply the faction/dialogue/contract tags, create the `FactionPlayerComponent` entry, and set the tier/reputation. An **already-aligned** character is blocked with a clear prompt to use **Reset Faction** first, then re-run. (Builds on the 12.14.2 Reset-Faction component fix.)
+
 ## [12.14.2] - 2026-06-29
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.14.2'
+$script:DuneToolVersion = '12.14.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.14.2',
+    [string]$Version = '12.14.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.14.2</Version>
+    <Version>12.14.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.14.2"
+#define MyAppVersion "12.14.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -146,37 +146,30 @@ WHERE a.id = {0}::bigint;
 function Invoke-DunePlayerGiveFactionRep {
     param([string]$Ip, [long]$ActorId, [int]$FactionId, [int]$Delta)
     if ($ActorId -le 0) { return @{ ok = $false; error = 'actor_id is required.' } }
-    $readSql = "SELECT COALESCE(reputation_amount, 0) AS rep FROM dune.player_faction_reputation WHERE actor_id = $ActorId::bigint AND faction_id = $FactionId::smallint;"
-    $cur = Invoke-DuneSqlQuery -Ip $Ip -Sql $readSql -ReadOnly $true -MaxRows 1 -TimeoutSec 15
-    $currentRep = 0
-    if ($cur.ok) {
-        $maps = ConvertTo-DuneRowMaps -Result $cur
-        if ($maps.Count -ge 1) { $currentRep = [int](ConvertTo-DuneInt $maps[0]['rep']) }
+    if ($FactionId -ne 1 -and $FactionId -ne 2) {
+        return @{ ok = $false; error = 'Faction standing can only be set for Atreides or Harkonnen.' }
     }
-    $newRep = $currentRep + $Delta
+    # actor_id here is the player_controller_id (webui sends p.controller_id).
+    $accSql = "SELECT COALESCE(account_id, 0)::text AS aid FROM dune.player_state WHERE player_controller_id = $ActorId::bigint LIMIT 1;"
+    $ar = Invoke-DuneSqlQuery -Ip $Ip -Sql $accSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $ar.ok) { return @{ ok = $false; error = "lookup account: $($ar.error)" } }
+    $amaps = ConvertTo-DuneRowMaps -Result $ar
+    $accountID = if ($amaps.Count -ge 1) { [int64](ConvertTo-DuneInt $amaps[0]['aid']) } else { 0 }
+    if ($accountID -le 0) { return @{ ok = $false; error = "no account for controller $ActorId." } }
+
+    # An already-aligned member must be reset before re-applying standing — otherwise
+    # we would stack a fresh recruitment on top of an existing membership.
+    $aligned = Get-DunePlayerAlignedFaction -Ip $Ip -ControllerId $ActorId
+    if ($aligned -ne 0) {
+        $an = Get-DuneFactionDisplayName $aligned
+        return @{ ok = $false; error = "This character is already a member of $an. Use Players -> Progression -> Reset Faction first, then set the standing again." }
+    }
+
+    # Unaligned: establish full membership at the requested standing (Delta from 0).
+    $newRep = $Delta
     if ($newRep -lt 0) { $newRep = 0 }
     if ($newRep -gt $script:DuneFactionRepCap) { $newRep = $script:DuneFactionRepCap }
-
-    $sql1 = "SELECT dune.set_player_faction_reputation($ActorId::bigint, $FactionId::smallint, $newRep::integer);"
-    $r1 = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql1 -ReadOnly $false -MaxRows 1 -TimeoutSec 30
-    if (-not $r1.ok) { return @{ ok = $false; error = "set_player_faction_reputation: $($r1.error)" } }
-
-    $fName = Get-DuneFactionDisplayName $FactionId
-    $safeName = ConvertTo-DuneSqlString $fName
-    $sql2 = [string]::Format($script:DuneFactionComponentRepSqlTpl, $ActorId, $safeName, $newRep)
-    $r2 = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql2 -ReadOnly $false -MaxRows 1 -TimeoutSec 30
-    if (-not $r2.ok) { return @{ ok = $false; error = "update FactionPlayerComponent rep: $($r2.error)" } }
-
-    $tier = Convert-DuneRepToTier $newRep
-    $tierName = Get-DuneFactionTierName $FactionId $tier
-    return @{
-        ok = $true
-        message = "Set $fName rep to $newRep -> tier $tier ($tierName) for actor $ActorId."
-        rep = $newRep
-        tier = $tier
-        tier_name = $tierName
-        faction = $fName
-    }
+    return Invoke-DuneEstablishFactionMembership -Ip $Ip -ControllerId $ActorId -AccountId $accountID -FactionId $FactionId -Rep $newRep
 }
 
 # ----- Set Faction Tier ----------------------------------------------------
@@ -184,25 +177,25 @@ function Invoke-DunePlayerSetFactionTier {
     param([string]$Ip, [long]$ActorId, [int]$FactionId, [int]$Tier)
     if ($ActorId -le 0) { return @{ ok = $false; error = 'actor_id is required.' } }
     if ($Tier -lt 0 -or $Tier -gt 20) { return @{ ok = $false; error = 'tier must be 0..20.' } }
+    if ($FactionId -ne 1 -and $FactionId -ne 2) {
+        return @{ ok = $false; error = 'Faction standing can only be set for Atreides or Harkonnen.' }
+    }
+    $accSql = "SELECT COALESCE(account_id, 0)::text AS aid FROM dune.player_state WHERE player_controller_id = $ActorId::bigint LIMIT 1;"
+    $ar = Invoke-DuneSqlQuery -Ip $Ip -Sql $accSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $ar.ok) { return @{ ok = $false; error = "lookup account: $($ar.error)" } }
+    $amaps = ConvertTo-DuneRowMaps -Result $ar
+    $accountID = if ($amaps.Count -ge 1) { [int64](ConvertTo-DuneInt $amaps[0]['aid']) } else { 0 }
+    if ($accountID -le 0) { return @{ ok = $false; error = "no account for controller $ActorId." } }
+
+    $aligned = Get-DunePlayerAlignedFaction -Ip $Ip -ControllerId $ActorId
+    if ($aligned -ne 0) {
+        $an = Get-DuneFactionDisplayName $aligned
+        return @{ ok = $false; error = "This character is already a member of $an. Use Players -> Progression -> Reset Faction first, then set the tier again." }
+    }
+
     $rep = $script:DuneFactionTierThresholds[$Tier]
     if ($Tier -gt 0) { $rep = $rep + 1 }
-
-    $sql1 = "SELECT dune.set_player_faction_reputation($ActorId::bigint, $FactionId::smallint, $rep::integer);"
-    $r1 = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql1 -ReadOnly $false -MaxRows 1 -TimeoutSec 30
-    if (-not $r1.ok) { return @{ ok = $false; error = "set_player_faction_reputation: $($r1.error)" } }
-
-    $fName = Get-DuneFactionDisplayName $FactionId
-    $safeName = ConvertTo-DuneSqlString $fName
-    $sql2 = [string]::Format($script:DuneFactionComponentRepSqlTpl, $ActorId, $safeName, $rep)
-    $r2 = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql2 -ReadOnly $false -MaxRows 1 -TimeoutSec 30
-    if (-not $r2.ok) { return @{ ok = $false; error = "update FactionPlayerComponent rep: $($r2.error)" } }
-
-    $tierName = Get-DuneFactionTierName $FactionId $Tier
-    return @{
-        ok = $true
-        message = "Set $fName to tier $Tier ($tierName) - rep $rep for actor $ActorId."
-        rep = $rep; tier = $Tier; tier_name = $tierName; faction = $fName
-    }
+    return Invoke-DuneEstablishFactionMembership -Ip $Ip -ControllerId $ActorId -AccountId $accountID -FactionId $FactionId -Rep $rep
 }
 
 # ----- Landsraad scrip (auto-resolve non-Solari currency) ------------------

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -838,30 +838,133 @@ VALUES (
 # §6 — Progression / journey / contracts / jobs / codex / tutorials
 # ---------------------------------------------------------------------------
 
+# Recruitment dialogue / contract-tracking tags per faction (Atreides=1, Harkonnen=2).
+# Returns $null for unsupported factions (only houses have a recruitment questline).
+function Get-DuneFactionRecruitTags {
+    param([int]$FactionId)
+    switch ($FactionId) {
+        1 { @{ dialogue='DialogueFlags.Factions.SentToMeetHawat';      aligned='DialogueFlags.Factions.AlignedAtreides';  metRec='DialogueFlags.Factions.MetHawat';        factionUnlocked='Contract.Tracking.AtreidesFactionUnlocked';  recruitmentDone='Contract.Tracking.AtreidesRecruitmentCompleted' } }
+        2 { @{ dialogue='DialogueFlags.Factions.SentToPiterDeVries';   aligned='DialogueFlags.Factions.AlignedHarkonnen'; metRec='DialogueFlags.Factions.MetPiterDeVries';  factionUnlocked='Contract.Tracking.HarkonnenFactionUnlocked'; recruitmentDone='Contract.Tracking.HarkonnenRecruitmentCompleted' } }
+        default { $null }
+    }
+}
+
+# UPSERT for the controller actor's FactionPlayerComponent.m_FactionDataArray entry.
+# Unlike $script:DuneFactionComponentRepSqlTpl (which only UPDATEs an existing entry
+# and silently no-ops when the array entry is missing), this creates the
+# FactionPlayerComponent / appends the faction entry / updates it in place, matching
+# the exact shape the game writes for a recruited member:
+#   { "Faction": { "Name": <name> }, "timestamp": <epoch>, "ReputationAmount": <int> }
+# Validated live (BEGIN/ROLLBACK) for create-from-nothing, append, and update.
+function Get-DuneFactionComponentUpsertSql {
+    param([long]$ActorId, [string]$FactionName, [int]$Rep)
+    $safe = ($FactionName -replace "'", "''")
+    return @"
+UPDATE dune.actors a SET properties = jsonb_set(
+    COALESCE(a.properties, '{}'::jsonb), '{FactionPlayerComponent}',
+    COALESCE(a.properties->'FactionPlayerComponent', '{}'::jsonb) || jsonb_build_object('m_FactionDataArray',
+      COALESCE((SELECT jsonb_agg(e) FROM jsonb_array_elements(
+                  COALESCE(a.properties->'FactionPlayerComponent'->'m_FactionDataArray', '[]'::jsonb)) e
+                WHERE e->'Faction'->>'Name' <> '$safe'), '[]'::jsonb)
+      || jsonb_build_array(jsonb_build_object('Faction', jsonb_build_object('Name', '$safe'),
+           'timestamp', to_jsonb(extract(epoch from now())), 'ReputationAmount', to_jsonb($($Rep)::int)))), true)
+  WHERE a.id = $($ActorId)::bigint;
+"@
+}
+
+# Returns the faction_id the controller is currently aligned to, or 0 if unaligned.
+# (change_player_faction(->neutral) deletes the player_faction row, so a present row
+# means the character is currently a faction member.)
+function Get-DunePlayerAlignedFaction {
+    param([string]$Ip, [long]$ControllerId)
+    $sql = "SELECT faction_id::text AS fid FROM dune.player_faction WHERE actor_id = $ControllerId::bigint LIMIT 1;"
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $r.ok) { return 0 }
+    $maps = ConvertTo-DuneRowMaps -Result $r
+    if ($maps.Count -eq 0) { return 0 }
+    return [int](ConvertTo-DuneInt $maps[0]['fid'])
+}
+
+# Establishes FULL faction membership for an OFFLINE, currently-UNALIGNED player so
+# the game honours it after a battlegroup restart: alignment + the recruitment /
+# ClimbTheRanks journey nodes + faction tags + the FactionPlayerComponent entry +
+# reputation. This mirrors a real recruited member (the trader unlocks and the
+# recruiter quest stops re-offering), closing the gap where rep-only writes landed
+# on rows the game ignores. Atreides/Harkonnen only.
+function Invoke-DuneEstablishFactionMembership {
+    param([string]$Ip, [long]$ControllerId, [long]$AccountId, [int]$FactionId, [int]$Rep)
+    if ($ControllerId -le 0) { return @{ ok = $false; error = 'controller id is required.' } }
+    if ($AccountId   -le 0) { return @{ ok = $false; error = 'account id is required.' } }
+    $recruit = Get-DuneFactionRecruitTags $FactionId
+    if (-not $recruit) { return @{ ok = $false; error = 'establish-membership supports Atreides or Harkonnen only.' } }
+    if ($Rep -lt 0) { $Rep = 0 }
+    if ($Rep -gt $script:DuneFactionRepCap) { $Rep = $script:DuneFactionRepCap }
+
+    $factionName  = Get-DuneFactionDisplayName $FactionId
+    $factionLower = $factionName.ToLowerInvariant()
+    $tier   = Convert-DuneRepToTier $Rep
+    $preset = if ($tier -ge 19) { 'rank19_eligible' } else { 'ch3_start' }
+
+    $fls = Get-DuneRawFuncomId -Ip $Ip -AccountId $AccountId
+    if (-not $fls.ok) { return @{ ok = $false; error = $fls.error } }
+    $safeFls = ConvertTo-DuneSqlString $fls.funcom_id
+
+    $nodes = Get-DuneNodesForPreset -Faction $factionLower -Preset $preset
+    if ($nodes.Count -eq 0) { return @{ ok = $false; error = 'progression-nodes catalog empty (data file missing?).' } }
+    $nodesArr = ConvertTo-DunePgTextArray $nodes
+
+    $allTags = @(
+        $recruit.dialogue, $recruit.aligned, $recruit.metRec,
+        $recruit.factionUnlocked, $recruit.recruitmentDone,
+        'DialogueFlags.Factions.FactionIntro',
+        'DialogueFlags.Factions.FactionRank1',
+        'DialogueFlags.Factions.FactionRank3',
+        'DialogueFlags.Factions.MetARecruiter',
+        'DialogueFlags.Factions.PlayedAllegianceCinematic',
+        'DialogueFlags.Factions.SeenAnvilCinematic'
+    )
+    if ($tier -ge 19) { $allTags += 'Journey.LandsraadContractsUnlocked' }
+    for ($t = 0; $t -le 5; $t++) { $allTags += "Faction.$factionName.Tier$t" }
+    $tagsArr = ConvertTo-DunePgTextArray $allTags
+
+    $compSql = Get-DuneFactionComponentUpsertSql -ActorId $ControllerId -FactionName $factionName -Rep $Rep
+
+    # Single transaction: complete recruitment nodes, align, write tags, set rep on
+    # the table, and upsert the FactionPlayerComponent entry the game reads at login.
+    $tx = @"
+BEGIN;
+SELECT dune.complete_journey_story_nodes_for_player('$safeFls'::text, $nodesArr);
+SELECT dune.change_player_faction($ControllerId::bigint, $FactionId::smallint, 3::smallint, NOW()::timestamp);
+SELECT dune.update_player_tags($AccountId::bigint, $tagsArr, ARRAY[]::text[]);
+SELECT dune.set_player_faction_reputation($ControllerId::bigint, $FactionId::smallint, $Rep::integer);
+$compSql
+COMMIT;
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $tx -ReadOnly $false -MaxRows 1 -TimeoutSec 90
+    if (-not $r.ok) {
+        Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
+        return @{ ok = $false; error = "establish-membership tx: $($r.error)" }
+    }
+
+    $tierName = Get-DuneFactionTierName $FactionId $tier
+    return @{
+        ok = $true
+        faction = $factionName; faction_id = $FactionId; rep = $Rep; tier = $tier; tier_name = $tierName
+        nodes = $nodes.Count; controller_id = $ControllerId
+        message = "Established $factionName membership at tier $tier ($tierName), rep $Rep - $($nodes.Count) recruitment nodes completed + faction tags + standing. Takes effect on next login."
+    }
+}
+
 function Invoke-DunePlayerProgressionUnlock {
     param([string]$Ip, [long]$ActorId, [string]$Faction, [string]$Preset)
     if ($ActorId -le 0) { return @{ ok = $false; error = 'actor_id is required.' } }
     $factionLower = $Faction.ToLowerInvariant()
-    $factionID = 0; $dialogue=''; $aligned=''; $metRec=''; $factionUnlocked=''; $recruitmentDone=''
-    switch ($factionLower) {
-        'atreides' {
-            $factionID = 1
-            $dialogue = 'DialogueFlags.Factions.SentToMeetHawat'
-            $aligned = 'DialogueFlags.Factions.AlignedAtreides'
-            $metRec = 'DialogueFlags.Factions.MetHawat'
-            $factionUnlocked = 'Contract.Tracking.AtreidesFactionUnlocked'
-            $recruitmentDone = 'Contract.Tracking.AtreidesRecruitmentCompleted'
-        }
-        'harkonnen' {
-            $factionID = 2
-            $dialogue = 'DialogueFlags.Factions.SentToPiterDeVries'
-            $aligned = 'DialogueFlags.Factions.AlignedHarkonnen'
-            $metRec = 'DialogueFlags.Factions.MetPiterDeVries'
-            $factionUnlocked = 'Contract.Tracking.HarkonnenFactionUnlocked'
-            $recruitmentDone = 'Contract.Tracking.HarkonnenRecruitmentCompleted'
-        }
-        default { return @{ ok = $false; error = 'faction must be atreides or harkonnen' } }
+    $factionID = switch ($factionLower) {
+        'atreides'  { 1 }
+        'harkonnen' { 2 }
+        default     { 0 }
     }
+    if ($factionID -eq 0) { return @{ ok = $false; error = 'faction must be atreides or harkonnen' } }
     $presetLower = $Preset.ToLowerInvariant()
     $targetTier = 0
     switch ($presetLower) {
@@ -888,61 +991,16 @@ LIMIT 1;
     if ($accountID -le 0) { return @{ ok = $false; error = "actor $ActorId has no owner_account_id." } }
     if ($controllerID -le 0) { return @{ ok = $false; error = "actor $ActorId has no controller (player_state row missing)." } }
 
-    $fls = Get-DuneRawFuncomId -Ip $Ip -AccountId $accountID
-    if (-not $fls.ok) { return @{ ok = $false; error = $fls.error } }
-    $safeFls = ConvertTo-DuneSqlString $fls.funcom_id
-
-    $nodes = Get-DuneNodesForPreset -Faction $factionLower -Preset $presetLower
-    if ($nodes.Count -eq 0) { return @{ ok = $false; error = 'progression-nodes catalog empty (data file missing?).' } }
-    $nodesArr = ConvertTo-DunePgTextArray $nodes
-
     $factionName = Get-DuneFactionDisplayName $factionID
-    $safeFactionName = ConvertTo-DuneSqlString $factionName
-
-    $allTags = @(
-        $dialogue, $aligned, $metRec,
-        $factionUnlocked, $recruitmentDone,
-        'DialogueFlags.Factions.FactionIntro',
-        'DialogueFlags.Factions.FactionRank1',
-        'DialogueFlags.Factions.FactionRank3',
-        'DialogueFlags.Factions.MetARecruiter',
-        'DialogueFlags.Factions.PlayedAllegianceCinematic',
-        'DialogueFlags.Factions.SeenAnvilCinematic'
-    )
-    if ($targetTier -ge 19) { $allTags += 'Journey.LandsraadContractsUnlocked' }
-    for ($t = 0; $t -le 5; $t++) {
-        $allTags += "Faction.$factionName.Tier$t"
-    }
-    $tagsArr = ConvertTo-DunePgTextArray $allTags
-
     $targetRep = $script:DuneFactionTierThresholds[$targetTier]
     if ($targetTier -gt 0) { $targetRep++ }
 
-    # Single transactional script — each statement uses literal values (we
-    # already sanitised). Pg "BEGIN ... COMMIT" works in one Invoke-DuneSqlQuery
-    # so long as the helper passes the whole string through pgx.
-    $tx = @"
-BEGIN;
-SELECT dune.complete_journey_story_nodes_for_player('$safeFls'::text, $nodesArr);
-SELECT dune.change_player_faction($controllerID::bigint, $factionID::smallint, 3::smallint, NOW()::timestamp);
-SELECT dune.update_player_tags($accountID::bigint, $tagsArr, ARRAY[]::text[]);
-SELECT dune.set_player_faction_reputation($controllerID::bigint, $factionID::smallint, $targetRep::integer);
-$([string]::Format($script:DuneFactionComponentRepSqlTpl, $controllerID, $safeFactionName, $targetRep))
-COMMIT;
-"@
-    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $tx -ReadOnly $false -MaxRows 1 -TimeoutSec 90
-    if (-not $r.ok) {
-        # Best-effort rollback (no-op if tx already aborted)
-        Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
-        return @{ ok = $false; error = "progression-unlock tx: $($r.error)" }
+    $res = Invoke-DuneEstablishFactionMembership -Ip $Ip -ControllerId $controllerID -AccountId $accountID -FactionId $factionID -Rep $targetRep
+    if ($res.ok) {
+        $res.message = ("Progression unlock ($presetLower/$factionLower): $($res.nodes) journey nodes completed + " +
+                        "$factionName tier tags 0-5 + rep tier $($res.tier) on controller $controllerID - takes effect on next login.")
     }
-
-    return @{
-        ok = $true
-        message = ("Progression unlock ($presetLower/$factionLower): $($nodes.Count) journey nodes completed + " +
-                   "$factionName tier tags 0-5 + rep tier $targetTier on controller $controllerID - takes effect on next login.")
-        nodes = $nodes.Count; faction = $factionName; tier = $targetTier; controller_id = $controllerID
-    }
+    return $res
 }
 
 function Invoke-DunePlayerProgressionReverse {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.14.2"
+$script:ToolVersion = "12.14.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/FactionMembership.Tests.ps1
+++ b/tests/FactionMembership.Tests.ps1
@@ -1,0 +1,152 @@
+# Tests the establish-faction-membership path: the FactionPlayerComponent upsert
+# SQL builder, the recruitment-tag map, and the alignment guard / delegation in
+# Set Faction Tier + Give Faction Rep. DB layer is stubbed; no network.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'GameplayPlayers.ps1'   # ConvertTo-DuneSqlString
+    Import-DstLib 'PlayersWrites.ps1'     # ConvertTo-DunePgTextArray, component upsert, establish
+    Import-DstLib 'PlayersAdmin.ps1'      # rep actions, faction display/thresholds
+
+    # Minimal row-map helpers operating on a `maps` field (mirrors PlayersAdmin.Tests).
+    function global:ConvertTo-DuneRowMaps { param($Result) $m = if ($Result -and $Result.maps) { $Result.maps } else { @() }; return ,@($m) }
+    function global:ConvertTo-DuneInt     { param($Value) if ($null -eq $Value) { return 0 } return [int64]$Value }
+}
+
+AfterAll {
+    Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneInt     -ErrorAction SilentlyContinue
+}
+
+Describe 'Get-DuneFactionComponentUpsertSql' -Tag 'Pure' {
+    It 'builds a real-member-shaped array entry (Faction.Name + timestamp + ReputationAmount)' {
+        $sql = Get-DuneFactionComponentUpsertSql -ActorId 227 -FactionName 'Atreides' -Rep 2000
+        $sql | Should -Match "jsonb_build_object\('Faction', jsonb_build_object\('Name', 'Atreides'\)"
+        $sql | Should -Match "'ReputationAmount', to_jsonb\(2000::int\)"
+        $sql | Should -Match "'timestamp', to_jsonb\(extract\(epoch from now\(\)\)\)"
+    }
+    It 'targets the controller actor and replaces any existing entry for that faction' {
+        $sql = Get-DuneFactionComponentUpsertSql -ActorId 593 -FactionName 'Harkonnen' -Rep 5
+        $sql | Should -Match "WHERE a.id = 593::bigint"
+        $sql | Should -Match "WHERE e->'Faction'->>'Name' <> 'Harkonnen'"
+    }
+    It 'creates the component when missing (COALESCE empties, not a no-op UPDATE)' {
+        $sql = Get-DuneFactionComponentUpsertSql -ActorId 1 -FactionName 'Atreides' -Rep 0
+        $sql | Should -Match "COALESCE\(a.properties, '\{\}'::jsonb\)"
+        $sql | Should -Match "'\[\]'::jsonb"
+    }
+    It 'SQL-escapes single quotes in the faction name' {
+        $sql = Get-DuneFactionComponentUpsertSql -ActorId 1 -FactionName "O'Neil" -Rep 0
+        $sql | Should -Match "O''Neil"
+    }
+}
+
+Describe 'Get-DuneFactionRecruitTags' -Tag 'Pure' {
+    It 'returns Atreides recruitment tags for faction 1' {
+        $t = Get-DuneFactionRecruitTags 1
+        $t.aligned         | Should -Be 'DialogueFlags.Factions.AlignedAtreides'
+        $t.recruitmentDone | Should -Be 'Contract.Tracking.AtreidesRecruitmentCompleted'
+    }
+    It 'returns Harkonnen recruitment tags for faction 2' {
+        (Get-DuneFactionRecruitTags 2).aligned | Should -Be 'DialogueFlags.Factions.AlignedHarkonnen'
+    }
+    It 'returns $null for unsupported factions' {
+        Get-DuneFactionRecruitTags 4 | Should -BeNullOrEmpty
+        Get-DuneFactionRecruitTags 3 | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Invoke-DuneEstablishFactionMembership' -Tag 'Establish' {
+    BeforeEach {
+        $script:capturedTx = $null
+        function global:Invoke-DuneSqlQuery {
+            param([string]$Ip, [string]$Sql, [bool]$ReadOnly, [int]$MaxRows, [int]$TimeoutSec)
+            if (-not $ReadOnly) { $script:capturedTx = $Sql }
+            return @{ ok = $true; maps = @(); message = 'SELECT 1' }
+        }
+        function global:Get-DuneRawFuncomId { param($Ip, $AccountId) return @{ ok = $true; funcom_id = 'FLSTEST' } }
+        function global:Get-DuneNodesForPreset { param($Faction, $Preset) return @('DA_FQ_ClimbTheRanks.JoinAHouse', 'DA_FQ_ClimbTheRanks.JoinAHouse.StrikeADeal.TalkToARecruiter') }
+    }
+    AfterEach {
+        Remove-Item function:global:Invoke-DuneSqlQuery     -ErrorAction SilentlyContinue
+        Remove-Item function:global:Get-DuneRawFuncomId     -ErrorAction SilentlyContinue
+        Remove-Item function:global:Get-DuneNodesForPreset  -ErrorAction SilentlyContinue
+    }
+
+    It 'rejects unsupported factions' {
+        $r = Invoke-DuneEstablishFactionMembership -Ip '1.2.3.4' -ControllerId 227 -AccountId 19 -FactionId 4 -Rep 100
+        $r.ok    | Should -BeFalse
+        $r.error | Should -Match 'Atreides or Harkonnen'
+    }
+    It 'writes a single transaction with all five membership steps' {
+        $r = Invoke-DuneEstablishFactionMembership -Ip '1.2.3.4' -ControllerId 227 -AccountId 19 -FactionId 1 -Rep 2000
+        $r.ok | Should -BeTrue
+        $script:capturedTx | Should -Match 'complete_journey_story_nodes_for_player'
+        $script:capturedTx | Should -Match 'change_player_faction\(227::bigint, 1::smallint, 3::smallint'
+        $script:capturedTx | Should -Match 'update_player_tags\(19::bigint'
+        $script:capturedTx | Should -Match 'set_player_faction_reputation\(227::bigint, 1::smallint, 2000::integer'
+        $script:capturedTx | Should -Match "jsonb_build_object\('Name', 'Atreides'\)"
+    }
+    It 'applies the recruitment + tier tags' {
+        Invoke-DuneEstablishFactionMembership -Ip '1.2.3.4' -ControllerId 227 -AccountId 19 -FactionId 1 -Rep 2000 | Out-Null
+        $script:capturedTx | Should -Match 'DialogueFlags.Factions.AlignedAtreides'
+        $script:capturedTx | Should -Match 'Faction.Atreides.Tier5'
+    }
+    It 'clamps reputation to the cap' {
+        $r = Invoke-DuneEstablishFactionMembership -Ip '1.2.3.4' -ControllerId 227 -AccountId 19 -FactionId 1 -Rep 999999
+        $r.rep | Should -Be 12474
+    }
+}
+
+Describe 'Invoke-DunePlayerSetFactionTier / GiveFactionRep alignment guard' -Tag 'Establish' {
+    BeforeEach {
+        $script:aligned = @()          # ConvertTo-DuneRowMaps-style maps for player_faction
+        $script:establishArgs = $null
+        function global:Invoke-DuneSqlQuery {
+            param([string]$Ip, [string]$Sql, [bool]$ReadOnly, [int]$MaxRows, [int]$TimeoutSec)
+            if ($Sql -match 'AS aid')        { return @{ ok = $true; maps = @(@{ aid = 19 }) } }
+            if ($Sql -match 'player_faction') { return @{ ok = $true; maps = $script:aligned } }
+            return @{ ok = $true; maps = @(); message = 'SELECT 1' }
+        }
+        function global:Invoke-DuneEstablishFactionMembership {
+            param($Ip, $ControllerId, $AccountId, $FactionId, $Rep)
+            $script:establishArgs = @{ ControllerId = $ControllerId; AccountId = $AccountId; FactionId = $FactionId; Rep = $Rep }
+            return @{ ok = $true; message = 'established' }
+        }
+    }
+    AfterEach {
+        Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DuneEstablishFactionMembership -ErrorAction SilentlyContinue
+    }
+
+    It 'blocks Set Faction Tier on an already-aligned character' {
+        $script:aligned = @(@{ fid = 2 })
+        $r = Invoke-DunePlayerSetFactionTier -Ip '1.2.3.4' -ActorId 227 -FactionId 1 -Tier 5
+        $r.ok    | Should -BeFalse
+        $r.error | Should -Match 'already a member'
+        $script:establishArgs | Should -BeNullOrEmpty
+    }
+    It 'establishes membership for an unaligned character at the tier reputation' {
+        $script:aligned = @()
+        $r = Invoke-DunePlayerSetFactionTier -Ip '1.2.3.4' -ActorId 227 -FactionId 1 -Tier 5
+        $r.ok | Should -BeTrue
+        $script:establishArgs.FactionId | Should -Be 1
+        $script:establishArgs.Rep       | Should -Be 2000   # tier 5 threshold 1999 + 1
+    }
+    It 'blocks Give Faction Rep on an aligned character' {
+        $script:aligned = @(@{ fid = 1 })
+        $r = Invoke-DunePlayerGiveFactionRep -Ip '1.2.3.4' -ActorId 227 -FactionId 1 -Delta 500
+        $r.ok    | Should -BeFalse
+        $r.error | Should -Match 'already a member'
+    }
+    It 'establishes membership for unaligned Give Faction Rep at the delta standing' {
+        $script:aligned = @()
+        $r = Invoke-DunePlayerGiveFactionRep -Ip '1.2.3.4' -ActorId 227 -FactionId 1 -Delta 500
+        $r.ok | Should -BeTrue
+        $script:establishArgs.Rep | Should -Be 500
+    }
+    It 'rejects non-house factions' {
+        Invoke-DunePlayerSetFactionTier -Ip '1.2.3.4' -ActorId 227 -FactionId 4 -Tier 5 | Select-Object -ExpandProperty ok | Should -BeFalse
+        Invoke-DunePlayerGiveFactionRep -Ip '1.2.3.4' -ActorId 227 -FactionId 3 -Delta 500 | Select-Object -ExpandProperty ok | Should -BeFalse
+    }
+}


### PR DESCRIPTION
**Release PR for v12.14.3.** Hold at the publish gate: do **not** merge/tag/publish until Coastal gives the go (and the Hawk in-game confirmation is in). All 5 version stamps + CHANGELOG + bug_report placeholder are bumped; installer built.

## Problem
Reported by Iron_Beard (char **Gorgo**, unaligned/never-recruited): **Set Faction Tier** + **Give Faction Rep** offline → DST showed rep 2000, but in-game Anton still offered the *initial* recruit quest, standing read 0, the faction trader stayed locked, even after a full battlegroup restart.

**Root cause (evidenced on the live dev DB — the account_id→character_id rekey theory was disproven):** these actions were **rep-only**. They inserted a `player_faction_reputation` row (which DST reads back and displays) but the `FactionPlayerComponent` UPDATE **silently no-ops** on a character with no existing array entry, and they never joined the faction or ran recruitment. The game gates the trader / standing / Anton's dialogue on **membership + recruitment**, not a bare rep number.

## Fix — establish full membership (Coastal's decision)
For an **offline, unaligned** character, Set Faction Tier / Give Faction Rep now establish full membership in one transaction via a shared `Invoke-DuneEstablishFactionMembership`: `change_player_faction` + `complete_journey_story_nodes_for_player` (ch3_start ClimbTheRanks nodes) + `update_player_tags` (faction/dialogue/contract + `Faction.<F>.Tier0..5`) + `set_player_faction_reputation` + the new `Get-DuneFactionComponentUpsertSql` (creates/append/updates the `FactionPlayerComponent` entry in the real-member shape — fixes the no-op-on-missing). **Already-aligned** characters are blocked and steered to **Reset Faction** first. `Invoke-DunePlayerProgressionUnlock` is refactored to reuse the same helper. Atreides/Harkonnen only.

Builds on **#405** (v12.14.2 — Reset Faction now also zeros `FactionPlayerComponent`); also bundles **#404** (Vosper credit). All on top of v12.14.2 → ships as **v12.14.3**.

## Release contents
- 5 version stamps bumped 12.14.2 → 12.14.3 (`app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/installer/DuneServer.iss`, `dune-server.ps1`).
- `CHANGELOG.md` `[12.14.3] - 2026-06-29` entry; `bug_report.yml` placeholder → v12.14.3.
- Installer built: `DuneServerSetup.exe` (≈46 MB), version-stamp + BOM + PS-5.1 parse pre-flights all green; copied to the main checkout's `app/installer/output/`.

## Validation
- 16 new Pester tests (`tests/FactionMembership.Tests.ps1`); **full suite 371/371 green**.
- Live dev DB (BEGIN/ROLLBACK + a committed apply on test char Hawk-i5, then reset back to none): the real function-generated TX reproduces a real recruited member byte-for-byte (`player_faction` + rep table + `FactionPlayerComponent` + recruiter journey node complete + tags), all controller-keyed.
- **Fremen-methodology sweep:** no hidden per-player faction/recruitment flag exists beyond what establish writes — the write set is DB-complete.

## Gate (why "hold")
Whether the **game honours** DB-built membership at runtime is confirmed in-game (Hawk: BG restart → Anton/trader/standing). Merge/tag/publish only after that passes and Coastal gives the go. If it fails, the gate is a runtime-only mechanism not backed by any persisted row → fall back to guard + steer.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>