### PR TITLE
Fix: Backup Schedule Save button stays clickable when nothing has changed

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.16.3"
+      placeholder: "v12.16.4"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [12.16.4] - 2026-07-04
+
+### Changed
+
+- **Backup Schedule Save buttons stay clickable when there are no pending changes.** Both the top-level *Save schedule* button and the *Completed backup pods* *Save* button previously disabled themselves once the UI values matched what's on disk, which prevented force-re-writing the crontab. That was painful when a DST release changes the shape of the emitted cron (e.g. v12.16.3's prune-line fix) — the on-disk cron stays as the old version's version until Save re-runs, but Save was disabled. Now Save stays clickable as long as the VM is up; the tooltip still tells you whether there are unsaved changes.
+
 ## [12.16.3] - 2026-07-04
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.16.3'
+$script:DuneToolVersion = '12.16.4'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.16.3',
+    [string]$Version = '12.16.4',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.16.3</Version>
+    <Version>12.16.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.16.3"
+#define MyAppVersion "12.16.4"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.16.3"
+$script:ToolVersion = "12.16.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -953,9 +953,9 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
           <button
             type="button"
             onClick={() => void save()}
-            disabled={!vmRunning || loading || saving || !dirty}
+            disabled={!vmRunning || loading || saving}
             className="btn-primary"
-            title={dirty ? 'Install the new schedule on the VM' : 'No changes to save'}
+            title={dirty ? 'Install the new schedule on the VM' : 'Re-write the schedule on the VM (no unsaved changes)'}
           >
             <Icon name={saving ? 'Loader2' : 'Save'} size={14} className={saving ? 'animate-spin' : ''} />
             {saving ? 'Saving…' : 'Save schedule'}
@@ -1091,11 +1091,11 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
           <button
             type="button"
             onClick={() => void save()}
-            disabled={!vmRunning || saving || pruning || !dumpPodsDirty}
+            disabled={!vmRunning || saving || pruning}
             className="btn-primary"
             title={dumpPodsDirty
               ? 'Persist these retention values into the schedule so they survive reload and drive the auto-prune.'
-              : 'No unsaved changes.'}
+              : 'Re-write the schedule on the VM (no unsaved changes).'}
           >
             <Icon name={saving ? 'Loader2' : 'Save'} size={14} className={saving ? 'animate-spin' : ''} />
             {saving ? 'Saving…' : 'Save retention'}


### PR DESCRIPTION
## Bug

On Database → **Backup Schedule** card, the **Save schedule** button gated on `!dirty`, so once the UI matched what's on disk (either after saving, or on a fresh load) the button went disabled and the user couldn't force a re-save. The sibling **Save** button in the *Completed backup pods* retention row had the identical problem, gated on `!dumpPodsDirty`.

## Why it matters (v12.16.3 upgrade scenario)

v12.16.3 shipped a fix for the backup prune line (glob was one directory too shallow + `*.backup*` matched the `.yaml` sidecars, halving effective retention). Upgrading the tool alone does not touch the on-disk cron block — it was written by the previous version and stays as-is until Save re-runs.

But Save was disabled, because NOTHING in the UI values changed (preset, keep-last, keep-pods are all still what the old cron already says). Users had no way to trigger the rewrite without artificially poking a value and un-poking it.

## Root cause

Both Save buttons had `!dirty` / `!dumpPodsDirty` in their `disabled` predicate. The `dirty` memos themselves are fine — we still use them for tooltip text — but they shouldn't gate whether the button is clickable.

## Fix

`webui/src/pages/Database.tsx`, 2 tiny changes:

- Primary *Save schedule* button — drop `!dirty` from `disabled`; tooltip now reads "Re-write the schedule on the VM (no unsaved changes)" when clean.
- *Completed backup pods* Save button — drop `!dumpPodsDirty` from `disabled`; tooltip similarly clarifies re-write vs. save.

Surgical. `save()` unchanged. Backend unchanged. `managedBlockLooksTampered` detection unchanged.

## Verify

- `webui/npm run build` — clean, zero TS errors.
- `app/installer/Build-Installer.ps1` — success, BOM pre-flight passed.
- Installer copied to primary checkout.

## Version

`12.16.3` → `12.16.4` (patch). All 5 stamps + CHANGELOG entry + bug-report template placeholder updated.