### PR TITLE
Fix: Set Starter Class "account_id is required" (frontend/backend contract mismatch)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.16.1"
+      placeholder: "v12.16.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [12.16.2] - 2026-07-04
+
+### Fixed
+
+- **Gameplay Admin → Players → Set Starter Class** no longer fails with a red `account_id is required` toast. The frontend was posting `{pawn_id, class_id}` (using the character/pawn id) while the backend expected `{account_id, job}` — a straight contract mismatch. Corrected the `setStarterClass` API call to send `account_id` + `job` and to use `player.account_id` at the call site, matching the pattern of every other write in this section (rename, update tags, delete tutorials, etc.). Backend contract unchanged.
+
 ## [12.16.1] - 2026-07-03
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.16.1'
+$script:DuneToolVersion = '12.16.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.16.1',
+    [string]$Version = '12.16.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.16.1</Version>
+    <Version>12.16.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.16.1"
+#define MyAppVersion "12.16.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.16.1"
+$script:ToolVersion = "12.16.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1905,9 +1905,9 @@ export function resetJobSkills(pawnId: number, jobId: string) {
   })
 }
 
-export function setStarterClass(pawnId: number, classId: string) {
+export function setStarterClass(accountId: number, job: string) {
   return api<WriteResult>('/api/gameplay/players/set-starter-class', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, class_id: classId }),
+    method: 'POST', body: JSON.stringify({ account_id: accountId, job }),
   })
 }
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -1053,7 +1053,7 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
                 if (typed.trim().toLowerCase() !== 'i acknowledge') {
                   return Promise.reject(new Error('Did not type "i acknowledge" — change aborted.'))
                 }
-                return setStarterClass(player.id, job)
+                return setStarterClass(player.account_id, job)
               })} />
           ) : def.custom === 'update-tags' ? (
             <UpdateTagsForm busy={busy} accountId={player.account_id} demo={false}

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -169,7 +169,7 @@ describe('Phase C/D/E/F — items, vehicles, teleport, progression, jobs', () =>
     expect(last().url).toBe('/api/gameplay/players/reset-job-skills')
 
     await gp.setStarterClass(11, 'fremen')
-    expect(last().body).toEqual({ pawn_id: 11, class_id: 'fremen' })
+    expect(last().body).toEqual({ account_id: 11, job: 'fremen' })
 
     await gp.deleteTutorials(5)
     expect(last().url).toBe('/api/gameplay/players/delete-tutorials')


### PR DESCRIPTION
## Bug

On **Gameplay Admin → Players → Identity → Set Starter Class**, clicking the orange **Set Starter Class** button after choosing a class (e.g. Bene Gesserit) showed a red toast: `account_id is required`. Reported by Coastal live in v12.16.1.

## Root cause

Frontend/backend contract mismatch.

- **Frontend** (`webui/src/api/gameplay.ts`) was POSTing `{ pawn_id, class_id }` and using `player.id` (the character/pawn id).
- **Backend** (`app/server/routes/PlayersWrites.ps1`) reads `{ account_id, job }`.

Result: backend never saw `account_id`, returned 400. Every other write in this section (rename, update tags, delete tutorials, wipe codex, etc.) already uses `player.account_id` — this one was the odd one out.

## Fix (surgical)

1. `webui/src/api/gameplay.ts` — `setStarterClass(accountId, job)` now sends `{ account_id, job }`.
2. `webui/src/pages/gameplay/players/sections.tsx` — call site updated to `setStarterClass(player.account_id, job)`.
3. `webui/tests/api/gameplay.test.ts` — test updated to expect the new body.

Backend contract unchanged.

## Verification

- `npm run build` in `webui/` — clean, zero TS errors.
- `npx vitest run tests/api/gameplay.test.ts` — 45/45 passing.
- `pwsh app/installer/Build-Installer.ps1` — clean build, `DuneServerSetup.exe` (46.06 MB) produced.
- Installer copied to primary checkout at `<LOCAL_REPO_ROOT>\DST-DuneServerTool\app\installer\output\DuneServerSetup.exe`.

## Version

Bumped `12.16.1` → **`12.16.2`** across all five stamps (`app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/installer/DuneServer.iss`, `dune-server.ps1`), rolled `CHANGELOG.md`, updated `bug_report.yml` placeholder.