### PR TITLE
Fix Battlegroup Info panel breaking when server title contains spaces (v12.16.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.16.0"
+      placeholder: "v12.16.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [12.16.1] - 2026-07-03
+
+### Fixed
+
+- **Dashboard → Battlegroup info** now reads its five fields (Status / Database / Gateway / Director / Uptime) directly from the Battlegroup CRD JSON via `kubectl`, so a server title that contains spaces (e.g. `Reapers - DST`) no longer shifts every column. Root cause: Funcom's `battlegroup status` script parses `kubectl get battlegroups --no-headers` with positional `awk` tokens, so a multi-word TITLE was making the panel show garbage like *Database: 2, Gateway: Ready, Director: 2/2, Uptime: Healthy*. The raw-output pane (HIDE RAW OUTPUT toggle) still shows Funcom's script output unchanged for debugging.
+
 ## [12.16.0] - 2026-07-03
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.16.0'
+$script:DuneToolVersion = '12.16.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.16.0',
+    [string]$Version = '12.16.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.16.0</Version>
+    <Version>12.16.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.16.0"
+#define MyAppVersion "12.16.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Status.ps1
+++ b/app/server/lib/Status.ps1
@@ -187,15 +187,30 @@ function Get-DuneBattlegroupSnapshotFresh {
         # doesn't pop a transient conhost window for each spawn (the original
         # `& ssh ... 2>$errFile` allocates a fresh console when the runspace
         # parent's hidden console handle isn't inherited).
+        # Compound remote command: run Funcom's `battlegroup status` for the raw
+        # text pane + game-server table (kept as-is), THEN dump the Battlegroup
+        # CRD as JSON so we can rebuild the Battlegroup Info panel from
+        # canonical field values instead of the awk-parsed row Funcom's script
+        # emits. Reason: `battlegroup status` ultimately shells out to
+        # `sudo kubectl get battlegroups --no-headers | awk '{print $3, $6, ...}'`
+        # (fixed positional tokens), so a server TITLE with spaces
+        # (e.g. `Reapers - DST`) shifts every column and the Info panel shows
+        # `Database: 2, Gateway: Ready, …` instead of the real values. Reading
+        # from JSON (`.status.phase`, `.status.database.phase`,
+        # `.status.utilities.serverGateway.phase`, etc.) is immune to that.
+        # Sentinels split the two payloads inside a single SSH round-trip.
+        $remoteCmd = 'echo __DST_BG_STATUS_BEGIN__; /home/dune/.dune/bin/battlegroup status 2>&1; echo __DST_BG_STATUS_END__; echo __DST_BG_JSON_BEGIN__; NS=$(sudo /usr/local/bin/kubectl get ns --no-headers -o custom-columns=N:.metadata.name 2>/dev/null | grep -m1 ^funcom-seabass-); if [ -n "$NS" ]; then sudo /usr/local/bin/kubectl get battlegroups -n $NS -o json 2>/dev/null; fi; echo __DST_BG_JSON_END__'
         $r = Invoke-DuneSshHidden -Ip $vm.ip -KeyPath $sshKey -TimeoutSec 15 -SshOptions @(
             '-o','StrictHostKeyChecking=no'
             '-o','LogLevel=ERROR'
             '-o','ConnectTimeout=10'
             '-o','BatchMode=yes'
-        ) -RemoteCommand '/home/dune/.dune/bin/battlegroup status'
-        $raw    = $r.Stdout
+        ) -RemoteCommand $remoteCmd
+        $split  = Split-DuneBgCompoundOutput -Lines $r.Stdout
+        $raw    = $split.StatusLines
         $exit   = $r.Exit
         $sshErr = $r.Stderr
+        $bgJsonInfo = ConvertFrom-DuneBgJsonStatus -JsonText $split.JsonText
 
         # `battlegroup status` (a kubectl wrapper) can write status-shaped text —
         # notably the empty-namespace "No resources found" stopped signal — to
@@ -231,6 +246,17 @@ function Get-DuneBattlegroupSnapshotFresh {
         $result.name        = $parsed.name
         $result.info        = $parsed.info
         $result.gameServers = $parsed.gameServers
+        # Prefer the JSON-derived Info block when available: Funcom's
+        # `battlegroup status` script mangles this row when the server TITLE
+        # contains spaces (see the compound remote-command comment above), and
+        # JSON is the single source of truth for the five fields the Info
+        # panel shows. Falls back to the parsed text when JSON is missing
+        # (e.g. transient kubectl error or namespace lookup failure) so
+        # display doesn't get worse than before.
+        if ($bgJsonInfo) {
+            $result.info = $bgJsonInfo.info
+            if ($bgJsonInfo.name -and -not $result.name) { $result.name = $bgJsonInfo.name }
+        }
         return $result
     } catch {
         $msg = $_.Exception.Message
@@ -241,6 +267,125 @@ function Get-DuneBattlegroupSnapshotFresh {
         }
         return $result
     }
+}
+
+# Split the sentinel-delimited compound remote output into the raw
+# `battlegroup status` text (still used for the raw-output pane + the game
+# server table) and the raw `kubectl get battlegroups -o json` body. Any
+# stray shell lines outside both regions are discarded so a login MOTD or
+# `sudo` password prompt (shouldn't happen — sudoers is passwordless — but
+# would otherwise leak into the parsed text) can't slip into either payload.
+# Returns @{ StatusLines = string[]; JsonText = string }.
+function Split-DuneBgCompoundOutput {
+    param([string[]]$Lines)
+    $out = @{ StatusLines = @(); JsonText = '' }
+    if (-not $Lines) { return $out }
+    $statusBuf = New-Object System.Collections.Generic.List[string]
+    $jsonBuf   = New-Object System.Collections.Generic.List[string]
+    $mode = 'none'
+    foreach ($line in $Lines) {
+        switch -Regex ($line) {
+            '^__DST_BG_STATUS_BEGIN__\s*$' { $mode = 'status'; continue }
+            '^__DST_BG_STATUS_END__\s*$'   { $mode = 'none';   continue }
+            '^__DST_BG_JSON_BEGIN__\s*$'   { $mode = 'json';   continue }
+            '^__DST_BG_JSON_END__\s*$'     { $mode = 'none';   continue }
+            default {
+                if ($mode -eq 'status') { $statusBuf.Add($line) | Out-Null }
+                elseif ($mode -eq 'json') { $jsonBuf.Add($line) | Out-Null }
+            }
+        }
+    }
+    # No sentinels at all → treat every line as raw status text so callers on
+    # older VMs (or a partial SSH read) still see something usable.
+    if ($statusBuf.Count -eq 0 -and $jsonBuf.Count -eq 0) {
+        $out.StatusLines = @($Lines)
+        return $out
+    }
+    $out.StatusLines = @($statusBuf.ToArray())
+    $out.JsonText    = ($jsonBuf.ToArray() -join "`n").Trim()
+    return $out
+}
+
+# Parse `kubectl get battlegroups -n <ns> -o json` and return the Battlegroup
+# Info fields shown in the dashboard panel. Field paths were confirmed live
+# against the Funcom `igw.funcom.com/v1 BattleGroup` CRD:
+#   .status.phase                                → BG Status
+#   .status.database.phase                       → Database
+#   .status.utilities.serverGateway.phase        → Gateway
+#   .status.utilities.director.phase             → Director
+#   humanize(now − .status.startTimestamp)       → Uptime
+# Returns $null when JSON is missing or lacks a usable `.status` — the
+# caller then keeps the (pre-existing) text-parsed values so behaviour never
+# regresses below the current baseline.
+function ConvertFrom-DuneBgJsonStatus {
+    param([string]$JsonText)
+    if (-not $JsonText) { return $null }
+    try { $obj = $JsonText | ConvertFrom-Json -ErrorAction Stop } catch { return $null }
+    if (-not $obj) { return $null }
+    # `kubectl get battlegroups` returns a List; a single BG is expected but
+    # tolerate either shape defensively.
+    $item = $null
+    if ($obj.PSObject.Properties['items'] -and $obj.items) { $item = $obj.items[0] }
+    elseif ($obj.PSObject.Properties['status'])            { $item = $obj }
+    if (-not $item -or -not $item.status) { return $null }
+    $status = $item.status
+    $utilities = if ($status.PSObject.Properties['utilities']) { $status.utilities } else { $null }
+    $dbPhase  = if ($status.PSObject.Properties['database'] -and $status.database)  { $status.database.phase }  else { '' }
+    $gwPhase  = if ($utilities -and $utilities.PSObject.Properties['serverGateway'] -and $utilities.serverGateway) { $utilities.serverGateway.phase } else { '' }
+    $dirPhase = if ($utilities -and $utilities.PSObject.Properties['director']      -and $utilities.director)      { $utilities.director.phase }      else { '' }
+    $uptime = ''
+    if ($status.PSObject.Properties['startTimestamp'] -and $status.startTimestamp) {
+        try {
+            $raw = $status.startTimestamp
+            $dt = if ($raw -is [datetime]) {
+                $raw
+            } else {
+                [datetime]::Parse([string]$raw, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind)
+            }
+            $uptime = Format-DuneKubeAge -Start $dt
+        } catch {}
+    }
+    $name = ''
+    if ($item.PSObject.Properties['metadata'] -and $item.metadata -and $item.metadata.name) { $name = [string]$item.metadata.name }
+    return @{
+        info = @{
+            status   = if ($status.phase) { [string]$status.phase } else { '' }
+            database = if ($dbPhase)  { [string]$dbPhase }  else { '' }
+            gateway  = if ($gwPhase)  { [string]$gwPhase }  else { '' }
+            director = if ($dirPhase) { [string]$dirPhase } else { '' }
+            uptime   = [string]$uptime
+        }
+        name = $name
+    }
+}
+
+# Kubernetes-style humanized duration (matches `kubectl`'s AGE column via
+# k8s.io/apimachinery/pkg/util/duration.HumanDuration) so the Uptime cell
+# still reads "12m", "3h5m", "2d4h", "45d" like the original text row did.
+function Format-DuneKubeAge {
+    param([datetime]$Start)
+    $span = [datetime]::UtcNow - $Start.ToUniversalTime()
+    $s = [int64]$span.TotalSeconds
+    if ($s -lt 0) { return '0s' }
+    if ($s -lt 60)          { return "${s}s" }
+    $m = [int64]([math]::Floor($s / 60))
+    if ($m -lt 60)          { return "${m}m" }
+    $h = [int64]([math]::Floor($m / 60))
+    if ($h -lt 10) {
+        $mm = $m - $h * 60
+        if ($mm -gt 0) { return "${h}h${mm}m" }
+        return "${h}h"
+    }
+    if ($h -lt 48)          { return "${h}h" }
+    $d = [int64]([math]::Floor($h / 24))
+    if ($d -lt 8) {
+        $hh = $h - $d * 24
+        if ($hh -gt 0) { return "${d}d${hh}h" }
+        return "${d}d"
+    }
+    if ($d -lt 365 * 2)     { return "${d}d" }
+    $y = [int64]([math]::Floor($d / 365))
+    return "${y}y"
 }
 
 # Parse `battlegroup status` output into structured shape:

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.16.0"
+$script:ToolVersion = "12.16.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## What
Dashboard → **Battlegroup info** now reads its five fields (Status / Database / Gateway / Director / Uptime) from the Battlegroup CRD JSON via `sudo kubectl get battlegroups -n <ns> -o json` instead of Funcom's `battlegroup status` text.

