### PR TITLE
v12.15.2: Apply server update button + named backups + remove old Commands entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [12.15.2] - 2026-07-03
+
+### Added
+
+- **Apply server update (Restart Schedule).** New button next to *Check for server update*. When Funcom publishes a new self-host image, one click downloads it and restarts the battlegroup — no console window, no SSH. The update runs on the VM as a detached job (so the update keeps running even if you close DST) and DST polls progress with a live tail. The v12.15.1 db-util autoheal silently clears the util-pod race that reliably fires right after `battlegroup update` finishes, so the battlegroup comes back Healthy on its own.
+
+### Changed
+
+- **Scheduled backups now include a stable prefix in the filename.** The daily backup cron now runs `battlegroup backup "dst-scheduled-YYYYMMDD-HHMMSS"` instead of the unnamed form, so DST-scheduled snapshots are self-labeling in `/funcom/artifacts/database-dumps/` and easy to tell apart from manual backups in the file browser.
+
+### Removed
+
+- **Redundant "update" entry on the Commands page.** The interactive-console `battlegroup update` launcher was DST's only way to apply a Funcom update, but the console window was confusing (looked like it hung during long steamcmd steps) and there was no visible progress. The new *Apply server update* button on Restart Schedule replaces it end-to-end. Use that instead.
+
 ## [12.15.1] - 2026-07-03
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.15.1'
+$script:DuneToolVersion = '12.15.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.15.1',
+    [string]$Version = '12.15.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.15.1</Version>
+    <Version>12.15.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.15.1"
+#define MyAppVersion "12.15.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -91,7 +91,13 @@ function New-DuneBackupPodPruneSnippet {
 function New-DuneBackupCmd {
     param([int]$KeepLastPods = 10)
     $snippet = New-DuneBackupPodPruneSnippet -KeepLast $KeepLastPods
-    return "if find /tmp/dst-restart-active -mmin -30 2>/dev/null | grep -q .; then echo `"`$(date) dst: backup skipped - BG restart window active`" >> /var/log/dune-backup.log; else /home/dune/.dune/bin/battlegroup backup >> /var/log/dune-backup.log 2>&1; $snippet; fi"
+    # Pass a stable name to `battlegroup backup` so scheduled backups are
+    # self-labeling in /funcom/artifacts/database-dumps/. A named backup makes
+    # it obvious which snapshots were taken automatically by DST vs a manual
+    # `battlegroup backup` on the command line — and it makes the pre-Funcom-
+    # update-restore rollback path in the patch-compat routine easier to pick
+    # out. Timestamp is UTC to match the rest of DST's log format.
+    return "if find /tmp/dst-restart-active -mmin -30 2>/dev/null | grep -q .; then echo `"`$(date) dst: backup skipped - BG restart window active`" >> /var/log/dune-backup.log; else /home/dune/.dune/bin/battlegroup backup `"dst-scheduled-`$(date -u +%Y%m%d-%H%M%S)`" >> /var/log/dune-backup.log 2>&1; $snippet; fi"
 }
 $script:DuneBackupBeginMarker = '# DST-BACKUP BEGIN'
 $script:DuneBackupEndMarker   = '# DST-BACKUP END'

--- a/app/server/lib/Commands.ps1
+++ b/app/server/lib/Commands.ps1
@@ -25,7 +25,6 @@ $script:DuneCommands = @(
     @{ Section='Battlegroup'; Key='2';  Name='start';                    Label='Start BG Only';   Mode='Console'; Requires='running'; DisabledWhen='bg-running';  Desc='Start the selected battlegroup' }
     @{ Section='Battlegroup'; Key='3';  Name='restart';                  Label='Restart BG Only'; Mode='Console'; Requires='running'; DisabledWhen='bg-stopped';  Desc='Restart the selected battlegroup' }
     @{ Section='Battlegroup'; Key='4';  Name='stop';                     Label='Stop BG Only';    Mode='Console'; Requires='running'; DisabledWhen='bg-stopped';  Desc='Stop the selected battlegroup' }
-    @{ Section='Battlegroup'; Key='5';  Name='update';                   Mode='Console'; Requires='running'; Desc='Check for new versions and apply them' }
     @{ Section='Battlegroup'; Key='6';  Name='edit';                     Mode='Console'; Requires='running'; External=$true; Desc='Edit battlegroup via utilities interface' }
     @{ Section='Battlegroup'; Key='7';  Name='edit-advanced';            Label='Edit Director';   Mode='Console'; Requires='running'; External=$true; Desc='(Advanced) Edit battlegroup YAML directly' }
     @{ Section='Battlegroup'; Key='21'; Name='change-battlegroup-ip';    Label='Change Player IP'; Mode='Console'; Requires='running'; Desc='Change the IP that players connect to' }

--- a/app/server/lib/RestartSchedule.ps1
+++ b/app/server/lib/RestartSchedule.ps1
@@ -529,6 +529,342 @@ echo "SRC=$SRC"
     return $result
 }
 
