### PR TITLE
Fix: Fresh Start restore now filters to purchased unlocks only (CHOAM + MTX)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.16.4"
+      placeholder: "v12.16.5"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [12.16.5] - 2026-07-04
+
+### Fixed
+
+- **Fresh Start over-restored faction-earned building sets.** The restore path unioned the ENTIRE `learned_building_sets` + `new_buildable_pieces` snapshot back onto the fresh character, which included faction-earned sets (Atre_*/Hark_*/Fremen_*/AtreidesSet/HarkonnenSet) and base/advanced tech patents — unlocks a Rank-0 fresh character shouldn't yet have. Restore now filters to purchased-only (`^(MTX_|Choam)`) so faction sets and tech-tree unlocks re-populate naturally as the character re-progresses. Snapshots taken with earlier versions still work — the filter runs at restore time. UI + CHANGELOG labels also updated from "builds" to "purchases" to accurately describe the scope.
+
 ## [12.16.4] - 2026-07-04
 
 ### Changed
@@ -41,7 +47,7 @@ here cover everything those tags shipped.
 
 ### Added
 
-- **Fresh Start (keep builds & cosmetics).** New action under *Players → Progression*. A genuinely fresh character can only be made in-game (the game engine rebuilds the entire quest journal, skill trees and starter content from the character on every login, so an in-place database reset can't produce one). Fresh Start instead preserves the two things you're entitled to keep across a restart — your unlocked **building sets/pieces** and **cosmetics**. Flow: **1)** *Snapshot* the character's builds + cosmetics (saved locally, keyed by character name); **2)** delete and recreate the character in-game with the **same name** (delete via the in-game Funcom browser so the name is kept) and spawn in; **3)** *Restore* — DST grants those builds + cosmetics back onto the fresh character by name. Everything else (quests, skills, faction, tech) starts genuinely fresh. Restore requires the player to be offline.
+- **Fresh Start (keep purchases).** New action under *Players → Progression*. A genuinely fresh character can only be made in-game (the engine rebuilds journal / skills / abilities / starter content from the character on every login), so an in-place DB reset can't produce one. Fresh Start instead preserves the things a player **paid for** — real-money MTX sets/pieces, CHOAM-shop purchases (patents + deco placeables), and the unlocked cosmetics list. Flow: **1)** *Snapshot* (saved locally on the DST host, keyed by character name); **2)** delete and recreate the character in-game with the **same name**; **3)** *Restore* — grants the paid unlocks back onto the fresh character by name. Faction-earned sets (Atre_*/Hark_*/Fremen_*/AtreidesSet/HarkonnenSet) and base/advanced tech patents intentionally are NOT restored — they re-populate as the fresh character re-progresses faction rank and tech tree. Restore requires the player to be offline.
 
 ## [12.15.2] - 2026-07-03
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.16.4'
+$script:DuneToolVersion = '12.16.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.16.4',
+    [string]$Version = '12.16.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.16.4</Version>
+    <Version>12.16.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.16.4"
+#define MyAppVersion "12.16.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1495,8 +1495,19 @@ function Invoke-DunePlayerRestoreBuilds {
     $off = Test-DunePlayerOffline -Ip $Ip -PawnId $pawnID
     if (-not $off.ok) { return @{ ok = $false; error = "Player must be offline to restore builds. $($off.reason)" } }
 
