### PR TITLE
Public IP Apply hardening: refresh stale status pods + save LastApplied before verify + IP-surface audit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.14.7"
+      placeholder: "v12.14.8"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ here cover everything those tags shipped.
 
 ### Added
 
-- **`step audit-ip-surfaces` cross-checks every IP-holding surface at end of Apply.** Verifies all three utility envs (`director`, `serverGateway`, `textRouter`) and `status.utilities.messageQueues.statuses.{game,admin}.amqpAddress` match the target public IP. Flags private `amqpAddress` values (`10.`, `172.16-31.`, `192.168.`) and CGNAT (`100.64.0.0/10`) per Sora's Discord tip 2026-05-27: *"amqpAddress must be publicly routable, not a LAN address."* Mismatches are surfaced in the bg-ip step detail as a warning; the Apply still completes so the rest of the flow finishes.
+- **`step audit-ip-surfaces` cross-checks every IP-holding surface at end of Apply.** Verifies all three utility envs (`director`, `serverGateway`, `textRouter`) and `status.utilities.messageQueues.statuses.{game,admin}.amqpAddress` match the target public IP. Flags private `amqpAddress` values (`10.`, `172.16-31.`, `192.168.`) and CGNAT (`100.64.0.0/10`) — `amqpAddress` must be a publicly routable IP so clients can queue to join. Mismatches are surfaced in the bg-ip step detail as a warning; the Apply still completes so the rest of the flow finishes.
 
 ## [12.14.7] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.14.8] - 2026-07-01
+
+### Fixed
+
+- **Public IP Apply now force-refreshes the utility-pod status fields.** `status.database.address`, `status.database.pgHeroAddress`, `status.utilities.*.address`, and `status.utilities.messageQueues.statuses.*.amqpAddress` / `.managementAddress` only populate at pod-**object** creation, not on container restart. The pre-existing `step utilities-ip` patched `HOST_DATACENTER_IP_ADDRESS` env vars, which the operator picked up as a container restart — that was never enough to refresh status. New `step refresh-status-pods` force-deletes `db-dbdepl`, `db-util-*`, `fb-deploy`, `mq-admin`, and `mq-game` pods so the StatefulSet / Deployment controllers recreate them and the operator repopulates status with the current public IP. Discovered when an ISP IP change left `status.database.address` stuck at the pre-change IP forever until the pods were manually kicked.
+- **`LastAppliedPublicIp` now persists even when the final TCP verify transiently fails.** Previously `Save-DuneConfig` ran after the verify step, so a transient TCP 31982 external-reachability failure (common right after an ISP IP change while router forwards are still catching up) skipped the save and left DST's UI showing the pre-change "last applied" value until the user ran Apply a second time. Now saved as soon as the CR mutate + servers-ready wait complete, independent of verify.
+
+### Added
+
+- **`step audit-ip-surfaces` cross-checks every IP-holding surface at end of Apply.** Verifies all three utility envs (`director`, `serverGateway`, `textRouter`) and `status.utilities.messageQueues.statuses.{game,admin}.amqpAddress` match the target public IP. Flags private `amqpAddress` values (`10.`, `172.16-31.`, `192.168.`) and CGNAT (`100.64.0.0/10`) per Sora's Discord tip 2026-05-27: *"amqpAddress must be publicly routable, not a LAN address."* Mismatches are surfaced in the bg-ip step detail as a warning; the Apply still completes so the rest of the flow finishes.
+
 ## [12.14.7] - 2026-06-30
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.14.7'
+$script:DuneToolVersion = '12.14.8'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.14.7',
+    [string]$Version = '12.14.8',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.14.7</Version>
+    <Version>12.14.8</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.14.7"
+#define MyAppVersion "12.14.8"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -956,9 +956,8 @@ step audit-ip-surfaces
 # does. Adds an authoritative check after the operator has had a chance to
 # reconcile (~10s post pod-delete). Reports AUDIT_OK or per-surface mismatches
 # so the PowerShell side can surface them to the user. Also flags CGNAT
-# (100.64.0.0/10) and private amqpAddress values (per Sora's Discord tip
-# 2026-05-27: "check the IP the VM is reporting to Funcom's server browser;
-# amqpAddress must be publicly routable, not a LAN address"). Requires jq.
+# (100.64.0.0/10) and private amqpAddress values — the amqpAddress must be a
+# publicly routable IP so clients can queue to join. Requires jq.
 if command -v jq >/dev/null 2>&1; then
   sleep 10  # give the operator a moment to repopulate status after pod deletes
   AUDIT_MISMATCHES=0

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -933,6 +933,77 @@ else
   echo "jq not available; skipping utility HOST_DATACENTER_IP_ADDRESS reconcile"
 fi
 
