### PR TITLE
Add: Discover All Placeable Buildables + Discover All Tech one-clicks (self-seeding catalog)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.16.7"
+      placeholder: "v12.16.8"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [12.16.8] - 2026-07-04
+
+### Added
+
+- **Discover All Placeable Buildables** and **Discover All Tech (Buildables + Recipes + Groups)** one-click actions under *Players → Progression*. Both insert missing tech-knowledge entries into the character's Intel terminal with `UnlockedState = NotPurchased` — the entries appear in the terminal, but Intel points still need to be spent to fully unlock (matches the in-game `UnlockAllSkills` cheat behavior, scoped to buildable patents in the first action, and blanket to buildables + recipes + starter-pack groups in the second). Existing unlocks on the target character are preserved verbatim; only missing keys are added. The catalog of ItemKeys is derived at click time from the union across all characters on your own server (self-seeding — no DST update needed as Funcom adds content, and the catalog is only as complete as your most-discovered player). Offline-only (pawn JSON is RAM-authoritative while a player is connected). Takes effect on next login.
+
 ## [12.16.7] - 2026-07-04
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.16.7'
+$script:DuneToolVersion = '12.16.8'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.16.7',
+    [string]$Version = '12.16.8',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.16.7</Version>
+    <Version>12.16.8</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.16.7"
+#define MyAppVersion "12.16.8"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -2345,3 +2345,128 @@ LIMIT 1;
 
     return @{ ok = $true; result = $out }
 }
