### PR TITLE
Fresh Start (keep builds & cosmetics) — v12.16.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.15.0"
+      placeholder: "v12.16.0"
     validations:
       required: true
 
@@ -94,6 +94,7 @@ body:
         - Web portal — Gameplay Admin — Players — Unlock Trainers (skill-tree ownership status) / Unlock Main Quest / Complete Contract (clear stuck contract) / Apply Quick Preset (Progression)
         - Web portal — Gameplay Admin — Players — Progression Unlock (Ch3 Start / Rank 19 Eligible, Atreides/Harkonnen)
         - Web portal — Gameplay Admin — Players — Reset Faction (wipe rep + faction tags + ClimbTheRanks + faction contract items / stuck contract card, offline)
+        - Web portal — Gameplay Admin — Players — Fresh Start (Snapshot builds + cosmetics / Restore builds by name after in-game delete + recreate; offline to restore)
         - Web portal — Gameplay Admin — Players — Tags (search/add typeahead + tag list)
         - Web portal — Gameplay Admin — Players — Landsraad (contribution editor)
         - Web portal — Gameplay Admin — Bases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [12.16.0] - 2026-07-03
+
+### Added
+
+- **Fresh Start (keep builds & cosmetics).** New action under *Players → Progression*. A genuinely fresh character can only be made in-game (the game engine rebuilds the entire quest journal, skill trees and starter content from the character on every login, so an in-place database reset can't produce one). Fresh Start instead preserves the two things you're entitled to keep across a restart — your unlocked **building sets/pieces** and **cosmetics**. Flow: **1)** *Snapshot* the character's builds + cosmetics (saved locally, keyed by character name); **2)** delete and recreate the character in-game with the **same name** (delete via the in-game Funcom browser so the name is kept) and spawn in; **3)** *Restore* — DST grants those builds + cosmetics back onto the fresh character by name. Everything else (quests, skills, faction, tech) starts genuinely fresh. Restore requires the player to be offline.
+
 ## [12.15.2] - 2026-07-03
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.15.2'
+$script:DuneToolVersion = '12.16.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.15.2',
+    [string]$Version = '12.16.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.15.2</Version>
+    <Version>12.16.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.15.2"
+#define MyAppVersion "12.16.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1353,95 +1353,177 @@ WHERE a.id = $pawnID::bigint
 }
 
 # ---------------------------------------------------------------------------
-# Fresh Start (keep unlocks) -- hardest-possible progression reset. Wipes a
-# character's story/quest/faction/contract progression AND character power
-# (crafting recipes, tech-knowledge data, specializations + keystones) so the
-# player can replay ALL content, while KEEPING only: cosmetics
-# (CustomizationLibraryActorComponent), building sets (dune.building_progression),
-# and Steam achievements (journey nodes 'DA_ACH%'). Inventory, bases, Intel
-# (m_TechKnowledgePoints) and class skill-tree modules are left untouched
-# (Coastal's locked scope, 2026-07-03).
+# Fresh Start (keep builds & cosmetics) -- snapshot + restore-by-name.
 #
-# Offline-only (route-gated): journey rows, player_tags, and the pawn component
-# blobs are RAM-authoritative while the player is connected, so an online edit is
-# overwritten on logout -- same guard as Reset Faction / Wipe Journey.
+# A genuinely-fresh character can ONLY be produced by the game engine: the player
+# deletes the character in-game, recreates it, and spawns. An in-place DB wipe
+# does NOT work -- the engine rebuilds the journey journal, skill-tree scaffold
+# and ability slots from the character's footprint on every login (verified live
+# 2026-07-03: deleting all 1979 non-achievement journey rows just made the engine
+# recreate them and reveal 1195). So Fresh Start does not wipe anything.
 #
