### PR TITLE
Grant All Tech: top Intel up to 5000 floor + drop EXPERIMENTAL badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [Unreleased]
+
+### Changed
+
+- **Grant All Tech Recipes** now tops the character's Intel up to a **5000** floor as part of the action (raise-only — a higher existing balance is left untouched), and its **EXPERIMENTAL** badge is removed. The recipes are marked Purchased, but the game charges Intel per recipe when the character redeems them on next login, so with a 0 Intel balance nothing actually unlocked (which is why it looked unverified). 5000 Intel is a live-verified amount that covers the full 449-recipe set with headroom. The Intel write is applied in the same transaction as the recipe grant. (Grant All Skills remains flagged EXPERIMENTAL — unchanged.)
+
 ## [12.16.8] - 2026-07-04
 
 ### Added

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1768,7 +1768,18 @@ AND COALESCE(
 # character's Intel terminal (TechKnowledgePlayerComponent.m_TechKnowledge.m_TechKnowledgeData).
 # Existing entries are preserved verbatim (their UnlockedState is NOT downgraded).
 # Missing keys are appended as {ItemKey, bIsNewEntry:true, UnlockedState:"Purchased"}.
-# Does NOT touch m_TechKnowledgePoints. Offline-only. Same catalog for every character.
+# Offline-only. Same catalog for every character.
+#
+# Intel floor: the granted recipes are marked "Purchased" but the game charges
+# Intel per recipe when the character redeems them on next login - with a 0
+# Intel balance nothing actually unlocks (this is why the action used to look
+# unverified/experimental). Live-verified that ~5000 Intel covers the full
+# 449-recipe set with headroom. So this action now also tops the character's
+# Intel up to a 5000 floor (raise-only; a higher existing balance is left
+# untouched), written directly to m_TechKnowledgePoints in the same transaction.
+# This bypasses the manual Award Intel feature's conservative 2779 clamp on
+# purpose - 5000 is a live-verified working value.
+$script:DuneGrantAllTechIntelFloor = 5000
 function Invoke-DunePlayerGrantAllTech {
     param([string]$Ip, [long]$AccountId)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
@@ -1812,6 +1823,23 @@ SET properties = jsonb_set(
     true)
 WHERE a.id = $pawnID::bigint;
 "@)
+    # Intel floor: raise m_TechKnowledgePoints to at least the floor so the
+    # character can actually redeem the just-granted recipes on login. GREATEST
+    # keeps any higher existing balance untouched. Same component, different
+    # subkey than the recipe grant above, so this doesn't clobber it.
+    $intelFloor = [int]$script:DuneGrantAllTechIntelFloor
+    [void]$sb.AppendLine(@"
+UPDATE dune.actors
+SET properties = jsonb_set(
+    COALESCE(properties, '{}'::jsonb),
+    '{TechKnowledgePlayerComponent}',
+    COALESCE(properties -> 'TechKnowledgePlayerComponent', '{}'::jsonb)
+        || jsonb_build_object('m_TechKnowledgePoints',
+            to_jsonb(GREATEST(
+                COALESCE((properties #>> '{TechKnowledgePlayerComponent,m_TechKnowledgePoints}')::int, 0),
+                $intelFloor))))
+WHERE id = $pawnID::bigint;
+"@)
     [void]$sb.AppendLine('COMMIT;')
 
     # -Bulk for the ~40 KB payload (449 ItemKeys inline) - see grant-all-skills.
@@ -1822,8 +1850,9 @@ WHERE a.id = $pawnID::bigint;
     }
     return @{
         ok = $true
-        message = "Granted every tech recipe ($($itemKeys.Count) total) on the character (existing entries preserved, Intel points untouched). Takes effect on next login."
+        message = "Granted every tech recipe ($($itemKeys.Count) total) on the character (existing entries preserved) and topped Intel up to at least $intelFloor so the recipes can be redeemed. Takes effect on next login."
         catalog_size = $itemKeys.Count
+        intel_floor = $intelFloor
     }
 }
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -671,9 +671,9 @@ const ACTIONS: ActionDef[] = [
     rowNote: 'Unlock every skill (1 point each). Existing preserved. Does not add skill points. Offline.',
     confirm: p => `Grant every skill to ${p.name}?\n\nMarks every skill (145 total) as unlocked (SkillPointsSpent=1). Existing entries preserved. Skill-point pool untouched. Player must be offline.`,
     run: p => grantAllSkills(p.account_id) },
-  { id: 'grant-all-tech', group: 'Progression', label: 'Grant All Tech Recipes', icon: 'BookOpenCheck', offlineOnly: true, experimental: true,
-    rowNote: 'Purchase every buildable + recipe + starter group. Existing preserved. Does not add Intel. Offline.',
-    confirm: p => `Grant every tech recipe to ${p.name}?\n\nMarks every buildable patent, crafting recipe, and starter group (449 total) as Purchased in the Intel terminal. Existing entries preserved. Intel points untouched. Player must be offline.`,
+  { id: 'grant-all-tech', group: 'Progression', label: 'Grant All Tech Recipes', icon: 'BookOpenCheck', offlineOnly: true,
+    rowNote: 'Purchase every buildable + recipe + starter group. Existing preserved. Tops Intel up to 5000 so recipes can be redeemed. Offline.',
+    confirm: p => `Grant every tech recipe to ${p.name}?\n\nMarks every buildable patent, crafting recipe, and starter group (449 total) as Purchased in the Intel terminal, and tops the character's Intel up to at least 5000 (a higher balance is left untouched) so the recipes can actually be redeemed on next login. Existing entries preserved. Player must be offline.`,
     run: p => grantAllTech(p.account_id) },
 
   // ----- Items -----


### PR DESCRIPTION
## What

**Grant All Tech Recipes** (Players → Progression) now tops the character's Intel up to a **5000 floor** as part of the action, and its **EXPERIMENTAL** badge is removed.

## Why

The action marks all 449 buildable patents / crafting recipes / starter groups as `Purchased`, but the **game charges Intel per recipe when the character redeems them on next login**. With a 0 Intel balance, nothing actually unlocked in-game — which is exactly why the retroactive effect looked unverified and the action was flagged EXPERIMENTAL.

Live-confirmed that ~5000 Intel covers the full 449-recipe set with headroom to spare (recipes redeemed with points left over, no clamp hit).

## How

- **Backend** (`app/server/lib/PlayersWrites.ps1`): a second `UPDATE` in the same transaction as the recipe grant raises `TechKnowledgePlayerComponent.m_TechKnowledgePoints` to `GREATEST(current, 5000)` — **raise-only**, so a higher existing balance is never reduced. Written directly (bypasses the manual *Award Intel* feature's conservative 2779 clamp, which `5000` is live-verified to exceed safely). Floor is a named constant `$script:DuneGrantAllTechIntelFloor = 5000`.
- **UI** (`webui/src/pages/gameplay/players/sections.tsx`): removed `experimental: true`; rowNote + confirm dialog now state the Intel top-up. **Grant All Skills stays EXPERIMENTAL** (separately unverified — unchanged).
- **CHANGELOG**: `[Unreleased] → Changed` entry.

## Validation

- `PlayersWrites.ps1` parses clean; retains its UTF-8 BOM (has non-ASCII bytes).
- webui `tsc -b && vite build` passes (only the pre-existing chunk-size warning).
- Not yet live end-to-end tested against an offline character.

Offline-only guard is unchanged (grant writes to the pawn's TechKnowledge component, RAM-authoritative while online).