### PR TITLE
Fresh Start snapshot: capture full building set/piece arrays (PS 5.1 fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ here cover everything those tags shipped.
 ### Fixed
 
 - **Fresh Start restore now reliably targets the recreated character, and verifies the result.** The restore step resolved the live character **by name**, which could land on a stale/duplicate row (or silently no-op) so purchases and cosmetics didn't actually appear in-game even though the tool reported success. It now resolves the live pawn by the snapshot's **account id** (stable across the in-game delete + recreate; falls back to name for older snapshots), and after the write it **reads back the actual cosmetics / building-set / piece counts** and reports them — warning explicitly if cosmetics were expected but didn't land, instead of the old blind "+ cosmetics" success message.
+- **Fresh Start snapshot now captures all building sets/pieces (previously only 1).** Under Windows PowerShell 5.1 (the runtime the backend compiles to), the snapshot's JSON parse collapsed a multi-element building-set/piece array into a single wrapper object, so a character with hundreds of unlocks was snapshotted as "1 building set, 1 piece" and Restore then re-granted **0** sets/pieces. The arrays are now parsed into flat string lists, so the full set/piece list is captured and restored. Restore and the snapshot list also defensively unwrap any snapshot saved in the old malformed shape. (Cosmetics were never affected — they're stored as a raw string.)
 
 ## [12.16.8] - 2026-07-04
 

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1506,11 +1506,15 @@ function Save-DuneFreshStartSnapshots {
 function Get-DuneFreshStartSnapshotList {
     $out = @()
     foreach ($s in (Get-DuneFreshStartSnapshots)) {
+        # Unwrap the pre-fix {value=[...]; Count=N} wrapper so the displayed
+        # counts are accurate for both old and new snapshots.
+        $setsList   = @($s.building_sets    | ForEach-Object { if ($_ -and ($_.PSObject.Properties.Name -contains 'value')) { $_.value } else { $_ } })
+        $piecesList = @($s.buildable_pieces | ForEach-Object { if ($_ -and ($_.PSObject.Properties.Name -contains 'value')) { $_.value } else { $_ } })
         $out += [ordered]@{
             name      = [string]$s.name
             saved_at  = [string]$s.saved_at
-            sets      = @($s.building_sets).Count
-            pieces    = @($s.buildable_pieces).Count
+            sets      = $setsList.Count
+            pieces    = $piecesList.Count
             cosmetics = [bool]([string]$s.cosmetics)
         }
     }
@@ -1542,9 +1546,16 @@ SELECT
     $name = [string]$row['name']
     if (-not $name) { return @{ ok = $false; error = 'character has no name.' } }
 
+    # Parse the to_json arrays into FLAT string arrays. NOTE (Windows PowerShell
+    # 5.1, the runtime DuneServer.exe compiles to): the form
+    # `@([string]$x | ConvertFrom-Json)` collapses a multi-element JSON array into
+    # a SINGLE {value=[...]; Count=N} wrapper object instead of N strings, so the
+    # snapshot stored 1 "set" (the wrapper) and Restore's `-match` filter then saw
+    # 1 non-matching object and restored 0. Parse WITHOUT the [string] cast prefix
+    # and expand each element to a plain string so it serializes as a flat array.
     $sets = @(); $pieces = @()
-    try { if ([string]$row['sets'])   { $sets   = @([string]$row['sets']   | ConvertFrom-Json) } } catch {}
-    try { if ([string]$row['pieces']) { $pieces = @([string]$row['pieces'] | ConvertFrom-Json) } } catch {}
+    try { if ($row['sets']   -and [string]$row['sets'])   { $sets   = @(($row['sets']   | ConvertFrom-Json) | ForEach-Object { [string]$_ }) } } catch {}
+    try { if ($row['pieces'] -and [string]$row['pieces']) { $pieces = @(($row['pieces'] | ConvertFrom-Json) | ForEach-Object { [string]$_ }) } } catch {}
     $cosmeticsJson = [string]$row['cosmetics']
 
     $snap = [ordered]@{
@@ -1631,8 +1642,13 @@ function Invoke-DunePlayerRestoreBuilds {
     # unlocks, so restoring the whole array over-grants faction perks to a Rank-0
     # character.
     $purchasedRx = '^(MTX_|Choam)'
-    $filteredSets   = @($s.building_sets    | Where-Object { [string]$_ -match $purchasedRx })
-    $filteredPieces = @($s.buildable_pieces | Where-Object { [string]$_ -match $purchasedRx })
+    # Defensive unwrap: snapshots saved before the array-wrapping fix stored
+    # sets/pieces as a single {value=[...]; Count=N} object (PS 5.1 quirk). If we
+    # see that shape, pull the inner .value so those old snapshots still restore.
+    $rawSets   = @($s.building_sets    | ForEach-Object { if ($_ -and ($_.PSObject.Properties.Name -contains 'value')) { $_.value } else { $_ } } | ForEach-Object { [string]$_ })
+    $rawPieces = @($s.buildable_pieces | ForEach-Object { if ($_ -and ($_.PSObject.Properties.Name -contains 'value')) { $_.value } else { $_ } } | ForEach-Object { [string]$_ })
+    $filteredSets   = @($rawSets   | Where-Object { $_ -match $purchasedRx })
+    $filteredPieces = @($rawPieces | Where-Object { $_ -match $purchasedRx })
     $setsArr   = ConvertTo-DunePgTextArray ($filteredSets   | ForEach-Object { [string]$_ })
     $piecesArr = ConvertTo-DunePgTextArray ($filteredPieces | ForEach-Object { [string]$_ })
     $cosmetics = [string]$s.cosmetics


### PR DESCRIPTION
## Root cause

Fresh Start snapshotted a character with **hundreds of building unlocks** as just **"1 building set, 1 piece"**, and Restore then re-granted **0** sets/pieces (the original "Restored 0 set(s) + 0 piece(s)").

The bug is a **Windows PowerShell 5.1** quirk (the runtime `DuneServer.exe` compiles to via PS2EXE). The snapshot parsed the DB's `to_json(learned_building_sets)` array with:

```powershell
@([string]$row['sets'] | ConvertFrom-Json)
```

In PS 5.1 the `[string]` cast prefix makes this **collapse a 164-element JSON array into a single `{value=[...]; Count=164}` wrapper object** instead of 164 strings (pwsh does not do this, which is why it looked fine in earlier out-of-runtime tests). So:

- `building_sets` stored `[ {value:[164…], Count:164} ]` — one wrapper element.
- The snapshot count showed **1**.
- Restore's `Where-Object { $_ -match '^(MTX_|Choam)' }` iterated that **1 non-matching object** → filtered to **0** → nothing restored.

Cosmetics were never affected because they're stored as a **raw JSON string**, not a parsed array.

## Fix

- Parse the `to_json` arrays **without** the `[string]` cast prefix and expand each element to a plain string (`... | ConvertFrom-Json | ForEach-Object { [string]$_ }`), so they serialize as flat arrays.
- **Defensive unwrap** in Restore and in the snapshot-list count: if a snapshot was already saved in the old `{value, Count}` shape, pull the inner `.value` so it still restores/counts correctly.

## Validation

- Verified in **PowerShell 5.1**: a real 164-element `learned_building_sets` array now round-trips through parse → `ConvertTo-Json -Depth 60` → reparse as **164 flat strings** (element type `String`), where the old code produced **1**.
- `PlayersWrites.ps1` parses clean; retains its UTF-8 BOM.

Backend-only; no UI change. Composes with the prior Fresh Start restore fix (account_id resolution + post-write verification), which will now report the true set/piece counts.