### PR TITLE
Fix: Reset Faction now clears all faction state (tags + revealed journey nodes) + optional Deep reset for lore

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.16.5"
+      placeholder: "v12.16.6"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [12.16.6] - 2026-07-04
+
+### Fixed
+
+- **Reset Faction now actually resets faction state.** It was only clearing a small subset of what "reset faction" implies — leaving hundreds of faction-related tags and 80+ revealed ClimbTheRanks journey nodes on the character. Concretely, it now also (a) sets `reveal_condition_state = false` on all `DA_FQ_ClimbTheRanks%` journey nodes (previously only `complete_condition_state` was cleared, so the STORY tab still rendered every previously-revealed chapter as an active quest card — this was the root cause of a multi-day stuck "Hunting Skorda" contract card observed live), and (b) deletes six additional tag families that are all faction storyline state: `Contract.Tracking.FactionStory.*` (rank grid + milestones), `Contract.Tracking.Completed.FactionStoryline.*`, `Contract.Tracking.Completed.MaasKharet*`, `Contract.Target.Dialogue.FactionRank*`, `Contract.Target.Location/Lore.MaasKharet*`, and `DialogueFlags.Factions.*` / `DialogueFlags.IntroductionDone.ThufirHawat`+`PiterDeVries`+`MaasKharet`. Verified live against a stuck faction storyline. Faction scope (`atreides` / `harkonnen` / `both`) is preserved — single-faction reset is conservative and only wipes obvious per-faction tags; `both` wipes the shared markers as well. Success toast now reports counts (tags removed, journey nodes reset, lore cleared).
+
+### Added
+
+- **Reset Faction → Deep reset checkbox.** New optional flag on the Reset Faction action. When enabled, ALSO wipes faction-related Dunipedia lore fragments the character unlocked (House Atreides / House Harkonnen / TheRiseOfHouseAtreides / Ariste / Baron / Feyd / Glossu / Leto / Paul / Jessica sub-trees). Neutral world lore (`ManualOfTheFriendlyDesert`, `WarForArrakis.Bandits`) is preserved. Default OFF — opt-in for users who want a truly "never played this faction" state including codex.
+
 ## [12.16.5] - 2026-07-04
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.16.5'
+$script:DuneToolVersion = '12.16.6'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.16.5',
+    [string]$Version = '12.16.6',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.16.5</Version>
+    <Version>12.16.6</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.16.5"
+#define MyAppVersion "12.16.6"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1077,7 +1077,7 @@ COMMIT;
 # for the chosen faction (or both). Offline-only — the game holds this state in
 # RAM while connected. $Faction = 'atreides' | 'harkonnen' | 'both'.
 function Invoke-DunePlayerResetFaction {
-    param([string]$Ip, [long]$AccountId, [string]$Faction)
+    param([string]$Ip, [long]$AccountId, [string]$Faction, [bool]$Deep = $false)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
     $fl = ([string]$Faction).ToLowerInvariant()
     if ($fl -ne 'atreides' -and $fl -ne 'harkonnen' -and $fl -ne 'both') {
@@ -1089,6 +1089,113 @@ function Invoke-DunePlayerResetFaction {
 
     $factions = if ($fl -eq 'both') { @('Atreides','Harkonnen') } else { @((Get-Culture).TextInfo.ToTitleCase($fl)) }
     $charScope = "character_id IN (SELECT id FROM dune.player_state WHERE account_id=$AccountId::bigint)"
+    $isBoth = ($fl -eq 'both')
+
+    # Build the tag LIKE patterns for the wipe. The wildcard %Atreides%/%Harkonnen%/
+    # %Atre%/%Hark% patterns handle per-faction suffixed tags (e.g.
+    # R*C*Completed_Atreides, Fac_Atre_*, DialogueFlags.*Atre*).
+    # Single-faction scope: only wipe tags that clearly belong to that faction.
+    # 'both' scope: also wipe the shared / neutral faction-storyline markers below.
+    $likes = [System.Collections.Generic.List[string]]::new()
+    [void]$likes.Add("tag LIKE 'Faction.%'")
+    [void]$likes.Add("tag LIKE 'FactionStoryline%'")
+    [void]$likes.Add("tag LIKE 'DialogueFlags.Factions.%'")
+    [void]$likes.Add("tag LIKE 'Contract.Faction.%'")
+    [void]$likes.Add("tag = 'Journey.LandsraadContractsUnlocked'")
+    [void]$likes.Add("tag LIKE 'Contract.Tracking.%FactionUnlocked'")
+    [void]$likes.Add("tag LIKE 'Contract.Tracking.%RecruitmentCompleted'")
+    if ($isBoth) {
+        [void]$likes.Add("tag LIKE '%Atreides%'")
+        [void]$likes.Add("tag LIKE '%Harkonnen%'")
+        [void]$likes.Add("tag LIKE '%Atre%'")
+        [void]$likes.Add("tag LIKE '%Hark%'")
+    } else {
+        # single-faction: match the specific faction's tag variants
+        if ($fl -eq 'atreides') {
+            [void]$likes.Add("tag LIKE '%Atreides%'")
+            [void]$likes.Add("tag LIKE '%Atre%'")
+        } else {
+            [void]$likes.Add("tag LIKE '%Harkonnen%'")
+            [void]$likes.Add("tag LIKE '%Hark%'")
+        }
+    }
+    # --- FactionStory rank grid + milestones (R*C*Completed, SentToMeetAndreaGanan,
+    #     TalkedToDeserter, TestOfLoyaltyCompleted, etc.). Per-faction rows are
+    #     suffixed (R*C*Completed_Atreides / _Harkonnen) and already covered above;
+    #     the un-suffixed neutral shared markers here are only safe on 'both'.
+    [void]$likes.Add("tag LIKE 'Contract.Tracking.FactionStory.%'")
+    # --- Named faction storyline beats (FindSkorda, RecoverSpyReport). A player is on
+    #     only one faction path at a time, so these are safe to wipe on any scope.
+    [void]$likes.Add("tag LIKE 'Contract.Tracking.Completed.FactionStoryline.%'")
+    # --- MaasKharet faction-agent contracts + dialogue + locations + lore.
+    [void]$likes.Add("tag LIKE 'Contract.Tracking.Completed.MaasKharet%'")
+    [void]$likes.Add("tag LIKE 'Contract.Target.Dialogue.FactionRank%'")
+    [void]$likes.Add("tag LIKE 'Contract.Target.Location.MaasKharet%'")
+    [void]$likes.Add("tag LIKE 'Contract.Target.Lore.MaasKharet%'")
+    # --- Rank 4 Arrakeen Social Hub banquet sub-state (BlackMarketVendorInterrogated,
+    #     WarehouseInvestigated). Shared faction-milestone dialogue.
+    [void]$likes.Add("tag LIKE 'Contract.Target.Dialogue.Arrakeen_Social_Hub.Banquet.%'")
+    # --- Faction-recruiter introduction flags. Atreides = ThufirHawat; Harkonnen =
+    #     PiterDeVries. MaasKharet is the shared cross-faction agent. Match by name
+    #     so single-faction scope only clears the matching recruiter.
+    if ($isBoth -or $fl -eq 'atreides') {
+        [void]$likes.Add("tag = 'DialogueFlags.IntroductionDone.ThufirHawat'")
+    }
+    if ($isBoth -or $fl -eq 'harkonnen') {
+        [void]$likes.Add("tag = 'DialogueFlags.IntroductionDone.PiterDeVries'")
+    }
+    [void]$likes.Add("tag = 'DialogueFlags.IntroductionDone.MaasKharet'")
+    [void]$likes.Add("tag = 'Contract.Tracking.FactionsKytheriaInvestigationCompleted'")
+    $likesJoined = ($likes -join ' OR ')
+    # Reset ClimbTheRanks journey nodes to incomplete (NOT delete — deleting stops
+    # the game re-offering them, so the recruiter quest can't be replayed). Also
+    # clear reveal_condition_state — otherwise the STORY tab still renders every
+    # previously-revealed chapter as an active quest card (root cause of the stuck
+    # "Hunting Skorda" and similar cards observed on live characters).
+    # Deep reset — optional. Wipe faction-related Dunipedia lore fragments so the
+    # character reads as if the faction storyline was never encountered. Neutral
+    # world lore (ManualOfTheFriendlyDesert, WarForArrakis.Bandits) is preserved.
+    $deepPatterns = [System.Collections.Generic.List[string]]::new()
+    if ($Deep) {
+        if ($isBoth -or $fl -eq 'atreides') {
+            [void]$deepPatterns.Add("story_node_id LIKE 'DA_Dunipedia_KnownUniverse.TheRiseOfHouseAtreides%'")
+            [void]$deepPatterns.Add("story_node_id LIKE 'DA_Dunipedia_WarForArrakis.Ariste Atreides%'")
+            [void]$deepPatterns.Add("story_node_id LIKE 'DA_Dunipedia_WarForArrakis.House Atreides%'")
+            [void]$deepPatterns.Add("story_node_id LIKE 'DA_Dunipedia_WarForArrakis.Leto Atreides%'")
+            [void]$deepPatterns.Add("story_node_id LIKE 'DA_Dunipedia_WarForArrakis.Paul Atreides%'")
+            [void]$deepPatterns.Add("story_node_id LIKE 'DA_Dunipedia_WarForArrakis.Jessica%'")
+        }
+        if ($isBoth -or $fl -eq 'harkonnen') {
+            [void]$deepPatterns.Add("story_node_id LIKE 'DA_Dunipedia_WarForArrakis.Baron Vladimir Harkonnen%'")
+            [void]$deepPatterns.Add("story_node_id LIKE 'DA_Dunipedia_WarForArrakis.Feyd Rautha Harkonnen%'")
+            [void]$deepPatterns.Add("story_node_id LIKE 'DA_Dunipedia_WarForArrakis.Glossu Rabban Harkonnen%'")
+            [void]$deepPatterns.Add("story_node_id LIKE 'DA_Dunipedia_WarForArrakis.House Harkonnen%'")
+        }
+    }
+    $hasDeep = ($Deep -and $deepPatterns.Count -gt 0)
+    $deepJoined = if ($hasDeep) { ($deepPatterns -join ' OR ') } else { '' }
+
+    # --- Pre-count what will change, for a useful success message. Character
+    #     name too, so the toast reads naturally.
+    $loreCountSql = if ($hasDeep) {
+        "(SELECT COUNT(*) FROM dune.journey_story_node WHERE $charScope AND ($deepJoined))"
+    } else { '0::bigint' }
+    $countSql = @"
+SELECT
+  (SELECT COALESCE(properties->'CharacterProfileComponent'->>'m_CharacterName','account '||$AccountId::text) FROM dune.actors WHERE id=$controllerID::bigint) AS name,
+  (SELECT COUNT(*) FROM dune.player_tags WHERE $charScope AND ($likesJoined)) AS tag_n,
+  (SELECT COUNT(*) FROM dune.journey_story_node WHERE $charScope AND story_node_id LIKE 'DA_FQ_ClimbTheRanks%') AS node_n,
+  $loreCountSql AS lore_n
+"@
+    $cr = Invoke-DuneSqlQuery -Ip $Ip -Sql $countSql -ReadOnly $true -MaxRows 1 -TimeoutSec 30
+    $tagN = 0; $nodeN = 0; $loreN = 0; $playerName = "account $AccountId"
+    if ($cr.ok -and $cr.rows -and $cr.rows.Count -gt 0) {
+        $row0 = $cr.rows[0]
+        if ($row0.name) { $playerName = [string]$row0.name }
+        $tagN  = [int]$row0.tag_n
+        $nodeN = [int]$row0.node_n
+        $loreN = [int]$row0.lore_n
+    }
 
     $sb = [System.Text.StringBuilder]::new()
     [void]$sb.AppendLine('BEGIN;')
@@ -1102,20 +1209,11 @@ function Invoke-DunePlayerResetFaction {
     [void]$sb.AppendLine([string]::Format($script:DuneFactionComponentRepSqlTpl, $controllerID, 'Atreides', 0))
     [void]$sb.AppendLine([string]::Format($script:DuneFactionComponentRepSqlTpl, $controllerID, 'Harkonnen', 0))
     [void]$sb.AppendLine("SELECT dune.change_player_faction($controllerID::bigint, 3::smallint, 3::smallint, NOW()::timestamp);")
-    # remove every faction-related tag (full + abbreviated names, recruitment, alignment)
-    $likes = @(
-        "tag LIKE 'Faction.%'", "tag LIKE 'FactionStoryline%'",
-        "tag LIKE 'DialogueFlags.Factions.%'", "tag LIKE 'Contract.Faction.%'",
-        "tag LIKE '%Atreides%'", "tag LIKE '%Harkonnen%'",
-        "tag LIKE '%Atre%'", "tag LIKE '%Hark%'",
-        "tag = 'Journey.LandsraadContractsUnlocked'",
-        "tag LIKE 'Contract.Tracking.%FactionUnlocked'",
-        "tag LIKE 'Contract.Tracking.%RecruitmentCompleted'"
-    ) -join ' OR '
-    [void]$sb.AppendLine("DELETE FROM dune.player_tags WHERE $charScope AND ($likes);")
-    # reset ClimbTheRanks journey nodes to incomplete (NOT delete — deleting stops
-    # the game re-offering them, so the recruiter quest can't be replayed)
-    [void]$sb.AppendLine("UPDATE dune.journey_story_node SET complete_condition_state='false'::jsonb, has_pending_reward=false WHERE $charScope AND story_node_id LIKE 'DA_FQ_ClimbTheRanks%';")
+    [void]$sb.AppendLine("DELETE FROM dune.player_tags WHERE $charScope AND ($likesJoined);")
+    [void]$sb.AppendLine("UPDATE dune.journey_story_node SET complete_condition_state='false'::jsonb, reveal_condition_state='false'::jsonb, has_pending_reward=false WHERE $charScope AND story_node_id LIKE 'DA_FQ_ClimbTheRanks%';")
+    if ($hasDeep) {
+        [void]$sb.AppendLine("UPDATE dune.journey_story_node SET complete_condition_state='false'::jsonb, reveal_condition_state='false'::jsonb, has_pending_reward=false WHERE $charScope AND ($deepJoined);")
+    }
     # Remove lingering faction-storyline contract ITEMS (Fac_Atre_* / Fac_Hark_*) from
     # the pawn's contract inventory (inventory_type 29). The rep/tag/journey reset above
     # does NOT touch these item rows, so without this the completed-but-uncleared faction
@@ -1134,7 +1232,9 @@ function Invoke-DunePlayerResetFaction {
         Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
         return @{ ok = $false; error = "reset-faction tx: $($r.error)" }
     }
-    return @{ ok = $true; message = "Reset faction for account $AccountId - rep zeroed (table + FactionPlayerComponent), alignment cleared, faction tags removed, faction contract items + tracked card cleared, ClimbTheRanks reset to incomplete. Takes effect on next login."; faction = $fl }
+    $lorePart = if ($hasDeep) { ", cleared $loreN Dunipedia lore node(s)" } else { '' }
+    $msg = "Reset faction for '$playerName' ($fl): removed $tagN tag(s), reset $nodeN ClimbTheRanks node(s)$lorePart. Takes effect on next login."
+    return @{ ok = $true; message = $msg; faction = $fl; deep = [bool]$Deep; tags = $tagN; nodes = $nodeN; lore = $loreN }
 }
 
 function Invoke-DunePlayerApplyProgressionPreset {

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -193,19 +193,21 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/progression-reverse
     }
 }
 
-# POST /api/gameplay/players/faction/reset  { account_id, faction }
+# POST /api/gameplay/players/faction/reset  { account_id, faction, deep? }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/faction/reset' -Handler {
     param($req, $res, $routeParams, $body)
     try {
         $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
         $fac = [string](Get-DuneBodyValue -Body $body -Name 'faction')
+        $deepRaw = Get-DuneBodyValue -Body $body -Name 'deep'
+        $deep = [bool]$deepRaw
         if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
         if (-not $fac) { Write-DuneError -Response $res -Status 400 -Message 'faction is required (atreides|harkonnen|both).'; return }
         Invoke-DunePlayerWriteRoute -Response $res -Action {
             param($ip)
             $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
             if (-not $off.ok) { return @{ ok = $false; error = "Player must be offline to reset faction. $($off.reason)" } }
-            Invoke-DunePlayerResetFaction -Ip $ip -AccountId $acc -Faction $fac
+            Invoke-DunePlayerResetFaction -Ip $ip -AccountId $acc -Faction $fac -Deep $deep
         }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Reset faction failed: $($_.Exception.Message)"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.16.5"
+$script:ToolVersion = "12.16.6"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1778,9 +1778,9 @@ export function wipeJourney(accountId: number) {
   })
 }
 
-export function resetFaction(accountId: number, faction: 'atreides' | 'harkonnen' | 'both') {
+export function resetFaction(accountId: number, faction: 'atreides' | 'harkonnen' | 'both', deep = false) {
   return api<WriteResult>('/api/gameplay/players/faction/reset', {
-    method: 'POST', body: JSON.stringify({ account_id: accountId, faction }),
+    method: 'POST', body: JSON.stringify({ account_id: accountId, faction, deep }),
   })
 }
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -661,7 +661,7 @@ const ACTIONS: ActionDef[] = [
       return wipeJourney(p.account_id)
     } },
   { id: 'reset-faction', group: 'Progression', label: 'Reset Faction', icon: 'Swords', custom: 'reset-faction', offlineOnly: true,
-    rowNote: 'Wipe ALL faction rep + tags + ClimbTheRanks nodes to start fresh. Player must be offline.',
+    rowNote: 'Wipe faction rep + tags + ClimbTheRanks nodes (revealed AND completed) so the character reads as pre-faction. Optional Deep also clears Dunipedia lore. Player must be offline.',
     run: () => Promise.resolve({ message: '' }) },
   { id: 'fresh-start', group: 'Progression', label: 'Fresh Start (keep purchases)', icon: 'Sunrise', custom: 'fresh-start',
     rowNote: 'Snapshot purchased sets/pieces (CHOAM shop + MTX) + cosmetic unlocks, delete + recreate the character (same name) in-game, then restore. Offline to restore. Faction sets and tech unlocks re-earn naturally.',
@@ -1020,8 +1020,8 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
               })} />
           ) : def.custom === 'reset-faction' ? (
             <ResetFactionForm busy={busy} playerName={player.name}
-              onReset={() => runAction(def, async () => {
-                const r = await resetFaction(player.account_id, 'both')
+              onReset={(deep) => runAction(def, async () => {
+                const r = await resetFaction(player.account_id, 'both', deep)
                 return { message: r.message || `Reset faction for ${player.name}.` }
               })} />
           ) : def.custom === 'fresh-start' ? (
@@ -2199,20 +2199,31 @@ function CompleteContractForm({ busy, onSubmit }: { busy: boolean; onSubmit: (co
 function ResetFactionForm({ busy, playerName, onReset }: {
   busy: boolean
   playerName: string
-  onReset: () => void
+  onReset: (deep: boolean) => void
 }) {
+  const [deep, setDeep] = useState(false)
   const go = () => {
+    const extra = deep ? '\nDEEP RESET: also wipes faction-related Dunipedia lore fragments (House Atreides/Harkonnen/Leto/Paul/Baron/Feyd/etc.).' : ''
     const typed = window.prompt(
-      `Reset ALL faction progression for ${playerName} — zeroes rep, removes every faction tag, and resets ClimbTheRanks journey nodes for both factions. Cannot be undone.\n\nType  reset faction  to proceed:`
+      `Reset ALL faction progression for ${playerName} — zeroes rep, removes every faction tag (rank grid, MaasKharet, storyline milestones), and resets ClimbTheRanks journey nodes (revealed AND completed) for both factions. Cannot be undone.${extra}\n\nType  reset faction  to proceed:`
     ) || ''
     if (typed.trim().toLowerCase() !== 'reset faction') return
-    onReset()
+    onReset(deep)
   }
   return (
     <div className="space-y-2">
-      <p className="text-[11px] text-text-dim">Removes Atreides + Harkonnen rep, tags, and faction journey nodes. Player must be offline; takes effect on next login.</p>
+      <p className="text-[11px] text-text-dim">Removes Atreides + Harkonnen rep, tags, and faction journey nodes (both revealed &amp; completed state). Player must be offline; takes effect on next login.</p>
+      <label className="flex items-start gap-2 text-[12px] text-text cursor-pointer select-none">
+        <input type="checkbox" checked={deep} disabled={busy}
+          onChange={e => setDeep(e.target.checked)}
+          className="mt-0.5 h-3.5 w-3.5 rounded border-border bg-surface-2 accent-ibad" />
+        <span>
+          <span className="font-medium">Deep reset</span>
+          <span className="text-text-dim"> — also wipe faction lore + Dunipedia entries for this faction (House Atreides / Harkonnen character codex).</span>
+        </span>
+      </label>
       <button className="btn-danger w-full" disabled={busy} onClick={go}>
-        <Icon name="Swords" size={13} /> Reset Faction
+        <Icon name="Swords" size={13} /> Reset Faction{deep ? ' (Deep)' : ''}
       </button>
     </div>
   )


### PR DESCRIPTION
## Bug

**Reset Faction** (Gameplay Admin → Players → Progression → Reset Faction) was only wiping roughly 15% of faction state. Verified live on two characters this session: post-reset dumps still had **hundreds of faction-related tags** and **80+ revealed `DA_FQ_ClimbTheRanks%` journey nodes**. That leftover state is the root cause of the multi-day stuck "Hunting Skorda" contract card observed on one character — the game keeps rendering the card because the underlying journey nodes are still marked `reveal=true`.

## Root cause (two concrete bugs)

**1. Journey nodes.** The old SQL was:

```sql
UPDATE dune.journey_story_node
   SET complete_condition_state='false'::jsonb, has_pending_reward=false
 WHERE ... story_node_id LIKE 'DA_FQ_ClimbTheRanks%';
```

Only `complete_condition_state` was cleared — `reveal_condition_state` was left untouched. Result: every previously-revealed chapter kept rendering as an active quest card on the STORY tab.

**2. Tags.** The old delete pattern only matched a handful of Fac_Atre_%/Fac_Hark_% + %RecruitmentCompleted rows. It **missed six full tag families** that are all faction-storyline state:

| Family | Match pattern |
|---|---|
| FactionStory rank grid + milestones | `Contract.Tracking.FactionStory.%` |
| Faction storyline named beats | `Contract.Tracking.Completed.FactionStoryline.%` |
| MaasKharet contracts (faction agent) | `Contract.Tracking.Completed.MaasKharet%` |
| FactionRank NPC dialogue | `Contract.Target.Dialogue.FactionRank%` |
| MaasKharet locations/lore | `Contract.Target.Location/Lore.MaasKharet%` |
| Faction recruiter intros | `DialogueFlags.IntroductionDone.ThufirHawat` / `PiterDeVries` / `MaasKharet` |
| Rank 4 banquet sub-state | `Contract.Target.Dialogue.Arrakeen_Social_Hub.Banquet.%` |
| Kytheria investigation flag | `Contract.Tracking.FactionsKytheriaInvestigationCompleted` |

## Fix

`Invoke-DunePlayerResetFaction` (`app/server/lib/PlayersWrites.ps1`):

- Clears `reveal_condition_state` alongside `complete_condition_state` on ClimbTheRanks nodes.
- Wipes all the missing tag families above.
- Preserves faction scope (`atreides` / `harkonnen` / `both`) — single-faction mode is conservative and only wipes the matching faction's tags + recruiter (ThufirHawat for Atreides, PiterDeVries for Harkonnen); `both` also wipes the shared/neutral markers (rank grid, banquet sub-state).
- Success message now reports counts: `Reset faction for '<name>' (<faction>): removed N tag(s), reset M ClimbTheRanks node(s)[, cleared K Dunipedia lore node(s)]. Takes effect on next login.`

## New feature — Deep reset checkbox

Optional boolean flag on the Reset Faction action. When ON, the reset also wipes faction-related **Dunipedia lore fragments** on the character's `journey_story_node` (House Atreides / House Harkonnen / TheRiseOfHouseAtreides / Ariste / Baron Vladimir / Feyd Rautha / Glossu Rabban / Leto / Paul / Jessica sub-trees). Neutral world lore (`DA_Dunipedia_ManualOfTheFriendlyDesert.*`, `DA_Dunipedia_WarForArrakis.Bandits*`) is preserved. Default OFF — opt-in for users who want a truly "never played this faction" state including the codex.

Wired through: `ResetFactionForm` UI checkbox → `resetFaction()` API → `body.deep` on `POST /api/gameplay/players/faction/reset` → `Invoke-DunePlayerResetFaction -Deep`.

## Verify

- PS parse-check clean on the four touched `.ps1` files.
- `webui` `tsc -b && vite build` clean.
- `pwsh app/installer/Build-Installer.ps1` clean, 46.06 MB `DuneServerSetup.exe` produced and copied to the primary checkout.

## Versioning

- Bumped 5 stamps to **12.16.6** (`app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/installer/DuneServer.iss`, `dune-server.ps1`).
- Rolled `CHANGELOG.md` `[12.16.6] - 2026-07-04`.
- Bumped `.github/ISSUE_TEMPLATE/bug_report.yml` `tool_version` placeholder to `v12.16.6`.

If the Fresh Start PR (`12.16.5`) merges first, this branch will rebase and take their stamps on top of `main` under `12.16.6`.