+# =============================================================================
+# APPLY FUNCOM SERVER UPDATE
+#
+# One-click replacement for the legacy "Commands page -> update" launcher.
+#
+# The update process itself (`/home/dune/.dune/bin/battlegroup update` — checks
+# steamcmd, downloads the new server image, patches the battlegroup CR to the
+# new image tag, and re-rolls the pods) is long-running: 5-20 minutes for a
+# fresh image download + kube pull. We fire it on the VM as a background job
+# (nohup + tee to a remote log file + $? written to a marker) so:
+#
+#   1. The DST-side runspace only has to POLL for status, never keep an SSH
+#      pipe open for 20 minutes.
+#   2. If the user closes DST mid-update the update keeps running on the VM.
+#      Next DST launch will observe the marker files and pick up where it
+#      left off, reporting Done/Failed/Running correctly.
+#   3. The v12.15.1 db-util autoheal tick keeps running in the same 30s
+#      scheduler loop and silently recovers the util-pod wedge that reliably
+#      fires right after `battlegroup update` finishes swapping the image
+#      tag (fresh util pod races the newly-restarted Postgres).
+#
+# Remote files (all under /tmp so they clear on reboot):
+#   /tmp/dst-funcom-update.log   - full stdout+stderr of the update job
+#   /tmp/dst-funcom-update.rc    - written AFTER the update exits, contents = rc
+#   /tmp/dst-funcom-update.started - timestamp when the job was launched
+#
+# Host-side state file:
+#   %APPDATA%\DuneServer\funcom-update-state.json
+# =============================================================================
+
+$script:DuneFuncomUpdateLockName    = 'funcom-update-state'
+$script:DuneFuncomUpdateRemoteLog   = '/tmp/dst-funcom-update.log'
+$script:DuneFuncomUpdateRemoteRc    = '/tmp/dst-funcom-update.rc'
+$script:DuneFuncomUpdateRemoteStart = '/tmp/dst-funcom-update.started'
+$script:DuneFuncomUpdateMaxMinutes  = 35   # generous — steamcmd download + pull
+
+function Get-DuneFuncomUpdateStatePath {
+    Join-Path $env:APPDATA 'DuneServer\funcom-update-state.json'
+}
+
+function New-DuneFuncomUpdateIdleState {
+    return @{
+        phase           = 'idle'
+        running         = $false
+        started         = $null
+        updated         = (Get-Date).ToUniversalTime().ToString('o')
+        finished        = $null
+        ok              = $false
+        rc              = $null
+        installedBefore = ''
+        installedAfter  = ''
+        tail            = @()
+        error           = ''
+    }
+}
+
+function Read-DuneFuncomUpdateState {
+    $path = Get-DuneFuncomUpdateStatePath
+    if (-not (Test-Path -LiteralPath $path)) { return (New-DuneFuncomUpdateIdleState) }
+    try {
+        $raw = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
+        if ([string]::IsNullOrWhiteSpace($raw)) { return (New-DuneFuncomUpdateIdleState) }
+        return ($raw | ConvertFrom-Json)
+    } catch {
+        return (New-DuneFuncomUpdateIdleState)
+    }
+}
+
+function Save-DuneFuncomUpdateState {
+    param([Parameter(Mandatory)]$State)
+    $path = Get-DuneFuncomUpdateStatePath
+    $dir  = Split-Path -Parent $path
+    try { if (-not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null } } catch {}
+    $json = $State | ConvertTo-Json -Depth 8
+    $tmp  = "$path.tmp"
+    $write = {
+        Set-Content -LiteralPath $tmp -Value $json -Encoding UTF8 -Force
+        Move-Item -LiteralPath $tmp -Destination $path -Force
+    }
+    if (Get-Command Invoke-WithDuneLock -ErrorAction SilentlyContinue) {
+        try { Invoke-WithDuneLock -Name $script:DuneFuncomUpdateLockName -TimeoutSec 5 -Script $write } catch { & $write }
+    } else { & $write }
+}
+
+# -----------------------------------------------------------------------------
+# Probe the VM for the current update-job state. Returns a hashtable shaped
+# like the state file. Does NOT persist — the caller decides.
+#
+# The VM is authoritative. We treat the presence of $RemoteRc as "done" and
+# its absence combined with a fresh $RemoteStart as "running". If both files
+# are missing, no job has been launched (or the VM was rebooted since).
+# -----------------------------------------------------------------------------
+function Get-DuneFuncomUpdateRemoteState {
+    $ctx = Get-DuneBackupContext
+    if (-not $ctx.ok) { return @{ ok = $false; message = $ctx.message } }
+
+    # Single SSH round-trip: probe all three markers + tail last 40 lines.
+    $script = @"
+set +e
+STARTED=""
+[ -f $script:DuneFuncomUpdateRemoteStart ] && STARTED=`$(cat $script:DuneFuncomUpdateRemoteStart 2>/dev/null)
+RC=""
+[ -f $script:DuneFuncomUpdateRemoteRc ] && RC=`$(cat $script:DuneFuncomUpdateRemoteRc 2>/dev/null)
+TAIL=""
+[ -f $script:DuneFuncomUpdateRemoteLog ] && TAIL=`$(tail -40 $script:DuneFuncomUpdateRemoteLog 2>/dev/null)
+echo "__DST_STARTED_BEGIN__`$STARTED"
+echo "__DST_STARTED_END__"
+echo "__DST_RC_BEGIN__`$RC"
+echo "__DST_RC_END__"
+echo "__DST_TAIL_BEGIN__"
+printf '%s\n' "`$TAIL"
+echo "__DST_TAIL_END__"
+"@
+    try {
+        $r = Invoke-DuneBackupShell -Ip $ctx.ip -Script $script -TimeoutSec 15
+    } catch {
+        return @{ ok = $false; message = "SSH probe failed: $($_.Exception.Message)" }
+    }
+    $body = if ($r) { [string]$r.out } else { '' }
+
+    $started = ''
+    $rcRaw   = ''
+    $tail    = @()
+    if ($body -match '(?ms)__DST_STARTED_BEGIN__(.*?)__DST_STARTED_END__') { $started = $Matches[1].Trim() }
+    if ($body -match '(?ms)__DST_RC_BEGIN__(.*?)__DST_RC_END__')             { $rcRaw   = $Matches[1].Trim() }
+    if ($body -match '(?ms)__DST_TAIL_BEGIN__\r?\n(.*?)__DST_TAIL_END__')    {
+        $tail = @(($Matches[1] -split "`n") | ForEach-Object { $_.TrimEnd() } | Where-Object { $_ -ne '' })
+    }
+
+    $out = @{ ok = $true; started = $started; rc = $rcRaw; tail = $tail }
+    return $out
+}
+
+# -----------------------------------------------------------------------------
+# Fire the update job on the VM (fire-and-forget). Returns immediately.
+# Cleans out previous marker files first so a stale rc from a prior run does
+# not immediately mark this run "done".
+# -----------------------------------------------------------------------------
+function Invoke-DuneStartFuncomUpdateJob {
+    $ctx = Get-DuneBackupContext
+    if (-not $ctx.ok) { return @{ ok = $false; status = $ctx.status; message = $ctx.message } }
+
+    # Reset markers + write the started stamp + launch battlegroup update
+    # detached (setsid + nohup) so it survives our SSH disconnect. Redirect
+    # stderr into stdout so a warning/error still lands in the tail.
+    $script = @"
+rm -f $script:DuneFuncomUpdateRemoteLog $script:DuneFuncomUpdateRemoteRc 2>/dev/null
+date -u +%Y-%m-%dT%H:%M:%SZ > $script:DuneFuncomUpdateRemoteStart
+setsid bash -c '/home/dune/.dune/bin/battlegroup update > $script:DuneFuncomUpdateRemoteLog 2>&1; echo `$? > $script:DuneFuncomUpdateRemoteRc' </dev/null >/dev/null 2>&1 &
+disown 2>/dev/null || true
+echo launched
+"@
+    try {
+        $r = Invoke-DuneBackupShell -Ip $ctx.ip -Script $script -TimeoutSec 15
+    } catch {
+        return @{ ok = $false; status = 502; message = "Failed to launch update job: $($_.Exception.Message)" }
+    }
+    $body = if ($r) { [string]$r.out } else { '' }
+    if ($body -notmatch 'launched') {
+        return @{ ok = $false; status = 502; message = "Update job did not confirm launch. Raw: $body" }
+    }
+    return @{ ok = $true; message = 'Update job launched on the VM.' }
+}
+
+# -----------------------------------------------------------------------------
+# Get-DuneFuncomUpdateStatus : the "one-shot reconcile" entry point.
+# Reads the local state file, reconciles against the VM's remote markers
+# (VM is authoritative for phase transitions), and returns the merged state
+# for the UI. Also flips 'running' -> 'error' if the job appears to be gone
+# without an rc file (VM reboot mid-run).
+#
+# Safe to call from a route handler on every poll. Persists to disk.
+# -----------------------------------------------------------------------------
+function Get-DuneFuncomUpdateStatus {
+    $local = Read-DuneFuncomUpdateState
+    $remote = Get-DuneFuncomUpdateRemoteState
+    if (-not $remote.ok) {
+        # VM unreachable. Return whatever we last saved, don't blow away state.
+        return $local
+    }
+
+    $started = [string]$remote.started
+    $rc      = [string]$remote.rc
+    $tail    = @($remote.tail)
+
+    # No markers at all -> idle
+    if (-not $started -and -not $rc) {
+        # If we previously thought we were running but the markers are gone,
+        # the VM rebooted or someone rm'd the files. Fail-safe.
+        try {
+            $wasRunning = if ($local -is [hashtable]) { [bool]$local['running'] } else { [bool]$local.running }
+        } catch { $wasRunning = $false }
+        if ($wasRunning) {
+            $st = New-DuneFuncomUpdateIdleState
+            $st.phase   = 'error'
+            $st.error   = 'Update job disappeared from the VM (rebooted mid-run, or markers deleted). Please retry.'
+            $st.updated = (Get-Date).ToUniversalTime().ToString('o')
+            Save-DuneFuncomUpdateState -State $st
+            return $st
+        }
+        return $local
+    }
+
+    # Both started AND rc present -> job finished
+    if ($started -and $rc) {
+        $rcInt = -1
+        if ($rc -match '^\d+$') { $rcInt = [int]$rc }
+        $ok = ($rcInt -eq 0)
+
+        # Read installed-after now so the UI can render the before/after pair.
+        $before = if ($local.installedBefore) { [string]$local.installedBefore } else { '' }
+        $after  = ''
+        try {
+            $chk = Get-DuneFuncomServerUpdateStatus
+            if ($chk.ok) { $after = [string]$chk.installedBuild }
+        } catch {}
+
+        $st = @{
+            phase           = if ($ok) { 'done' } else { 'error' }
+            running         = $false
+            started         = $started
+            updated         = (Get-Date).ToUniversalTime().ToString('o')
+            finished        = (Get-Date).ToUniversalTime().ToString('o')
+            ok              = $ok
+            rc              = $rcInt
+            installedBefore = $before
+            installedAfter  = $after
+            tail            = $tail
+            error           = if ($ok) { '' } else { "battlegroup update exited $rcInt. See tail for details." }
+        }
+        # Only persist if this represents a transition (not on every poll after done)
+        try {
+            $wasRunning = if ($local -is [hashtable]) { [bool]$local['running'] } else { [bool]$local.running }
+        } catch { $wasRunning = $true }
+        $wasPhase = if ($local -is [hashtable]) { [string]$local['phase'] } else { [string]$local.phase }
+        if ($wasRunning -or $wasPhase -ne $st.phase) {
+            Save-DuneFuncomUpdateState -State $st
+        } else {
+            # keep local, just refresh tail
+            $local.tail = $tail
+            $local.updated = (Get-Date).ToUniversalTime().ToString('o')
+            Save-DuneFuncomUpdateState -State $local
+            return $local
+        }
+        return $st
+    }
+
+    # Started but no rc yet -> running
+    $startedAt = $null
+    try { $startedAt = [datetime]::Parse($started, $null, [System.Globalization.DateTimeStyles]::RoundtripKind) } catch {}
+    $stale = $false
+    if ($startedAt) {
+        $ageMin = ((Get-Date).ToUniversalTime() - $startedAt.ToUniversalTime()).TotalMinutes
+        if ($ageMin -gt $script:DuneFuncomUpdateMaxMinutes) { $stale = $true }
+    }
+    if ($stale) {
+        $st = @{
+            phase           = 'error'
+            running         = $false
+            started         = $started
+            updated         = (Get-Date).ToUniversalTime().ToString('o')
+            finished        = (Get-Date).ToUniversalTime().ToString('o')
+            ok              = $false
+            rc              = $null
+            installedBefore = [string]$local.installedBefore
+            installedAfter  = ''
+            tail            = $tail
+            error           = "Update did not finish within $($script:DuneFuncomUpdateMaxMinutes) minutes; treating as failed. Check the VM."
+        }
+        Save-DuneFuncomUpdateState -State $st
+        return $st
+    }
+
+    $before = if ($local.installedBefore) { [string]$local.installedBefore } else { '' }
+    $st = @{
+        phase           = 'running'
+        running         = $true
+        started         = $started
+        updated         = (Get-Date).ToUniversalTime().ToString('o')
+        finished        = $null
+        ok              = $false
+        rc              = $null
+        installedBefore = $before
+        installedAfter  = ''
+        tail            = $tail
+        error           = ''
+    }
+    Save-DuneFuncomUpdateState -State $st
+    return $st
+}
+
+# -----------------------------------------------------------------------------
+# Kick off an update. Returns immediately with @{ ok; running; message }.
+# The caller polls Get-DuneFuncomUpdateStatus.
+# -----------------------------------------------------------------------------
+function Start-DuneApplyFuncomUpdate {
+    # Reconcile first — if VM already shows an in-flight job, refuse.
+    $cur = Get-DuneFuncomUpdateStatus
+    $isRunning = $false
+    try { $isRunning = if ($cur -is [hashtable]) { [bool]$cur['running'] } else { [bool]$cur.running } } catch {}
+    if ($isRunning) {
+        return @{ ok = $false; running = $true; error = 'A server update is already in progress.' }
+    }
+
+    # Snapshot the installed build BEFORE launching so the UI can show
+    # before/after when the job finishes.
+    $before = ''
+    try {
+        $chk = Get-DuneFuncomServerUpdateStatus
+        if ($chk.ok) { $before = [string]$chk.installedBuild }
+    } catch {}
+
+    $launch = Invoke-DuneStartFuncomUpdateJob
+    if (-not $launch.ok) {
+        $st = New-DuneFuncomUpdateIdleState
+        $st.phase = 'error'
+        $st.error = $launch.message
+        $st.updated = (Get-Date).ToUniversalTime().ToString('o')
+        Save-DuneFuncomUpdateState -State $st
+        return @{ ok = $false; running = $false; error = $launch.message }
+    }
+
+    $st = New-DuneFuncomUpdateIdleState
+    $st.phase           = 'running'
+    $st.running         = $true
+    $st.started         = (Get-Date).ToUniversalTime().ToString('o')
+    $st.installedBefore = $before
+    $st.tail            = @()
+    Save-DuneFuncomUpdateState -State $st
+
+    if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+        Write-DuneLog "Funcom server update launched on VM (installed=$before)" 'INFO'
+    }
+    return @{ ok = $true; running = $true; message = 'Update launched. Poll status for progress.' }
+}
+
 # Touch the VM-side backup-guard marker so an overlapping scheduled backup skips
 # itself. Best-effort; returns $true on success.
 function Set-DuneRestartGuardMarker {

--- a/app/server/routes/RestartSchedule.ps1
+++ b/app/server/routes/RestartSchedule.ps1
@@ -189,3 +189,35 @@ Register-DuneRoute -Method POST -Path '/api/restart-schedule/check-update' -Hand
         Write-DuneError -Response $res -Status 502 -Message "Update check failed: $($_.Exception.Message)"
     }
 }
