### PR TITLE
Add full backup manager (list all + delete + sort/search) on Database page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [Unreleased]
+
+### Added
+
+- **Full backup manager on the Database page.** The *Backup Schedule* card's "Recent backups" list (previously capped at the last 5) is now a complete backup manager. It lists **all** `.backup` files in the VM's dump directory in a scrollable table, with a **filename search box**, a **sort** control (Newest / Oldest / Largest / Smallest / Name A→Z), and a "showing N of M" count. Each row keeps the existing **Download** action and adds a **Delete** action; **multi-select checkboxes** plus a bulk **Delete (N)** button allow removing several backups at once. Deletes are confirmed (`window.confirm`), remove both the `.backup` file and its `.yaml` sidecar on the VM, and are validated server-side (path must be under the dump dir, end in `.backup`, no traversal) and gated behind the VM lock. Import (upload) and dump-dir size readout are unchanged.
+
 ## [12.16.7] - 2026-07-04
 
 ### Added
@@ -6867,7 +6873,7 @@ at the time. Also folds in the v3.0.1 / v3.1.2 patches.
   (`ssh`, `Gameplay Admin`, `setup-guide`, `report-issue`). _(originally
   3.1.2)_
 
-[Unreleased]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v6.1.2...HEAD
+[Unreleased]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v12.16.6...HEAD
 [6.1.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v6.0.1...v6.1.2
 [6.0.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v5.0.2...v6.0.1
 [5.0.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v4.5.2...v5.0.2

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -546,14 +546,21 @@ function Get-DuneBackupHistory {
         [int]$LogLines = 50
     )
     if ($Recent -lt 1)   { $Recent = 1 }
-    if ($Recent -gt 100) { $Recent = 100 }
+    if ($Recent -gt 1000) { $Recent = 1000 }
     if ($LogLines -lt 1)    { $LogLines = 1 }
     if ($LogLines -gt 500)  { $LogLines = 500 }
 
+    # Stat every backup file (bounded to 5000 so xargs stays sane), sort newest-
+    # first, THEN cap to $Recent. The old code capped BEFORE stat/sort, so a
+    # dump dir with more files than the cap returned an arbitrary slice instead
+    # of the newest N. The manager UI requests a high $Recent to list them all;
+    # emit the true total so the UI can show "showing N of M".
     $script = @"
+echo '__DST_SECTION:COUNT'
+sudo find $script:DuneBackupDumpDir -maxdepth 3 -type f -name '*.backup' 2>/dev/null | wc -l
 echo '__DST_SECTION:FILES'
 sudo find $script:DuneBackupDumpDir -maxdepth 3 -type f -name '*.backup' 2>/dev/null \
-  | head -200 \
+  | head -5000 \
   | xargs -r -I{} sudo stat -c '%Y|%s|%n' '{}' 2>/dev/null \
   | sort -rn \
   | head -$Recent
@@ -595,13 +602,109 @@ sudo du -sh $script:DuneBackupDumpDir 2>/dev/null | awk '{print `$1}' || true
     $logTail = if ($sections.ContainsKey('LOG'))  { ($sections['LOG']  -join "`n").TrimEnd("`n") } else { '' }
     $diskUse = if ($sections.ContainsKey('DISK')) { ($sections['DISK'] -join '').Trim() } else { '' }
 
+    $total = $files.Count
+    if ($sections.ContainsKey('COUNT')) {
+        $countStr = ($sections['COUNT'] -join '').Trim()
+        $parsed = 0
+        if ([int]::TryParse($countStr, [ref]$parsed)) { $total = $parsed }
+    }
+
     return @{
         recent        = $files
+        total         = $total
         logTail       = $logTail
         dumpDirPath   = $script:DuneBackupDumpDir
         dumpDirSize   = $diskUse
         logPath       = '/var/log/dune-backup.log'
     }
+}
+
+# -----------------------------------------------------------------------------
+# Public: delete one or more `.backup` files from the VM's dump directory (plus
+# each file's `.yaml` sidecar, which Funcom writes alongside every dump). Every
+# path is validated HARD before any rm runs so this can only ever touch a
+# genuine backup file inside the dump dir:
+#   - must be an absolute path under $script:DuneBackupDumpDir
+#   - must end in `.backup`
+#   - must not contain `..` (no path traversal)
+# Returns @{ ok; deleted=@(); failed=@(@{path;reason}); message }.
+# -----------------------------------------------------------------------------
+function Remove-DuneBackupFiles {
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [Parameter(Mandatory)][string[]]$Paths
+    )
+    $deleted = New-Object System.Collections.Generic.List[string]
+    $failed  = New-Object System.Collections.Generic.List[object]
+    $valid   = New-Object System.Collections.Generic.List[string]
+
+    $root = $script:DuneBackupDumpDir
+    foreach ($p in $Paths) {
+        $path = if ($null -eq $p) { '' } else { ([string]$p).Trim() }
+        if (-not $path) {
+            $failed.Add(@{ path = $p; reason = 'Empty path.' }); continue
+        }
+        if ($path -match '\.\.') {
+            $failed.Add(@{ path = $path; reason = 'Path traversal not allowed.' }); continue
+        }
+        if ($path -notlike "$root/*") {
+            $failed.Add(@{ path = $path; reason = "Path must be inside $root." }); continue
+        }
+        if ($path -notmatch '\.backup$') {
+            $failed.Add(@{ path = $path; reason = 'Path must end in .backup.' }); continue
+        }
+        $valid.Add($path) | Out-Null
+    }
+
+    if ($valid.Count -eq 0) {
+        return @{ ok = $false; status = 400; deleted = @(); failed = @($failed); message = 'No valid backup paths to delete.' }
+    }
+
+    # Build a shell script that removes each validated file + its sidecar and
+    # prints a per-path result marker we can parse back. Single-quote each path
+    # for the shell (backups never contain single quotes; guard anyway).
+    $sb = New-Object System.Text.StringBuilder
+    foreach ($path in $valid) {
+        if ($path.Contains("'")) {
+            $failed.Add(@{ path = $path; reason = 'Path contains a single quote.' }); continue
+        }
+        $q = "'" + $path + "'"
+        # Only report OK when the .backup itself is gone after rm. The .yaml
+        # sidecar is best-effort (may not exist for manually-uploaded files).
+        [void]$sb.AppendLine("if sudo rm -f $q && sudo rm -f ${q}.yaml 2>/dev/null; then if [ ! -e $q ]; then echo `"__DEL_OK:$path`"; else echo `"__DEL_FAIL:$path|still present`"; fi; else echo `"__DEL_FAIL:$path|rm failed`"; fi")
+    }
+
+    if ($sb.Length -eq 0) {
+        return @{ ok = $false; status = 400; deleted = @(); failed = @($failed); message = 'No valid backup paths to delete.' }
+    }
+
+    $r = Invoke-DuneBackupShell -Ip $Ip -Script $sb.ToString() -TimeoutSec 60
+    if ($r.rc -lt 0) { throw 'SSH to VM failed (no exit code returned).' }
+
+    foreach ($ln in ($r.out -split "`n")) {
+        $line = $ln.Trim()
+        if ($line -like '__DEL_OK:*') {
+            $deleted.Add($line.Substring(9)) | Out-Null
+        } elseif ($line -like '__DEL_FAIL:*') {
+            $rest = $line.Substring(11)
+            $bar = $rest.IndexOf('|')
+            if ($bar -ge 0) {
+                $failed.Add(@{ path = $rest.Substring(0, $bar); reason = $rest.Substring($bar + 1) })
+            } else {
+                $failed.Add(@{ path = $rest; reason = 'Delete failed.' })
+            }
+        }
+    }
+
+    $ok = ($deleted.Count -gt 0) -and ($failed.Count -eq 0)
+    $msg = if ($failed.Count -eq 0) {
+        "Deleted $($deleted.Count) backup file(s)."
+    } elseif ($deleted.Count -gt 0) {
+        "Deleted $($deleted.Count); $($failed.Count) failed."
+    } else {
+        "Delete failed for all $($failed.Count) file(s)."
+    }
+    return @{ ok = $ok; deleted = @($deleted); failed = @($failed); message = $msg }
 }
 
 # -----------------------------------------------------------------------------

--- a/app/server/routes/BackupTransfer.ps1
+++ b/app/server/routes/BackupTransfer.ps1
@@ -7,6 +7,10 @@
 # POST /api/db/backup-upload    body: { localPath }
 #   SCP a local .backup file to the VM's dump directory so it appears in
 #   backup history and can be picked by the existing Restore command.
+#
+# POST /api/db/backup-delete    body: { paths: string[] }  (or { vmPath })
+#   Delete one or more .backup files (+ their .yaml sidecars) from the VM's
+#   dump directory. Every path is validated in Remove-DuneBackupFiles.
 
 Register-DuneRoute -Method POST -Path '/api/db/backup-download' -Handler {
     param($req, $res, $routeParams, $body)
@@ -183,5 +187,46 @@ Register-DuneRoute -Method POST -Path '/api/db/backup-upload' -Handler {
         remotePath = $remotePath
         sizeBytes  = $size
         message    = "Uploaded $('{0:N1}' -f ($size / 1MB)) MB to VM — it will appear in backup history."
+    }
+}
+
+Register-DuneRoute -Method POST -Path '/api/db/backup-delete' -Handler {
+    param($req, $res, $routeParams, $body)
+    $ctx = Get-DuneBackupContext
+    if (-not $ctx.ok) {
+        Write-DuneError -Response $res -Status $ctx.status -Message $ctx.message
+        return
+    }
+
+    # Accept either { paths: [...] } (bulk) or { vmPath: '...' } (single).
+    $paths = @()
+    if ($body -is [hashtable] -or $body -is [System.Collections.IDictionary]) {
+        if ($body.ContainsKey('paths')  -and $body['paths'])  { $paths = @($body['paths']) }
+        elseif ($body.ContainsKey('vmPath') -and $body['vmPath']) { $paths = @([string]$body['vmPath']) }
+    } elseif ($body) {
+        if ($body.paths)      { $paths = @($body.paths) }
+        elseif ($body.vmPath) { $paths = @([string]$body.vmPath) }
+    }
+    $paths = @($paths | Where-Object { $_ } | ForEach-Object { [string]$_ })
+    if ($paths.Count -eq 0) {
+        Write-DuneError -Response $res -Status 400 -Message 'Body must include paths (array) or vmPath (string).'
+        return
+    }
+    if ($paths.Count -gt 500) {
+        Write-DuneError -Response $res -Status 400 -Message 'Too many paths (max 500 per request).'
+        return
+    }
+
+    try {
+        $result = Invoke-WithDuneLock -Name 'backup-delete' -Script {
+            Remove-DuneBackupFiles -Ip $ctx.ip -Paths $paths
+        }
+        if (-not $result.ok -and $result.ContainsKey('status') -and $result.status) {
+            Write-DuneError -Response $res -Status ([int]$result.status) -Message $result.message
+            return
+        }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 502 -Message "Delete failed: $($_.Exception.Message)"
     }
 }

--- a/webui/src/api/database.ts
+++ b/webui/src/api/database.ts
@@ -82,6 +82,21 @@ export function uploadBackup(opts: { localPath: string }) {
   })
 }
 