## Why (verified live on the VM)
Funcom's `/home/dune/.dune/download/scripts/battlegroup.sh` pipes `sudo kubectl get battlegroups --no-headers` through `awk` with hardcoded positional column indexes (`$3, $6, $8, $9, $11`). When the server TITLE contains spaces, those extra tokens shift every column.

Live example after Coastal renamed the server to **Reapers - DST**:

```
Battlegroup Info
Status     Database   Gateway    Director   Uptime
---------- ---------- ---------- ---------- --------
-          2          Ready      2/2        Healthy
```

Every value was wrong. Actual truth from `kubectl get battlegroups`:

```
NAME  TITLE           PHASE     SIZE  SERVERGROUP  DATABASE  MQS  GATEWAY  DIRECTOR  AUTOSTOP  UPTIME  AGE
sh-…  Reapers - DST   Healthy   2     Running      Ready     2/2  Healthy  Healthy             12m     45d
```

## How
- One SSH round-trip now runs `battlegroup status` **and** `kubectl get battlegroups -n <ns> -o json`, split by sentinels.
- Info panel is rebuilt from JSON:
  - Status → `.status.phase`
  - Database → `.status.database.phase`
  - Gateway → `.status.utilities.serverGateway.phase`
  - Director → `.status.utilities.director.phase`
  - Uptime → humanised delta from `.status.startTimestamp` (kubectl-compatible `12m` / `3h5m` / `2d4h` / `45d`)
- Namespace is discovered inline via the existing `funcom-seabass-` prefix pattern used elsewhere in the code.
- Falls back to the pre-existing text parser if JSON is missing, so display never regresses.
- Raw-output pane (HIDE RAW OUTPUT) still shows Funcom's script unchanged — the mangled awk row is still visible there for debugging.

## Verified
Live SSH test against the current VM (`Reapers - DST` server, spaces in title):

| Field    | Before (script/awk)  | After (JSON)  |
| -------- | -------------------- | ------------- |
| Status   | – (blank)            | **Healthy**   |
| Database | 2                    | **Ready**     |
| Gateway  | Ready                | **Healthy**   |
| Director | 2/2                  | **Healthy**   |
| Uptime   | Healthy              | **15m**       |

## Release plumbing
- All 5 version stamps bumped to **12.16.1**.
- `CHANGELOG.md` new dated entry.
- `.github/ISSUE_TEMPLATE/bug_report.yml` `tool_version` placeholder refreshed.
- Installer built and copied to primary checkout: `<LOCAL_REPO_ROOT>\DST-DuneServerTool\app\installer\output\DuneServerSetup.exe` (46 MB).

Coastal handles the release + Discord post via the manual routine.