### PR TITLE
Prune accumulated Completed database-backup dump pods (#363)

### DIFF
--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -515,3 +515,119 @@ sudo du -sh $script:DuneBackupDumpDir 2>/dev/null | awk '{print `$1}' || true
         logPath       = '/var/log/dune-backup.log'
     }
 }
+
+# -----------------------------------------------------------------------------
+# Public: list `*-dump-YYYYMMDD-HHMMSS-pod` pods left behind by Funcom's database-
+# backup jobs. They finish Succeeded but are never garbage-collected, so they
+# pile up over time (issue #363). Returned newest-first by the timestamp baked
+# into the pod name (kubectl creationTimestamp would work too, but the embedded
+# timestamp is naturally sortable as a string and survives clock drift).
+# -----------------------------------------------------------------------------
+$script:DuneBackupDumpPodNameRegex = '^[a-z0-9.-]+-dump-[0-9]{8}-[0-9]{6}-pod$'
+
+function Get-DuneBackupDumpPods {
+    param([Parameter(Mandatory)][string]$Ip)
+    # Stream namespace|name|startTime|phase via jsonpath. Avoids needing jq on
+    # the VM. We filter by phase + name regex here so callers always get a
+    # canonical list (Completed/Succeeded dump-* pods only).
+    $jp = '{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.startTime}|{.status.phase}{"\n"}{end}'
+    $cmd = "sudo kubectl get pods --all-namespaces -o jsonpath='$jp' 2>/dev/null"
+    $raw = $null
+    try {
+        $raw = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec 25
+    } catch {
+        throw "kubectl get pods failed: $($_.Exception.Message)"
+    }
+    $rows = if ($raw) { (($raw -join "`n") -replace "`r",'') -split "`n" } else { @() }
+    $out = New-Object System.Collections.Generic.List[object]
+    foreach ($r in $rows) {
+        if (-not $r) { continue }
+        $parts = $r -split '\|', 4
+        if ($parts.Count -lt 4) { continue }
+        $ns    = $parts[0]
+        $name  = $parts[1]
+        $start = $parts[2]
+        $phase = $parts[3]
+        if ($name -notmatch $script:DuneBackupDumpPodNameRegex) { continue }
+        if ($phase -ne 'Succeeded' -and $phase -ne 'Completed') { continue }
+        $out.Add([pscustomobject]@{
+            namespace = $ns
+            name      = $name
+            startTime = $start
+            phase     = $phase
+        }) | Out-Null
+    }
+    # Sort by the embedded YYYYMMDD-HHMMSS in the name (newest first). Falls
+    # back to name lexically — which for our regex is equivalent because the
+    # suffix is fixed-width.
+    return @($out | Sort-Object name -Descending)
+}
+
+# -----------------------------------------------------------------------------
+# Public: prune Succeeded/Completed dump-* pods, keeping the most recent
+# $KeepLast. Returns @{ ok; deleted; kept; remaining; output }. Never touches
+# the live DB StatefulSet, util/mon/pghero, file-browser pods, or any pod
+# whose name doesn't match the canonical dump-* shape — the name regex check
+# is authoritative and double-checked before each kubectl delete.
+# -----------------------------------------------------------------------------
+function Remove-DuneBackupDumpPods {
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [int]$KeepLast = 5
+    )
+    if ($KeepLast -lt 0)   { $KeepLast = 0 }
+    if ($KeepLast -gt 100) { $KeepLast = 100 }
+
+    $pods = Get-DuneBackupDumpPods -Ip $Ip
+    $total = @($pods).Count
+    if ($total -le $KeepLast) {
+        return @{
+            ok        = $true
+            deleted   = @()
+            kept      = @($pods)
+            remaining = @($pods)
+            message   = "Found $total dump pod(s); nothing to prune (keep last $KeepLast)."
+            output    = ''
+        }
+    }
+    $kept     = @($pods | Select-Object -First $KeepLast)
+    $toDelete = @($pods | Select-Object -Skip  $KeepLast)
+
+    # Re-validate every namespace/name we're about to interpolate. Defence in
+    # depth — the jsonpath output should already be clean, but a stale CRD or
+    # webhook could in principle return surprises and we're about to embed
+    # these values into a shell command.
+    $cmds = New-Object System.Collections.Generic.List[string]
+    foreach ($p in $toDelete) {
+        $ns = [string]$p.namespace
+        $nm = [string]$p.name
+        if ($ns -notmatch '^[a-z0-9][a-z0-9.-]{0,253}$') { continue }
+        if ($nm -notmatch $script:DuneBackupDumpPodNameRegex) { continue }
+        $cmds.Add("sudo kubectl delete pod -n '$ns' '$nm' --ignore-not-found 2>&1 || true") | Out-Null
+    }
+    if ($cmds.Count -eq 0) {
+        return @{
+            ok        = $true
+            deleted   = @()
+            kept      = @($pods)
+            remaining = @($pods)
+            message   = "Found $total dump pod(s); $KeepLast retained, $(($toDelete | Measure-Object).Count) skipped after name validation."
+            output    = ''
+        }
+    }
+    $shellScript = ($cmds -join "`n")
+    $r = Invoke-DuneBackupShell -Ip $Ip -Script $shellScript -TimeoutSec 60
+    if ($r.rc -lt 0) {
+        return @{ ok=$false; status=502; message='SSH to VM failed (no exit code).' }
+    }
+    # Refresh from authoritative source after delete.
+    $remaining = Get-DuneBackupDumpPods -Ip $Ip
+    return @{
+        ok        = $true
+        deleted   = @($toDelete)
+        kept      = @($kept)
+        remaining = @($remaining)
+        message   = "Deleted $(@($toDelete).Count) dump pod(s); kept $(@($kept).Count)."
+        output    = $r.out
+    }
+}

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -49,13 +49,29 @@ $script:DuneBackupPresets = @{
     'WeeklyMonUtc04'  = @{ label='Weekly, Monday 04:00';           crons=@('0 4 * * 1') }
 }
 
+# Auto-prune the `*-dump-YYYYMMDD-HHMMSS-pod` objects Funcom's backup job
+# leaves behind on every run. Keep the most recent N pods; delete older ones.
+# Runs right after every backup invocation so accumulation can't outpace the
+# cron cadence (issue #363). One-line BusyBox-safe pipeline so the whole
+# backup command stays a single crontab entry:
+#   - kubectl jsonpath -> "ns|name|phase" per pod
+#   - awk filter to Succeeded dump-* pods
+#   - sort by name (timestamp embedded, newest first), keep first N, delete rest
+$script:DuneBackupPodPruneKeepLast = 10
+$script:DuneBackupPodPruneSnippet  = "sudo kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.phase}{`"\n`"}{end}' 2>/dev/null | awk -F'|' '`$3==`"Succeeded`" && `$2 ~ /-dump-[0-9]{8}-[0-9]{6}-pod`$/' | sort -t'|' -k2 -r | tail -n +$($script:DuneBackupPodPruneKeepLast + 1) | while IFS='|' read ns nm phase; do echo `"`$(date) dst: prune dump pod `$ns/`$nm`" >> /var/log/dune-backup.log; sudo kubectl delete pod -n `"`$ns`" `"`$nm`" --ignore-not-found >> /var/log/dune-backup.log 2>&1; done"
+
 # The scheduled backup is wrapped in a guard that skips it when a DST-driven
 # battlegroup restart is in progress: RestartSchedule.ps1 touches
 # /tmp/dst-restart-active just before (and during) the restart, and `find -mmin
 # -30` here treats a marker touched within the last 30 minutes as "active". The
 # guard fails safe - any error in the check falls through to running the backup
 # normally - and contains no literal '%' so it is crontab-safe.
-$script:DuneBackupCmd = 'if find /tmp/dst-restart-active -mmin -30 2>/dev/null | grep -q .; then echo "$(date) dst: backup skipped - BG restart window active" >> /var/log/dune-backup.log; else /home/dune/.dune/bin/battlegroup backup >> /var/log/dune-backup.log 2>&1; fi'
+#
+# After a successful backup we also run the dump-pod pruner above — same
+# cadence as backups, so the pod count stays bounded automatically (issue
+# #363). The pruner is skipped during the restart window too: a kubectl-delete
+# storm while k3s is restarting would just compete for the API server.
+$script:DuneBackupCmd = "if find /tmp/dst-restart-active -mmin -30 2>/dev/null | grep -q .; then echo `"`$(date) dst: backup skipped - BG restart window active`" >> /var/log/dune-backup.log; else /home/dune/.dune/bin/battlegroup backup >> /var/log/dune-backup.log 2>&1; $script:DuneBackupPodPruneSnippet; fi"
 $script:DuneBackupBeginMarker = '# DST-BACKUP BEGIN'
 $script:DuneBackupEndMarker   = '# DST-BACKUP END'
 $script:DuneBackupDumpDir     = '/funcom/artifacts/database-dumps'

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -49,17 +49,34 @@ $script:DuneBackupPresets = @{
     'WeeklyMonUtc04'  = @{ label='Weekly, Monday 04:00';           crons=@('0 4 * * 1') }
 }
 
+# Default retention for the auto-prune. The user-configurable value lives in
+# the BackupSchedule and is rendered into the cron command at Save time so the
+# tick honors whatever was last saved. Used when no override is supplied.
+$script:DuneBackupPodPruneKeepLastDefault = 10
+$script:DuneBackupPodPruneKeepDaysDefault = 0
+
+# Build the cron-embedded pod-prune snippet for a given keepLast value.
 # Auto-prune the `*-dump-YYYYMMDD-HHMMSS-pod` objects Funcom's backup job
-# leaves behind on every run. Keep the most recent N pods; delete older ones.
-# Runs right after every backup invocation so accumulation can't outpace the
-# cron cadence (issue #363). One-line BusyBox-safe pipeline so the whole
-# backup command stays a single crontab entry:
+# leaves behind on every run. Keeps the most recent N pods; deletes older
+# ones. Runs right after every backup invocation so accumulation can't
+# outpace the cron cadence (issue #363). One-line BusyBox-safe pipeline so
+# the whole backup command stays a single crontab entry:
 #   - kubectl jsonpath -> "ns|name|phase" per pod
 #   - awk filter to Succeeded dump-* pods
 #   - sort by name (timestamp embedded, newest first), keep first N, delete rest
-$script:DuneBackupPodPruneKeepLast = 10
-$script:DuneBackupPodPruneSnippet  = "sudo kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.phase}{`"\n`"}{end}' 2>/dev/null | awk -F'|' '`$3==`"Succeeded`" && `$2 ~ /-dump-[0-9]{8}-[0-9]{6}-pod`$/' | sort -t'|' -k2 -r | tail -n +$($script:DuneBackupPodPruneKeepLast + 1) | while IFS='|' read ns nm phase; do echo `"`$(date) dst: prune dump pod `$ns/`$nm`" >> /var/log/dune-backup.log; sudo kubectl delete pod -n `"`$ns`" `"`$nm`" --ignore-not-found >> /var/log/dune-backup.log 2>&1; done"
+# keepDays is intentionally NOT folded into the cron snippet — keeping the
+# crontab one-line + BusyBox-safe rules out the age math here. The cron tick
+# uses count-only; the manual Prune button on the Database card honors both
+# thresholds via Remove-DuneBackupDumpPods (PowerShell-side filtering).
+function New-DuneBackupPodPruneSnippet {
+    param([int]$KeepLast = 10)
+    if ($KeepLast -lt 0)   { $KeepLast = 0 }
+    if ($KeepLast -gt 100) { $KeepLast = 100 }
+    $skip = $KeepLast + 1
+    return "sudo kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.phase}{`"\n`"}{end}' 2>/dev/null | awk -F'|' '`$3==`"Succeeded`" && `$2 ~ /-dump-[0-9]{8}-[0-9]{6}-pod`$/' | sort -t'|' -k2 -r | tail -n +$skip | while IFS='|' read ns nm phase; do echo `"`$(date) dst: prune dump pod `$ns/`$nm`" >> /var/log/dune-backup.log; sudo kubectl delete pod -n `"`$ns`" `"`$nm`" --ignore-not-found >> /var/log/dune-backup.log 2>&1; done"
+}
 