-    $setsArr   = ConvertTo-DunePgTextArray (@($s.building_sets)    | ForEach-Object { [string]$_ })
-    $piecesArr = ConvertTo-DunePgTextArray (@($s.buildable_pieces) | ForEach-Object { [string]$_ })
+    # Only restore what the player *paid for*: real-money MTX items (MTX_*) and
+    # CHOAM-shop purchases (Choam_*). Faction-earned sets (Atre_*/Hark_*/Fremen_*/
+    # AtreidesSet/HarkonnenSet) get re-earned by re-progressing faction rank, and
+    # tutorial/base patents (Basic*/Advanced*/Large*/Deathstill/etc.) get re-granted
+    # by the fresh character's starter tech tree. Verified live on 2026-07-04 - the
+    # building_progression columns are a mixed bag of purchased + earned + tutorial
+    # unlocks, so restoring the whole array over-grants faction perks to a Rank-0
+    # character.
+    $purchasedRx = '^(MTX_|Choam)'
+    $filteredSets   = @($s.building_sets    | Where-Object { [string]$_ -match $purchasedRx })
+    $filteredPieces = @($s.buildable_pieces | Where-Object { [string]$_ -match $purchasedRx })
+    $setsArr   = ConvertTo-DunePgTextArray ($filteredSets   | ForEach-Object { [string]$_ })
+    $piecesArr = ConvertTo-DunePgTextArray ($filteredPieces | ForEach-Object { [string]$_ })
     $cosmetics = [string]$s.cosmetics
 
     $sb = [System.Text.StringBuilder]::new()
@@ -1522,8 +1533,8 @@ function Invoke-DunePlayerRestoreBuilds {
     $cosMsg = if ($cosmetics) { ' + cosmetics' } else { '' }
     return @{
         ok = $true
-        message = "Restored builds for '$Name' - $(@($s.building_sets).Count) building set(s), $(@($s.buildable_pieces).Count) piece(s)$cosMsg. Takes effect on next login."
-        sets = @($s.building_sets).Count; pieces = @($s.buildable_pieces).Count
+        message = "Restored $($filteredSets.Count) purchased set(s) + $($filteredPieces.Count) purchased piece(s)$cosMsg onto '$Name'. Faction sets, tutorial patents, and tech-tree unlocks will re-populate as the character progresses. Takes effect on next login."
+        sets = $filteredSets.Count; pieces = $filteredPieces.Count
     }
 }
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.16.4"
+$script:ToolVersion = "12.16.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -663,8 +663,8 @@ const ACTIONS: ActionDef[] = [
   { id: 'reset-faction', group: 'Progression', label: 'Reset Faction', icon: 'Swords', custom: 'reset-faction', offlineOnly: true,
     rowNote: 'Wipe ALL faction rep + tags + ClimbTheRanks nodes to start fresh. Player must be offline.',
     run: () => Promise.resolve({ message: '' }) },
-  { id: 'fresh-start', group: 'Progression', label: 'Fresh Start (keep builds)', icon: 'Sunrise', custom: 'fresh-start',
-    rowNote: 'Snapshot builds + cosmetics, delete + recreate the character (same name) in-game, then restore. Offline to restore.',
+  { id: 'fresh-start', group: 'Progression', label: 'Fresh Start (keep purchases)', icon: 'Sunrise', custom: 'fresh-start',
+    rowNote: 'Snapshot purchased sets/pieces (CHOAM shop + MTX) + cosmetic unlocks, delete + recreate the character (same name) in-game, then restore. Offline to restore. Faction sets and tech unlocks re-earn naturally.',
     run: () => Promise.resolve({ message: '' }) },
 
   // ----- Items -----
@@ -1088,10 +1088,12 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
   )
 }
 
-// Fresh Start (keep builds & cosmetics) — two-step snapshot/restore flow. A truly
+// Fresh Start (keep purchases) — two-step snapshot/restore flow. A truly
 // fresh character can only be produced by deleting + recreating it in-game; DST
