### PR TITLE
Mobile: mirror desktop isOnline() so Players Online count matches Player Admin

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -187,7 +187,10 @@ export default function App() {
     try {
       const res = await apiFetch(serverInfo, '/api/gameplay/players');
       const data = await res.json();
-      const online = (data.players || []).filter((p: any) => p.online_status === 'Online');
+      // Mirror webui/src/pages/gameplay/PlayersTab.tsx isOnline helper exactly,
+      // so the mobile Players Online count matches Player Admin in the desktop app.
+      const isOnline = (s: any) => typeof s === 'string' && s.toLowerCase().includes('online');
+      const online = (data.players || []).filter((p: any) => isOnline(p.online_status));
       setPlayers(online);
     } catch (e) {
       alert(`Failed to fetch players: ${e}`);


### PR DESCRIPTION
## Summary

- Mobile Players Online list was filtering with strict `=== 'Online'` while desktop Player Admin uses `s.toLowerCase().includes('online')` ([webui/src/pages/gameplay/PlayersTab.tsx:20](../blob/main/webui/src/pages/gameplay/PlayersTab.tsx#L20)).
- Both hit the same `/api/gameplay/players` endpoint with the same auth — only the client-side filter differed.
- Iron_Beard's `#android-testing` report ("Players Online (0) but friend actively online") = mobile filter narrower than the server contract.
- Fix: port the desktop helper verbatim into `fetchPlayers` so the two surfaces apply the same rule to the same data.

## Why not a server change

Desktop reads `player_state.online_status` directly and shows the right count today. Funcom's enum cast preserves `'Online'` in the standard path, but the desktop's `includes('online')` is permissive enough that any incidental casing variation in any auxiliary code path still resolves. Mobile's strict-equal was the only mismatch.

## Test plan

- [ ] With a player actively in-game, confirm mobile "Players Online (N)" matches the desktop Player Admin count.
- [ ] Confirm the previously-affected report (Iron_Beard test in #android-testing) no longer shows count=0 with a connected friend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)