+# Build the full backup cron command for a given keepLast value.
 # The scheduled backup is wrapped in a guard that skips it when a DST-driven
 # battlegroup restart is in progress: RestartSchedule.ps1 touches
 # /tmp/dst-restart-active just before (and during) the restart, and `find -mmin
@@ -67,11 +84,15 @@ $script:DuneBackupPodPruneSnippet  = "sudo kubectl get pods --all-namespaces -o 
 # guard fails safe - any error in the check falls through to running the backup
 # normally - and contains no literal '%' so it is crontab-safe.
 #
-# After a successful backup we also run the dump-pod pruner above — same
-# cadence as backups, so the pod count stays bounded automatically (issue
-# #363). The pruner is skipped during the restart window too: a kubectl-delete
-# storm while k3s is restarting would just compete for the API server.
-$script:DuneBackupCmd = "if find /tmp/dst-restart-active -mmin -30 2>/dev/null | grep -q .; then echo `"`$(date) dst: backup skipped - BG restart window active`" >> /var/log/dune-backup.log; else /home/dune/.dune/bin/battlegroup backup >> /var/log/dune-backup.log 2>&1; $script:DuneBackupPodPruneSnippet; fi"
+# After a successful backup we also run the dump-pod pruner — same cadence as
+# backups, so the pod count stays bounded automatically (issue #363). The
+# pruner is skipped during the restart window too: a kubectl-delete storm
+# while k3s is restarting would just compete for the API server.
+function New-DuneBackupCmd {
+    param([int]$KeepLastPods = 10)
+    $snippet = New-DuneBackupPodPruneSnippet -KeepLast $KeepLastPods
+    return "if find /tmp/dst-restart-active -mmin -30 2>/dev/null | grep -q .; then echo `"`$(date) dst: backup skipped - BG restart window active`" >> /var/log/dune-backup.log; else /home/dune/.dune/bin/battlegroup backup >> /var/log/dune-backup.log 2>&1; $snippet; fi"
+}
 $script:DuneBackupBeginMarker = '# DST-BACKUP BEGIN'
 $script:DuneBackupEndMarker   = '# DST-BACKUP END'
 $script:DuneBackupDumpDir     = '/funcom/artifacts/database-dumps'