-// snapshots the player's unlocked building sets + cosmetics beforehand and restores
-// them by NAME onto the recreated character (name is the stable key across delete).
+// snapshots the player's purchased sets/pieces (CHOAM + MTX) + cosmetic unlocks
+// beforehand and restores them by NAME onto the recreated character (name is the
+// stable key across delete). Faction-earned sets and tech-tree unlocks are NOT
+// restored — they re-populate naturally as the character re-progresses.
 function FreshStartForm({ busy, player, runAction }: {
   busy: boolean
   player: Player
@@ -1112,12 +1114,12 @@ function FreshStartForm({ busy, player, runAction }: {
   return (
     <div className="space-y-3 text-sm">
       <div className="rounded-lg bg-surface-2 border border-border/50 p-3 text-text-dim text-xs leading-relaxed">
-        A real fresh start is done in-game: <b className="text-text">1)</b> snapshot below, <b className="text-text">2)</b> delete + recreate the character with the <b className="text-text">same name</b> (delete via the in-game Funcom browser so the name can be reused) and spawn in, <b className="text-text">3)</b> restore. Only the building sets + cosmetics you already unlocked are carried over — everything else (quests, skills, faction, tech) starts genuinely fresh from the game.
+        A real fresh start is done in-game: <b className="text-text">1)</b> snapshot below, <b className="text-text">2)</b> delete + recreate the character with the <b className="text-text">same name</b> (delete via the in-game Funcom browser so the name can be reused) and spawn in, <b className="text-text">3)</b> restore. Only your <b className="text-text">purchased</b> CHOAM/MTX sets + pieces and unlocked cosmetics are carried over — faction-earned sets and tech unlocks re-populate naturally as you re-progress, and everything else (quests, skills, faction rank) starts genuinely fresh from the game.
       </div>
 
       <div className="card p-3 space-y-2">
