### PR TITLE
Park client Game.ini changes inside the DST managed block

### DIFF
--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -463,9 +463,13 @@ function Set-DuneIniValuesInPlace {
 }
 
 # Apply client-apply updates to the LOCAL client Game.ini. Validates that every
-# key is schema-flagged ClientApply (blocks arbitrary local writes) and upserts
-# in place. Does NOT auto-backup (manual backups only). Also scrubs the
-# deprecated no-op multiplier keys so the client file stays clean.
+# key is schema-flagged ClientApply (blocks arbitrary local writes) and routes
+# the write through the same managed-block writer the server-side files use.
+# That way every DST-touched key sits in a clearly marked block at the bottom
+# of the file (issue #YYY — users want to copy-paste the DST section to share
+# with friends connecting to their server, without hand-picking edits scattered
+# through the file). Also scrubs the deprecated no-op multiplier keys so the
+# client file stays clean. Does NOT auto-backup (manual backups only).
 # Returns @{ ok; path; backup; created; applied; items } (backup always '').
 function Save-DuneGameConfigClient {
     param([object[]]$Updates, [string]$Dir = '', [string]$DefaultsRaw = '')
@@ -510,7 +514,10 @@ function Save-DuneGameConfigClient {
     # Game.ini has no prior struct, seed the full DefaultGame.ini struct so the
     # other members are preserved (the route supplies $DefaultsRaw).
     $folded = Convert-DuneStructUpdates -Raw $existing -Updates $clean.ToArray() -DefaultsRaw $DefaultsRaw
-    $new    = Set-DuneIniValuesInPlace -Raw $existing -Updates $folded -QuotedKeys $quoted
+    # Route through the managed-block writer (same as the server files). Every
+    # DST-touched section lands in a marker-delimited block at the bottom; the
+    # user's unrelated sections (audio, video, etc.) stay where they were.
+    $new    = ConvertTo-DuneIniManaged -Raw $existing -Updates $folded -QuotedKeys $quoted
     $new    = $new -replace "`r?`n", "`r`n"   # local file is Windows CRLF
 
     # No auto-backup: client backups are manual to avoid piling up .dstbak files.

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -297,6 +297,44 @@ Describe 'DuneGameConfigSchema: CraftingSettings fields' -Tag 'GameConfig' {
         (Get-EffectiveValue -Raw $raw -Section $script:SecCrafting -Key 'm_RepairCostWeight') | Should -Be '0.25'
         (Get-EffectiveValue -Raw $raw -Section $script:SecCrafting -Key 'm_RecyclerOutputWeight') | Should -Be '1.75'
     }
+
+    It 'parks client-touched sections inside the DST managed block at the bottom' {
+        # Users want to copy the DST section to share with players connecting to
+        # their server, so every DST-touched key must live below the BEGIN marker
+        # and unrelated sections (audio/video) must stay where they were.
+        $dir = (Get-PSDrive TestDrive).Root
+        $path = Join-Path $dir 'Game.ini'
+        [IO.File]::WriteAllText($path, @"
+[Audio]
+MasterVolume=0.8
+
+[$script:SecCrafting]
+m_RepairCostWeight=1.0
+
+[Video]
+ResolutionScale=100
+"@)
+        $result = Save-DuneGameConfigClient -Dir $dir -Updates @(
+            @{ key='m_RepairCostWeight'; value='0.25' }
+        )
+        $result.ok | Should -BeTrue
+        $raw = [IO.File]::ReadAllText($path)
+
+        # DST markers present
+        $raw | Should -Match ([regex]::Escape($script:DstManagedBegin))
+        $raw | Should -Match ([regex]::Escape($script:DstManagedEnd))
+
+        # Touched section lives below the BEGIN marker
+        $beginIdx     = $raw.IndexOf($script:DstManagedBegin)
+        $craftingIdx  = $raw.IndexOf('[' + $script:SecCrafting + ']')
+        $craftingIdx | Should -BeGreaterThan $beginIdx
+
+        # Untouched sections stay above the BEGIN marker
+        $raw.IndexOf('[Audio]') | Should -BeLessThan $beginIdx
+        $raw.IndexOf('[Video]') | Should -BeLessThan $beginIdx
+        $raw.IndexOf('[Audio]') | Should -BeGreaterOrEqual 0
+        $raw.IndexOf('[Video]') | Should -BeGreaterOrEqual 0
+    }
 }
 
 Describe 'GameConfig: reset-to-default removes the key from the INI' -Tag 'GameConfig' {


### PR DESCRIPTION
## Summary
Users have been asking for a clear way to see what DST has changed in their **local** \`Game.ini\` so they can copy and share that section with players connecting to their server. The two server-side files (\`UserGame.ini\`, \`UserEngine.ini\`) have always done this via the managed-block markers; the local client \`Game.ini\` was the holdout.

\`Save-DuneGameConfigClient\` was calling \`Set-DuneIniValuesInPlace\`, which edited values wherever it found them — so DST-touched keys ended up scattered through the file with no markers around them. This PR routes the client write through the same \`ConvertTo-DuneIniManaged\` path the server files use:

- Every DST-touched section is relocated into a marker-delimited block at the bottom of \`Game.ini\`
- The \`; ===== Dune Server Tool (DST) managed section BEGIN / END =====\` markers + \"Last write\" timestamp + \"do not hand-edit\" header
- Unrelated user sections (audio, video, etc.) stay where they were

## Test plan
- [x] \`Invoke-Pester tests/GameConfig.Tests.ps1\` — 37/37 pass, including the new regression
- [ ] Open Game Config, change a \`ClientApply\` key (e.g. Water Consumption Rate), click **Apply to client**
- [ ] Confirm \`%LOCALAPPDATA%\DuneSandbox\Saved\Config\WindowsClient\Game.ini\` has the DST managed block at the bottom with the new value inside
- [ ] Confirm any pre-existing non-DST sections (audio, video, etc.) are unchanged in their original positions