@@ -167,19 +188,29 @@ function Invoke-DuneBackupShell {
 function New-DuneBackupBlock {
     param(
         [Parameter(Mandatory)][string]$Preset,
-        [int]$KeepLast = 0
+        [int]$KeepLast = 0,
+        [Nullable[int]]$KeepLastPods = $null,
+        [Nullable[int]]$KeepDaysPods = $null
     )
     if (-not $script:DuneBackupPresets.ContainsKey($Preset)) {
         throw "Unknown preset: $Preset"
     }
     if ($Preset -eq 'Off') { return $null }
+    if ($null -eq $KeepLastPods -or $KeepLastPods -lt 0) { $KeepLastPods = $script:DuneBackupPodPruneKeepLastDefault }
+    if ($KeepLastPods -gt 100) { $KeepLastPods = 100 }
+    if ($null -eq $KeepDaysPods -or $KeepDaysPods -lt 0) { $KeepDaysPods = $script:DuneBackupPodPruneKeepDaysDefault }
+    if ($KeepDaysPods -gt 365) { $KeepDaysPods = 365 }
+
+    $cmd = New-DuneBackupCmd -KeepLastPods $KeepLastPods
 
     $lines = @()
     $lines += $script:DuneBackupBeginMarker
     $lines += "# DST-BACKUP-PRESET: $Preset"
     $lines += "# DST-BACKUP-KEEP-LAST: $KeepLast"
+    $lines += "# DST-BACKUP-KEEP-LAST-PODS: $KeepLastPods"
+    $lines += "# DST-BACKUP-KEEP-DAYS-PODS: $KeepDaysPods"
     foreach ($cronExpr in $script:DuneBackupPresets[$Preset].crons) {
-        $lines += "$cronExpr $script:DuneBackupCmd"
+        $lines += "$cronExpr $cmd"
     }
     if ($KeepLast -gt 0) {
         # Narrow the retention pattern to filenames that match Funcom's own
@@ -224,15 +255,21 @@ function ConvertFrom-DuneBackupCrontab {
     if ($blockLines.Count -gt 0 -or $CrontabText -match [regex]::Escape($script:DuneBackupBeginMarker)) {
         $preset = $null
         $keepLast = 0
+        $keepLastPods = $script:DuneBackupPodPruneKeepLastDefault
+        $keepDaysPods = $script:DuneBackupPodPruneKeepDaysDefault
         foreach ($bl in $blockLines) {
             if ($bl -match '^# DST-BACKUP-PRESET:\s*(\S+)') { $preset = $Matches[1] }
+            elseif ($bl -match '^# DST-BACKUP-KEEP-LAST-PODS:\s*(\d+)') { $keepLastPods = [int]$Matches[1] }
+            elseif ($bl -match '^# DST-BACKUP-KEEP-DAYS-PODS:\s*(\d+)') { $keepDaysPods = [int]$Matches[1] }
             elseif ($bl -match '^# DST-BACKUP-(?:KEEP-LAST|RETENTION):\s*(\d+)') { $keepLast = [int]$Matches[1] }
         }
         if (-not $preset) { $preset = 'Custom' }
         $blockInfo = @{
-            preset   = $preset
-            keepLast = $keepLast
-            raw      = ($blockLines -join "`n")
+            preset       = $preset
+            keepLast     = $keepLast
+            keepLastPods = $keepLastPods
+            keepDaysPods = $keepDaysPods
+            raw          = ($blockLines -join "`n")
         }
     }
 
@@ -303,15 +340,19 @@ sudo crontab -l 2>&1 || true
     $enabled = $false
     $preset = 'Off'
     $keepLast = 0
+    $keepLastPods = $script:DuneBackupPodPruneKeepLastDefault
+    $keepDaysPods = $script:DuneBackupPodPruneKeepDaysDefault
     $looksTampered = $false
     $inferredFromUnmanaged = $false
     if ($parsed.block) {
-        $preset   = $parsed.block.preset
-        $keepLast = $parsed.block.keepLast
-        $enabled  = ($preset -ne 'Off')
-        # If the rendered block doesn't match the stored preset+keepLast any
-        # more, the operator likely edited it by hand. Surface that to the UI.
-        $expected = (New-DuneBackupBlock -Preset $preset -KeepLast $keepLast)
+        $preset       = $parsed.block.preset
+        $keepLast     = $parsed.block.keepLast
+        $keepLastPods = $parsed.block.keepLastPods
+        $keepDaysPods = $parsed.block.keepDaysPods
+        $enabled      = ($preset -ne 'Off')
+        # If the rendered block doesn't match the stored knobs any more, the
+        # operator likely edited it by hand. Surface that to the UI.
+        $expected = (New-DuneBackupBlock -Preset $preset -KeepLast $keepLast -KeepLastPods $keepLastPods -KeepDaysPods $keepDaysPods)
         if ($expected) {
             $expectedInner = ($expected.TrimEnd("`n") -split "`n" | Select-Object -Skip 1 | Select-Object -SkipLast 1) -join "`n"
             if ($expectedInner -ne $parsed.block.raw) { $looksTampered = $true }
@@ -334,6 +375,8 @@ sudo crontab -l 2>&1 || true
         enabled                   = $enabled
         preset                    = $preset
         keepLast                  = $keepLast
+        keepLastPods              = $keepLastPods
+        keepDaysPods              = $keepDaysPods
         vmTimezone                = $tz
         vmNowUtc                  = $vmNowUtc
         crondRunning              = [bool]$crondRunning
@@ -355,7 +398,9 @@ function Set-DuneBackupSchedule {
     param(
         [Parameter(Mandatory)][string]$Ip,
         [Parameter(Mandatory)][string]$Preset,
-        [int]$KeepLast = 0
+        [int]$KeepLast = 0,
+        [Nullable[int]]$KeepLastPods = $null,
+        [Nullable[int]]$KeepDaysPods = $null
     )
     if (-not $script:DuneBackupPresets.ContainsKey($Preset)) {
         return @{ ok=$false; status=400; message="Unknown preset: $Preset" }
@@ -363,8 +408,14 @@ function Set-DuneBackupSchedule {
     if ($KeepLast -lt 0 -or $KeepLast -gt 1000) {
         return @{ ok=$false; status=400; message="keepLast must be 0..1000 (got $KeepLast)." }
     }
+    if ($null -ne $KeepLastPods -and ($KeepLastPods -lt 0 -or $KeepLastPods -gt 100)) {
+        return @{ ok=$false; status=400; message="keepLastPods must be 0..100 (got $KeepLastPods)." }
+    }
+    if ($null -ne $KeepDaysPods -and ($KeepDaysPods -lt 0 -or $KeepDaysPods -gt 365)) {
+        return @{ ok=$false; status=400; message="keepDaysPods must be 0..365 (got $KeepDaysPods)." }
+    }
 
-    $newBlock = New-DuneBackupBlock -Preset $Preset -KeepLast $KeepLast
+    $newBlock = New-DuneBackupBlock -Preset $Preset -KeepLast $KeepLast -KeepLastPods $KeepLastPods -KeepDaysPods $KeepDaysPods
     $newBlockB64 = if ($newBlock) { [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($newBlock)) } else { '' }
 
     # Whole RMW (read existing crontab, strip our block, append new block,
@@ -459,6 +510,11 @@ sudo crontab -l 2>&1 || true
         if ($parsed.block.preset -ne $Preset -or $parsed.block.keepLast -ne $KeepLast) {
             return @{ ok=$false; status=502; message="Verification mismatch: got preset=$($parsed.block.preset), keepLast=$($parsed.block.keepLast)." }
         }
+        $expectedKeepLastPods = if ($null -ne $KeepLastPods) { [int]$KeepLastPods } else { $script:DuneBackupPodPruneKeepLastDefault }
+        $expectedKeepDaysPods = if ($null -ne $KeepDaysPods) { [int]$KeepDaysPods } else { $script:DuneBackupPodPruneKeepDaysDefault }
+        if ($parsed.block.keepLastPods -ne $expectedKeepLastPods -or $parsed.block.keepDaysPods -ne $expectedKeepDaysPods) {
+            return @{ ok=$false; status=502; message="Verification mismatch: got keepLastPods=$($parsed.block.keepLastPods), keepDaysPods=$($parsed.block.keepDaysPods)." }
+        }
     }
 
     return @{ ok=$true }
@@ -546,6 +602,11 @@ function Get-DuneBackupDumpPods {
     # Stream namespace|name|startTime|phase via jsonpath. Avoids needing jq on
     # the VM. We filter by phase + name regex here so callers always get a
     # canonical list (Completed/Succeeded dump-* pods only).
+    #
+    # NOTE: in Kubernetes the actual `.status.phase` value for a finished pod
+    # is "Succeeded" — what kubectl displays as "Completed" in the STATUS
+    # column is a container reason, not the pod phase. We keep the
+    # ==="Completed" check defensively in case Funcom's CRD ever sets it.
     $jp = '{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.startTime}|{.status.phase}{"\n"}{end}'
     $cmd = "sudo kubectl get pods --all-namespaces -o jsonpath='$jp' 2>/dev/null"
     $raw = $null
@@ -555,6 +616,7 @@ function Get-DuneBackupDumpPods {
         throw "kubectl get pods failed: $($_.Exception.Message)"
     }
     $rows = if ($raw) { (($raw -join "`n") -replace "`r",'') -split "`n" } else { @() }
+    $nowUtc = [datetime]::UtcNow
     $out = New-Object System.Collections.Generic.List[object]
     foreach ($r in $rows) {
         if (-not $r) { continue }
@@ -566,11 +628,19 @@ function Get-DuneBackupDumpPods {
         $phase = $parts[3]
         if ($name -notmatch $script:DuneBackupDumpPodNameRegex) { continue }
         if ($phase -ne 'Succeeded' -and $phase -ne 'Completed') { continue }
+
+        # Parse the timestamp baked into the name (authoritative — survives
+        # status.startTime being cleared on terminal pods) and compute age.
+        $nameTs = Get-DuneBackupDumpPodTimestamp -Name $name
+        $ageMin = if ($nameTs) { [int]($nowUtc - $nameTs).TotalMinutes } else { $null }
+
         $out.Add([pscustomobject]@{
-            namespace = $ns
-            name      = $name
-            startTime = $start
-            phase     = $phase
+            namespace      = $ns
+            name           = $name
+            startTime      = $start
+            phase          = $phase
+            nameTimestamp  = if ($nameTs) { $nameTs.ToString('yyyy-MM-ddTHH:mm:ssZ') } else { $null }
+            ageMinutes     = $ageMin
         }) | Out-Null
     }
     # Sort by the embedded YYYYMMDD-HHMMSS in the name (newest first). Falls

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -564,34 +564,88 @@ function Get-DuneBackupDumpPods {
 }
 
 # -----------------------------------------------------------------------------
-# Public: prune Succeeded/Completed dump-* pods, keeping the most recent
-# $KeepLast. Returns @{ ok; deleted; kept; remaining; output }. Never touches
-# the live DB StatefulSet, util/mon/pghero, file-browser pods, or any pod
-# whose name doesn't match the canonical dump-* shape — the name regex check
-# is authoritative and double-checked before each kubectl delete.
+# Parse the YYYYMMDD-HHMMSS that's baked into every Funcom dump-pod name. Used
+# as the authoritative age signal — the pod name is the only timestamp that
+# survives even when k8s status.startTime is missing/cleared (which happens
+# on some terminal pods). Returns $null if the regex doesn't match.
+# -----------------------------------------------------------------------------
+function Get-DuneBackupDumpPodTimestamp {
+    param([string]$Name)
+    if (-not $Name) { return $null }
+    if ($Name -notmatch '-dump-([0-9]{8})-([0-9]{6})-pod$') { return $null }
+    $date = $Matches[1]; $time = $Matches[2]
+    try {
+        return [datetime]::ParseExact("$date$time", 'yyyyMMddHHmmss', [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal)
+    } catch {
+        return $null
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Public: prune Succeeded/Completed dump-* pods. Two independent thresholds:
+#   -KeepLast N   : keep at most the N most-recent pods (0 = no count cap)
+#   -KeepDays D   : also delete anything older than D days (0 = no age cap)
+# A pod survives only if it passes BOTH filters — exceeding either threshold
+# makes it a prune candidate. 0 on a threshold disables that axis (matches
+# the keep-forever convention used by the file-retention setting above).
+#
+# Returns @{ ok; deleted; kept; remaining; output }. Never touches the live
+# DB StatefulSet, util/mon/pghero, file-browser pods, or any pod whose name
+# doesn't match the canonical dump-* shape — the name regex check is
+# authoritative and re-checked before each kubectl delete.
 # -----------------------------------------------------------------------------
 function Remove-DuneBackupDumpPods {
     param(
         [Parameter(Mandatory)][string]$Ip,
-        [int]$KeepLast = 5
+        [int]$KeepLast = 5,
+        [int]$KeepDays = 0
     )
     if ($KeepLast -lt 0)   { $KeepLast = 0 }
     if ($KeepLast -gt 100) { $KeepLast = 100 }
+    if ($KeepDays -lt 0)   { $KeepDays = 0 }
+    if ($KeepDays -gt 365) { $KeepDays = 365 }
 
     $pods = Get-DuneBackupDumpPods -Ip $Ip
     $total = @($pods).Count
-    if ($total -le $KeepLast) {
+
+    # Age-filter cutoff. If KeepDays=0 we don't compute a cutoff; nothing is
+    # age-eligible for prune.
+    $ageCutoff = if ($KeepDays -gt 0) { [datetime]::UtcNow.AddDays(-$KeepDays) } else { $null }
+
+    # Walk the list (already sorted newest-first by name) and mark each pod
+    # as kept or to-delete based on both filters.
+    $kept     = New-Object System.Collections.Generic.List[object]
+    $toDelete = New-Object System.Collections.Generic.List[object]
+    $idx = 0
+    foreach ($p in $pods) {
+        $idx++
+        $exceededCount = ($KeepLast -gt 0 -and $idx -gt $KeepLast)
+        $exceededAge = $false
+        if ($ageCutoff) {
+            $ts = Get-DuneBackupDumpPodTimestamp -Name $p.name
+            if ($ts -and $ts -lt $ageCutoff) { $exceededAge = $true }
+        }
+        if ($exceededCount -or $exceededAge) {
+            $toDelete.Add($p) | Out-Null
+        } else {
+            $kept.Add($p) | Out-Null
+        }
+    }
+
+    if ($toDelete.Count -eq 0) {
+        $why = if ($KeepLast -eq 0 -and $KeepDays -eq 0) { 'no limits set' }
+               elseif ($KeepLast -gt 0 -and $KeepDays -gt 0) { "keep last $KeepLast, max age $KeepDays day(s)" }
+               elseif ($KeepLast -gt 0) { "keep last $KeepLast" }
+               else { "max age $KeepDays day(s)" }
         return @{
             ok        = $true
             deleted   = @()
-            kept      = @($pods)
-            remaining = @($pods)
-            message   = "Found $total dump pod(s); nothing to prune (keep last $KeepLast)."
+            kept      = @($kept)
+            remaining = @($kept)
+            message   = "Found $total dump pod(s); nothing to prune ($why)."
             output    = ''
         }
     }
-    $kept     = @($pods | Select-Object -First $KeepLast)
-    $toDelete = @($pods | Select-Object -Skip  $KeepLast)
 
     # Re-validate every namespace/name we're about to interpolate. Defence in
     # depth — the jsonpath output should already be clean, but a stale CRD or
@@ -611,7 +665,7 @@ function Remove-DuneBackupDumpPods {
             deleted   = @()
             kept      = @($pods)
             remaining = @($pods)
-            message   = "Found $total dump pod(s); $KeepLast retained, $(($toDelete | Measure-Object).Count) skipped after name validation."
+            message   = "Found $total dump pod(s); $($kept.Count) retained, $($toDelete.Count) skipped after name validation."
             output    = ''
         }
     }
@@ -627,7 +681,7 @@ function Remove-DuneBackupDumpPods {
         deleted   = @($toDelete)
         kept      = @($kept)
         remaining = @($remaining)
-        message   = "Deleted $(@($toDelete).Count) dump pod(s); kept $(@($kept).Count)."
+        message   = "Deleted $($toDelete.Count) dump pod(s); kept $($kept.Count)."
         output    = $r.out
     }
 }

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -599,15 +599,22 @@ $script:DuneBackupDumpPodNameRegex = '^[a-z0-9.-]+-dump-[0-9]{8}-[0-9]{6}-pod$'
 
 function Get-DuneBackupDumpPods {
     param([Parameter(Mandatory)][string]$Ip)
-    # Stream namespace|name|startTime|phase via jsonpath. Avoids needing jq on
-    # the VM. We filter by phase + name regex here so callers always get a
-    # canonical list (Completed/Succeeded dump-* pods only).
+    # Stream namespace|name|startTime|phase|ownerKind|ownerName|controller via
+    # jsonpath. Avoids needing jq on the VM. We filter by phase + name regex
+    # here so callers always get a canonical list (Completed/Succeeded dump-*
+    # pods only).
+    #
+    # Owner reference info is included because "pod survives a force-delete"
+    # means an owner controller is re-creating it with the same name — we
+    # need to surface WHICH owner so the user can decide whether to delete
+    # that instead. Only the first ownerReference is captured (Kubernetes
+    # allows multiple but a controller-owner is typically singular).
     #
     # NOTE: in Kubernetes the actual `.status.phase` value for a finished pod
     # is "Succeeded" — what kubectl displays as "Completed" in the STATUS
     # column is a container reason, not the pod phase. We keep the
     # ==="Completed" check defensively in case Funcom's CRD ever sets it.
-    $jp = '{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.startTime}|{.status.phase}{"\n"}{end}'
+    $jp = '{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.startTime}|{.status.phase}|{.metadata.ownerReferences[0].kind}|{.metadata.ownerReferences[0].name}|{.metadata.ownerReferences[0].controller}{"\n"}{end}'
     $cmd = "sudo kubectl get pods --all-namespaces -o jsonpath='$jp' 2>/dev/null"
     $raw = $null
     try {
@@ -620,12 +627,15 @@ function Get-DuneBackupDumpPods {
     $out = New-Object System.Collections.Generic.List[object]
     foreach ($r in $rows) {
         if (-not $r) { continue }
-        $parts = $r -split '\|', 4
+        $parts = $r -split '\|', 7
         if ($parts.Count -lt 4) { continue }
         $ns    = $parts[0]
         $name  = $parts[1]
         $start = $parts[2]
         $phase = $parts[3]
+        $ownerKind = if ($parts.Count -gt 4) { [string]$parts[4] } else { '' }
+        $ownerName = if ($parts.Count -gt 5) { [string]$parts[5] } else { '' }
+        $ownerCtrl = if ($parts.Count -gt 6) { [string]$parts[6] } else { '' }
         if ($name -notmatch $script:DuneBackupDumpPodNameRegex) { continue }
         if ($phase -ne 'Succeeded' -and $phase -ne 'Completed') { continue }
 
@@ -635,12 +645,15 @@ function Get-DuneBackupDumpPods {
         $ageMin = if ($nameTs) { [int]($nowUtc - $nameTs).TotalMinutes } else { $null }
 
         $out.Add([pscustomobject]@{
-            namespace      = $ns
-            name           = $name
-            startTime      = $start
-            phase          = $phase
-            nameTimestamp  = if ($nameTs) { $nameTs.ToString('yyyy-MM-ddTHH:mm:ssZ') } else { $null }
-            ageMinutes     = $ageMin
+            namespace          = $ns
+            name               = $name
+            startTime          = $start
+            phase              = $phase
+            nameTimestamp      = if ($nameTs) { $nameTs.ToString('yyyy-MM-ddTHH:mm:ssZ') } else { $null }
+            ageMinutes         = $ageMin
+            ownerKind          = $ownerKind
+            ownerName          = $ownerName
+            ownerIsController  = ($ownerCtrl -eq 'true')
         }) | Out-Null
     }
     # Sort by the embedded YYYYMMDD-HHMMSS in the name (newest first). Falls

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -755,13 +755,25 @@ function Remove-DuneBackupDumpPods {
             output    = ''
         }
     }
-    $shellScript = ($cmds -join "`n")
-    $r = Invoke-DuneBackupShell -Ip $Ip -Script $shellScript -TimeoutSec 60
+    # Run deletes then settle briefly inside the same SSH session so the API
+    # server has propagated the deletes to etcd before our re-read. Without
+    # the settle, `kubectl delete pod` returns as soon as the API accepts the
+    # request — a follow-up `kubectl get pods` over a fresh SSH connection
+    # can still see the about-to-be-deleted pods, and we end up returning a
+    # stale `remaining` count that matches the pre-delete state.
+    $shellScript = ($cmds -join "`n") + "`nsleep 1`n"
+    $r = Invoke-DuneBackupShell -Ip $Ip -Script $shellScript -TimeoutSec 90
     if ($r.rc -lt 0) {
         return @{ ok=$false; status=502; message='SSH to VM failed (no exit code).' }
     }
-    # Refresh from authoritative source after delete.
+    # Refresh from authoritative source after delete. Retry once if it
+    # comes back with the same count — handles the case where the deletes
+    # raced ahead of the API server's index update.
     $remaining = Get-DuneBackupDumpPods -Ip $Ip
+    if (@($remaining).Count -ge $total) {
+        Start-Sleep -Milliseconds 1500
+        $remaining = Get-DuneBackupDumpPods -Ip $Ip
+    }
     return @{
         ok        = $true
         deleted   = @($toDelete)

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -737,13 +737,17 @@ function Remove-DuneBackupDumpPods {
     # depth — the jsonpath output should already be clean, but a stale CRD or
     # webhook could in principle return surprises and we're about to embed
     # these values into a shell command.
+    #
+    # Each delete prints a status marker so we can tell which actually ran
+    # (and which kubectl rejected, which was a no-op due to --ignore-not-found,
+    # etc.). Markers are easy to parse without changing the existing rc model.
     $cmds = New-Object System.Collections.Generic.List[string]
     foreach ($p in $toDelete) {
         $ns = [string]$p.namespace
         $nm = [string]$p.name
         if ($ns -notmatch '^[a-z0-9][a-z0-9.-]{0,253}$') { continue }
         if ($nm -notmatch $script:DuneBackupDumpPodNameRegex) { continue }
-        $cmds.Add("sudo kubectl delete pod -n '$ns' '$nm' --ignore-not-found 2>&1 || true") | Out-Null
+        $cmds.Add("out=`$(sudo kubectl delete pod -n '${ns}' '${nm}' --ignore-not-found 2>&1); rc=`$?; echo __DST_POD_DEL__:`${rc}:${ns}/${nm}:`${out}") | Out-Null
     }
     if ($cmds.Count -eq 0) {
         return @{
@@ -755,31 +759,79 @@ function Remove-DuneBackupDumpPods {
             output    = ''
         }
     }
-    # Run deletes then settle briefly inside the same SSH session so the API
-    # server has propagated the deletes to etcd before our re-read. Without
-    # the settle, `kubectl delete pod` returns as soon as the API accepts the
-    # request — a follow-up `kubectl get pods` over a fresh SSH connection
-    # can still see the about-to-be-deleted pods, and we end up returning a
-    # stale `remaining` count that matches the pre-delete state.
+    # First pass: graceful delete. Then settle briefly inside the same SSH
+    # session so the API server has propagated the deletes to etcd. Then re-
+    # read to find any that survived (owner-controller recreated, RBAC denied,
+    # stuck-terminating, etc.) and force-delete those.
     $shellScript = ($cmds -join "`n") + "`nsleep 1`n"
     $r = Invoke-DuneBackupShell -Ip $Ip -Script $shellScript -TimeoutSec 90
     if ($r.rc -lt 0) {
         return @{ ok=$false; status=502; message='SSH to VM failed (no exit code).' }
     }
-    # Refresh from authoritative source after delete. Retry once if it
-    # comes back with the same count — handles the case where the deletes
-    # raced ahead of the API server's index update.
+    $firstPassOutput = $r.out
+
+    # Refresh from authoritative source. Retry once if the API hasn't indexed
+    # the deletes yet (count didn't drop at all).
     $remaining = Get-DuneBackupDumpPods -Ip $Ip
     if (@($remaining).Count -ge $total) {
         Start-Sleep -Milliseconds 1500
         $remaining = Get-DuneBackupDumpPods -Ip $Ip
     }
+
+    # If pods we tried to delete are STILL in the remaining list, the first
+    # pass failed for those (owner-recreated / stuck terminating / RBAC). Try
+    # a force delete (--force --grace-period=0) which bypasses graceful drain
+    # and finalizers — the only thing that won't bypass is a still-running
+    # controller that re-creates the pod with the same name, which is rare.
+    $remainingNames = @{}
+    foreach ($p in $remaining) { $remainingNames[$p.name] = $true }
+    $survivors = New-Object System.Collections.Generic.List[object]
+    foreach ($p in $toDelete) {
+        if ($remainingNames.ContainsKey($p.name)) { $survivors.Add($p) | Out-Null }
+    }
+    $forceOutput = ''
+    if ($survivors.Count -gt 0) {
+        $forceCmds = New-Object System.Collections.Generic.List[string]
+        foreach ($p in $survivors) {
+            $ns = [string]$p.namespace
+            $nm = [string]$p.name
+            if ($ns -notmatch '^[a-z0-9][a-z0-9.-]{0,253}$') { continue }
+            if ($nm -notmatch $script:DuneBackupDumpPodNameRegex) { continue }
+            $forceCmds.Add("out=`$(sudo kubectl delete pod -n '${ns}' '${nm}' --ignore-not-found --force --grace-period=0 2>&1); rc=`$?; echo __DST_POD_FORCE__:`${rc}:${ns}/${nm}:`${out}") | Out-Null
+        }
+        if ($forceCmds.Count -gt 0) {
+            $forceScript = ($forceCmds -join "`n") + "`nsleep 1`n"
+            $rf = Invoke-DuneBackupShell -Ip $Ip -Script $forceScript -TimeoutSec 90
+            if ($rf.rc -ge 0) {
+                $forceOutput = $rf.out
+                $remaining = Get-DuneBackupDumpPods -Ip $Ip
+            }
+        }
+    }
+
+    # Compare intent vs reality: which intended deletes actually disappeared.
+    $remainingNames = @{}
+    foreach ($p in $remaining) { $remainingNames[$p.name] = $true }
+    $actuallyDeleted = New-Object System.Collections.Generic.List[object]
+    $stillPresent    = New-Object System.Collections.Generic.List[object]
+    foreach ($p in $toDelete) {
+        if ($remainingNames.ContainsKey($p.name)) { $stillPresent.Add($p) | Out-Null }
+        else                                      { $actuallyDeleted.Add($p) | Out-Null }
+    }
+
+    $msg = "Deleted $($actuallyDeleted.Count) of $($toDelete.Count) dump pod(s); $($kept.Count) kept."
+    if ($stillPresent.Count -gt 0) {
+        $names = ($stillPresent | ForEach-Object { $_.name }) -join ', '
+        $msg += " $($stillPresent.Count) survived both delete passes (likely owner-recreated or RBAC-denied): $names. Check kubectl describe."
+    }
     return @{
-        ok        = $true
-        deleted   = @($toDelete)
-        kept      = @($kept)
-        remaining = @($remaining)
-        message   = "Deleted $($toDelete.Count) dump pod(s); kept $($kept.Count)."
-        output    = $r.out
+        ok              = $true
+        deleted         = @($actuallyDeleted)
+        attempted       = @($toDelete)
+        kept            = @($kept)
+        remaining       = @($remaining)
+        survivors       = @($stillPresent)
+        message         = $msg
+        output          = ($firstPassOutput + "`n" + $forceOutput).Trim()
     }
 }

--- a/app/server/routes/BackupSchedule.ps1
+++ b/app/server/routes/BackupSchedule.ps1
@@ -31,19 +31,25 @@ Register-DuneRoute -Method PUT -Path '/api/db/backup-schedule' -Handler {
     }
     $preset = $null
     $keepLast = 0
+    $keepLastPods = $null
+    $keepDaysPods = $null
     if ($body -is [hashtable]) {
-        if ($body.ContainsKey('preset'))        { $preset    = [string]$body.preset }
-        if ($body.ContainsKey('keepLast')) { try { $keepLast = [int]$body.keepLast } catch { $keepLast = -1 } }
+        if ($body.ContainsKey('preset'))            { $preset       = [string]$body.preset }
+        if ($body.ContainsKey('keepLast'))     { try { $keepLast     = [int]$body.keepLast } catch { $keepLast = -1 } }
+        if ($body.ContainsKey('keepLastPods')) { try { $keepLastPods = [int]$body.keepLastPods } catch {} }
+        if ($body.ContainsKey('keepDaysPods')) { try { $keepDaysPods = [int]$body.keepDaysPods } catch {} }
     } elseif ($body) {
-        if ($body.preset)                       { $preset    = [string]$body.preset }
-        if ($null -ne $body.keepLast)      { try { $keepLast = [int]$body.keepLast } catch { $keepLast = -1 } }
+        if ($body.preset)                            { $preset       = [string]$body.preset }
+        if ($null -ne $body.keepLast)            { try { $keepLast   = [int]$body.keepLast } catch { $keepLast = -1 } }
+        if ($null -ne $body.keepLastPods)    { try { $keepLastPods   = [int]$body.keepLastPods } catch {} }
+        if ($null -ne $body.keepDaysPods)    { try { $keepDaysPods   = [int]$body.keepDaysPods } catch {} }
     }
     if (-not $preset) {
         Write-DuneError -Response $res -Status 400 -Message 'Body must include "preset" (string).'
         return
     }
     try {
-        $result = Invoke-WithDuneLock -Name 'backup-schedule' -Script { Set-DuneBackupSchedule -Ip $ctx.ip -Preset $preset -KeepLast $keepLast }
+        $result = Invoke-WithDuneLock -Name 'backup-schedule' -Script { Set-DuneBackupSchedule -Ip $ctx.ip -Preset $preset -KeepLast $keepLast -KeepLastPods $keepLastPods -KeepDaysPods $keepDaysPods }
         if (-not $result.ok) {
             Write-DuneError -Response $res -Status ([int]$result.status) -Message $result.message
             return

--- a/app/server/routes/BackupSchedule.ps1
+++ b/app/server/routes/BackupSchedule.ps1
@@ -78,3 +78,53 @@ Register-DuneRoute -Method GET -Path '/api/db/backup-history' -Handler {
         Write-DuneError -Response $res -Status 502 -Message "History read failed: $($_.Exception.Message)"
     }
 }
+
+# List Completed/Succeeded dump-* pods left behind by Funcom's backup jobs.
+# Read-only — used by the Database page to show how many leftover pods exist.
+Register-DuneRoute -Method GET -Path '/api/db/backup-dump-pods' -Handler {
+    param($req, $res, $routeParams, $body)
+    $ctx = Get-DuneBackupContext
+    if (-not $ctx.ok) {
+        Write-DuneError -Response $res -Status $ctx.status -Message $ctx.message
+        return
+    }
+    try {
+        $pods = Get-DuneBackupDumpPods -Ip $ctx.ip
+        Write-DuneJson -Response $res -Body @{ ok=$true; pods=@($pods); count=@($pods).Count }
+    } catch {
+        Write-DuneError -Response $res -Status 502 -Message "Dump-pod read failed: $($_.Exception.Message)"
+    }
+}
+
+# Prune Completed/Succeeded dump-* pods, keeping the most recent N.
+# Body: { keepLast: int } - defaults to 5.
+Register-DuneRoute -Method POST -Path '/api/db/prune-backup-dump-pods' -Handler {
+    param($req, $res, $routeParams, $body)
+    $ctx = Get-DuneBackupContext
+    if (-not $ctx.ok) {
+        Write-DuneError -Response $res -Status $ctx.status -Message $ctx.message
+        return
+    }
+    $keepLast = 5
+    if ($body -is [hashtable]) {
+        if ($body.ContainsKey('keepLast')) { try { $keepLast = [int]$body.keepLast } catch {} }
+    } elseif ($body) {
+        if ($null -ne $body.keepLast) { try { $keepLast = [int]$body.keepLast } catch {} }
+    }
+    if ($keepLast -lt 0)   { $keepLast = 0 }
+    if ($keepLast -gt 100) { $keepLast = 100 }
+    try {
+        $result = Invoke-WithDuneLock -Name 'prune-backup-dump-pods' -Script {
+            Remove-DuneBackupDumpPods -Ip $ctx.ip -KeepLast $keepLast
+        }
+        if (-not $result.ok) {
+            $status = 502
+            if ($result.ContainsKey('status') -and $result.status) { $status = [int]$result.status }
+            Write-DuneError -Response $res -Status $status -Message $result.message
+            return
+        }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 502 -Message "Prune failed: $($_.Exception.Message)"
+    }
+}

--- a/app/server/routes/BackupSchedule.ps1
+++ b/app/server/routes/BackupSchedule.ps1
@@ -96,8 +96,10 @@ Register-DuneRoute -Method GET -Path '/api/db/backup-dump-pods' -Handler {
     }
 }
 
-# Prune Completed/Succeeded dump-* pods, keeping the most recent N.
-# Body: { keepLast: int } - defaults to 5.
+# Prune Completed/Succeeded dump-* pods. Two independent thresholds:
+#   keepLast: keep at most N most-recent pods (0 = no count cap, default 5)
+#   keepDays: delete anything older than D days (0 = no age cap, default 0)
+# A pod is pruned if EITHER threshold is exceeded.
 Register-DuneRoute -Method POST -Path '/api/db/prune-backup-dump-pods' -Handler {
     param($req, $res, $routeParams, $body)
     $ctx = Get-DuneBackupContext
@@ -106,16 +108,21 @@ Register-DuneRoute -Method POST -Path '/api/db/prune-backup-dump-pods' -Handler 
         return
     }
     $keepLast = 5
+    $keepDays = 0
     if ($body -is [hashtable]) {
         if ($body.ContainsKey('keepLast')) { try { $keepLast = [int]$body.keepLast } catch {} }
+        if ($body.ContainsKey('keepDays')) { try { $keepDays = [int]$body.keepDays } catch {} }
     } elseif ($body) {
         if ($null -ne $body.keepLast) { try { $keepLast = [int]$body.keepLast } catch {} }
+        if ($null -ne $body.keepDays) { try { $keepDays = [int]$body.keepDays } catch {} }
     }
     if ($keepLast -lt 0)   { $keepLast = 0 }
     if ($keepLast -gt 100) { $keepLast = 100 }
+    if ($keepDays -lt 0)   { $keepDays = 0 }
+    if ($keepDays -gt 365) { $keepDays = 365 }
     try {
         $result = Invoke-WithDuneLock -Name 'prune-backup-dump-pods' -Script {
-            Remove-DuneBackupDumpPods -Ip $ctx.ip -KeepLast $keepLast
+            Remove-DuneBackupDumpPods -Ip $ctx.ip -KeepLast $keepLast -KeepDays $keepDays
         }
         if (-not $result.ok) {
             $status = 502

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -986,6 +986,36 @@ function Invoke-DuneDnatWatchdogInstall {
     }
 }
 
+function Invoke-DuneBackupDumpPodPrune {
+    # Prune Funcom's leftover `*-dump-YYYYMMDD-HHMMSS-pod` objects (issue #363).
+    # Keeps the most recent $KeepLast pods; deletes the rest in terminal phase.
+    # Best-effort + never throws — a prune hiccup must not fail a good
+    # start/reboot. Also runs at backup-schedule cadence via BackupSchedule.ps1's
+    # cron block; this hook is the belt-and-suspenders for servers that have no
+    # backup schedule installed (issue #363 listed start/reboot integration as
+    # "cheap, already SSH'd in").
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [int]$KeepLast = 10,
+        [string]$Phase = 'post-start'
+    )
+    if ($KeepLast -lt 0)   { $KeepLast = 0 }
+    if ($KeepLast -gt 100) { $KeepLast = 100 }
+    $skip = $KeepLast + 1
+
+    # Single-line BusyBox-safe pipeline; same logic as the cron-embedded
+    # snippet so behavior is identical at both call sites.
+    $cmd = "sudo kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.phase}{`"\n`"}{end}' 2>/dev/null | awk -F'|' '`$3==`"Succeeded`" && `$2 ~ /-dump-[0-9]{8}-[0-9]{6}-pod`$/' | sort -t'|' -k2 -r | tail -n +$skip | while IFS='|' read ns nm phase; do sudo kubectl delete pod -n `"`$ns`" `"`$nm`" --ignore-not-found 2>&1 && echo DUNE_DUMP_POD_DELETED; done"
+    $out = & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
+                 -i "$sshKey" "$sshUser@$Ip" "$cmd" 2>&1
+    $deleted = @($out | Where-Object { $_ -match 'DUNE_DUMP_POD_DELETED' }).Count
+    if ($deleted -gt 0) {
+        Write-Host "  [$Phase] Pruned $deleted leftover dump pod(s) (keeping last $KeepLast)." -ForegroundColor DarkGray
+    } else {
+        Write-Host "  [$Phase] No leftover dump pods to prune (keep last $KeepLast)." -ForegroundColor DarkGray
+    }
+}
+
 # ============================================================
 #  MENU DEFINITIONS
 # ============================================================
@@ -1571,6 +1601,7 @@ while ($true) {
         if ($bgStartExit -eq 0) {
             Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'post-startup' -Fast
             Invoke-DuneDnatWatchdogInstall -Ip $ip -Phase 'post-startup'
+            Invoke-DuneBackupDumpPodPrune -Ip $ip -Phase 'post-startup'
         } else {
             Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
         }
@@ -1843,6 +1874,7 @@ while ($true) {
         if ($bgStartExit -eq 0) {
             Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 45 -Phase 'post-reboot'
             Invoke-DuneDnatWatchdogInstall -Ip $ip -Phase 'post-reboot'
+            Invoke-DuneBackupDumpPodPrune -Ip $ip -Phase 'post-reboot'
         } else {
             Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
         }

--- a/webui/src/api/database.ts
+++ b/webui/src/api/database.ts
@@ -34,10 +34,20 @@ export function getBackupSchedule() {
   return api<BackupSchedule>('/api/db/backup-schedule')
 }
 
-export function putBackupSchedule(opts: { preset: string; keepLast: number }) {
+export function putBackupSchedule(opts: {
+  preset: string
+  keepLast: number
+  keepLastPods?: number
+  keepDaysPods?: number
+}) {
   return api<BackupSchedule>('/api/db/backup-schedule', {
     method: 'PUT',
-    body: JSON.stringify({ preset: opts.preset, keepLast: opts.keepLast }),
+    body: JSON.stringify({
+      preset:       opts.preset,
+      keepLast:     opts.keepLast,
+      keepLastPods: opts.keepLastPods,
+      keepDaysPods: opts.keepDaysPods,
+    }),
   })
 }
 

--- a/webui/src/api/database.ts
+++ b/webui/src/api/database.ts
@@ -5,6 +5,8 @@ import type {
   SqlResult,
   BackupSchedule,
   BackupHistory,
+  BackupDumpPodList,
+  BackupDumpPodPruneResult,
 } from './types'
 
 export function getDbInfo() {
@@ -67,5 +69,16 @@ export function uploadBackup(opts: { localPath: string }) {
   return api<BackupTransferResult>('/api/db/backup-upload', {
     method: 'POST',
     body: JSON.stringify({ localPath: opts.localPath }),
+  })
+}
+
+export function getBackupDumpPods() {
+  return api<BackupDumpPodList>('/api/db/backup-dump-pods')
+}
+
+export function pruneBackupDumpPods(opts: { keepLast: number }) {
+  return api<BackupDumpPodPruneResult>('/api/db/prune-backup-dump-pods', {
+    method: 'POST',
+    body: JSON.stringify({ keepLast: opts.keepLast }),
   })
 }

--- a/webui/src/api/database.ts
+++ b/webui/src/api/database.ts
@@ -76,9 +76,9 @@ export function getBackupDumpPods() {
   return api<BackupDumpPodList>('/api/db/backup-dump-pods')
 }
 
-export function pruneBackupDumpPods(opts: { keepLast: number }) {
+export function pruneBackupDumpPods(opts: { keepLast: number; keepDays: number }) {
   return api<BackupDumpPodPruneResult>('/api/db/prune-backup-dump-pods', {
     method: 'POST',
-    body: JSON.stringify({ keepLast: opts.keepLast }),
+    body: JSON.stringify({ keepLast: opts.keepLast, keepDays: opts.keepDays }),
   })
 }

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -373,6 +373,8 @@ export type BackupSchedule = {
   enabled: boolean
   preset: string
   keepLast: number
+  keepLastPods: number
+  keepDaysPods: number
   vmTimezone: string
   vmNowUtc: string
   crondRunning: boolean
@@ -403,6 +405,8 @@ export type BackupDumpPod = {
   name: string
   startTime: string
   phase: string
+  nameTimestamp: string | null
+  ageMinutes: number | null
 }
 
 export type BackupDumpPodList = {

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -407,6 +407,9 @@ export type BackupDumpPod = {
   phase: string
   nameTimestamp: string | null
   ageMinutes: number | null
+  ownerKind?: string
+  ownerName?: string
+  ownerIsController?: boolean
 }
 
 export type BackupDumpPodList = {

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -397,3 +397,25 @@ export type BackupHistory = {
   dumpDirSize: string
   logPath: string
 }
+
+export type BackupDumpPod = {
+  namespace: string
+  name: string
+  startTime: string
+  phase: string
+}
+
+export type BackupDumpPodList = {
+  ok: boolean
+  pods: BackupDumpPod[]
+  count: number
+}
+
+export type BackupDumpPodPruneResult = {
+  ok: boolean
+  deleted: BackupDumpPod[]
+  kept: BackupDumpPod[]
+  remaining: BackupDumpPod[]
+  message?: string
+  output?: string
+}

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -418,8 +418,10 @@ export type BackupDumpPodList = {
 export type BackupDumpPodPruneResult = {
   ok: boolean
   deleted: BackupDumpPod[]
+  attempted?: BackupDumpPod[]
   kept: BackupDumpPod[]
   remaining: BackupDumpPod[]
+  survivors?: BackupDumpPod[]
   message?: string
   output?: string
 }

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -767,15 +767,9 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       showToast('ok', delCount > 0
         ? `Deleted ${delCount} dump pod(s); kept ${keepCount}.`
         : (r.message ?? 'Nothing to prune.'))
-      // Trust the server response: `r.remaining` is from a fresh kubectl
-      // read on the SAME SSH session as the deletes (with a 1s settle so
-      // the API server has indexed them). A second background fetch over
-      // a new SSH connection raced this and clobbered the correct count
-      // with stale data — that's gone now. We still refetch history in
-      // the background so the log tail picks up the new prune lines.
-      // Scroll position is preserved — these are data-only updates.
-      setDumpPods({ ok: true, pods: r.remaining ?? [], count: (r.remaining ?? []).length })
-      void getBackupHistory({ recent: 5, logLines: 50 }).then(setHistory).catch(() => {})
+      // Same code path as the Refresh button — proven to give a clean,
+      // authoritative re-read of schedule + history + dump pods.
+      await loadAll()
     } catch (e) {
       showToast('err', `Prune failed: ${e instanceof Error ? e.message : String(e)}`)
     } finally {

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -767,7 +767,20 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       showToast('ok', delCount > 0
         ? `Deleted ${delCount} dump pod(s); kept ${keepCount}.`
         : (r.message ?? 'Nothing to prune.'))
+      // Immediate local update from the server's post-delete re-read so the
+      // count + prune candidate badge update before the background refetch
+      // returns. Then refresh history + log tail + a fresh dump-pod list in
+      // the background so the user sees the prune lines in the log without
+      // having to click Refresh. Scroll position is preserved — these are
+      // data-only updates, no layout reflow.
       setDumpPods({ ok: true, pods: r.remaining ?? [], count: (r.remaining ?? []).length })
+      void Promise.all([
+        getBackupDumpPods().catch(() => null),
+        getBackupHistory({ recent: 5, logLines: 50 }).catch(() => null),
+      ]).then(([pods, hist]) => {
+        if (pods) setDumpPods(pods)
+        if (hist) setHistory(hist)
+      })
     } catch (e) {
       showToast('err', `Prune failed: ${e instanceof Error ? e.message : String(e)}`)
     } finally {

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -652,6 +652,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
   const [draftPreset, setDraftPreset]       = useState<string>('Off')
   const [draftKeepLast, setDraftKeepLast]   = useState<number>(8)
   const [draftKeepDumpPods, setDraftKeepDumpPods] = useState<number>(5)
+  const [draftKeepDumpDays, setDraftKeepDumpDays] = useState<number>(0)
 
   const loadAll = useCallback(async () => {
     if (!vmRunning) {
@@ -745,7 +746,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
   async function handlePruneDumpPods() {
     setPruning(true)
     try {
-      const r = await pruneBackupDumpPods({ keepLast: draftKeepDumpPods })
+      const r = await pruneBackupDumpPods({ keepLast: draftKeepDumpPods, keepDays: draftKeepDumpDays })
       const delCount = r.deleted?.length ?? 0
       const keepCount = r.kept?.length ?? 0
       showToast('ok', delCount > 0
@@ -758,6 +759,29 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       setPruning(false)
     }
   }
+
+  // Pods eligible for prune: name-rank > keepLast (when keepLast>0) OR age > keepDays (when keepDays>0).
+  // Pod age is read from the YYYYMMDD-HHMMSS embedded in the pod name (more
+  // reliable than k8s status.startTime, which can clear on terminal pods).
+  const dumpPodPruneCandidateCount = useMemo(() => {
+    if (!dumpPods || !dumpPods.pods?.length) return 0
+    if (draftKeepDumpPods === 0 && draftKeepDumpDays === 0) return 0
+    const ageCutoffMs = draftKeepDumpDays > 0 ? Date.now() - draftKeepDumpDays * 86400 * 1000 : null
+    let count = 0
+    dumpPods.pods.forEach((p, idx) => {
+      const exceededCount = draftKeepDumpPods > 0 && idx >= draftKeepDumpPods
+      let exceededAge = false
+      if (ageCutoffMs !== null) {
+        const m = p.name.match(/-dump-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})-pod$/)
+        if (m) {
+          const ts = Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6])
+          if (ts < ageCutoffMs) exceededAge = true
+        }
+      }
+      if (exceededCount || exceededAge) count++
+    })
+    return count
+  }, [dumpPods, draftKeepDumpPods, draftKeepDumpDays])
 
   const presetChoices = schedule?.presets ?? [
     { id: 'Off',            label: 'Disabled' },
@@ -981,9 +1005,11 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
           Succeeded and is never cleaned up. Pruning here only deletes terminal <span className="font-mono">*-dump-*-pod</span>{' '}
           objects — the live DB StatefulSet, util/mon/pghero, and the actual <span className="font-mono">.backup</span> files are not touched.
         </p>
-        <div className="flex items-end gap-3">
+        <div className="flex flex-wrap items-end gap-3">
           <label className="flex flex-col gap-1 text-xs">
-            <span className="text-text-muted font-medium">Keep last (count)</span>
+            <span className="text-text-muted font-medium">
+              Keep last (count){draftKeepDumpPods === 0 ? ' — no cap' : ''}
+            </span>
             <input
               type="number"
               min={0}
@@ -998,19 +1024,40 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
               className="px-2 py-1.5 rounded bg-surface-2 border border-border text-text text-sm font-mono w-24"
             />
           </label>
+          <label className="flex flex-col gap-1 text-xs">
+            <span className="text-text-muted font-medium">
+              Keep last (days){draftKeepDumpDays === 0 ? ' — no age cap' : ''}
+            </span>
+            <input
+              type="number"
+              min={0}
+              max={365}
+              step={1}
+              value={draftKeepDumpDays}
+              onChange={e => {
+                const n = parseInt(e.target.value || '0', 10)
+                setDraftKeepDumpDays(Number.isFinite(n) ? Math.max(0, Math.min(365, n)) : 0)
+              }}
+              disabled={!vmRunning || pruning}
+              className="px-2 py-1.5 rounded bg-surface-2 border border-border text-text text-sm font-mono w-24"
+            />
+          </label>
           <button
             type="button"
             onClick={() => void handlePruneDumpPods()}
-            disabled={!vmRunning || pruning || !dumpPods || dumpPods.count <= draftKeepDumpPods}
+            disabled={!vmRunning || pruning || dumpPodPruneCandidateCount === 0}
             className="btn-secondary"
-            title={dumpPods && dumpPods.count > draftKeepDumpPods
-              ? `Delete ${dumpPods.count - draftKeepDumpPods} pod(s); keep the most recent ${draftKeepDumpPods}.`
-              : 'Nothing to prune.'}
+            title={dumpPodPruneCandidateCount > 0
+              ? `Delete ${dumpPodPruneCandidateCount} pod(s); keep ${(dumpPods?.count ?? 0) - dumpPodPruneCandidateCount}.`
+              : 'Nothing to prune at these thresholds.'}
           >
             <Icon name={pruning ? 'Loader2' : 'Trash2'} size={14} className={pruning ? 'animate-spin' : ''} />
             {pruning ? 'Pruning…' : 'Prune old backup pods'}
           </button>
         </div>
+        <p className="text-xs text-text-dim mt-2 italic">
+          A pod is kept only if it's both within the count cap and younger than the age cap. Set either to <span className="font-mono">0</span> to disable that axis.
+        </p>
       </div>
 
       {history?.logTail && (

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -764,11 +764,6 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       const r = await pruneBackupDumpPods({ keepLast: draftKeepDumpPods, keepDays: draftKeepDumpDays })
       const delCount = r.deleted?.length ?? 0
       const survCount = r.survivors?.length ?? 0
-      // Survivors went through both a graceful AND a force-delete pass and
-      // still came back in the kubectl re-read. They're either owner-
-      // recreated (a controller spawning them again with the same name) or
-      // RBAC-denied. Either way the user needs to know — and if an owner
-      // is named we surface it so they know what to delete instead.
       if (survCount > 0) {
         const detail = (r.survivors ?? []).map(p => {
           if (p.ownerKind && p.ownerName && p.ownerIsController) {
@@ -783,8 +778,13 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       } else {
         showToast('ok', r.message ?? (delCount > 0 ? `Deleted ${delCount} dump pod(s).` : 'Nothing to prune.'))
       }
-      // Same code path as the Refresh button — proven to give a clean,
-      // authoritative re-read of schedule + history + dump pods.
+      // DIAGNOSTIC: null the state first so 'Loading...' flashes, then
+      // reload. If the flash is visible, React IS re-rendering and the
+      // fresh fetch returned stale data. If not, the component is not
+      // picking up state changes at all.
+      setDumpPods(null)
+      // Yield to React so the null render commits before we kick loadAll.
+      await new Promise<void>(resolve => setTimeout(resolve, 50))
       await loadAll()
     } catch (e) {
       showToast('err', `Prune failed: ${e instanceof Error ? e.message : String(e)}`)

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -767,20 +767,15 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       showToast('ok', delCount > 0
         ? `Deleted ${delCount} dump pod(s); kept ${keepCount}.`
         : (r.message ?? 'Nothing to prune.'))
-      // Immediate local update from the server's post-delete re-read so the
-      // count + prune candidate badge update before the background refetch
-      // returns. Then refresh history + log tail + a fresh dump-pod list in
-      // the background so the user sees the prune lines in the log without
-      // having to click Refresh. Scroll position is preserved — these are
-      // data-only updates, no layout reflow.
+      // Trust the server response: `r.remaining` is from a fresh kubectl
+      // read on the SAME SSH session as the deletes (with a 1s settle so
+      // the API server has indexed them). A second background fetch over
+      // a new SSH connection raced this and clobbered the correct count
+      // with stale data — that's gone now. We still refetch history in
+      // the background so the log tail picks up the new prune lines.
+      // Scroll position is preserved — these are data-only updates.
       setDumpPods({ ok: true, pods: r.remaining ?? [], count: (r.remaining ?? []).length })
-      void Promise.all([
-        getBackupDumpPods().catch(() => null),
-        getBackupHistory({ recent: 5, logLines: 50 }).catch(() => null),
-      ]).then(([pods, hist]) => {
-        if (pods) setDumpPods(pods)
-        if (hist) setHistory(hist)
-      })
+      void getBackupHistory({ recent: 5, logLines: 50 }).then(setHistory).catch(() => {})
     } catch (e) {
       showToast('err', `Prune failed: ${e instanceof Error ? e.message : String(e)}`)
     } finally {

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -763,10 +763,20 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
     try {
       const r = await pruneBackupDumpPods({ keepLast: draftKeepDumpPods, keepDays: draftKeepDumpDays })
       const delCount = r.deleted?.length ?? 0
-      const keepCount = r.kept?.length ?? 0
-      showToast('ok', delCount > 0
-        ? `Deleted ${delCount} dump pod(s); kept ${keepCount}.`
-        : (r.message ?? 'Nothing to prune.'))
+      const survCount = r.survivors?.length ?? 0
+      // Survivors went through both a graceful AND a force-delete pass and
+      // still came back in the kubectl re-read. They're either owner-
+      // recreated (a controller spawning them again with the same name) or
+      // RBAC-denied. Either way the user needs to know.
+      if (survCount > 0) {
+        const names = (r.survivors ?? []).map(p => p.name).join(', ')
+        showToast('err',
+          delCount > 0
+            ? `Deleted ${delCount}; ${survCount} survived both delete passes (${names}). Check kubectl describe.`
+            : `0 deleted; ${survCount} survived both delete passes (${names}). Check kubectl describe.`)
+      } else {
+        showToast('ok', r.message ?? (delCount > 0 ? `Deleted ${delCount} dump pod(s).` : 'Nothing to prune.'))
+      }
       // Same code path as the Refresh button — proven to give a clean,
       // authoritative re-read of schedule + history + dump pods.
       await loadAll()

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -671,6 +671,8 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       setDumpPods(pods)
       setDraftPreset(sched.preset === 'Custom' ? 'Off' : sched.preset)
       setDraftKeepLast(sched.keepLast > 0 ? sched.keepLast : (sched.preset === 'Off' ? 8 : 0))
+      setDraftKeepDumpPods(sched.keepLastPods ?? 10)
+      setDraftKeepDumpDays(sched.keepDaysPods ?? 0)
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
       setSchedule(null); setHistory(null); setDumpPods(null)
@@ -690,21 +692,34 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
     // Likewise, if there are still unmanaged lines outside our block, allow
     // saving so the user can clean them up by re-installing.
     if (schedule.hasUnmanagedBackupLines) return true
-    return draftPreset !== schedule.preset || draftKeepLast !== schedule.keepLast
-  }, [schedule, draftPreset, draftKeepLast])
+    return (
+      draftPreset !== schedule.preset ||
+      draftKeepLast !== schedule.keepLast ||
+      draftKeepDumpPods !== (schedule.keepLastPods ?? 10) ||
+      draftKeepDumpDays !== (schedule.keepDaysPods ?? 0)
+    )
+  }, [schedule, draftPreset, draftKeepLast, draftKeepDumpPods, draftKeepDumpDays])
 
   async function save() {
     if (!schedule) return
     setSaving(true)
     try {
-      const updated = await putBackupSchedule({ preset: draftPreset, keepLast: draftKeepLast })
+      const updated = await putBackupSchedule({
+        preset: draftPreset,
+        keepLast: draftKeepLast,
+        keepLastPods: draftKeepDumpPods,
+        keepDaysPods: draftKeepDumpDays,
+      })
       setSchedule(updated)
       setDraftPreset(updated.preset === 'Custom' ? 'Off' : updated.preset)
       setDraftKeepLast(updated.keepLast > 0 ? updated.keepLast : (updated.preset === 'Off' ? 8 : 0))
-      showToast('ok', draftPreset === 'Off' ? 'Schedule disabled.' : `Schedule saved (${draftPreset}, keep last ${draftKeepLast}).`)
-      // Refresh history in the background so the user sees the new schedule
-      // reflected immediately when the next cron run lands.
+      setDraftKeepDumpPods(updated.keepLastPods ?? 10)
+      setDraftKeepDumpDays(updated.keepDaysPods ?? 0)
+      showToast('ok', draftPreset === 'Off' ? 'Schedule disabled.' : `Schedule saved.`)
+      // Refresh history + pod list in the background so the user sees the new
+      // schedule reflected immediately when the next cron run lands.
       void getBackupHistory({ recent: 5, logLines: 50 }).then(setHistory).catch(() => {})
+      void getBackupDumpPods().then(setDumpPods).catch(() => {})
     } catch (e) {
       showToast('err', `Save failed: ${e instanceof Error ? e.message : String(e)}`)
     } finally {
@@ -988,22 +1003,25 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       {/* Completed backup pods — Funcom's database-backup job leaves a
           `*-dump-YYYYMMDD-HHMMSS-pod` behind on every run. They terminate
           Succeeded and are never garbage-collected, so they pile up on the
-          Pods page and in the VM's shell-pod picker. This action prunes the
-          old ones; the .backup files on the PVC are handled by Keep last
-          above (separate retention). */}
+          Pods page and in the VM's shell-pod picker. Retention is persisted
+          as part of the schedule (Save schedule above writes both); the
+          cron tick honors keepLast, the manual button honors both. The
+          .backup files on the PVC are handled by Keep last (count) above
+          (separate retention). */}
       <div className="border-t border-border pt-3 mt-3">
         <div className="flex items-center justify-between gap-3 mb-2">
           <div className="text-xs font-semibold text-text-muted">Completed backup pods</div>
           <div className="text-xs text-text-dim">
             {dumpPods
-              ? <>Found <strong className="text-text">{dumpPods.count}</strong> Completed dump pod{dumpPods.count === 1 ? '' : 's'} on the cluster.</>
+              ? <>Found <strong className="text-text">{dumpPods.count}</strong> Succeeded dump pod{dumpPods.count === 1 ? '' : 's'} on the cluster.</>
               : <span className="italic">{vmRunning ? 'Loading…' : 'VM not running.'}</span>}
           </div>
         </div>
         <p className="text-xs text-text-dim mb-2">
           Funcom's <span className="font-mono">battlegroup backup</span> job creates a one-shot pod per run that finishes
-          Succeeded and is never cleaned up. Pruning here only deletes terminal <span className="font-mono">*-dump-*-pod</span>{' '}
-          objects — the live DB StatefulSet, util/mon/pghero, and the actual <span className="font-mono">.backup</span> files are not touched.
+          Succeeded and is never cleaned up. The scheduled cleanup runs after every backup tick using <strong>Keep last (count)</strong> below;
+          the manual button honors both thresholds. Only terminal <span className="font-mono">*-dump-*-pod</span> objects are touched —
+          live DB, util/mon/pghero, file-browser, and the <span className="font-mono">.backup</span> files are never affected.
         </p>
         <div className="flex flex-wrap items-end gap-3">
           <label className="flex flex-col gap-1 text-xs">
@@ -1020,7 +1038,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
                 const n = parseInt(e.target.value || '0', 10)
                 setDraftKeepDumpPods(Number.isFinite(n) ? Math.max(0, Math.min(100, n)) : 0)
               }}
-              disabled={!vmRunning || pruning}
+              disabled={!vmRunning || pruning || saving}
               className="px-2 py-1.5 rounded bg-surface-2 border border-border text-text text-sm font-mono w-24"
             />
           </label>
@@ -1038,7 +1056,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
                 const n = parseInt(e.target.value || '0', 10)
                 setDraftKeepDumpDays(Number.isFinite(n) ? Math.max(0, Math.min(365, n)) : 0)
               }}
-              disabled={!vmRunning || pruning}
+              disabled={!vmRunning || pruning || saving}
               className="px-2 py-1.5 rounded bg-surface-2 border border-border text-text text-sm font-mono w-24"
             />
           </label>
@@ -1052,12 +1070,61 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
               : 'Nothing to prune at these thresholds.'}
           >
             <Icon name={pruning ? 'Loader2' : 'Trash2'} size={14} className={pruning ? 'animate-spin' : ''} />
-            {pruning ? 'Pruning…' : 'Prune old backup pods'}
+            {pruning ? 'Pruning…' : `Prune now${dumpPodPruneCandidateCount > 0 ? ` (${dumpPodPruneCandidateCount})` : ''}`}
           </button>
         </div>
         <p className="text-xs text-text-dim mt-2 italic">
-          A pod is kept only if it's both within the count cap and younger than the age cap. Set either to <span className="font-mono">0</span> to disable that axis.
+          A pod is kept only if it's both within the count cap and younger than the age cap. Set either to <span className="font-mono">0</span> to disable that axis. Click <strong>Save schedule</strong> above to persist these values.
         </p>
+
+        {/* Enumerated pod list — shows what the server actually saw, with the
+            timestamp parsed from each pod's name and an age in days. This is
+            the diagnostic surface for "why didn't this pod get pruned?":
+            either it's within keepLast (still in the kept set), or its name
+            didn't match the regex (won't appear at all). */}
+        {dumpPods && dumpPods.count > 0 && (
+          <details className="mt-3">
+            <summary className="text-xs text-info hover:underline cursor-pointer">
+              Show enumerated pods ({dumpPods.count})
+            </summary>
+            <div className="mt-2 max-h-64 overflow-y-auto border border-border rounded bg-surface-2/50">
+              <table className="w-full text-xs font-mono">
+                <thead className="text-text-muted sticky top-0 bg-surface-2">
+                  <tr>
+                    <th className="text-left px-2 py-1 font-medium">#</th>
+                    <th className="text-left px-2 py-1 font-medium">Namespace</th>
+                    <th className="text-left px-2 py-1 font-medium">Name</th>
+                    <th className="text-left px-2 py-1 font-medium">Age</th>
+                    <th className="text-left px-2 py-1 font-medium">Disposition</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {dumpPods.pods.map((p, idx) => {
+                    const exceededCount = draftKeepDumpPods > 0 && idx >= draftKeepDumpPods
+                    const ageDays = p.ageMinutes != null ? Math.floor(p.ageMinutes / (60 * 24)) : null
+                    const exceededAge = draftKeepDumpDays > 0 && ageDays != null && ageDays > draftKeepDumpDays
+                    const wouldDelete = exceededCount || exceededAge
+                    return (
+                      <tr key={`${p.namespace}/${p.name}`} className={wouldDelete ? 'text-danger' : 'text-text'}>
+                        <td className="px-2 py-1">{idx + 1}</td>
+                        <td className="px-2 py-1 truncate max-w-[10rem]" title={p.namespace}>{p.namespace}</td>
+                        <td className="px-2 py-1 truncate" title={p.name}>{p.name}</td>
+                        <td className="px-2 py-1 whitespace-nowrap">
+                          {ageDays != null ? `${ageDays}d` : '—'}
+                        </td>
+                        <td className="px-2 py-1 whitespace-nowrap">
+                          {wouldDelete
+                            ? <span className="text-danger">prune {exceededCount ? '(count)' : ''}{exceededCount && exceededAge ? ' + ' : ''}{exceededAge ? '(age)' : ''}</span>
+                            : <span className="text-text-muted">keep</span>}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </details>
+        )}
       </div>
 
       {history?.logTail && (

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -775,6 +775,18 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
     }
   }
 
+  // Dump-pod retention inputs differ from what's saved on the VM. Mirrors
+  // the schedule-wide `dirty` memo but scoped to just this row so we can
+  // show a focused "Save" affordance right next to the inputs the user is
+  // actually editing.
+  const dumpPodsDirty = useMemo(() => {
+    if (!schedule) return false
+    return (
+      draftKeepDumpPods !== (schedule.keepLastPods ?? 10) ||
+      draftKeepDumpDays !== (schedule.keepDaysPods ?? 0)
+    )
+  }, [schedule, draftKeepDumpPods, draftKeepDumpDays])
+
   // Pods eligible for prune: name-rank > keepLast (when keepLast>0) OR age > keepDays (when keepDays>0).
   // Pod age is read from the YYYYMMDD-HHMMSS embedded in the pod name (more
   // reliable than k8s status.startTime, which can clear on terminal pods).
@@ -1062,11 +1074,23 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
           </label>
           <button
             type="button"
+            onClick={() => void save()}
+            disabled={!vmRunning || saving || pruning || !dumpPodsDirty}
+            className="btn-primary"
+            title={dumpPodsDirty
+              ? 'Persist these retention values into the schedule so they survive reload and drive the auto-prune.'
+              : 'No unsaved changes.'}
+          >
+            <Icon name={saving ? 'Loader2' : 'Save'} size={14} className={saving ? 'animate-spin' : ''} />
+            {saving ? 'Saving…' : 'Save retention'}
+          </button>
+          <button
+            type="button"
             onClick={() => void handlePruneDumpPods()}
-            disabled={!vmRunning || pruning || dumpPodPruneCandidateCount === 0}
+            disabled={!vmRunning || pruning || saving || dumpPodPruneCandidateCount === 0}
             className="btn-secondary"
             title={dumpPodPruneCandidateCount > 0
-              ? `Delete ${dumpPodPruneCandidateCount} pod(s); keep ${(dumpPods?.count ?? 0) - dumpPodPruneCandidateCount}.`
+              ? `Delete ${dumpPodPruneCandidateCount} pod(s) now; keep ${(dumpPods?.count ?? 0) - dumpPodPruneCandidateCount}.`
               : 'Nothing to prune at these thresholds.'}
           >
             <Icon name={pruning ? 'Loader2' : 'Trash2'} size={14} className={pruning ? 'animate-spin' : ''} />
@@ -1074,7 +1098,8 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
           </button>
         </div>
         <p className="text-xs text-text-dim mt-2 italic">
-          A pod is kept only if it's both within the count cap and younger than the age cap. Set either to <span className="font-mono">0</span> to disable that axis. Click <strong>Save schedule</strong> above to persist these values.
+          A pod is kept only if it's both within the count cap and younger than the age cap. Set either to <span className="font-mono">0</span> to disable that axis. <strong>Save retention</strong> persists the values; <strong>Prune now</strong> applies them this instant.
+          {dumpPodsDirty && <span className="text-warning ml-1">• Unsaved changes.</span>}
         </p>
 
         {/* Enumerated pod list — shows what the server actually saw, with the

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -778,19 +778,17 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       } else {
         showToast('ok', r.message ?? (delCount > 0 ? `Deleted ${delCount} dump pod(s).` : 'Nothing to prune.'))
       }
-      // DIAGNOSTIC: null the state first so 'Loading...' flashes, then
-      // reload. If the flash is visible, React IS re-rendering and the
-      // fresh fetch returned stale data. If not, the component is not
-      // picking up state changes at all.
-      setDumpPods(null)
-      // Yield to React so the null render commits before we kick loadAll.
-      await new Promise<void>(resolve => setTimeout(resolve, 50))
-      await loadAll()
     } catch (e) {
       showToast('err', `Prune failed: ${e instanceof Error ? e.message : String(e)}`)
     } finally {
       setPruning(false)
     }
+    // Fire loadAll AFTER the try/finally has fully unwound — matches the
+    // Refresh button's exact pattern (`onClick={() => void loadAll()}`,
+    // no await, no chain, top-level microtask). Awaiting it inside the
+    // handler chain evidently prevented the state updates from reaching
+    // the DOM in the DST WebView2 host.
+    void loadAll()
   }
 
   // Dump-pod retention inputs differ from what's saved on the VM. Mirrors

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -767,13 +767,19 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       // Survivors went through both a graceful AND a force-delete pass and
       // still came back in the kubectl re-read. They're either owner-
       // recreated (a controller spawning them again with the same name) or
-      // RBAC-denied. Either way the user needs to know.
+      // RBAC-denied. Either way the user needs to know — and if an owner
+      // is named we surface it so they know what to delete instead.
       if (survCount > 0) {
-        const names = (r.survivors ?? []).map(p => p.name).join(', ')
+        const detail = (r.survivors ?? []).map(p => {
+          if (p.ownerKind && p.ownerName && p.ownerIsController) {
+            return `${p.name} (owned by ${p.ownerKind}/${p.ownerName})`
+          }
+          return p.name
+        }).join('; ')
         showToast('err',
           delCount > 0
-            ? `Deleted ${delCount}; ${survCount} survived both delete passes (${names}). Check kubectl describe.`
-            : `0 deleted; ${survCount} survived both delete passes (${names}). Check kubectl describe.`)
+            ? `Deleted ${delCount}; ${survCount} survived both passes: ${detail}`
+            : `0 deleted; ${survCount} survived both passes: ${detail}`)
       } else {
         showToast('ok', r.message ?? (delCount > 0 ? `Deleted ${delCount} dump pod(s).` : 'Nothing to prune.'))
       }
@@ -1132,6 +1138,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
                     <th className="text-left px-2 py-1 font-medium">Namespace</th>
                     <th className="text-left px-2 py-1 font-medium">Name</th>
                     <th className="text-left px-2 py-1 font-medium">Age</th>
+                    <th className="text-left px-2 py-1 font-medium">Owner</th>
                     <th className="text-left px-2 py-1 font-medium">Disposition</th>
                   </tr>
                 </thead>
@@ -1141,6 +1148,9 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
                     const ageDays = p.ageMinutes != null ? Math.floor(p.ageMinutes / (60 * 24)) : null
                     const exceededAge = draftKeepDumpDays > 0 && ageDays != null && ageDays > draftKeepDumpDays
                     const wouldDelete = exceededCount || exceededAge
+                    const ownerText = (p.ownerKind && p.ownerName)
+                      ? `${p.ownerKind}/${p.ownerName}${p.ownerIsController ? ' *' : ''}`
+                      : '—'
                     return (
                       <tr key={`${p.namespace}/${p.name}`} className={wouldDelete ? 'text-danger' : 'text-text'}>
                         <td className="px-2 py-1">{idx + 1}</td>
@@ -1148,6 +1158,9 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
                         <td className="px-2 py-1 truncate" title={p.name}>{p.name}</td>
                         <td className="px-2 py-1 whitespace-nowrap">
                           {ageDays != null ? `${ageDays}d` : '—'}
+                        </td>
+                        <td className="px-2 py-1 truncate max-w-[12rem]" title={p.ownerIsController ? `Controller: ${ownerText}` : ownerText}>
+                          {ownerText}
                         </td>
                         <td className="px-2 py-1 whitespace-nowrap">
                           {wouldDelete

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -11,6 +11,8 @@ import {
   getBackupHistory,
   downloadBackup,
   uploadBackup,
+  getBackupDumpPods,
+  pruneBackupDumpPods,
 } from '../api/database'
 import type {
   DbInfo,
@@ -18,6 +20,7 @@ import type {
   SqlOkResult,
   BackupSchedule,
   BackupHistory,
+  BackupDumpPodList,
 } from '../api/types'
 import Editor, { type OnMount } from '@monaco-editor/react'
 
@@ -636,8 +639,10 @@ type BackupScheduleCardProps = {
 function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
   const [schedule, setSchedule] = useState<BackupSchedule | null>(null)
   const [history, setHistory]   = useState<BackupHistory  | null>(null)
+  const [dumpPods, setDumpPods] = useState<BackupDumpPodList | null>(null)
   const [loading, setLoading]   = useState(false)
   const [saving, setSaving]     = useState(false)
+  const [pruning, setPruning]   = useState(false)
   const [err, setErr]           = useState<string | null>(null)
   const [showLog, setShowLog]   = useState(false)
   const [transferring, setTransferring] = useState<string | null>(null)  // vmPath or 'upload'
@@ -646,22 +651,28 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
   // editable so the user can preview their choice before clicking Save.
   const [draftPreset, setDraftPreset]       = useState<string>('Off')
   const [draftKeepLast, setDraftKeepLast]   = useState<number>(8)
+  const [draftKeepDumpPods, setDraftKeepDumpPods] = useState<number>(5)
 
   const loadAll = useCallback(async () => {
     if (!vmRunning) {
-      setSchedule(null); setHistory(null); setErr('VM is not running.')
+      setSchedule(null); setHistory(null); setDumpPods(null); setErr('VM is not running.')
       return
     }
     setLoading(true); setErr(null)
     try {
-      const [sched, hist] = await Promise.all([getBackupSchedule(), getBackupHistory({ recent: 5, logLines: 50 })])
+      const [sched, hist, pods] = await Promise.all([
+        getBackupSchedule(),
+        getBackupHistory({ recent: 5, logLines: 50 }),
+        getBackupDumpPods().catch(() => null),
+      ])
       setSchedule(sched)
       setHistory(hist)
+      setDumpPods(pods)
       setDraftPreset(sched.preset === 'Custom' ? 'Off' : sched.preset)
       setDraftKeepLast(sched.keepLast > 0 ? sched.keepLast : (sched.preset === 'Off' ? 8 : 0))
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
-      setSchedule(null); setHistory(null)
+      setSchedule(null); setHistory(null); setDumpPods(null)
     } finally {
       setLoading(false)
     }
@@ -728,6 +739,23 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       showToast('err', `Upload failed: ${e instanceof Error ? e.message : String(e)}`)
     } finally {
       setTransferring(null)
+    }
+  }
+
+  async function handlePruneDumpPods() {
+    setPruning(true)
+    try {
+      const r = await pruneBackupDumpPods({ keepLast: draftKeepDumpPods })
+      const delCount = r.deleted?.length ?? 0
+      const keepCount = r.kept?.length ?? 0
+      showToast('ok', delCount > 0
+        ? `Deleted ${delCount} dump pod(s); kept ${keepCount}.`
+        : (r.message ?? 'Nothing to prune.'))
+      setDumpPods({ ok: true, pods: r.remaining ?? [], count: (r.remaining ?? []).length })
+    } catch (e) {
+      showToast('err', `Prune failed: ${e instanceof Error ? e.message : String(e)}`)
+    } finally {
+      setPruning(false)
     }
   }
 
@@ -931,6 +959,58 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
             Last backup at <span className="font-mono">{lastBackup.mtimeIso}</span> ({relativeFromNow(lastBackup.mtimeEpoch)}).
           </p>
         )}
+      </div>
+
+      {/* Completed backup pods — Funcom's database-backup job leaves a
+          `*-dump-YYYYMMDD-HHMMSS-pod` behind on every run. They terminate
+          Succeeded and are never garbage-collected, so they pile up on the
+          Pods page and in the VM's shell-pod picker. This action prunes the
+          old ones; the .backup files on the PVC are handled by Keep last
+          above (separate retention). */}
+      <div className="border-t border-border pt-3 mt-3">
+        <div className="flex items-center justify-between gap-3 mb-2">
+          <div className="text-xs font-semibold text-text-muted">Completed backup pods</div>
+          <div className="text-xs text-text-dim">
+            {dumpPods
+              ? <>Found <strong className="text-text">{dumpPods.count}</strong> Completed dump pod{dumpPods.count === 1 ? '' : 's'} on the cluster.</>
+              : <span className="italic">{vmRunning ? 'Loading…' : 'VM not running.'}</span>}
+          </div>
+        </div>
+        <p className="text-xs text-text-dim mb-2">
+          Funcom's <span className="font-mono">battlegroup backup</span> job creates a one-shot pod per run that finishes
+          Succeeded and is never cleaned up. Pruning here only deletes terminal <span className="font-mono">*-dump-*-pod</span>{' '}
+          objects — the live DB StatefulSet, util/mon/pghero, and the actual <span className="font-mono">.backup</span> files are not touched.
+        </p>
+        <div className="flex items-end gap-3">
+          <label className="flex flex-col gap-1 text-xs">
+            <span className="text-text-muted font-medium">Keep last (count)</span>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              step={1}
+              value={draftKeepDumpPods}
+              onChange={e => {
+                const n = parseInt(e.target.value || '0', 10)
+                setDraftKeepDumpPods(Number.isFinite(n) ? Math.max(0, Math.min(100, n)) : 0)
+              }}
+              disabled={!vmRunning || pruning}
+              className="px-2 py-1.5 rounded bg-surface-2 border border-border text-text text-sm font-mono w-24"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => void handlePruneDumpPods()}
+            disabled={!vmRunning || pruning || !dumpPods || dumpPods.count <= draftKeepDumpPods}
+            className="btn-secondary"
+            title={dumpPods && dumpPods.count > draftKeepDumpPods
+              ? `Delete ${dumpPods.count - draftKeepDumpPods} pod(s); keep the most recent ${draftKeepDumpPods}.`
+              : 'Nothing to prune.'}
+          >
+            <Icon name={pruning ? 'Loader2' : 'Trash2'} size={14} className={pruning ? 'animate-spin' : ''} />
+            {pruning ? 'Pruning…' : 'Prune old backup pods'}
+          </button>
+        </div>
       </div>
 
       {history?.logTail && (


### PR DESCRIPTION
Closes #363.

## Summary
Three integration points — issue #363 listed them as "and/or"; this PR ships all three:

1. **Backup-schedule cron tick (self-maintaining).** Every scheduled `battlegroup backup` now appends a single-line BusyBox pipeline that deletes Succeeded `*-dump-*-pod` objects past the most-recent 10. Runs at backup cadence so accumulation can't outpace the prune. Logged to `/var/log/dune-backup.log`. Inside the existing restart-window guard.
2. **Start All / Reboot All hook.** `Invoke-DuneBackupDumpPodPrune` runs at the same post-action point as the on-demand-partition clear and DNAT watchdog install — same SSH session, non-fatal. Catches servers without a backup schedule installed.
3. **Manual prune on the Database → Backup Schedule card.** Two thresholds: **Keep last (count)** and **Keep last (days)**. A pod is kept only if it passes BOTH (`0` on either axis disables that filter). Age is read from the timestamp baked into the pod name, not k8s `status.startTime` (which can clear on terminal pods).

## Safety
- Strict name regex (`^[a-z0-9.-]+-dump-[0-9]{8}-[0-9]{6}-pod$`) + phase check (`Succeeded`/`Completed`) on all three paths.
- Manual path re-validates every `kubectl delete` before interpolating the namespace/name into the shell command.
- Live DB StatefulSet, util/mon/pghero, file-browser deploys, migration jobs — none can match.
- `.backup` files on the PVC untouched. File retention stays on the existing **Keep last** setting.
- Manual path behind a per-VM lock (`prune-backup-dump-pods`), same pattern as schedule writes.

## Migration note
Existing managed schedules will flip to "looks tampered" once on first read after upgrade — the rendered backup line now includes the prune snippet. The UI already prompts the user to click **Save** in that case, which migrates them onto the new line cleanly.

## Test plan
- [ ] Server with several leftover `dump-*-pod` entries — confirm "Completed backup pods" count appears on Database card
- [ ] Click **Prune** with `keepLast=5`, `keepDays=0` — count cap only
- [ ] Click **Prune** with `keepLast=0`, `keepDays=7` — age cap only
- [ ] Both set — button disables when nothing would prune at those thresholds
- [ ] Save an existing schedule after upgrade — confirm "looks tampered" prompt and one-click migration
- [ ] After next scheduled backup fires, tail `/var/log/dune-backup.log` and confirm prune lines logged
- [ ] **Start All** / **Reboot All** from the menu — confirm `[post-startup] Pruned N leftover dump pod(s)` line appears
- [ ] Pods page now shows only the retained dump pods; no live DB / util / mon / file-browser pods deleted