+step refresh-status-pods
+# status.database.address, status.database.pgHeroAddress, status.utilities.*.address,
+# and status.utilities.messageQueues.statuses.*.amqp/managementAddress are only
+# populated at POD-OBJECT CREATION (not on container restart). Container-only
+# restarts driven by the operator, `battlegroup change-battlegroup-ip`, or the
+# `step utilities-ip` CR-env patch above will NOT refresh these fields — they
+# stay at whichever IP was current at last pod-object creation. Force-delete
+# the pods that own external-address status fields so the StatefulSet /
+# Deployment controllers recreate them and the operator repopulates status
+# with the CURRENT HOST_DATACENTER_IP_ADDRESS. Discovered 2026-07-01 after an
+# ISP IP change left status.database.address pointing at the pre-change IP
+# forever until the pods were manually kicked. Non-blocking; kube waits are
+# on the PowerShell side.
+STALE_STATUS_PATTERN="^${BG_NAME}-(db-dbdepl|db-util-|fb-deploy|mq-admin|mq-game)"
+for POD in $(sudo kubectl get pods -n "$BG_NS" --no-headers -o custom-columns=':metadata.name' 2>/dev/null | grep -E "$STALE_STATUS_PATTERN"); do
+  sudo kubectl delete pod -n "$BG_NS" "$POD" --wait=false 2>&1 | sed 's/^/  /'
+done
+
+step audit-ip-surfaces
+# Cross-place IP audit: verify every surface that should hold NEW_IP actually
+# does. Adds an authoritative check after the operator has had a chance to
+# reconcile (~10s post pod-delete). Reports AUDIT_OK or per-surface mismatches
+# so the PowerShell side can surface them to the user. Also flags CGNAT
+# (100.64.0.0/10) and private amqpAddress values (per Sora's Discord tip
+# 2026-05-27: "check the IP the VM is reporting to Funcom's server browser;
+# amqpAddress must be publicly routable, not a LAN address"). Requires jq.
+if command -v jq >/dev/null 2>&1; then
+  sleep 10  # give the operator a moment to repopulate status after pod deletes
+  AUDIT_MISMATCHES=0
+  AUDIT_REPORT=""
+
+  # Utility envs — every HOST_DATACENTER_IP_ADDRESS should equal NEW_IP.
+  for u in director serverGateway textRouter; do
+    val=$(sudo kubectl get battlegroup "$BG_NAME" -n "$BG_NS" -o json 2>/dev/null | jq -r ".spec.utilities.$u.spec.envVars // [] | map(select(.name==\"HOST_DATACENTER_IP_ADDRESS\")) | .[0].value // \"MISSING\"")
+    if [ "$val" != "$NEW_IP" ]; then
+      AUDIT_REPORT="$AUDIT_REPORT  MISMATCH utilities.$u HOST_DATACENTER_IP_ADDRESS: got '$val' expected '$NEW_IP'\n"
+      AUDIT_MISMATCHES=$((AUDIT_MISMATCHES + 1))
+    fi
+  done
+
+  # amqpAddress (game + admin). host portion must equal NEW_IP.
+  for mq in game admin; do
+    val=$(sudo kubectl get battlegroup "$BG_NAME" -n "$BG_NS" -o json 2>/dev/null | jq -r ".status.utilities.messageQueues.statuses.$mq.amqpAddress // \"MISSING\"")
+    host=$(printf '%s' "$val" | cut -d: -f1)
+    if [ "$host" != "$NEW_IP" ]; then
+      AUDIT_REPORT="$AUDIT_REPORT  MISMATCH status.utilities.messageQueues.statuses.$mq.amqpAddress: got '$val' expected '$NEW_IP:*'\n"
+      AUDIT_MISMATCHES=$((AUDIT_MISMATCHES + 1))
+    fi
+    # Sora's rule: amqpAddress must be publicly routable (not private, not CGNAT).
+    case "$host" in
+      10.*|172.1[6-9].*|172.2[0-9].*|172.3[0-1].*|192.168.*)
+        AUDIT_REPORT="$AUDIT_REPORT  PRIVATE-AMQP-ADDR $mq.amqpAddress='$val' — LAN address, players cannot join.\n"
+        AUDIT_MISMATCHES=$((AUDIT_MISMATCHES + 1))
+        ;;
+      100.6[4-9].*|100.[7-9][0-9].*|100.1[0-1][0-9].*|100.12[0-7].*)
+        AUDIT_REPORT="$AUDIT_REPORT  CGNAT-AMQP-ADDR $mq.amqpAddress='$val' — behind Carrier-Grade NAT (100.64.0.0/10); contact ISP.\n"
+        AUDIT_MISMATCHES=$((AUDIT_MISMATCHES + 1))
+        ;;
+    esac
+  done
+
+  if [ "$AUDIT_MISMATCHES" -eq 0 ]; then
+    echo "AUDIT_OK all IP surfaces match $NEW_IP"
+  else
+    printf 'AUDIT_MISMATCH count=%d\n' "$AUDIT_MISMATCHES"
+    printf '%b' "$AUDIT_REPORT"
+  fi
+else
+  echo "AUDIT_SKIP jq not available"
+fi
+
 # Echo BG namespace so the PowerShell-side wait loop can target it directly
 # without re-discovering on every poll.
 printf 'BG_NS=%s\nBG_NAME=%s\n' "$BG_NS" "$BG_NAME"