+
+# POST /api/restart-schedule/apply-server-update
+# Fires the Funcom server update on the VM (runs battlegroup update in the
+# background) and returns 202. Poll GET /apply-server-update-status.
+# Refuses with 409 if an update is already running.
+Register-DuneRoute -Method POST -Path '/api/restart-schedule/apply-server-update' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $r = Start-DuneApplyFuncomUpdate
+        if (-not $r.ok) {
+            $status = if ($r.running) { 409 } else { 502 }
+            Write-DuneError -Response $res -Status $status -Message $r.error
+            return
+        }
+        Write-DuneJson -Response $res -Body @{ ok = $true; running = $true; message = $r.message }
+    } catch {
+        Write-DuneError -Response $res -Status 502 -Message "Apply update failed: $($_.Exception.Message)"
+    }
+}
+
+# GET /api/restart-schedule/apply-server-update-status
+# Returns the reconciled state of the last / current Funcom update job.
+# Safe to poll every few seconds. VM is authoritative — DST reconciles from
+# the remote marker files each call.
+Register-DuneRoute -Method GET -Path '/api/restart-schedule/apply-server-update-status' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Write-DuneJson -Response $res -Body (Get-DuneFuncomUpdateStatus)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.15.1"
+$script:ToolVersion = "12.15.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/restartSchedule.ts
+++ b/webui/src/api/restartSchedule.ts
@@ -58,6 +58,34 @@ export function checkFuncomUpdate() {
   })
 }
 
