### PR TITLE
Enable remote control by default for all sessions

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,3 +1,3 @@
 automation:
   auto_issue_session: true
-  remote_control: false
+  remote_control: true


### PR DESCRIPTION
Set `remote_control: true` in `.github/github-app.yml`.

The Copilot desktop app writes `remote_control: true` into this tracked file at runtime, which repeatedly dirtied the main working copy and blocked `git checkout main` during new-session creation. Baking `true` into main fixes both: remote control is on for every session, and the app's runtime write now produces no diff so the tree stays clean.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>