### PR TITLE
chore(mobile): bump iOS buildNumber to 11 (TestFlight rebuild for v12.14.6)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -15,7 +15,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.coastal.duneserver",
-      "buildNumber": "9",
+      "buildNumber": "11",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSLocalNetworkUsageDescription": "Dune Server Tool connects to your private game server over a secure connection.",


### PR DESCRIPTION
## Summary

iOS buildNumber 10 → 11 for the EAS TestFlight rebuild that picks up the [v12.14.6 mobile isOnline fix](https://github.com/coastal-ms/DST-DuneServerTool/pull/410). buildNumber 10 was already built/shipped on 2026-06-25 from an uncommitted local edit; this commit folds the bump-to-11 with the prior never-committed bump-to-10.

Standalone mobile bump — no desktop impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)