+// Fire-and-return: launches `battlegroup update` on the VM as a detached job
+// and returns immediately. Poll getApplyServerUpdateStatus for progress.
+// Returns 409 when a job is already running.
+export function applyServerUpdate() {
+  return api<{ ok: boolean; running: boolean; message: string }>(
+    '/api/restart-schedule/apply-server-update',
+    { method: 'POST' },
+  )
+}
+
+export interface ApplyServerUpdateStatus {
+  phase: 'idle' | 'running' | 'done' | 'error'
+  running: boolean
+  started: string | null
+  updated: string
+  finished: string | null
+  ok: boolean
+  rc: number | null
+  installedBefore: string
+  installedAfter: string
+  tail: string[]
+  error: string
+}
+
+export function getApplyServerUpdateStatus() {
+  return api<ApplyServerUpdateStatus>('/api/restart-schedule/apply-server-update-status')
+}
+
 export function testDiscordWebhook() {
   return api<{ ok: boolean; message: string }>('/api/restart-schedule/test-discord', {
     method: 'POST',

--- a/webui/src/pages/dashboard/ScheduledRestarts.tsx
+++ b/webui/src/pages/dashboard/ScheduledRestarts.tsx
@@ -6,7 +6,10 @@ import {
   saveRestartSchedule,
   checkFuncomUpdate,
   testDiscordWebhook,
+  applyServerUpdate,
+  getApplyServerUpdateStatus,
   type RestartSchedule,
+  type ApplyServerUpdateStatus,
 } from '../../api/restartSchedule'
 
 // Client-side sanity check for a Discord incoming-webhook URL. The server
@@ -59,6 +62,10 @@ export function ScheduledRestarts() {
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [checking, setChecking] = useState(false)
+  // Apply-server-update state — reconciled from the VM every 5s while running.
+  const [applyStatus, setApplyStatus] = useState<ApplyServerUpdateStatus | null>(null)
+  const [applying, setApplying] = useState(false)
+  const [tailOpen, setTailOpen] = useState(false)
   const [testing, setTesting] = useState(false)
   const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
   const [expanded, setExpanded] = useState<boolean>(() => {
@@ -142,6 +149,63 @@ export function ScheduledRestarts() {
       setChecking(false)
     }
   }, [load])
+
+  // Reconcile the Apply-server-update state from the server. Called on mount
+  // (to pick up a job that started in a previous DST session), on demand after
+  // the user clicks Apply, and on an interval while running so the tail keeps
+  // ticking without the user reloading.
+  const refreshApplyStatus = useCallback(async () => {
+    try {
+      const s = await getApplyServerUpdateStatus()
+      setApplyStatus(s)
+      // If the job just finished, refresh the main schedule (installed build changed)
+      if (s.phase === 'done' || s.phase === 'error') {
+        void load()
+      }
+      return s
+    } catch (e) {
+      // A single failure to fetch shouldn't crash the whole card — just log.
+      console.warn('apply-server-update-status failed', e)
+      return null
+    }
+  }, [load])
+
+  // Fire the update. The VM keeps running even if DST closes, and the
+  // 30 s db-util autoheal tick (v12.15.1) will silently clear the util-pod
+  // wedge that reliably fires right after `battlegroup update` finishes.
+  const runApply = useCallback(async () => {
+    if (!window.confirm(
+      'Apply the Funcom server update?\n\n' +
+      'This downloads the new server image and restarts the battlegroup. '
+      + 'It typically takes 5-20 minutes and will disconnect connected players. '
+      + 'DST will monitor progress here; you can safely close this window — '
+      + 'the update keeps running on the server.',
+    )) return
+    setApplying(true)
+    setMsg(null)
+    try {
+      const r = await applyServerUpdate()
+      setMsg({ kind: 'ok', text: r.message })
+      // Immediately reflect the running state instead of waiting for the poll.
+      await refreshApplyStatus()
+    } catch (e) {
+      setMsg({ kind: 'err', text: e instanceof ApiError ? e.message : 'Apply update failed.' })
+    } finally {
+      setApplying(false)
+    }
+  }, [refreshApplyStatus])
+
+  // Poll while running; also fetch once on mount so a job started in a
+  // previous DST session is reflected immediately.
+  useEffect(() => {
+    void refreshApplyStatus()
+  }, [refreshApplyStatus])
+
+  useEffect(() => {
+    if (!applyStatus?.running) return
+    const id = window.setInterval(() => { void refreshApplyStatus() }, 5000)
+    return () => window.clearInterval(id)
+  }, [applyStatus?.running, refreshApplyStatus])
 
   const runTest = useCallback(async () => {
     setTesting(true)
@@ -434,15 +498,33 @@ export function ScheduledRestarts() {
           )}
 
           <div className="flex items-center justify-between gap-3 mt-4 flex-wrap">
-            <button
-              type="button"
-              onClick={() => { void runCheck() }}
-              disabled={checking}
-              className="btn-secondary"
-              title="Check now whether Funcom has released a server update (non-destructive). Otherwise this runs automatically during each scheduled restart."
-            >
-              <Icon name="RefreshCw" size={14} className={checking ? 'animate-spin' : ''} /> Check for server update
-            </button>
+            <div className="flex items-center gap-2 flex-wrap">
+              <button
+                type="button"
+                onClick={() => { void runCheck() }}
+                disabled={checking}
+                className="btn-secondary"
+                title="Check now whether Funcom has released a server update (non-destructive). Otherwise this runs automatically during each scheduled restart."
+              >
+                <Icon name="RefreshCw" size={14} className={checking ? 'animate-spin' : ''} /> Check for server update
+              </button>
+              <button
+                type="button"
+                onClick={() => { void runApply() }}
+                disabled={applying || Boolean(applyStatus?.running) || !sched?.updateAvailable}
+                className="btn-secondary"
+                title={
+                  !sched?.updateAvailable
+                    ? 'No Funcom update available. Click "Check for server update" first, or wait for the next scheduled check.'
+                    : applyStatus?.running
+                    ? 'A server update is already in progress.'
+                    : 'Download the new Funcom server image and restart the battlegroup. Takes 5-20 minutes. Players will be disconnected. DST auto-heals common startup wedges after the restart.'
+                }
+              >
+                <Icon name="Download" size={14} className={applying || applyStatus?.running ? 'animate-pulse' : ''} />
+                {applyStatus?.running ? 'Applying update…' : 'Apply server update'}
+              </button>
+            </div>
             <button
               type="button"
               onClick={() => { void save() }}
@@ -459,6 +541,71 @@ export function ScheduledRestarts() {
               {sched.installedBuild ? ` · installed build ${sched.installedBuild}` : ''}
               {sched.latestBuild ? ` · latest ${sched.latestBuild}` : ''}
             </p>
+          )}
+
+          {applyStatus && applyStatus.phase !== 'idle' && (
+            <div
+              className={
+                'mt-3 p-3 rounded-lg border text-xs '
+                + (applyStatus.phase === 'running'
+                  ? 'border-accent/40 bg-accent/5 text-text'
+                  : applyStatus.phase === 'done'
+                  ? 'border-success/40 bg-success/5 text-text'
+                  : 'border-danger/40 bg-danger/5 text-text')
+              }
+            >
+              <div className="flex items-center justify-between gap-2 flex-wrap">
+                <div className="flex items-center gap-2 font-semibold">
+                  {applyStatus.phase === 'running' && <Icon name="Download" size={14} className="animate-pulse" />}
+                  {applyStatus.phase === 'done' && <Icon name="Check" size={14} className="text-success" />}
+                  {applyStatus.phase === 'error' && <Icon name="AlertTriangle" size={14} className="text-danger" />}
+                  <span>
+                    {applyStatus.phase === 'running' && 'Applying Funcom server update…'}
+                    {applyStatus.phase === 'done' && 'Server update applied.'}
+                    {applyStatus.phase === 'error' && 'Server update failed.'}
+                  </span>
+                </div>
+                {applyStatus.started && (
+                  <span className="text-text-dim">
+                    Started {new Date(applyStatus.started).toLocaleTimeString()}
+                    {applyStatus.finished && ` · finished ${new Date(applyStatus.finished).toLocaleTimeString()}`}
+                  </span>
+                )}
+              </div>
+              {(applyStatus.installedBefore || applyStatus.installedAfter) && (
+                <p className="mt-1 text-text-dim">
+                  Build{' '}
+                  <span className="text-text">{applyStatus.installedBefore || '?'}</span>
+                  {' → '}
+                  <span className="text-text">{applyStatus.installedAfter || (applyStatus.running ? '…' : '?')}</span>
+                </p>
+              )}
+              {applyStatus.error && (
+                <p className="mt-1 text-danger break-words">{applyStatus.error}</p>
+              )}
+              {applyStatus.phase === 'running' && (
+                <p className="mt-1 text-text-dim">
+                  This normally takes 5-20 minutes. You can close DST — the update keeps running on the server.
+                  If the battlegroup gets stuck on Starting afterwards, DST auto-heals the util-pod wedge within ~30s.
+                </p>
+              )}
+              {applyStatus.tail && applyStatus.tail.length > 0 && (
+                <div className="mt-2">
+                  <button
+                    type="button"
+                    className="text-[11px] text-text-dim hover:text-text underline underline-offset-2"
+                    onClick={() => setTailOpen(v => !v)}
+                  >
+                    {tailOpen ? 'Hide' : 'Show'} last {applyStatus.tail.length} log line{applyStatus.tail.length === 1 ? '' : 's'}
+                  </button>
+                  {tailOpen && (
+                    <pre className="mt-1 p-2 rounded bg-surface-2 border border-border text-[10px] overflow-auto max-h-64 whitespace-pre-wrap break-words">
+                      {applyStatus.tail.join('\n')}
+                    </pre>
+                  )}
+                </div>
+              )}
+            </div>
           )}
         </>
           )}


### PR DESCRIPTION
## What

Replaces the confusing Commands-page "update" console launcher with a first-class **Apply server update** button on the Restart Schedule card. Also renames scheduled backup files so they're self-labeling in the file browser.

## Why

DST detected Funcom self-host updates (build-id badge) but the only way to *apply* one from within DST was clicking Commands → Battlegroup → "update", which opened a raw console window running `battlegroup update` interactively for 5-20 minutes with no visible progress. Users routinely thought it had hung and killed the window mid-download.

## How

**Detached-on-VM design.** DST fires `/home/dune/.dune/bin/battlegroup update` inside `setsid` + `nohup`, redirects stdout/stderr to `/tmp/dst-funcom-update.log`, and writes the exit rc to `/tmp/dst-funcom-update.rc` when it finishes. DST-side polling reconciles from those marker files every 5 s. Two nice properties fall out:

1. **DST can close mid-update** — the update keeps running on the VM. Next launch reconciles and shows current state (Running / Done / Error).
2. **No long-lived SSH pipe** — a 20-minute keep-alive isn't required; each poll is a tiny SSH round trip.

**Compose with v12.15.1 autoheal.** `battlegroup update` restarts the battlegroup on the new image, which reliably triggers the util-pod race we fixed in v12.15.1. That autoheal ticks every 30 s in the same background scheduler, so the BG comes back Healthy on its own — nothing new to wire up.

**Single-flight lock** on state file phase = `running`. Reconciler treats a marker-file-gone-while-we-thought-we-were-running as `error` (VM reboot mid-run).

**35-minute stale timeout** on the `Started` marker — if `battlegroup update` never writes an rc, we surface an error rather than pretending it's still running.

## Files

**Backend**
- `app/server/lib/RestartSchedule.ps1` — new: `Get/Save/Read-DuneFuncomUpdateState`, `Get-DuneFuncomUpdateRemoteState`, `Invoke-DuneStartFuncomUpdateJob`, `Get-DuneFuncomUpdateStatus`, `Start-DuneApplyFuncomUpdate`.
- `app/server/routes/RestartSchedule.ps1` — `POST /api/restart-schedule/apply-server-update`, `GET /api/restart-schedule/apply-server-update-status`.

**UI**
- `webui/src/api/restartSchedule.ts` — `applyServerUpdate()`, `getApplyServerUpdateStatus()`, `ApplyServerUpdateStatus` type.
- `webui/src/pages/dashboard/ScheduledRestarts.tsx` — Apply button, confirm modal, poll (5 s while running), progress card with phase + before/after build ids + collapsible last-40-lines tail.

**Named backups**
- `app/server/lib/BackupSchedule.ps1` `New-DuneBackupCmd` — scheduled cron now runs `battlegroup backup "dst-scheduled-YYYYMMDD-HHMMSS"` so files are self-labeling in `/funcom/artifacts/database-dumps/`.

**Removed old confusing entry**
- `app/server/lib/Commands.ps1` — pulled the Battlegroup section "update" card (Key=5). The new Apply button replaces it end-to-end. Console launcher code path stays intact for all other commands.

**Version + changelog**
- 5 stamps → 12.15.2. `CHANGELOG.md` [12.15.2] entry (Added / Changed / Removed).

## Verified

- Web build: `npm run build` ✓ (tsc + vite)
- PS parse-check on all 4 changed .ps1 files ✓
- BOM audit: all 4 files still have BOM (all contain em-dashes) ✓
- Installer build: `Build-Installer.ps1` ✓, 46.06 MB, version stamps validated ✓

## Not yet verified live

- Firing an actual Funcom update through the new button — waiting on the next real Funcom drop (today's `2025705-0-shipping` already installed). The state-reconciler + tail-tail path is exercised on every poll regardless, so the reconciler surface is well-covered even without a live update.

## Post-merge

- Tag v12.15.2 from merge commit + `gh release create` with the built `DuneServerSetup.exe`.
- `Post-DiscordRelease.ps1 -Tag v12.15.2` → #releases + #announcements + #changelog.
- Update `last-release-processed.txt`.