@@ -1005,8 +1076,33 @@ echo "BGIP_VERIFY_DONE"
             } else {
                 'Battlegroup IP propagated; servers still coming up after 5 minutes (this can take a few more minutes - check Server Health).'
             }
-            $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'bg-ip' 'Propagate IP to battlegroup + restart' 'done' $bgDetail $rawBg
+            # Surface audit-ip-surfaces result inline so users see when an
+            # HOST_DATACENTER_IP_ADDRESS env, amqpAddress, or private/CGNAT
+            # value didn't reconcile cleanly. Non-fatal — reported but the
+            # step still completes so the rest of the apply flow finishes.
+            $bgStatus = 'done'
+            if ($rawMutate -match '(?m)^AUDIT_MISMATCH count=(\d+)') {
+                $bgDetail = "$bgDetail`nAudit found $($Matches[1]) IP-surface mismatch(es) — see raw output."
+                $bgStatus = 'warning'
+            }
+            $steps[$steps.Count - 1] = New-DunePublicIpStepResult 'bg-ip' 'Propagate IP to battlegroup + restart' $bgStatus $bgDetail $rawBg
             & $pub
+
+            # Persist LastApplied/LastResolved as soon as the CR mutate + servers-ready
+            # wait complete, BEFORE the verify step. Verify's TCP 31982 external check
+            # can transiently fail after an ISP IP change (router forwards may not have
+            # reconciled to the new WAN IP yet). Persisting here means the UI shows the
+            # correct "last applied" value even if verify throws — otherwise the user
+            # sees stale LastAppliedPublicIp in dune-server.config until they run Apply
+            # a second time. Discovered 2026-07-01 during an ISP IP flap: CR + pods
+            # were reconciled but LastAppliedPublicIp stayed at the pre-flap IP.
+            Save-DuneConfig -Config @{
+                PublicIpMode = $Mode
+                DdnsHostname = if ($Mode -eq 'ddns') { $Hostname } else { '' }
+                ManualPublicIp = if ($Mode -eq 'manual') { $target } else { '' }
+                LastResolvedPublicIp = $target
+                LastAppliedPublicIp = $target
+            } | Out-Null
 
             # --- Verify --------------------------------------------------------
             $steps.Add((New-DunePublicIpStepResult 'verify' 'Verify external IP + RabbitMQ port' 'running' "Checking node ExternalIP and TCP $target:31982.")) | Out-Null

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.14.7"
+$script:ToolVersion = "12.14.8"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webui",
   "private": true,
-  "version": "12.5.9",
+  "version": "12.5.10",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Three hardening fixes for the Public IP Apply flow, discovered during an ISP IP-flap investigation on 2026-07-01 (Reapers server tonight).

1. **Force pod-object delete for status refresh.** `status.database.address`, `status.database.pgHeroAddress`, `status.utilities.*.address`, and `status.utilities.messageQueues.statuses.*.amqp/managementAddress` only populate at pod-**object** creation, not on container restart. New `step refresh-status-pods` force-deletes `db-dbdepl`, `db-util-*`, `fb-deploy`, `mq-admin`, `mq-game` pods so StatefulSet/Deployment controllers recreate them and the operator repopulates status.

2. **`Save-DuneConfig` moved before verify.** Verify's TCP 31982 external check can transiently fail after an ISP IP change while router forwards catch up. Previously that skipped the config save and left DST's UI showing the pre-change `LastAppliedPublicIp` until Apply ran a second time.

3. **`step audit-ip-surfaces`** cross-checks every IP-holding surface at end of Apply: all 3 utility envs plus `status.utilities.messageQueues.statuses.{game,admin}.amqpAddress`. Flags private (`10.`, `172.16-31.`, `192.168.`) and CGNAT (`100.64.0.0/10`) `amqpAddress` values so operators see when the address isn't publicly routable.

## Test plan

- [x] Reproduced the stale-status bug live: IP change → `status.database.address` stuck at pre-change IP until DB pod force-deleted. This PR's `step refresh-status-pods` performs that delete automatically as part of Apply.
- [x] Reproduced the `LastAppliedPublicIp` skip: verify threw on transient TCP unreach after IP change, `Save-DuneConfig` skipped. Manually re-applying a second time cleared it. This PR persists before verify so single-apply is enough.
- [x] Installer built cleanly at `app/installer/output/DuneServerSetup.exe` (46.05 MB) with all 5 version stamps at 12.14.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)