### PR TITLE
Fix: Backup prune never fires (wrong glob depth + double-counted yaml sidecars)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.16.2"
+      placeholder: "v12.16.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [12.16.3] - 2026-07-04
+
+### Fixed
+
+- **Backup Schedule → retention prune now actually deletes old backups.** Two stacked bugs meant the scheduled prune has never removed a single file since the feature shipped, so `keep-last = 6` was effectively `keep-last = infinity`. **(1)** The prune glob was one directory level too shallow — `battlegroup backup` writes to `/funcom/artifacts/database-dumps/<sh-hash-name>/<file>.backup`, but DST globbed `/funcom/artifacts/database-dumps/*.backup*`, which matched zero files. Fixed by descending one level (`/*/`). **(2)** Each backup produces two files on disk (`.backup` + `.backup.yaml` sidecar), and the old pattern `*.backup*` matched both, so `keep-last = N` really kept N/2 real backups. Now we count only `.backup` files and delete the `.yaml` sidecar alongside each pruned entry. Manually named snapshots (e.g. `pre-patch-1_4_10_1.backup`) are still preserved by the `-YYYYMMDD-HHMMSS` shape gate.
+
+> ⚠️ **Existing installs must click *Save* once on the Backup Schedule card after upgrading** to rewrite the crontab with the fixed prune line. Upgrading the tool alone does not touch the on-disk cron block — it was written by the previous version and stays as-is until the schedule is saved again.
+
 ## [12.16.2] - 2026-07-04
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.16.2'
+$script:DuneToolVersion = '12.16.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.16.2',
+    [string]$Version = '12.16.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.16.2</Version>
+    <Version>12.16.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.16.2"
+#define MyAppVersion "12.16.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -219,11 +219,21 @@ function New-DuneBackupBlock {
         $lines += "$cronExpr $cmd"
     }
     if ($KeepLast -gt 0) {
-        # Narrow the retention pattern to filenames that match Funcom's own
-        # battlegroup-dump naming (<bg>-YYYYMMDD-HHMMSS.backup[.yaml]) so we
-        # never delete a manually-named snapshot like 'pre-patch-X.backup'.
-        $namePat = '*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].backup*'
-        $find = "ls -t $script:DuneBackupDumpDir/$namePat 2>/dev/null | tail -n +$($KeepLast + 1) | xargs -r rm"
+        # Retention prune. Notes on the shape of this glob:
+        #   (i)  `battlegroup backup` writes to
+        #        /funcom/artifacts/database-dumps/<sh-hash-name>/<file>.backup,
+        #        so we need `/*/` to descend one level into the per-battlegroup
+        #        subdir. A shallow `$DumpDir/*.backup` matches nothing.
+        #   (ii) Each backup produces TWO files on disk: `<name>.backup` and
+        #        its `<name>.backup.yaml` sidecar. We match only `.backup` for
+        #        counting so keep-last=N means N real backups (not N/2), and
+        #        delete the `.yaml` sidecar alongside each pruned entry.
+        #   (iii)The `-YYYYMMDD-HHMMSS.backup` shape gate preserves manually
+        #        named snapshots like 'pre-patch-1_4_10_1.backup' -- they
+        #        never match this pattern, so we can't prune them by accident.
+        $namePat = '*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].backup'
+        $skip = $KeepLast + 1
+        $find = "ls -t $script:DuneBackupDumpDir/*/$namePat 2>/dev/null | tail -n +$skip | while IFS= read -r f; do rm -f `"`$f`" `"`$f.yaml`"; done"
         $lines += "15 5 * * * $find"
     }
     $lines += $script:DuneBackupEndMarker

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.16.2"
+$script:ToolVersion = "12.16.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Bug

The scheduled backup **retention prune has never actually deleted a file** since the feature shipped. Verified live on the maintainer's VM this session: `/funcom/artifacts/database-dumps/sh-<hash>/` was carrying 60+ backup pairs going back 6 weeks with `keep-last = 6` set.

## Root cause — two stacked bugs

**1. Wrong glob depth.** `battlegroup backup` writes to `/funcom/artifacts/database-dumps/<sh-hash-name>/<file>.backup`. DST's prune globbed `/funcom/artifacts/database-dumps/*.backup*` — one directory level too shallow — so the glob matched zero files and nothing was ever pruned.

**2. Yaml sidecar double-count.** Each backup writes two files on disk: `<name>.backup` **and** `<name>.backup.yaml`. The pattern `*.backup*` matched **both**, so `tail -n +$((keep+1))` on that list meant `keep-last = 6` really retained 6 *files* = 3 real backups. Effective retention was half what the UI advertised.

## Fix

In `app/server/lib/BackupSchedule.ps1`, the emitted prune line now:

- descends one level via `/*/` into the per-battlegroup subdir,
- matches only `.backup` (not `.backup.yaml`) for counting, so `keep-last = N` = N real backups,
- deletes the `.yaml` sidecar alongside each pruned `.backup` file,
- still preserves manually-named snapshots (e.g. `pre-patch-1_4_10_1.backup`) via the `-YYYYMMDD-HHMMSS` shape gate in the middle of the pattern.

Rendered example (`keep-last = 6`):

```sh
15 5 * * * ls -t /funcom/artifacts/database-dumps/*/*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].backup 2>/dev/null | tail -n +7 | while IFS= read -r f; do rm -f "$f" "$f.yaml"; done
```

## ⚠️ Post-upgrade caveat (also called out in CHANGELOG)

**Existing installs must click *Save* once on the Backup Schedule card after upgrading** to rewrite the crontab with the fixed prune line. Upgrading the tool alone does not touch the on-disk cron block — the previous version's line stays as-is until the schedule is saved again.

## Version + stamps

- `12.16.2` → `12.16.3` across all five stamp files, plus bug-report template placeholder.
- CHANGELOG entry added under `## [12.16.3] - 2026-07-04`.

## Verification

- PS parse-check on `BackupSchedule.ps1`: 0 errors.
- Rendered `New-DuneBackupBlock -Preset 'Every6Hours' -KeepLast 6` and confirmed the emitted cron line matches the expected shape above.
- `webui` build: ✓ green.
- `pwsh app/installer/Build-Installer.ps1`: ✓ built `DuneServerSetup.exe` (46.06 MB), BOM pre-flight passed. Installer copied into the primary checkout at the expected path.
- No test files reference the prune-line shell text (`grep 'tail -n' / 'DST-BACKUP'` under `webui/tests` and `app/server` — none matched).

## Scope guardrails

Surgical: only the prune line + its comment block changed in `BackupSchedule.ps1`. Dump-pod prune snippet untouched. `# DST-BACKUP-KEEP-LAST:` header semantics unchanged.