+
+# ---------------------------------------------------------------------------
+# Discover tech-knowledge entries (self-seeding catalog).
+# Inserts missing entries into the pawn's
+#   TechKnowledgePlayerComponent.m_TechKnowledge.m_TechKnowledgeData[]
+# with UnlockedState = 'NotPurchased' for every ItemKey whose prefix matches
+# one of $Prefixes. Matches the in-game UnlockAllSkills / UnlockAllAbilities
+# cheat behavior (entries appear discovered in the Intel terminal, but Intel
+# points still need to be spent to fully unlock). Existing entries on the
+# target character are preserved verbatim; only missing keys are added.
+#
+# Catalog is derived at CALL TIME from the union of all characters on the
+# server that already have entries in the requested prefix set - no static
+# catalog to maintain, and the set grows organically as players play. This
+# means "discover all" is only as complete as the server's most-discovered
+# character (documented in the UI copy).
+#
+# $Prefixes is an array of Postgres-regex fragments (e.g. '^BLD_'). Case
+# sensitive - matches Funcom's ItemKey convention.
+#
+# Offline-only at the route layer (pawn JSON is RAM-authoritative while the
+# player is connected; a live edit is overwritten on logout).
+# ---------------------------------------------------------------------------
+function Invoke-DunePlayerDiscoverTechEntries {
+    param([string]$Ip, [long]$AccountId, [string[]]$Prefixes)
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+    if (-not $Prefixes -or $Prefixes.Count -eq 0) { return @{ ok = $false; error = 'no prefixes specified.' } }
+
+    $pawnID = Get-DunePlayerPawnFromAccount -Ip $Ip -AccountId $AccountId
+    if ($pawnID -le 0) {
+        $err = "no pawn for account $AccountId."
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) { Write-DuneLog "DiscoverTech FAIL: $err" 'WARN' }
+        return @{ ok = $false; error = $err }
+    }
+
+    $prefixArr = ConvertTo-DunePgTextArray $Prefixes
+    $path = "'{TechKnowledgePlayerComponent,m_TechKnowledge,m_TechKnowledgeData}'"
+
+    # Single-statement CTE + UPDATE, wrapped in a transaction for atomicity.
+    # Uses COALESCE to seed an empty array when the tech path is missing on a
+    # fresh character (jsonb_set is then applied with create_missing=true).
+    $sql = @"
+BEGIN;
+WITH existing AS (
+    SELECT e AS entry
+    FROM dune.actors a, jsonb_array_elements(COALESCE(a.properties #> $path, '[]'::jsonb)) e
+    WHERE a.id = $pawnID::bigint
+),
+existing_keys AS (
+    SELECT entry->>'ItemKey' AS k FROM existing
+),
+catalog AS (
+    SELECT DISTINCT entry->>'ItemKey' AS k
+    FROM dune.actors a2,
+         jsonb_array_elements(a2.properties #> '{TechKnowledgePlayerComponent,m_TechKnowledge,m_TechKnowledgeData}') AS entry
+    WHERE a2.properties ? 'TechKnowledgePlayerComponent'
+      AND entry->>'ItemKey' ~ ANY($prefixArr)
+),
+missing AS (
+    SELECT k FROM catalog EXCEPT SELECT k FROM existing_keys
+),
+added_entries AS (
+    SELECT jsonb_build_object('ItemKey', k, 'bIsNewEntry', true, 'UnlockedState', 'NotPurchased') AS obj
+    FROM missing
+),
+merged AS (
+    SELECT
+        COALESCE((SELECT jsonb_agg(entry) FROM existing), '[]'::jsonb)
+        || COALESCE((SELECT jsonb_agg(obj) FROM added_entries), '[]'::jsonb) AS new_arr,
+        (SELECT COUNT(*) FROM added_entries)::int AS added_count,
+        (SELECT COUNT(*) FROM existing)::int      AS existing_count,
+        (SELECT COUNT(*) FROM catalog)::int       AS catalog_count
+)
+UPDATE dune.actors a
+SET properties = jsonb_set(
+    jsonb_set(
+        jsonb_set(
+            COALESCE(a.properties, '{}'::jsonb),
+            '{TechKnowledgePlayerComponent}',
+            COALESCE(a.properties -> 'TechKnowledgePlayerComponent', '{}'::jsonb),
+            true),
+        '{TechKnowledgePlayerComponent,m_TechKnowledge}',
+        COALESCE(a.properties #> '{TechKnowledgePlayerComponent,m_TechKnowledge}', '{}'::jsonb),
+        true),
+    $path,
+    (SELECT new_arr FROM merged),
+    true)
+WHERE a.id = $pawnID::bigint
+RETURNING (SELECT added_count FROM merged) AS added,
+          (SELECT existing_count FROM merged) AS already,
+          (SELECT catalog_count FROM merged) AS catalog;
+COMMIT;
+"@
+
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 5 -TimeoutSec 60
+    if (-not $r.ok) {
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) { Write-DuneLog "DiscoverTech FAIL: SQL error (pawn=$pawnID, prefixes=$($Prefixes -join ',')): $($r.error)" 'ERROR' }
+        return @{ ok = $false; error = "discover tech: $($r.error)" }
+    }
+
+    # Parse the RETURNING row (added / already / catalog) from the query output.
+    $added = 0; $already = 0; $catalog = 0
+    try {
+        $maps = ConvertTo-DuneRowMaps -Result $r
+        if ($maps -and $maps.Count -ge 1) {
+            $added   = [int](ConvertTo-DuneInt $maps[0]['added'])
+            $already = [int](ConvertTo-DuneInt $maps[0]['already'])
+            $catalog = [int](ConvertTo-DuneInt $maps[0]['catalog'])
+        }
+    } catch { }
+
+    if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+        Write-DuneLog "DiscoverTech OK: added=$added already=$already catalog=$catalog (pawn=$pawnID, account=$AccountId, prefixes=$($Prefixes -join ','))"
+    }
+
+    $msg = "Discovered $added new tech entries ($already already present, $catalog in server catalog). Intel points still need to be spent normally. Takes effect on next login."
+    if ($added -eq 0 -and $catalog -eq 0) {
+        $msg = "No entries in the server catalog yet for those prefixes - the catalog is derived from what any character on this server has already discovered. Have someone discover a few entries in-game first."
+    } elseif ($added -eq 0) {
+        $msg = "Nothing new to discover - this character already has all $catalog entries the server catalog knows about."
+    }
+
+    return @{ ok = $true; message = $msg; added = $added; already_present = $already; catalog_size = $catalog }
+}
+

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -588,3 +588,45 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/update-tags' -Handl
         Write-DuneError -Response $res -Status 500 -Message "Update tags failed: $($_.Exception.Message)"
     }
 }
