### PR TITLE
docs(mobile): remove stale 'Tailscale on the phone' guidance

### DIFF
--- a/mobile/APP_STORE.md
+++ b/mobile/APP_STORE.md
@@ -1,21 +1,31 @@
 # App Store Description Guidelines
 
-When publishing the **Dune Server Tool (DST)** mobile app to the Apple App Store or Google Play Store, make sure to include explicit instructions about the Tailscale requirement so users don't leave bad reviews when they can't connect.
+When publishing the **Dune Server Tool (DST)** mobile app to the Apple App Store
+or Google Play Store, make it clear that connecting requires the **server
+owner** to have Tailscale Funnel enabled on the host PC — but that the **phone
+itself needs nothing beyond this app**. This prevents bad reviews from users
+who install Tailscale on their phone thinking it's required (it isn't) and
+from users trying to connect to a host that hasn't set up remote access yet.
 
 ### Suggested App Store Description Snippet:
 
 ```text
 Dune Server Tool (DST) Mobile Companion
 
-Manage and monitor your private Dune: Awakening server right from your phone. View server status, manage players, and perform admin actions on the go.
+Manage and monitor your private Dune: Awakening server right from your phone.
+View server status, manage players, and perform admin actions on the go.
 
-⚠️ IMPORTANT REQUIREMENTS ⚠️
-To securely connect to your server without exposing it to the public internet, this app REQUIRES Tailscale.
+⚠️ REQUIREMENTS (server-side only)
+To connect, the DST server owner must have set up Tailscale Funnel on the host
+PC running DST. This gives their DST a stable public HTTPS address that your
+phone can reach securely without exposing the server to the wider internet.
 
-Before you can connect:
-1. You must have the Tailscale VPN app installed and active on your mobile device.
-2. The DST Desktop server owner must have Tailscale running on the server PC.
-3. The server owner must add your Tailscale account to their network (Tailnet).
+You do NOT need to install Tailscale on your phone. You do NOT need to be on
+the server owner's Tailscale network. Just install this app, then scan the
+pairing QR code shown in DST Desktop → Settings → Mobile App. The QR encodes
+the host's Funnel URL and a per-device token that authenticates you.
 
-Once connected to Tailscale, simply scan the pairing QR code from the DST Desktop app Settings tab to link your phone.
+If you can't connect, the host almost certainly hasn't finished the Tailscale
+Funnel setup yet — ask them to check DST Desktop → Settings → Mobile App for
+the "Remote access ready" indicator.
 ```

--- a/mobile/EXPO.md
+++ b/mobile/EXPO.md
@@ -13,25 +13,27 @@ install Expo Go and open our published project.
 
 ## For testers (end users)
 
-You need two apps on your phone: **Expo Go** (runs the DST app) and **Tailscale**
-(secure connection to the server). You never expose the server to the internet.
+You need **one** app on your phone: **Expo Go** (runs the DST app). You do
+**not** need Tailscale on the phone — the server owner runs Tailscale Funnel
+on their host PC, which exposes DST to the internet on a stable public HTTPS
+URL. Your phone talks to that URL directly, authenticated by a per-device
+pairing token.
 
 1. **Install Expo Go**
    - iOS: App Store → "Expo Go"
    - Android: Play Store → "Expo Go"
-2. **Install Tailscale** and sign in to the **same** account the server owner added
-   you to. Confirm it says **Connected**.
-3. **Open the DST app in Expo Go** using the link/QR the server owner (or our
+2. **Open the DST app in Expo Go** using the link/QR the server owner (or our
    testing channel) shares:
    - Tap the link on your phone, or
    - Open Expo Go → scan the QR we provide.
-4. **Pair with the server**
+3. **Pair with the server**
    - On the host PC: DST Desktop → **Settings → Mobile App** → a QR pairing code.
    - In the DST app: **Scan** that QR. No camera? Tap **Enter Code Manually** and
-     type the IP, Port, and Token shown on the Settings card.
+     type the URL, Port, and Token shown on the Settings card.
 
-If "Can't reach server": Tailscale isn't Connected (on the phone or the PC), or
-DST isn't running on the host.
+If "Can't reach server": the host hasn't finished setting up Tailscale Funnel
+(check DST Desktop → Settings → Mobile App on the host for the remote-access
+status indicator), or DST isn't running on the host.
 
 ---
 


### PR DESCRIPTION
## Why

`mobile/APP_STORE.md` and `mobile/EXPO.md` still described the **pre-Funnel mesh model** — the one that required users to install Tailscale on their phone and join the host's tailnet. That model was retired on 2026-06-22 when Tailscale Funnel became the validated remote transport (`lib/Tailscale.ps1`, `lib/MobileBridge.ps1`, and the settled architecture note in Chroma).

The stale docs bit us today: Duke (the personal-llm support bot) faithfully surfaced the "install Tailscale on your phone" advice to a user in `#ask-duke`, because Duke's KB ingested both files. Answer was corrected in-thread + the KB will be re-ingested.

## Current (correct) architecture

- **HOST** runs Tailscale + `tailscale funnel --bg http://127.0.0.1:47900` → gets a stable public `*.ts.net` HTTPS URL that fronts the DST bridge
- **PHONE** needs nothing beyond the DST app. The pairing QR from `Settings → Mobile App` encodes the Funnel URL + a per-device token
- No Tailscale install on the phone, no tailnet membership, no VPN on the phone
- Same URL also serves the browser magic-link portal (`<funnelUrl>/?key=<token>`) for tablets

## Changes

- `mobile/APP_STORE.md` — reframed the app-store snippet: requirements are **server-side only**; phone needs only the DST app
- `mobile/EXPO.md` — dropped step 2 (install Tailscale on phone), corrected the "can't reach server" hint to point at host-side Funnel setup

Docs-only. No code, no tests, no release impact.