### PR TITLE
chore(mobile): sync iOS buildNumber to 13 (EAS auto-bumped)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -15,7 +15,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.coastal.duneserver",
-      "buildNumber": "12",
+      "buildNumber": "13",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSLocalNetworkUsageDescription": "Dune Server Tool connects to your private game server over a secure connection.",


### PR DESCRIPTION
EAS production profile autoIncrement bumped iOS buildNumber 12 -> 13 for the Server-State-card fix build (id 33f78378-d17e-4443-a4f8-00ae89de1a6f). Syncing app.json with what's in TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)