-# Composition: a single transaction for the DML-only wipes (journey / tags /
-# contract items+pointer / recipe + tech-knowledge blobs) then the two existing
-# helpers that run their own transactions -- Invoke-DunePlayerResetFaction (rep,
-# alignment, faction tags, ClimbTheRanks, faction contract items) and
-# Invoke-DunePlayerResetAllSpecs (specialization_tracks + keystones). Every step
-# is idempotent, so a partial failure is safe to re-run.
-#
-# WARNING - FRAGILE keep/wipe boundaries: Funcom renames tag prefixes and
-# journey node-id patterns every patch (they already rekeyed player_tags and
-# journey account_id -> character_id). Re-verify 'DA_ACH%', the tag allow-list,
-# and the component JSON paths against a reference character each server update;
-# never hardcode blindly. Chroma:
-# dst-fresh-start-feature-spec-and-fragile-keep-wipe-classification-2026-07-03.
-function Invoke-DunePlayerFreshStart {
+# Instead it preserves the two things a player is entitled to keep across a fresh
+# restart -- their unlocked BUILDING SETS/pieces (dune.building_progression) and
+# COSMETICS (actors.properties->CustomizationLibraryActorComponent). Character
+# NAME is the stable key across delete+recreate (account_id / character_id change;
+# the name does not). Flow:
+#   1) Snapshot builds + cosmetics BEFORE the delete -> saved to
+#      %APPDATA%\DuneServer\fresh-start-snapshots.json keyed by name.
+#   2) Player deletes + recreates the character in-game with the SAME name, spawns.
+#   3) Restore-by-name grants the snapshot's building sets + cosmetics onto the
+#      new character (offline-only; unioned with the fresh character's starter set
+#      so nothing is lost).
+# ---------------------------------------------------------------------------
+
+function Get-DuneFreshStartSnapshotPath {
+    $dir = Join-Path $env:APPDATA 'DuneServer'
+    if (-not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
+    return (Join-Path $dir 'fresh-start-snapshots.json')
+}
+
+function Get-DuneFreshStartSnapshots {
+    $path = Get-DuneFreshStartSnapshotPath
+    if (-not (Test-Path -LiteralPath $path)) { return @() }
+    try {
+        $raw = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
+        if (-not $raw) { return @() }
+        $obj = $raw | ConvertFrom-Json -ErrorAction Stop
+        $list = if ($obj -is [System.Array]) { $obj } elseif ($obj.snapshots) { $obj.snapshots } else { @() }
+        return @($list)
+    } catch { return @() }
+}
+
+function Save-DuneFreshStartSnapshots {
+    param($Snapshots)
+    $path = Get-DuneFreshStartSnapshotPath
+    $json = @{ snapshots = @($Snapshots) } | ConvertTo-Json -Depth 60
+    $tmp = "$path.tmp"
+    Set-Content -LiteralPath $tmp -Value $json -Encoding UTF8 -Force
+    Move-Item -LiteralPath $tmp -Destination $path -Force
+}
+
+# Metadata-only list of saved snapshots for the UI (no bulky cosmetics blob).
+function Get-DuneFreshStartSnapshotList {
+    $out = @()
+    foreach ($s in (Get-DuneFreshStartSnapshots)) {
+        $out += [ordered]@{
+            name      = [string]$s.name
+            saved_at  = [string]$s.saved_at
+            sets      = @($s.building_sets).Count
+            pieces    = @($s.buildable_pieces).Count
+            cosmetics = [bool]([string]$s.cosmetics)
+        }
+    }
+    return @($out)
+}
+
+# Capture a character's unlocked building sets/pieces + cosmetics to the snapshot
+# store, keyed by character name. Run this BEFORE the player deletes the character
+# (the data is character-bound and is destroyed with the character).
+function Invoke-DunePlayerSnapshotBuilds {
     param([string]$Ip, [long]$AccountId)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
-
-    $controllerID = Get-DunePlayerControllerFromAccount -Ip $Ip -AccountId $AccountId
-    if ($controllerID -le 0) { return @{ ok = $false; error = "no player_controller for account $AccountId." } }
     $pawnID = Get-DunePlayerPawnFromAccount -Ip $Ip -AccountId $AccountId
     if ($pawnID -le 0) { return @{ ok = $false; error = "no pawn for account $AccountId." } }
 
-    $charScope = "character_id IN (SELECT id FROM dune.player_state WHERE account_id=$AccountId::bigint)"
+    $sql = @"
+SELECT
+  (SELECT character_name FROM dune.player_state WHERE account_id=$AccountId::bigint LIMIT 1) AS name,
+  (SELECT id::text FROM dune.player_state WHERE account_id=$AccountId::bigint LIMIT 1) AS character_id,
+  (SELECT to_json(learned_building_sets)::text FROM dune.building_progression WHERE character_id=(SELECT id FROM dune.player_state WHERE account_id=$AccountId::bigint LIMIT 1)) AS sets,
+  (SELECT to_json(new_buildable_pieces)::text FROM dune.building_progression WHERE character_id=(SELECT id FROM dune.player_state WHERE account_id=$AccountId::bigint LIMIT 1)) AS pieces,
+  (SELECT (properties #> '{CustomizationLibraryActorComponent,m_UnlockedCustomizationSerializableList}')::text FROM dune.actors WHERE id=$pawnID::bigint) AS cosmetics;
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 30
+    if (-not $r.ok) { return @{ ok = $false; error = "snapshot read: $($r.error)" } }
+    $maps = ConvertTo-DuneRowMaps -Result $r
+    if ($maps.Count -eq 0) { return @{ ok = $false; error = "no character for account $AccountId." } }
+    $row = $maps[0]
+    $name = [string]$row['name']
+    if (-not $name) { return @{ ok = $false; error = 'character has no name.' } }
 
-    # --- Step 1: DML-only wipes in one transaction ------------------------------
-    $sb = [System.Text.StringBuilder]::new()
-    [void]$sb.AppendLine('BEGIN;')
-    # Journey: reset every node EXCEPT Steam achievements (DA_ACH%) to incomplete
-    # (complete + reveal -> false), NOT delete -- deleting can stop the game
-    # re-offering quests, so the player could not actually replay them.
-    [void]$sb.AppendLine("UPDATE dune.journey_story_node SET complete_condition_state='false'::jsonb, reveal_condition_state='false'::jsonb, has_pending_reward=false WHERE $charScope AND story_node_id NOT LIKE 'DA_ACH%';")
-    # Progression tags: explicit prefix ALLOW-LIST (NOT delete-all). Cosmetic /
-    # building-set / achievement state does not live under these prefixes and so
-    # survives. Contract.Tracking.*Kill* kill-counter tags match Contract.% and
-    # are removed here (kills have no dedicated table).
-    $tagLikes = @(
-        "tag LIKE 'Contract.%'", "tag LIKE 'Journey.%'", "tag LIKE 'JourneySets.%'",
-        "tag LIKE 'DialogueFlags.%'", "tag LIKE 'Exploration.%'", "tag LIKE 'DunipediaFlags.%'",
-        "tag LIKE 'BigMoments.%'", "tag LIKE 'NPE.%'", "tag LIKE 'Faction.%'",
-        "tag LIKE 'Character.Keystone.%'"
-    ) -join ' OR '
-    [void]$sb.AppendLine("DELETE FROM dune.player_tags WHERE $charScope AND ($tagLikes);")
-    # Contract items: remove ALL contract cards in the pawn's contract inventory
-    # (inventory_type 29), then reset the tracked-contract pointer -- every item is
-    # gone so any non-'!!itm#0' value now dangles.
-    [void]$sb.AppendLine("DELETE FROM dune.items WHERE template_id='ContractItem' AND inventory_id IN (SELECT id FROM dune.inventories WHERE actor_id=$pawnID::bigint AND inventory_type=29);")
-    [void]$sb.AppendLine("UPDATE dune.actors a SET properties = jsonb_set(a.properties, '{ContractsCoordinatorComponent,m_TrackedContractItemUid}', to_jsonb('!!itm#0'::text)) WHERE a.id=$pawnID::bigint AND a.properties ? 'ContractsCoordinatorComponent' AND COALESCE(a.properties->'ContractsCoordinatorComponent'->>'m_TrackedContractItemUid','!!itm#0') <> '!!itm#0';")
-    # Crafting recipes: empty the known-recipe list (verified shape: single
-    # m_KnownItemRecipes array of recipe objects, ~496 entries on a maxed char).
-    [void]$sb.AppendLine("UPDATE dune.actors SET properties = jsonb_set(properties, '{CraftingRecipesLibraryActorComponent,m_KnownItemRecipes}', '[]'::jsonb) WHERE id=$pawnID::bigint AND properties #> '{CraftingRecipesLibraryActorComponent,m_KnownItemRecipes}' IS NOT NULL;")
-    # Tech knowledge: empty the learned-tech list ONLY. Intel currency
-    # (m_TechKnowledgePoints) and m_NextTechTreeUpgradeIndex are intentionally KEPT
-    # per the locked scope -- do not blind-null the whole component.
-    [void]$sb.AppendLine("UPDATE dune.actors SET properties = jsonb_set(properties, '{TechKnowledgePlayerComponent,m_TechKnowledge,m_TechKnowledgeData}', '[]'::jsonb) WHERE id=$pawnID::bigint AND properties #> '{TechKnowledgePlayerComponent,m_TechKnowledge,m_TechKnowledgeData}' IS NOT NULL;")
-    [void]$sb.AppendLine('COMMIT;')
+    $sets = @(); $pieces = @()
+    try { if ([string]$row['sets'])   { $sets   = @([string]$row['sets']   | ConvertFrom-Json) } } catch {}
+    try { if ([string]$row['pieces']) { $pieces = @([string]$row['pieces'] | ConvertFrom-Json) } } catch {}
+    $cosmeticsJson = [string]$row['cosmetics']
 
-    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sb.ToString() -ReadOnly $false -MaxRows 1 -TimeoutSec 120
-    if (-not $r.ok) {
-        Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
-        return @{ ok = $false; error = "fresh-start core tx: $($r.error)" }
+    $snap = [ordered]@{
+        name             = $name
+        saved_at         = (Get-Date).ToUniversalTime().ToString('o')
+        account_id       = $AccountId
+        character_id     = [int64](ConvertTo-DuneInt $row['character_id'])
+        building_sets    = @($sets)
+        buildable_pieces = @($pieces)
+        cosmetics        = $cosmeticsJson   # raw JSON string, reapplied verbatim
     }
+    # Replace any existing snapshot for the same name (case-insensitive -ne).
+    $others = @(Get-DuneFreshStartSnapshots | Where-Object { [string]$_.name -ne $name })
+    Save-DuneFreshStartSnapshots -Snapshots (@($snap) + $others)
 
-    # --- Step 2: faction (rep + alignment + faction tags + ClimbTheRanks +
-    # faction contract items/pointer). Own transaction; idempotent.
-    $fr = Invoke-DunePlayerResetFaction -Ip $Ip -AccountId $AccountId -Faction 'both'
-    if (-not $fr.ok) { return @{ ok = $false; error = "fresh-start faction: $($fr.error)"; partial = $true } }
-
-    # --- Step 3: specializations + keystones (keyed by controller id).
-    $sr = Invoke-DunePlayerResetAllSpecs -Ip $Ip -ControllerId $controllerID
-    if (-not $sr.ok) { return @{ ok = $false; error = "fresh-start specs: $($sr.error)"; partial = $true } }
-
+    $cosMsg = if ($cosmeticsJson) { 'cosmetics captured' } else { 'no cosmetics found' }
     return @{
         ok = $true
-        message = "Fresh Start complete for account $AccountId - journey reset (Steam achievements kept), progression tags removed, faction + contracts cleared, crafting recipes + tech knowledge wiped, specializations + keystones reset. KEPT: cosmetics, building sets, Steam achievements, inventory, bases, Intel, class skill trees. Takes effect on next login."
-        kept  = @('cosmetics','building sets','Steam achievements','inventory','bases','Intel','class skill trees')
-        wiped = @('journey','progression tags','faction','contracts','crafting recipes','tech knowledge','specializations','keystones')
+        message = "Snapshot saved for '$name' - $($sets.Count) building set(s), $($pieces.Count) piece(s), $cosMsg. Now delete + recreate the character with the SAME name in-game, spawn, then use Restore."
+        name = $name; sets = $sets.Count; pieces = $pieces.Count; cosmetics = [bool]$cosmeticsJson
+    }
+}
+
+# Restore a saved snapshot's building sets/pieces + cosmetics onto the CURRENT
+# live character with the given name (the freshly recreated one). Offline-only:
+# building_progression and the pawn cosmetics component are RAM-authoritative
+# while connected. Unions with whatever the fresh character already has so its
+# starter unlocks are never lost.
+function Invoke-DunePlayerRestoreBuilds {
+    param([string]$Ip, [string]$Name)
+    if (-not $Name) { return @{ ok = $false; error = 'name is required.' } }
+    $snap = @(Get-DuneFreshStartSnapshots | Where-Object { [string]$_.name -eq $Name })
+    if ($snap.Count -eq 0) { return @{ ok = $false; error = "no saved snapshot for '$Name' - snapshot the character before deleting it." } }
+    $s = $snap[0]
+
+    $safeName = ConvertTo-DuneSqlString $Name
+    $idSql = "SELECT id::text AS cid, player_pawn_id::text AS pawn FROM dune.player_state WHERE character_name = '$safeName' ORDER BY last_login_time DESC NULLS LAST LIMIT 1;"
+    $ir = Invoke-DuneSqlQuery -Ip $Ip -Sql $idSql -ReadOnly $true -MaxRows 1 -TimeoutSec 15
+    if (-not $ir.ok) { return @{ ok = $false; error = "resolve character: $($ir.error)" } }
+    $imaps = ConvertTo-DuneRowMaps -Result $ir
+    if ($imaps.Count -eq 0) { return @{ ok = $false; error = "no live character named '$Name' - recreate it (same name) and spawn in first, then restore." } }
+    $charID = [int64](ConvertTo-DuneInt $imaps[0]['cid'])
+    $pawnID = [int64](ConvertTo-DuneInt $imaps[0]['pawn'])
+    if ($charID -le 0 -or $pawnID -le 0) { return @{ ok = $false; error = "character '$Name' has no pawn yet - spawn in first." } }
+
+    # Offline-only guard (pawn cosmetics + building_progression are overwritten on
+    # logout otherwise).
+    $off = Test-DunePlayerOffline -Ip $Ip -PawnId $pawnID
+    if (-not $off.ok) { return @{ ok = $false; error = "Player must be offline to restore builds. $($off.reason)" } }
+
+    $setsArr   = ConvertTo-DunePgTextArray (@($s.building_sets)    | ForEach-Object { [string]$_ })
+    $piecesArr = ConvertTo-DunePgTextArray (@($s.buildable_pieces) | ForEach-Object { [string]$_ })
+    $cosmetics = [string]$s.cosmetics
+
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine('BEGIN;')
+    # Building sets/pieces: union the snapshot into the current row (a fresh char
+    # always has a building_progression row with its starter sets).
+    [void]$sb.AppendLine("UPDATE dune.building_progression SET learned_building_sets = ARRAY(SELECT DISTINCT unnest(COALESCE(learned_building_sets,'{}'::text[]) || $setsArr)), new_buildable_pieces = ARRAY(SELECT DISTINCT unnest(COALESCE(new_buildable_pieces,'{}'::text[]) || $piecesArr)) WHERE character_id=$charID::bigint;")
+    # If the fresh char somehow has no row yet, insert one.
+    [void]$sb.AppendLine("INSERT INTO dune.building_progression (character_id, learned_building_sets, new_buildable_pieces) SELECT $charID::bigint, $setsArr, $piecesArr WHERE NOT EXISTS (SELECT 1 FROM dune.building_progression WHERE character_id=$charID::bigint);")
+    # Cosmetics: shallow-merge the snapshot's unlock object into the pawn's
+    # (snapshot is a superset, so its keys win).
+    if ($cosmetics) {
+        $safeCos = ConvertTo-DuneSqlString $cosmetics
+        [void]$sb.AppendLine("UPDATE dune.actors SET properties = jsonb_set(COALESCE(properties,'{}'::jsonb), '{CustomizationLibraryActorComponent,m_UnlockedCustomizationSerializableList}', COALESCE(properties #> '{CustomizationLibraryActorComponent,m_UnlockedCustomizationSerializableList}','{}'::jsonb) || '$safeCos'::jsonb, true) WHERE id=$pawnID::bigint;")
+    }
+    [void]$sb.AppendLine('COMMIT;')
+
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sb.ToString() -ReadOnly $false -MaxRows 1 -TimeoutSec 60
+    if (-not $r.ok) {
+        Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
+        return @{ ok = $false; error = "restore builds tx: $($r.error)" }
+    }
+    $cosMsg = if ($cosmetics) { ' + cosmetics' } else { '' }
+    return @{
+        ok = $true
+        message = "Restored builds for '$Name' - $(@($s.building_sets).Count) building set(s), $(@($s.buildable_pieces).Count) piece(s)$cosMsg. Takes effect on next login."
+        sets = @($s.building_sets).Count; pieces = @($s.buildable_pieces).Count
     }
 }
 

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1352,6 +1352,99 @@ WHERE a.id = $pawnID::bigint
     return @{ ok = $true; cleared = (Get-DuneSqlAffected $r) }
 }
 
+# ---------------------------------------------------------------------------
+# Fresh Start (keep unlocks) -- hardest-possible progression reset. Wipes a
+# character's story/quest/faction/contract progression AND character power
+# (crafting recipes, tech-knowledge data, specializations + keystones) so the
+# player can replay ALL content, while KEEPING only: cosmetics
+# (CustomizationLibraryActorComponent), building sets (dune.building_progression),
+# and Steam achievements (journey nodes 'DA_ACH%'). Inventory, bases, Intel
+# (m_TechKnowledgePoints) and class skill-tree modules are left untouched
+# (Coastal's locked scope, 2026-07-03).
+#
+# Offline-only (route-gated): journey rows, player_tags, and the pawn component
+# blobs are RAM-authoritative while the player is connected, so an online edit is
+# overwritten on logout -- same guard as Reset Faction / Wipe Journey.
+#
+# Composition: a single transaction for the DML-only wipes (journey / tags /
+# contract items+pointer / recipe + tech-knowledge blobs) then the two existing
+# helpers that run their own transactions -- Invoke-DunePlayerResetFaction (rep,
+# alignment, faction tags, ClimbTheRanks, faction contract items) and
+# Invoke-DunePlayerResetAllSpecs (specialization_tracks + keystones). Every step
+# is idempotent, so a partial failure is safe to re-run.
+#
+# WARNING - FRAGILE keep/wipe boundaries: Funcom renames tag prefixes and
+# journey node-id patterns every patch (they already rekeyed player_tags and
+# journey account_id -> character_id). Re-verify 'DA_ACH%', the tag allow-list,
+# and the component JSON paths against a reference character each server update;
+# never hardcode blindly. Chroma:
+# dst-fresh-start-feature-spec-and-fragile-keep-wipe-classification-2026-07-03.
+function Invoke-DunePlayerFreshStart {
+    param([string]$Ip, [long]$AccountId)
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+
+    $controllerID = Get-DunePlayerControllerFromAccount -Ip $Ip -AccountId $AccountId
+    if ($controllerID -le 0) { return @{ ok = $false; error = "no player_controller for account $AccountId." } }
+    $pawnID = Get-DunePlayerPawnFromAccount -Ip $Ip -AccountId $AccountId
+    if ($pawnID -le 0) { return @{ ok = $false; error = "no pawn for account $AccountId." } }
+
+    $charScope = "character_id IN (SELECT id FROM dune.player_state WHERE account_id=$AccountId::bigint)"
+
+    # --- Step 1: DML-only wipes in one transaction ------------------------------
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine('BEGIN;')
+    # Journey: reset every node EXCEPT Steam achievements (DA_ACH%) to incomplete
+    # (complete + reveal -> false), NOT delete -- deleting can stop the game
+    # re-offering quests, so the player could not actually replay them.
+    [void]$sb.AppendLine("UPDATE dune.journey_story_node SET complete_condition_state='false'::jsonb, reveal_condition_state='false'::jsonb, has_pending_reward=false WHERE $charScope AND story_node_id NOT LIKE 'DA_ACH%';")
+    # Progression tags: explicit prefix ALLOW-LIST (NOT delete-all). Cosmetic /
+    # building-set / achievement state does not live under these prefixes and so
+    # survives. Contract.Tracking.*Kill* kill-counter tags match Contract.% and
+    # are removed here (kills have no dedicated table).
+    $tagLikes = @(
+        "tag LIKE 'Contract.%'", "tag LIKE 'Journey.%'", "tag LIKE 'JourneySets.%'",
+        "tag LIKE 'DialogueFlags.%'", "tag LIKE 'Exploration.%'", "tag LIKE 'DunipediaFlags.%'",
+        "tag LIKE 'BigMoments.%'", "tag LIKE 'NPE.%'", "tag LIKE 'Faction.%'",
+        "tag LIKE 'Character.Keystone.%'"
+    ) -join ' OR '
+    [void]$sb.AppendLine("DELETE FROM dune.player_tags WHERE $charScope AND ($tagLikes);")
+    # Contract items: remove ALL contract cards in the pawn's contract inventory
+    # (inventory_type 29), then reset the tracked-contract pointer -- every item is
+    # gone so any non-'!!itm#0' value now dangles.
+    [void]$sb.AppendLine("DELETE FROM dune.items WHERE template_id='ContractItem' AND inventory_id IN (SELECT id FROM dune.inventories WHERE actor_id=$pawnID::bigint AND inventory_type=29);")
+    [void]$sb.AppendLine("UPDATE dune.actors a SET properties = jsonb_set(a.properties, '{ContractsCoordinatorComponent,m_TrackedContractItemUid}', to_jsonb('!!itm#0'::text)) WHERE a.id=$pawnID::bigint AND a.properties ? 'ContractsCoordinatorComponent' AND COALESCE(a.properties->'ContractsCoordinatorComponent'->>'m_TrackedContractItemUid','!!itm#0') <> '!!itm#0';")
+    # Crafting recipes: empty the known-recipe list (verified shape: single
+    # m_KnownItemRecipes array of recipe objects, ~496 entries on a maxed char).
+    [void]$sb.AppendLine("UPDATE dune.actors SET properties = jsonb_set(properties, '{CraftingRecipesLibraryActorComponent,m_KnownItemRecipes}', '[]'::jsonb) WHERE id=$pawnID::bigint AND properties #> '{CraftingRecipesLibraryActorComponent,m_KnownItemRecipes}' IS NOT NULL;")
+    # Tech knowledge: empty the learned-tech list ONLY. Intel currency
+    # (m_TechKnowledgePoints) and m_NextTechTreeUpgradeIndex are intentionally KEPT
+    # per the locked scope -- do not blind-null the whole component.
+    [void]$sb.AppendLine("UPDATE dune.actors SET properties = jsonb_set(properties, '{TechKnowledgePlayerComponent,m_TechKnowledge,m_TechKnowledgeData}', '[]'::jsonb) WHERE id=$pawnID::bigint AND properties #> '{TechKnowledgePlayerComponent,m_TechKnowledge,m_TechKnowledgeData}' IS NOT NULL;")
+    [void]$sb.AppendLine('COMMIT;')
+
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sb.ToString() -ReadOnly $false -MaxRows 1 -TimeoutSec 120
+    if (-not $r.ok) {
+        Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
+        return @{ ok = $false; error = "fresh-start core tx: $($r.error)" }
+    }
+
+    # --- Step 2: faction (rep + alignment + faction tags + ClimbTheRanks +
+    # faction contract items/pointer). Own transaction; idempotent.
+    $fr = Invoke-DunePlayerResetFaction -Ip $Ip -AccountId $AccountId -Faction 'both'
+    if (-not $fr.ok) { return @{ ok = $false; error = "fresh-start faction: $($fr.error)"; partial = $true } }
+
+    # --- Step 3: specializations + keystones (keyed by controller id).
+    $sr = Invoke-DunePlayerResetAllSpecs -Ip $Ip -ControllerId $controllerID
+    if (-not $sr.ok) { return @{ ok = $false; error = "fresh-start specs: $($sr.error)"; partial = $true } }
+
+    return @{
+        ok = $true
+        message = "Fresh Start complete for account $AccountId - journey reset (Steam achievements kept), progression tags removed, faction + contracts cleared, crafting recipes + tech knowledge wiped, specializations + keystones reset. KEPT: cosmetics, building sets, Steam achievements, inventory, bases, Intel, class skill trees. Takes effect on next login."
+        kept  = @('cosmetics','building sets','Steam achievements','inventory','bases','Intel','class skill trees')
+        wiped = @('journey','progression tags','faction','contracts','crafting recipes','tech knowledge','specializations','keystones')
+    }
+}
+
 function Invoke-DunePlayerCompleteContracts {
     param([string]$Ip, [long]$AccountId, [string[]]$ContractIds)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -212,24 +212,42 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/faction/reset' -Han
     }
 }
 
-# POST /api/gameplay/players/fresh-start  { account_id }
-# Hardest-possible progression reset: wipes journey/quests, progression tags,
-# faction, contracts, crafting recipes, tech-knowledge data, specializations +
-# keystones; KEEPS cosmetics, building sets, Steam achievements, inventory, bases,
-# Intel and class skill-tree modules. Offline-only (RAM-authoritative writes).
-Register-DuneRoute -Method POST -Path '/api/gameplay/players/fresh-start' -Handler {
+# POST /api/gameplay/players/fresh-start/snapshot  { account_id }
+# Capture the character's building sets/pieces + cosmetics to the snapshot store
+# (keyed by name). Run BEFORE the player deletes their character in-game.
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/fresh-start/snapshot' -Handler {
     param($req, $res, $routeParams, $body)
     try {
         $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
         if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
-        Invoke-DunePlayerWriteRoute -Response $res -Action {
-            param($ip)
-            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
-            if (-not $off.ok) { return @{ ok = $false; error = "Player must be offline to run a Fresh Start. $($off.reason)" } }
-            Invoke-DunePlayerFreshStart -Ip $ip -AccountId $acc
-        }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerSnapshotBuilds -Ip $ip -AccountId $acc }
     } catch {
-        Write-DuneError -Response $res -Status 500 -Message "Fresh Start failed: $($_.Exception.Message)"
+        Write-DuneError -Response $res -Status 500 -Message "Snapshot builds failed: $($_.Exception.Message)"
+    }
+}
+
+# GET /api/gameplay/players/fresh-start/snapshots  -> saved snapshot metadata
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/fresh-start/snapshots' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $list = Get-DuneFreshStartSnapshotList
+        Write-DuneJson -Response $res -Body @{ ok = $true; snapshots = @($list) }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "List snapshots failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/fresh-start/restore  { name }
+# Grant a saved snapshot's building sets + cosmetics onto the current live
+# character with that name (the recreated one). Offline-only (checked in-helper).
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/fresh-start/restore' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $name = [string](Get-DuneBodyValue -Body $body -Name 'name')
+        if (-not $name) { Write-DuneError -Response $res -Status 400 -Message 'name is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DunePlayerRestoreBuilds -Ip $ip -Name $name }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Restore builds failed: $($_.Exception.Message)"
     }
 }
 

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -212,6 +212,27 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/faction/reset' -Han
     }
 }
 