+
+# ---------------------------------------------------------------------------
+# Discover tech-knowledge (self-seeding catalog). Two prefix-scoped variants:
+#   /discover-buildables -> BLD_* only (matches "unlock all placeable buildables")
+#   /discover-all-tech   -> BLD_* + RCP_* + DA_GRP_* (blanket)
+# Both insert missing entries as NotPurchased; existing unlocks are preserved.
+# Offline-only (pawn JSON is RAM-authoritative while connected).
+# ---------------------------------------------------------------------------
+
+# POST /api/gameplay/players/discover-buildables  { account_id }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/discover-buildables' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
+        if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
+            if (-not $off.ok) { return @{ ok = $false; error = "Player must be offline to discover tech entries. $($off.reason)" } }
+            Invoke-DunePlayerDiscoverTechEntries -Ip $ip -AccountId $acc -Prefixes @('^BLD_')
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Discover buildables failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/discover-all-tech  { account_id }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/discover-all-tech' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $acc = Get-DuneBodyInt -Body $body -Name 'account_id'
+        if ($null -eq $acc -or $acc -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            $off = Test-DunePlayerOfflineByAccount -Ip $ip -AccountId $acc
+            if (-not $off.ok) { return @{ ok = $false; error = "Player must be offline to discover tech entries. $($off.reason)" } }
+            Invoke-DunePlayerDiscoverTechEntries -Ip $ip -AccountId $acc -Prefixes @('^BLD_','^RCP_','^DA_GRP_')
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Discover all tech failed: $($_.Exception.Message)"
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.16.7"
+$script:ToolVersion = "12.16.8"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1784,6 +1784,22 @@ export function resetFaction(accountId: number, faction: 'atreides' | 'harkonnen
   })
 }
 