-        <div className="font-medium text-text flex items-center gap-2"><Icon name="Save" size={14} /> Step 1 — Snapshot builds &amp; cosmetics</div>
-        <div className="text-text-dim text-xs">Captures {player.name}'s unlocked building sets + cosmetics. Do this <b>before</b> deleting the character (the data is destroyed with the character).</div>
+        <div className="font-medium text-text flex items-center gap-2"><Icon name="Save" size={14} /> Step 1 — Snapshot purchases &amp; cosmetics</div>
+        <div className="text-text-dim text-xs">Captures {player.name}'s purchased CHOAM/MTX sets + pieces + unlocked cosmetics. Do this <b>before</b> deleting the character (the data is destroyed with the character). Faction-earned sets and tech-tree unlocks are NOT snapshotted — they re-populate as the fresh character progresses.</div>
         <button type="button" disabled={busy}
           className="px-3 py-2 rounded-lg bg-ibad/20 border border-ibad/50 text-text hover:bg-ibad/30 disabled:opacity-50 text-sm font-medium"
           onClick={() => runAction(localDef, async () => {
@@ -1125,25 +1127,25 @@ function FreshStartForm({ busy, player, runAction }: {
             refresh()
             return { message: r.message || `Snapshot saved for ${player.name}.` }
           })}>
-          Snapshot {player.name}'s builds
+          Snapshot {player.name}'s purchases
         </button>
       </div>
 
       <div className="card p-3 space-y-2">
-        <div className="font-medium text-text flex items-center gap-2"><Icon name="Sunrise" size={14} /> Step 2 — Restore builds by name</div>
+        <div className="font-medium text-text flex items-center gap-2"><Icon name="Sunrise" size={14} /> Step 2 — Restore purchases by name</div>
         {loading ? (
           <div className="text-text-dim text-xs flex items-center gap-2"><Icon name="Loader2" size={13} className="animate-spin" /> Checking snapshots…</div>
         ) : snap ? (
           <>
-            <div className="text-text-dim text-xs">Saved snapshot for <b className="text-text">{snap.name}</b> — {snap.sets} building set{snap.sets === 1 ? '' : 's'}, {snap.pieces} piece{snap.pieces === 1 ? '' : 's'}{snap.cosmetics ? ' + cosmetics' : ''} ({new Date(snap.saved_at).toLocaleString()}).</div>
+            <div className="text-text-dim text-xs">Saved snapshot for <b className="text-text">{snap.name}</b> — {snap.sets} set{snap.sets === 1 ? '' : 's'}, {snap.pieces} piece{snap.pieces === 1 ? '' : 's'}{snap.cosmetics ? ' + cosmetics' : ''} ({new Date(snap.saved_at).toLocaleString()}). Restore filters to purchased-only (CHOAM + MTX).</div>
             <div className="text-warning text-xs">Only after you've recreated the character (same name) and spawned in. Player must be offline.</div>
             <button type="button" disabled={busy}
               className="px-3 py-2 rounded-lg bg-info/20 border border-info/50 text-text hover:bg-info/30 disabled:opacity-50 text-sm font-medium"
               onClick={() => runAction(localDef, async () => {
                 const r = await restoreBuilds(player.name)
-                return { message: r.message || `Restored builds for ${player.name}.` }
+                return { message: r.message || `Restored purchases for ${player.name}.` }
               })}>
-              Restore {player.name}'s builds
+              Restore {player.name}'s purchases
             </button>
           </>
         ) : (


### PR DESCRIPTION
## Bug

**Fresh Start (keep builds & cosmetics)** was misleading on two counts:

1. **Wrong labeling.** UI + CHANGELOG called the snapshot "builds + cosmetics", which reads as "placed structures + cosmetics". Placed structures aren't snapshotted at all — the snapshot writes to `dune.building_progression` columns, which are actually a **mixed store** of purchased + faction-earned + tutorial unlocks.
2. **Restore over-restored faction unlocks.** `Invoke-DunePlayerRestoreBuilds` union'd the ENTIRE `learned_building_sets` + `new_buildable_pieces` arrays onto the fresh character. Verified live on Coastal's `Coastal` character: the snapshot carries `Atre_BedroomSet_Patent`, `AtreidesSet`, `Hark_BasicLighting_Patent`, `HarkonnenSet`, base tech patents — unlocks a Rank-0 fresh character shouldn't yet have.

## Fix

`Invoke-DunePlayerRestoreBuilds` now filters both arrays against `^(MTX_|Choam)` before UNIONing. Only what the player **paid for** survives:

| Category | Prefix | Restored? |
|---|---|---|
| Real-money MTX | `MTX_*` | ✅ |
| CHOAM shop purchases | `Choam_*` | ✅ |
| Faction-earned sets | `Atre_*`, `Hark_*`, `Fremen_*`, `AtreidesSet`, `HarkonnenSet` | ❌ (re-earn by faction rank) |
| Base/tutorial patents | `Basic*_Patent`, `Advanced*_Patent`, `Large*`, `Deathstill_Patent`, etc. | ❌ (re-granted by starter tech tree) |

## Scope of changes

- **`app/server/lib/PlayersWrites.ps1`** — filter in `Invoke-DunePlayerRestoreBuilds`; success message now reports filtered counts.
- **`webui/src/pages/gameplay/players/sections.tsx`** — relabel "builds" → "purchases" throughout the Fresh Start UI (row label, rowNote, step headers, button text, comment).
- **`CHANGELOG.md`** — new `12.16.5` `### Fixed` entry; rewrote the `12.16.0` bullet to accurately describe the scope.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — placeholder bumped to `v12.16.5`.
- **Version stamps bumped `12.16.4` → `12.16.5`** across all 5 files: `app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/installer/DuneServer.iss`, `dune-server.ps1`.

## Explicitly NOT changed

- **Snapshot function** — still captures the full arrays (harmless, retains inspection value, and means older snapshots still work under the new restore filter).
- **Cosmetics restore path** — unchanged; the `m_UnlockedCustomizationSerializableList` blob is a separate cosmetics-only field with correct semantics.

## Verified

- PS parse check on `PlayersWrites.ps1` — OK.
- `webui/npm run build` — clean, zero TS errors.
- `pwsh app/installer/Build-Installer.ps1` — clean build (`DuneServerSetup.exe`, 46.06 MB).
- Installer copied to primary checkout's `app/installer/output/`.

Ready for manual test + release.