+# POST /api/gameplay/players/fresh-start  { account_id }
+# Hardest-possible progression reset: wipes journey/quests, progression tags,
+# faction, contracts, crafting recipes, tech-knowledge data, specializations +
+# keystones; KEEPS cosmetics, building sets, Steam achievements, inventory, bases,
+# Intel and class skill-tree modules. Offline-only (RAM-authoritative writes).
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/fresh-start' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
+        if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
+            if (-not $off.ok) { return @{ ok = $false; error = "Player must be offline to run a Fresh Start. $($off.reason)" } }
+            Invoke-DunePlayerFreshStart -Ip $ip -AccountId $acc
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Fresh Start failed: $($_.Exception.Message)"
+    }
+}
+
 # POST /api/gameplay/players/progression/apply-preset  { account_id, preset_id }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/progression/apply-preset' -Handler {
     param($req, $res, $routeParams, $body)

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.15.2"
+$script:ToolVersion = "12.16.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1784,6 +1784,16 @@ export function resetFaction(accountId: number, faction: 'atreides' | 'harkonnen
   })
 }
 
+// Fresh Start (keep unlocks) — hardest-possible progression reset. Wipes
+// journey/quests, progression tags, faction, contracts, crafting recipes,
+// tech-knowledge data, specializations + keystones; keeps cosmetics, building
+// sets, Steam achievements, inventory, bases, Intel and class skill trees.
+export function freshStart(accountId: number) {
+  return api<WriteResult>('/api/gameplay/players/fresh-start', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId }),
+  })
+}
+
 // Journey Nodes browser — reads every journey_story_node row for the account.
 export interface JourneyNode {
   node_id: string

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1784,13 +1784,31 @@ export function resetFaction(accountId: number, faction: 'atreides' | 'harkonnen
   })
 }
 
