### PR TITLE
chore(mobile): sync iOS buildNumber to 12 (EAS auto-bumped)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -15,7 +15,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.coastal.duneserver",
-      "buildNumber": "11",
+      "buildNumber": "12",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSLocalNetworkUsageDescription": "Dune Server Tool connects to your private game server over a secure connection.",


### PR DESCRIPTION
EAS production profile has \`autoIncrement: true\`. When the iOS build for #411 kicked off (build id d60212c7-c2b9-4ea0-ad2f-d41b9fe6c72d, sourced commit had buildNumber 11), EAS automatically bumped \`expo.ios.buildNumber\` from 11 to 12 and used 12 for the build. This commit syncs main with what's in TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)