### PR TITLE
fix(market-bot): stop overpaying sellers 10x on buy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Market Bot no longer overpays sellers 10× on purchase.** When Duke's Market Bot bought a player's sell order, it paid out (and debited its own balance) at 10× the listed price — e.g. an item listed for 83,000 Solari paid the seller 830,000. The game's exchange stores `item_price` 1:1 with the listed Solari and "Take Solari" credits it unscaled, but the payout path multiplied by 10 (a compensation added in an earlier release that a later Funcom patch made incorrect). Duke now pays the exact listed price, matching a normal player-to-player sale.
+
 ## [12.14.9] - 2026-06-30
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.14.9'
+$script:DuneToolVersion = '12.14.10'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.14.9',
+    [string]$Version = '12.14.10',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.14.9</Version>
+    <Version>12.14.10</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.14.9"
+#define MyAppVersion "12.14.10"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameplayBot.ps1
+++ b/app/server/lib/GameplayBot.ps1
@@ -1125,13 +1125,18 @@ LIMIT $limit
         $stack     = ConvertTo-DuneInt $row['actual_stack']
         if ($stack -le 0) { $stack = 1 }
         $totalCost = $price * $stack
-        # Player-facing Solari = stored item_price * 10 (the same convention the
-        # sell side uses, and the listing price the seller chose in-game). The
-        # seller payout order + Duke's balance debit are denominated in literal
-        # Solari, so they must use the *display* value, not the raw item_price.
-        # Writing the raw value here underpaid sellers 10x (issue #274).
-        $payoutUnit  = $price * 10
-        $payoutTotal = $totalCost * 10
+        # Player-facing Solari == the raw item_price column, 1:1 (verified against
+        # the live game DB): dune.dune_exchange_add_sell_order stores item_price
+        # exactly as the price the seller chose in-game, and
+        # dune.dune_exchange_retrieve_solaris_from_item ("Take Solari") credits
+        # SUM(item_price * stack_size) to the seller's balance with NO scaling.
+        # PR #275 (issue #274) multiplied by 10 to compensate for an older payout
+        # scaling, but the ~2026-06 Funcom patch removed that scaling, so the *10
+        # now OVERPAYS sellers 10x (e.g. an 83,000 listing paid out 830,000, as
+        # reported on Discord). Pay the raw listed price so Duke's payout and balance
+        # debit match a normal player-to-player sale exactly.
+        $payoutUnit  = $price
+        $payoutTotal = $totalCost
 
         # Over-market guard: dice hit, but bail if the price is above the window.
         if ($guardOn) {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.14.9"
+$script:ToolVersion = "12.14.10"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Summary

Fixes the **Duke Market Bot paying sellers 10× the listed price** when it buys a player's sell order (reported on Discord: an item listed for **83,000** Solari paid out **830,000**, a consistent ×10).

## Root cause (verified against the live game DB)

The exchange stores and pays Solari **1:1 with the listed `item_price`** — there is no ×10 in the game:

- `dune.dune_exchange_add_sell_order` inserts `item_price = in_item_price` (exactly the price the seller set in-game).
- `dune.dune_exchange_retrieve_solaris_from_item` ("Take Solari") credits `SUM(item_price * stack_size)` to the seller's balance, **unscaled**.

PR #275 (issue #274) multiplied the Market Bot payout by 10 to compensate for an older payout scaling. A **~2026-06 Funcom patch** removed that scaling, so the `* 10` now **overpays sellers 10×** and over-debits Duke's balance by the same factor.

## Fix

In the buy path (`Invoke-DuneBotBuyPlayerListings`, `app/server/lib/GameplayBot.ps1`):

```diff
- $payoutUnit  = $price * 10
- $payoutTotal = $totalCost * 10
+ $payoutUnit  = $price
+ $payoutTotal = $totalCost
```

Duke now pays the exact listed price (`item_price × stack`) and debits its own Solari balance by the same amount — identical to a normal player-to-player sale.

The listing side is unaffected: Duke's own listings already store `item_price` 1:1 (confirmed on the live DB — orders cap at `price_cap` = 100,000, not 1,000,000). The stale "× 10 display" values that remain are report-only preview fields, not money paths.

## Testing

- PowerShell parse-check passes; UTF-8 BOM preserved on `GameplayBot.ps1`.
- Root cause confirmed by dumping the two live exchange stored-function definitions (1:1, no scaling) and the live market `item_price` distribution.
- Recommended before public release: verify one in-game sale on a live server (Duke buys a listed item → seller's "Take Solari" now equals the listed price, not 10×).

## Notes

- Branched from `main` (v12.14.9); no version bump here — folds into the next release alongside the other pending fix.