-// Fresh Start (keep unlocks) — hardest-possible progression reset. Wipes
-// journey/quests, progression tags, faction, contracts, crafting recipes,
-// tech-knowledge data, specializations + keystones; keeps cosmetics, building
-// sets, Steam achievements, inventory, bases, Intel and class skill trees.
-export function freshStart(accountId: number) {
-  return api<WriteResult>('/api/gameplay/players/fresh-start', {
+// Fresh Start (keep builds & cosmetics) — snapshot + restore-by-name.
+// A truly-fresh character can only be made by the engine (delete + recreate
+// in-game). DST preserves the player's unlocked building sets + cosmetics: snapshot
+// them BEFORE the delete, then restore them by name onto the recreated character.
+export interface FreshStartSnapshot {
+  name: string
+  saved_at: string
+  sets: number
+  pieces: number
+  cosmetics: boolean
+}
+
+export function snapshotBuilds(accountId: number) {
+  return api<WriteResult>('/api/gameplay/players/fresh-start/snapshot', {
     method: 'POST', body: JSON.stringify({ account_id: accountId }),
+  })
+}
+
+export function getFreshStartSnapshots() {
+  return api<{ ok: boolean; snapshots: FreshStartSnapshot[] }>('/api/gameplay/players/fresh-start/snapshots')
+}
+
+export function restoreBuilds(name: string) {
+  return api<WriteResult>('/api/gameplay/players/fresh-start/restore', {
+    method: 'POST', body: JSON.stringify({ name }),
   })
 }
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -25,7 +25,7 @@ import {
   resetAllKeystones, resetAllSpecs, resetJourney, resetProgressionLive, resetSpec,
   restoreDestroyed,
   setFactionTier, setPlayerTags, setSkillPoints,
-  setStarterClass, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, wipeJourney, resetFaction,
+  setStarterClass, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, wipeJourney, resetFaction, freshStart,
   chatWhisper, isValidTemplateId, getItemCatalog, getCosmeticsCatalog, type CosmeticEntry,
   parseTcnoPackageText,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
@@ -663,6 +663,26 @@ const ACTIONS: ActionDef[] = [
   { id: 'reset-faction', group: 'Progression', label: 'Reset Faction', icon: 'Swords', custom: 'reset-faction', offlineOnly: true,
     rowNote: 'Wipe ALL faction rep + tags + ClimbTheRanks nodes to start fresh. Player must be offline.',
     run: () => Promise.resolve({ message: '' }) },
+  { id: 'fresh-start', group: 'Progression', label: 'Fresh Start (keep unlocks)', icon: 'Sunrise',
+    offlineOnly: true, doubleConfirm: true,
+    rowNote: 'Double confirmation required',
+    confirm: p => `FRESH START for ${p.name} — restart all content from the beginning.\n\n` +
+      `KEEPS: cosmetics, building sets, Steam achievements, inventory + bases, Intel, class skill trees.\n` +
+      `WIPES: journey / quests, all progression tags, faction, contracts, crafting recipes, tech knowledge, specializations + keystones.\n\n` +
+      `Player must be OFFLINE. Take a battlegroup backup first — this cannot be undone.\n\n` +
+      `This is the FIRST of two confirmations. If you continue, the next step asks you to type an acknowledgement before anything is wiped.`,
+    run: p => {
+      const typed = window.prompt(
+        `SECOND confirmation — FRESH START for ${p.name}.\n` +
+        `Wipes progression + power; keeps cosmetics / building sets / Steam achievements / inventory / bases / Intel / skill trees.\n` +
+        `This cannot be undone.\n\n` +
+        `Type  fresh start  to proceed:`
+      ) || ''
+      if (typed.trim().toLowerCase() !== 'fresh start') {
+        throw new Error('Did not type "fresh start" — Fresh Start aborted.')
+      }
+      return freshStart(p.account_id)
+    } },
 
   // ----- Items -----
   { id: 'give-item',      group: 'Items', label: 'Give Item', icon: 'PackagePlus', custom: 'give-item',

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -25,7 +25,7 @@ import {
   resetAllKeystones, resetAllSpecs, resetJourney, resetProgressionLive, resetSpec,
   restoreDestroyed,
   setFactionTier, setPlayerTags, setSkillPoints,
-  setStarterClass, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, wipeJourney, resetFaction, freshStart,
+  setStarterClass, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, wipeJourney, resetFaction, snapshotBuilds, getFreshStartSnapshots, restoreBuilds,
   chatWhisper, isValidTemplateId, getItemCatalog, getCosmeticsCatalog, type CosmeticEntry,
   parseTcnoPackageText,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
@@ -36,7 +36,7 @@ import {
   getContracts, completeContract,
   getVehicleKitCatalog,
   type Player, type PlayerEvent, type PlayerStats, type ProgressionPreset, type SpecTrackFull,
-  type CatalogItem, type ItemPackage, type GiveItemEntry,
+  type CatalogItem, type ItemPackage, type GiveItemEntry, type FreshStartSnapshot,
   type LandsraadHouse, type LandsraadIniSetting,
   type JourneyNode, type TrainerInfo, type TrainerStatus, type MainQuestInfo,
   type PlayerVehicleRow, type TeleportDestination,
@@ -571,7 +571,7 @@ interface ActionDef {
   liveOnly?: boolean      // requires player to be online (RMQ path)
   offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   fields?: ActionField[]
-  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'complete-contract' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'update-tags' | 'teleport-player' | 'teleport-location' | 'set-respawn' | 'reset-faction' | 'grant-cosmetic'
+  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'complete-contract' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'update-tags' | 'teleport-player' | 'teleport-location' | 'set-respawn' | 'reset-faction' | 'grant-cosmetic' | 'fresh-start'
   balance?: 'solari' | 'scrip' | 'intel'  // show the player's current balance read-only above the form
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
@@ -663,26 +663,9 @@ const ACTIONS: ActionDef[] = [
   { id: 'reset-faction', group: 'Progression', label: 'Reset Faction', icon: 'Swords', custom: 'reset-faction', offlineOnly: true,
     rowNote: 'Wipe ALL faction rep + tags + ClimbTheRanks nodes to start fresh. Player must be offline.',
     run: () => Promise.resolve({ message: '' }) },
-  { id: 'fresh-start', group: 'Progression', label: 'Fresh Start (keep unlocks)', icon: 'Sunrise',
-    offlineOnly: true, doubleConfirm: true,
-    rowNote: 'Double confirmation required',
-    confirm: p => `FRESH START for ${p.name} — restart all content from the beginning.\n\n` +
-      `KEEPS: cosmetics, building sets, Steam achievements, inventory + bases, Intel, class skill trees.\n` +
-      `WIPES: journey / quests, all progression tags, faction, contracts, crafting recipes, tech knowledge, specializations + keystones.\n\n` +
-      `Player must be OFFLINE. Take a battlegroup backup first — this cannot be undone.\n\n` +
-      `This is the FIRST of two confirmations. If you continue, the next step asks you to type an acknowledgement before anything is wiped.`,
-    run: p => {
-      const typed = window.prompt(
-        `SECOND confirmation — FRESH START for ${p.name}.\n` +
-        `Wipes progression + power; keeps cosmetics / building sets / Steam achievements / inventory / bases / Intel / skill trees.\n` +
-        `This cannot be undone.\n\n` +
-        `Type  fresh start  to proceed:`
-      ) || ''
-      if (typed.trim().toLowerCase() !== 'fresh start') {
-        throw new Error('Did not type "fresh start" — Fresh Start aborted.')
-      }
-      return freshStart(p.account_id)
-    } },
+  { id: 'fresh-start', group: 'Progression', label: 'Fresh Start (keep builds)', icon: 'Sunrise', custom: 'fresh-start',
+    rowNote: 'Snapshot builds + cosmetics, delete + recreate the character (same name) in-game, then restore. Offline to restore.',
+    run: () => Promise.resolve({ message: '' }) },
 
   // ----- Items -----
   { id: 'give-item',      group: 'Items', label: 'Give Item', icon: 'PackagePlus', custom: 'give-item',
@@ -1041,6 +1024,8 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
                 const r = await resetFaction(player.account_id, 'both')
                 return { message: r.message || `Reset faction for ${player.name}.` }
               })} />
+          ) : def.custom === 'fresh-start' ? (
+            <FreshStartForm busy={busy} player={player} runAction={runAction} />
           ) : def.custom === 'give-package' ? (
             <GivePackageForm busy={busy} playerName={player.name}
               onGive={(items, pkgName, overflow) => runAction(def, async () => {
@@ -1099,6 +1084,72 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
           )}
         </div>
       )}
+    </div>
+  )
+}
+
+// Fresh Start (keep builds & cosmetics) — two-step snapshot/restore flow. A truly
+// fresh character can only be produced by deleting + recreating it in-game; DST
+// snapshots the player's unlocked building sets + cosmetics beforehand and restores
+// them by NAME onto the recreated character (name is the stable key across delete).
+function FreshStartForm({ busy, player, runAction }: {
+  busy: boolean
+  player: Player
+  runAction: (def: ActionDef, exec: () => Promise<{ message: string }>) => void
+}) {
+  const [snap, setSnap] = useState<FreshStartSnapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const refresh = () => {
+    setLoading(true)
+    getFreshStartSnapshots()
+      .then(r => setSnap((r.snapshots || []).find(s => s.name.toLowerCase() === player.name.toLowerCase()) || null))
+      .catch(() => setSnap(null))
+      .finally(() => setLoading(false))
+  }
+  useEffect(() => { refresh() }, [player.name])
+  const localDef: ActionDef = { id: 'fresh-start', group: 'Progression', label: 'Fresh Start', icon: 'Sunrise', run: () => Promise.resolve({ message: '' }) }
+
+  return (
+    <div className="space-y-3 text-sm">
+      <div className="rounded-lg bg-surface-2 border border-border/50 p-3 text-text-dim text-xs leading-relaxed">
+        A real fresh start is done in-game: <b className="text-text">1)</b> snapshot below, <b className="text-text">2)</b> delete + recreate the character with the <b className="text-text">same name</b> (delete via the in-game Funcom browser so the name can be reused) and spawn in, <b className="text-text">3)</b> restore. Only the building sets + cosmetics you already unlocked are carried over — everything else (quests, skills, faction, tech) starts genuinely fresh from the game.
+      </div>
+
+      <div className="card p-3 space-y-2">
+        <div className="font-medium text-text flex items-center gap-2"><Icon name="Save" size={14} /> Step 1 — Snapshot builds &amp; cosmetics</div>
+        <div className="text-text-dim text-xs">Captures {player.name}'s unlocked building sets + cosmetics. Do this <b>before</b> deleting the character (the data is destroyed with the character).</div>
+        <button type="button" disabled={busy}
+          className="px-3 py-2 rounded-lg bg-ibad/20 border border-ibad/50 text-text hover:bg-ibad/30 disabled:opacity-50 text-sm font-medium"
+          onClick={() => runAction(localDef, async () => {
+            const r = await snapshotBuilds(player.account_id)
+            refresh()
+            return { message: r.message || `Snapshot saved for ${player.name}.` }
+          })}>
+          Snapshot {player.name}'s builds
+        </button>
+      </div>
+
+      <div className="card p-3 space-y-2">
+        <div className="font-medium text-text flex items-center gap-2"><Icon name="Sunrise" size={14} /> Step 2 — Restore builds by name</div>
+        {loading ? (
+          <div className="text-text-dim text-xs flex items-center gap-2"><Icon name="Loader2" size={13} className="animate-spin" /> Checking snapshots…</div>
+        ) : snap ? (
+          <>
+            <div className="text-text-dim text-xs">Saved snapshot for <b className="text-text">{snap.name}</b> — {snap.sets} building set{snap.sets === 1 ? '' : 's'}, {snap.pieces} piece{snap.pieces === 1 ? '' : 's'}{snap.cosmetics ? ' + cosmetics' : ''} ({new Date(snap.saved_at).toLocaleString()}).</div>
+            <div className="text-warning text-xs">Only after you've recreated the character (same name) and spawned in. Player must be offline.</div>
+            <button type="button" disabled={busy}
+              className="px-3 py-2 rounded-lg bg-info/20 border border-info/50 text-text hover:bg-info/30 disabled:opacity-50 text-sm font-medium"
+              onClick={() => runAction(localDef, async () => {
+                const r = await restoreBuilds(player.name)
+                return { message: r.message || `Restored builds for ${player.name}.` }
+              })}>
+              Restore {player.name}'s builds
+            </button>
+          </>
+        ) : (
+          <div className="text-text-dim text-xs">No saved snapshot for {player.name}. Snapshot first (Step 1).</div>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Fresh Start (keep builds & cosmetics) — v12.16.0

New **Players → Progression** action. A genuinely fresh character can only be produced in-game — the engine rebuilds the entire quest journal, skill trees, ability slots and starter content from the character on every login, so an in-place DB reset cannot make one (verified live: deleting all 1979 non-achievement journey rows just made the engine recreate + re-reveal them). Fresh Start instead preserves the two things a player is entitled to keep across a restart: unlocked **building sets/pieces** and **cosmetics**.

**Flow (character NAME is the stable key across delete+recreate):**
1. **Snapshot** the character's builds + cosmetics → saved to %APPDATA%\DuneServer\fresh-start-snapshots.json, keyed by name. Do this *before* deleting.
2. Player **deletes + recreates** the character in-game with the **same name** (via the in-game Funcom browser so the name is kept) and spawns fresh.
3. **Restore** — DST grants those builds + cosmetics back onto the fresh character by name (offline-only; unioned with the fresh starter set).

### Changes
- Backend (pp/server/lib/PlayersWrites.ps1): `Invoke-DunePlayerSnapshotBuilds` / `Get-DuneFreshStartSnapshotList` / `Invoke-DunePlayerRestoreBuilds` + snapshot-store helpers.
- Routes (pp/server/routes/PlayersWrites.ps1): `POST /api/gameplay/players/fresh-start/snapshot`, `GET .../snapshots`, `POST .../restore`.
- WebUI: two-step `FreshStartForm` + api client (`snapshotBuilds` / `getFreshStartSnapshots` / `restoreBuilds`).
- Version bump to 12.16.0 (5 stamps), CHANGELOG, bug-report template.

### Validation
- PowerShell parse-check clean (UTF-8 BOM preserved); `npm run build` clean (tsc passed).
- Restore SQL (building-set array union + cosmetics jsonb merge) validated against the live schema via ROLLBACK.
- Component shapes + engine-regeneration behaviour verified live on the reference server.