### PR TITLE
mobile: ASC API key paths in eas.json (non-interactive iOS submit)

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -27,7 +27,10 @@
   "submit": {
     "production": {
       "ios": {
-        "ascAppId": "6782716438"
+        "ascAppId": "6782716438",
+        "ascApiKeyPath": "../../local-only/secrets/ios-asc/AuthKey_Z552ZAF9YH.p8",
+        "ascApiKeyId": "Z552ZAF9YH",
+        "ascApiKeyIssuerId": "fafa8a48-72e7-40c5-836b-13f1417cda70"
       }
     }
   }


### PR DESCRIPTION
## Summary

\`eas submit --platform ios --latest --non-interactive\` was failing with "App Store Connect API Keys cannot be set up in --non-interactive mode" because the key wasn't pre-configured in the credential store and env vars (\`EXPO_ASC_*\`) aren't honored by submit. CLI has no flag for this either; the only path is configuring \`submit.production.ios\` in \`eas.json\`.

Verified: with this config, today's iOS buildNumber 12 submitted cleanly to TestFlight ([App Store Connect](https://appstoreconnect.apple.com/apps/6782716438/testflight/ios), submission \`a112a1c0-ad09-46f8-ba64-737c90b36294\`).

Values are non-secret identifiers; the actual .p8 key material stays in \`local-only/secrets/ios-asc/\` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)