### PR TITLE
v12.14.6: mobile Players Online count mirrors desktop helper

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.14.5"
+      placeholder: "v12.14.6"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.14.6] - 2026-06-29
+
+### Fixed
+
+- **Mobile companion app: Players Online count now matches Player Admin in the desktop app.** The mobile filter was strict-case (`=== 'Online'`) while the desktop helper is case-insensitive substring (`s.toLowerCase().includes('online')`); both surfaces hit the same `/api/gameplay/players` endpoint, so any incidental casing variation made the mobile show "Players Online (0)" while the desktop correctly listed the connected player. Mobile now mirrors the desktop helper verbatim. Reported in `#android-testing`.
+
 ## [12.14.5] - 2026-06-29
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.14.5'
+$script:DuneToolVersion = '12.14.6'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.14.5',
+    [string]$Version = '12.14.6',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.14.5</Version>
+    <Version>12.14.6</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.14.5"
+#define MyAppVersion "12.14.6"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.14.5"
+$script:ToolVersion = "12.14.6"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Summary

- Release-stamp PR for v12.14.6. The user-visible fix shipped as PR #409 (mobile filter now matches the desktop `isOnline()` helper verbatim, so `Players Online (N)` agrees with Player Admin).
- Bumps 5 version stamps + `bug_report.yml` placeholder + CHANGELOG entry (rolled `[Unreleased]` -> `[12.14.6]`).

## Files touched

- `app/DuneServer.ps1` · `app/build/Build-Exe.ps1` · `app/desktop/DuneShell/DuneShell.csproj` · `app/installer/DuneServer.iss` · `dune-server.ps1` — version stamps
- `.github/ISSUE_TEMPLATE/bug_report.yml` — `tool_version` placeholder
- `CHANGELOG.md` — `[12.14.6]` entry

Installer built locally (46.04 MB, `Verify-Version-Stamps` passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)