### PR TITLE
fix(mobile): Server State card sums players across all game servers

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -702,7 +702,16 @@ export default function App() {
             </View>
             <View style={styles.infoRow}>
               <Text style={styles.infoLabel}>Players:</Text>
-              <Text style={styles.infoValue}>{serverState.bg?.gameServers?.[0]?.players || '0 / 0'}</Text>
+              <Text style={styles.infoValue}>{(() => {
+                // Funcom's `battlegroup status` lists one row per game server
+                // (Overmap = Deep Desert, Survival_1 = Hagga, ...). Sum the
+                // per-row player counts so a connected player is visible
+                // regardless of which map they're on; picking gameServers[0]
+                // alphabetized to Overmap and missed anyone on Survival_1.
+                const rows = serverState.bg?.gameServers || [];
+                const total = rows.reduce((acc: number, r: any) => acc + (parseInt(r?.players, 10) || 0), 0);
+                return String(total);
+              })()}</Text>
             </View>
           </>
         ) : (


### PR DESCRIPTION
## Summary

- Mobile **Server State card** showed Players: 0 even with a connected player whom the **Players Online** list (separate code path) correctly listed.
- Root cause: \`serverState.bg?.gameServers?.[0]?.players\` reads only the first row from Funcom's \`battlegroup status\`. Funcom lists alphabetically — Overmap (Deep Desert) is \`[0]\`, Survival_1 (Hagga) is \`[1]\`. A player on Hagga showed as 0.
- Fix: sum players across all \`gameServers\` rows. Matches what desktop's Dashboard does (it iterates the full table).

## Test plan

- [ ] With a player connected on Hagga only, mobile Server State card shows "1" (not "0").
- [ ] With players on multiple maps, the count is the total across maps.
- [ ] With nobody connected, the count is "0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)