+// Discover tech-knowledge entries (self-seeding catalog).
+// - discoverAllBuildables: BLD_* only (matches "unlock all placeable buildables")
+// - discoverAllTech: BLD_* + RCP_* + DA_GRP_* (blanket)
+// Both insert missing entries as NotPurchased; existing unlocks are preserved.
+// Offline-only.
+export function discoverAllBuildables(accountId: number) {
+  return api<WriteResult>('/api/gameplay/players/discover-buildables', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId }),
+  })
+}
+export function discoverAllTech(accountId: number) {
+  return api<WriteResult>('/api/gameplay/players/discover-all-tech', {
+    method: 'POST', body: JSON.stringify({ account_id: accountId }),
+  })
+}
+
 // Fresh Start (keep builds & cosmetics) — snapshot + restore-by-name.
 // A truly-fresh character can only be made by the engine (delete + recreate
 // in-game). DST preserves the player's unlocked building sets + cosmetics: snapshot

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -26,6 +26,7 @@ import {
   restoreDestroyed,
   setFactionTier, setPlayerTags, setSkillPoints,
   setStarterClass, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, wipeJourney, resetFaction, snapshotBuilds, getFreshStartSnapshots, restoreBuilds, skipTutorial,
+  discoverAllBuildables, discoverAllTech,
   chatWhisper, isValidTemplateId, getItemCatalog, getCosmeticsCatalog, type CosmeticEntry,
   parseTcnoPackageText,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
@@ -622,6 +623,18 @@ const ACTIONS: ActionDef[] = [
   { id: 'apply-progression-preset', group: 'Progression', label: 'Apply Quick Preset', icon: 'Zap', custom: 'quick-presets', offlineOnly: true,
     rowNote: 'Completes a story/journey chapter instantly — incl. Find the Fremen (3rd ability slot + prescience). Player must be offline.',
     run: () => Promise.resolve({ message: '' }) },
+  { id: 'discover-buildables', group: 'Progression', label: 'Discover All Placeable Buildables', icon: 'Hammer', offlineOnly: true,
+    rowNote: 'Marks every BLD_* patent your server has ever seen as DISCOVERED (NotPurchased) so it appears in the Intel terminal. Points still need to be spent normally. Catalog is self-seeding from your own players.',
+    confirm: p => `Discover all placeable buildable patents on ${p.name}?\n\n` +
+      `Inserts every BLD_* ItemKey your server has ever discovered as NotPurchased on ${p.name}'s Intel terminal — same behavior as the in-game UnlockAll cheat scoped to buildables. Existing unlocks are preserved; only missing entries are added. Intel points still need to be spent normally.\n\n` +
+      `Catalog is derived at click time from the union across all characters on this server, so it's only as complete as your most-discovered player. Takes effect on next login.`,
+    run: p => discoverAllBuildables(p.account_id) },
+  { id: 'discover-all-tech', group: 'Progression', label: 'Discover All Tech (Buildables + Recipes + Groups)', icon: 'BookOpenCheck', offlineOnly: true,
+    rowNote: 'Blanket version: BLD_*, RCP_*, DA_GRP_* — every tech entry your server has seen as NotPurchased. Points still spent normally. Self-seeding catalog.',
+    confirm: p => `Discover ALL tech entries on ${p.name}?\n\n` +
+      `Blanket version — inserts every BLD_*, RCP_*, and DA_GRP_* ItemKey your server has ever discovered as NotPurchased. Same self-seeding catalog as the buildables-only version. Existing unlocks are preserved; Intel points still need to be spent normally.\n\n` +
+      `Catalog is only as complete as your server's most-discovered character. Takes effect on next login.`,
+    run: p => discoverAllTech(p.account_id) },
   { id: 'progression-unlock', group: 'Progression', label: 'Progression Unlock', icon: 'Milestone', custom: 'progression-unlock',
     rowNote: 'Completes DA_FQ_ClimbTheRanks journey nodes + writes faction tier tags',
     run: () => Promise.resolve({ message: '' }) },

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -576,7 +576,7 @@ interface ActionDef {
   balance?: 'solari' | 'scrip' | 'intel'  // show the player's current balance read-only above the form
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
-  rowNote?: string        // short italic note shown inline on the row heading
+  rowNote?: string        // description shown inside the expanded row (revealed on click)
   run: (p: Player, v: Record<string, string>) => Promise<{ message: string }>
 }
 
@@ -936,12 +936,6 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
         title={def.liveOnly ? 'Requires player to be online' : def.offlineOnly ? 'Requires player to be offline — the game caches this value in memory while online and overwrites it on logout' : undefined}>
         <Icon name={def.icon} size={14} className={`shrink-0 ${danger ? 'text-error' : 'text-text-dim'}`} />
         <span className="flex-1 min-w-0 truncate font-medium">{def.label}</span>
-        {def.rowNote && (
-          <span className="shrink-0 hidden sm:flex items-center gap-1.5 text-xs">
-            <span className="text-text-dim">---</span>
-            <span className="italic text-white">{def.rowNote}</span>
-          </span>
-        )}
         {def.liveOnly && (
           <span className="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-warning/20 text-warning border border-warning/50 shrink-0">LIVE REQ'D</span>
         )}
@@ -952,6 +946,9 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
       </button>
       {open && (
         <div className="border-t border-border p-3">
+          {def.rowNote && (
+            <div className="mb-3 text-xs italic text-text-dim leading-relaxed">{def.rowNote}</div>
+          )}
           {def.custom === 'give-item' ? (
             <GiveItemForm busy={busy} submitLabel={def.label}
               onSubmit={(tpl, qty, qual, overflow) => runAction(def, () => giveItem(player.id, tpl, qty, qual, overflow))}


### PR DESCRIPTION
## What

Two new one-click Progression actions under **Players → Progression**:

1. **Discover All Placeable Buildables** — targets `BLD_*` ItemKeys only (matches the placeable-buildable side of the in-game `UnlockAllSkills` cheat).
2. **Discover All Tech (Buildables + Recipes + Groups)** — blanket: `BLD_*`, `RCP_*`, `DA_GRP_*` (all three ItemKey prefixes DST sees on real characters).

Both insert missing entries into the character's tech-knowledge blob with `UnlockedState = "NotPurchased"` — the entries appear in the Intel terminal so the player can spend Intel points to unlock them. This is **honest DST behavior**: not a free grant, just makes them discoverable. Matches the cheat script.

## Mechanism

All tech-knowledge state lives on the pawn actor at:

```
dune.actors.properties
  → TechKnowledgePlayerComponent
    → m_TechKnowledge
      → m_TechKnowledgeData[]
        { "ItemKey": "BLD_...", "bIsNewEntry": true, "UnlockedState": "NotPurchased" }
```

Existing entries on the target character are preserved verbatim (their `UnlockedState` is not touched). Only **missing** keys are appended.

Offline-only, same constraint as every other actor-property write — RAM-authoritative on live players, would be overwritten on logout. Takes effect on next login.

## Self-seeding catalog (no static file)

Rather than bundling a static catalog with DST that goes stale with every Funcom content update, the catalog is derived **at click time** from the union of all characters on the target's own server:

```sql
SELECT DISTINCT entry->>'ItemKey'
FROM dune.actors a,
     jsonb_array_elements(a.properties -> 'TechKnowledgePlayerComponent' -> 'm_TechKnowledge' -> 'm_TechKnowledgeData') AS entry
WHERE a.properties ? 'TechKnowledgePlayerComponent'
  AND entry->>'ItemKey' ~ ANY($prefixes);
```

This gives every self-hoster a catalog scoped to what their own players have discovered so far — grows organically, no DST update needed as Funcom adds content.

**Documented caveat (surfaced in the UI):** the catalog is only as complete as the server's most-discovered character. On a brand-new server with 1–2 low-level chars, most entries won't be discovered yet, so "discover all" is a superset of what SOMEONE on the server has seen. Self-improves as players play.

## Backend

- `app/server/lib/PlayersWrites.ps1` — new helper `Invoke-DunePlayerDiscoverTechEntries -Ip -AccountId -Prefixes` builds the merged blob in a single transaction (BEGIN/COMMIT-wrapped CTE + UPDATE with `RETURNING`), returns `added` / `already_present` / `catalog_size` counts. Uses the existing `ConvertTo-DunePgTextArray` for the prefix regex array. Seeds missing intermediate paths (nested `jsonb_set` + `COALESCE`) so it works on fresh characters that haven't crafted yet.
- `app/server/routes/PlayersWrites.ps1` — new routes `POST /api/gameplay/players/discover-buildables` and `POST /api/gameplay/players/discover-all-tech`, both offline-checked via `Test-DunePlayerOfflineByAccount`.

## Frontend

- `webui/src/api/gameplay.ts` — `discoverAllBuildables(accountId)` + `discoverAllTech(accountId)` wrappers.
- `webui/src/pages/gameplay/players/sections.tsx` — two new `offlineOnly` Progression actions with confirm-dialog copy that explains the mechanism, the NotPurchased behavior, and the self-seeding catalog caveat.

## Version + CHANGELOG + template

- Bumped 5 version stamps to **12.16.8** (v12.16.7 is claimed by PR #447 which is currently open ahead of this).
- CHANGELOG entry added under `[12.16.8]` describing the two actions, the NotPurchased behavior, the self-seeding catalog, and the offline-only constraint.
- `bug_report.yml` `tool_version` placeholder bumped.

## Verify

- ✅ PS parse-check on all modified `.ps1` files.
- ✅ `webui/npm run build` — clean, zero TS errors.
- ✅ `pwsh app/installer/Build-Installer.ps1` — clean build, `DuneServerSetup.exe` 46.07 MB.

**Do NOT merge/tag/release** — Coastal handles the release.