+export type BackupDeleteResult = {
+  ok: boolean
+  deleted: string[]
+  failed: { path: string; reason: string }[]
+  message?: string
+  error?: string
+}
+
+export function deleteBackups(opts: { paths: string[] }) {
+  return api<BackupDeleteResult>('/api/db/backup-delete', {
+    method: 'POST',
+    body: JSON.stringify({ paths: opts.paths }),
+  })
+}
+
 export function getBackupDumpPods() {
   return api<BackupDumpPodList>('/api/db/backup-dump-pods')
 }

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -435,6 +435,7 @@ export type BackupFile = {
 
 export type BackupHistory = {
   recent: BackupFile[]
+  total?: number
   logTail: string
   dumpDirPath: string
   dumpDirSize: string

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -11,6 +11,7 @@ import {
   getBackupHistory,
   downloadBackup,
   uploadBackup,
+  deleteBackups,
   getBackupDumpPods,
   pruneBackupDumpPods,
 } from '../api/database'
@@ -647,6 +648,12 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
   const [showLog, setShowLog]   = useState(false)
   const [transferring, setTransferring] = useState<string | null>(null)  // vmPath or 'upload'
 
+  // Backup manager: search / sort / multi-select / delete.
+  const [search, setSearch]     = useState('')
+  const [sortBy, setSortBy]     = useState<'date-desc' | 'date-asc' | 'size-desc' | 'size-asc' | 'name'>('date-desc')
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [deleting, setDeleting] = useState(false)
+
   // Draft state — initialised from `schedule` when it loads, then locally
   // editable so the user can preview their choice before clicking Save.
   const [draftPreset, setDraftPreset]       = useState<string>('Off')
@@ -663,7 +670,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
     try {
       const [sched, hist, pods] = await Promise.all([
         getBackupSchedule(),
-        getBackupHistory({ recent: 5, logLines: 50 }),
+        getBackupHistory({ recent: 200, logLines: 50 }),
         getBackupDumpPods().catch(() => null),
       ])
       setSchedule(sched)
@@ -718,7 +725,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       showToast('ok', draftPreset === 'Off' ? 'Schedule disabled.' : `Schedule saved.`)
       // Refresh history + pod list in the background so the user sees the new
       // schedule reflected immediately when the next cron run lands.
-      void getBackupHistory({ recent: 5, logLines: 50 }).then(setHistory).catch(() => {})
+      void getBackupHistory({ recent: 200, logLines: 50 }).then(setHistory).catch(() => {})
       void getBackupDumpPods().then(setDumpPods).catch(() => {})
     } catch (e) {
       showToast('err', `Save failed: ${e instanceof Error ? e.message : String(e)}`)
@@ -750,12 +757,110 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       const r = await uploadBackup({ localPath })
       showToast('ok', r.message ?? 'Upload complete.')
       // Refresh history so the new file appears
-      void getBackupHistory({ recent: 5, logLines: 50 }).then(setHistory).catch(() => {})
+      void getBackupHistory({ recent: 200, logLines: 50 }).then(setHistory).catch(() => {})
     } catch (e) {
       showToast('err', `Upload failed: ${e instanceof Error ? e.message : String(e)}`)
     } finally {
       setTransferring(null)
     }
+  }
+
+  // Filename relative to the dump dir, for display + search.
+  function backupRelName(path: string): string {
+    return path.replace(/^\/funcom\/artifacts\/database-dumps\//, '')
+  }
+
+  // Filtered + sorted view of the full backup list.
+  const visibleBackups = useMemo(() => {
+    const all = history?.recent ?? []
+    const q = search.trim().toLowerCase()
+    const filtered = q
+      ? all.filter(f => backupRelName(f.path).toLowerCase().includes(q))
+      : all.slice()
+    filtered.sort((a, b) => {
+      switch (sortBy) {
+        case 'date-asc':  return a.mtimeEpoch - b.mtimeEpoch
+        case 'size-desc': return b.sizeBytes - a.sizeBytes
+        case 'size-asc':  return a.sizeBytes - b.sizeBytes
+        case 'name':      return backupRelName(a.path).localeCompare(backupRelName(b.path))
+        case 'date-desc':
+        default:          return b.mtimeEpoch - a.mtimeEpoch
+      }
+    })
+    return filtered
+  }, [history, search, sortBy])
+
+  // Drop selections that no longer exist after a refresh/delete.
+  useEffect(() => {
+    const present = new Set((history?.recent ?? []).map(f => f.path))
+    setSelected(prev => {
+      const next = new Set([...prev].filter(p => present.has(p)))
+      return next.size === prev.size ? prev : next
+    })
+  }, [history])
+
+  function toggleSelect(path: string) {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path); else next.add(path)
+      return next
+    })
+  }
+
+  function toggleSelectAllVisible() {
+    setSelected(prev => {
+      const allVisibleSelected = visibleBackups.length > 0 && visibleBackups.every(f => prev.has(f.path))
+      if (allVisibleSelected) {
+        const next = new Set(prev)
+        for (const f of visibleBackups) next.delete(f.path)
+        return next
+      }
+      const next = new Set(prev)
+      for (const f of visibleBackups) next.add(f.path)
+      return next
+    })
+  }
+
+  async function runDelete(paths: string[]) {
+    if (paths.length === 0) return
+    setDeleting(true)
+    try {
+      const r = await deleteBackups({ paths })
+      const del = r.deleted?.length ?? 0
+      const fail = r.failed?.length ?? 0
+      if (fail > 0) {
+        const detail = (r.failed ?? []).map(f => `${backupRelName(f.path)} (${f.reason})`).join('; ')
+        showToast('err', del > 0 ? `Deleted ${del}; ${fail} failed: ${detail}` : `Delete failed: ${detail}`)
+      } else {
+        showToast('ok', r.message ?? `Deleted ${del} backup${del === 1 ? '' : 's'}.`)
+      }
+      setSelected(new Set())
+      void getBackupHistory({ recent: 200, logLines: 50 }).then(setHistory).catch(() => {})
+    } catch (e) {
+      showToast('err', `Delete failed: ${e instanceof Error ? e.message : String(e)}`)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  function handleDeleteOne(path: string) {
+    const ok = window.confirm(
+      `Permanently delete this backup from the server?\n\n${backupRelName(path)}\n\n` +
+      'This removes the .backup file (and its .yaml sidecar) from the VM. It cannot be undone.'
+    )
+    if (!ok) return
+    void runDelete([path])
+  }
+
+  function handleDeleteSelected() {
+    const paths = [...selected]
+    if (paths.length === 0) return
+    const ok = window.confirm(
+      `Permanently delete ${paths.length} selected backup${paths.length === 1 ? '' : 's'} from the server?\n\n` +
+      'This removes the .backup files (and their .yaml sidecars) from the VM. It cannot be undone.'
+    )
+    if (!ok) return
+    void runDelete(paths)
   }
 
   async function handlePruneDumpPods() {
@@ -980,7 +1085,14 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
 
       <div className="border-t border-border pt-3 mt-1">
         <div className="flex items-center justify-between gap-3 mb-2">
-          <div className="text-xs font-semibold text-text-muted">Recent backups</div>
+          <div className="text-xs font-semibold text-text-muted">
+            All backups
+            {history ? (
+              <span className="text-text-dim font-normal ml-1">
+                (showing {visibleBackups.length} of {history.total ?? history.recent.length})
+              </span>
+            ) : null}
+          </div>
           <div className="flex items-center gap-3">
             <button
               type="button"
@@ -997,29 +1109,109 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
             </span>
           </div>
         </div>
+
+        {history && history.recent.length > 0 && (
+          <div className="flex items-center gap-2 mb-2">
+            <div className="relative flex-1 min-w-0">
+              <Icon name="Search" size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-text-dim pointer-events-none" />
+              <input
+                type="text"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                placeholder="Search by filename…"
+                className="w-full pl-7 pr-2 py-1 text-xs rounded bg-surface-2 border border-border text-text placeholder:text-text-dim"
+              />
+            </div>
+            <select
+              value={sortBy}
+              onChange={e => setSortBy(e.target.value as typeof sortBy)}
+              className="px-2 py-1 text-xs rounded bg-surface-2 border border-border text-text shrink-0"
+              title="Sort backups"
+            >
+              <option value="date-desc">Newest first</option>
+              <option value="date-asc">Oldest first</option>
+              <option value="size-desc">Largest first</option>
+              <option value="size-asc">Smallest first</option>
+              <option value="name">Name (A→Z)</option>
+            </select>
+            <button
+              type="button"
+              onClick={handleDeleteSelected}
+              disabled={selected.size === 0 || deleting || !!transferring}
+              className="btn-danger text-xs py-1 px-2 shrink-0"
+              title="Delete selected backups"
+            >
+              <Icon name={deleting ? 'Loader2' : 'Trash2'} size={12} className={deleting ? 'animate-spin' : ''} />
+              Delete{selected.size > 0 ? ` (${selected.size})` : ''}
+            </button>
+          </div>
+        )}
+
         {!history || history.recent.length === 0 ? (
           <p className="text-xs text-text-dim italic">
             {vmRunning ? 'No backup files found yet.' : 'VM not running.'}
           </p>
+        ) : visibleBackups.length === 0 ? (
+          <p className="text-xs text-text-dim italic">No backups match “{search}”.</p>
         ) : (
-          <ul className="text-xs font-mono space-y-1">
-            {history.recent.map(f => (
-              <li key={f.path} className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => void handleDownload(f.path)}
-                  disabled={!!transferring}
-                  className="text-info hover:text-info-bright disabled:opacity-40 shrink-0"
-                  title="Download to your PC"
-                >
-                  <Icon name={transferring === f.path ? 'Loader2' : 'Download'} size={12} className={transferring === f.path ? 'animate-spin' : ''} />
-                </button>
-                <span className="text-text">{f.mtimeIso}</span>
-                <span className="text-text-muted">{(f.sizeBytes / (1024 * 1024)).toFixed(1)} MB</span>
-                <span className="text-text-dim truncate" title={f.path}>{f.path.replace(/^\/funcom\/artifacts\/database-dumps\//, '')}</span>
-              </li>
-            ))}
-          </ul>
+          <div className="border border-border rounded max-h-72 overflow-y-auto">
+            <table className="w-full text-xs font-mono">
+              <thead className="sticky top-0 bg-surface-2 text-text-muted">
+                <tr>
+                  <th className="w-8 py-1 px-2 text-left">
+                    <input
+                      type="checkbox"
+                      checked={visibleBackups.length > 0 && visibleBackups.every(f => selected.has(f.path))}
+                      onChange={toggleSelectAllVisible}
+                      title="Select all shown"
+                    />
+                  </th>
+                  <th className="py-1 px-2 text-left font-semibold">Date</th>
+                  <th className="py-1 px-2 text-right font-semibold">Size</th>
+                  <th className="py-1 px-2 text-left font-semibold">File</th>
+                  <th className="w-16 py-1 px-2 text-right font-semibold">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleBackups.map(f => (
+                  <tr key={f.path} className="border-t border-border hover:bg-surface-2/50">
+                    <td className="py-1 px-2">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(f.path)}
+                        onChange={() => toggleSelect(f.path)}
+                      />
+                    </td>
+                    <td className="py-1 px-2 text-text whitespace-nowrap">{f.mtimeIso}</td>
+                    <td className="py-1 px-2 text-text-muted text-right whitespace-nowrap">{(f.sizeBytes / (1024 * 1024)).toFixed(1)} MB</td>
+                    <td className="py-1 px-2 text-text-dim truncate max-w-[16rem]" title={f.path}>{backupRelName(f.path)}</td>
+                    <td className="py-1 px-2">
+                      <div className="flex items-center gap-2 justify-end">
+                        <button
+                          type="button"
+                          onClick={() => void handleDownload(f.path)}
+                          disabled={!!transferring || deleting}
+                          className="text-info hover:text-info-bright disabled:opacity-40 shrink-0"
+                          title="Download to your PC"
+                        >
+                          <Icon name={transferring === f.path ? 'Loader2' : 'Download'} size={12} className={transferring === f.path ? 'animate-spin' : ''} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteOne(f.path)}
+                          disabled={!!transferring || deleting}
+                          className="text-danger hover:text-danger-bright disabled:opacity-40 shrink-0"
+                          title="Delete from server"
+                        >
+                          <Icon name="Trash2" size={12} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
         {lastBackup && (
           <p className="text-xs text-text-dim mt-2">


### PR DESCRIPTION
## What

Extends the **Backup Schedule** card on the Database page from a "last 5 recent backups" list into a full **backup manager**.

### Frontend (`webui`)
- The old "Recent backups" block is now an **All backups** manager:
  - **Filename search** box
  - **Sort** control: Newest / Oldest / Largest / Smallest / Name (A→Z)
  - Scrollable table of **all** backups with a "showing N of M" count
  - Per-row **Download** (existing) + **Delete** (new)
  - **Multi-select** checkboxes (incl. select-all-visible) + bulk **Delete (N)**
  - Delete uses `window.confirm`, then refreshes history and clears selection
- New `deleteBackups()` API + `BackupDeleteResult` / `total` types

### Backend (`app/server`)
- `Get-DuneBackupHistory`: now stats all dump files (bounded), **sorts then caps** (old code capped before sorting), and returns a `total` count
- New `Remove-DuneBackupFiles`: validates each path (must be under the dump dir, end in `.backup`, no traversal/quotes), `sudo rm`'s the `.backup` file **and** its `.yaml` sidecar, returns `deleted` / `failed`
- New `POST /api/db/backup-delete` route: VM-gated, wrapped in the VM lock, max 500 paths per call

## Notes
- **No version bump** — stamps stay at `12.16.7`; version chosen at release time. `CHANGELOG.md` `[Unreleased]` entry added.
- Both edited `.ps1` files parse clean and retain their UTF-8 BOM.
- `cd webui; npm run build` passes clean (tsc + vite).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>