### PR TITLE
Disable Grant All Tech Recipes (comment out UI button, keep backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ here cover everything those tags shipped.
 
 ### Changed
 
-- **Grant All Tech Recipes** now tops the character's Intel up to a **5000** floor as part of the action (raise-only — a higher existing balance is left untouched), and its **EXPERIMENTAL** badge is removed. The recipes are marked Purchased, but the game charges Intel per recipe when the character redeems them on next login, so with a 0 Intel balance nothing actually unlocked (which is why it looked unverified). 5000 Intel is a live-verified amount that covers the full 449-recipe set with headroom. The Intel write is applied in the same transaction as the recipe grant.
 - **Grant All Skills** now grants every skill at **max level** (previously each skill was only granted level 1) and its **EXPERIMENTAL** badge is removed. It writes a comfortably-high `SkillPointsSpent` value; the game reconciles that to a skill level on login and **caps each skill at its real maximum**, so multi-level perks/abilities/keystones/capstones reach full level and single-rank skills cap cleanly. Live-verified across every skill category (no overshoot or breakage, skill-point pool not overdrawn).
 
 ### Fixed

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -25,7 +25,7 @@ import {
   resetAllKeystones, resetAllSpecs, resetJourney, resetProgressionLive, resetSpec,
   restoreDestroyed,
   setFactionTier, setPlayerTags, setSkillPoints,
-  setStarterClass, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, wipeJourney, resetFaction, snapshotBuilds, getFreshStartSnapshots, restoreBuilds, grantAllSkills, grantAllTech,
+  setStarterClass, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, wipeJourney, resetFaction, snapshotBuilds, getFreshStartSnapshots, restoreBuilds, grantAllSkills,
   chatWhisper, isValidTemplateId, getItemCatalog, getCosmeticsCatalog, type CosmeticEntry,
   parseTcnoPackageText,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
@@ -671,10 +671,16 @@ const ACTIONS: ActionDef[] = [
     rowNote: 'Unlock every skill at max level. The game caps each skill at its real max on login. Offline.',
     confirm: p => `Grant every skill to ${p.name} at max level?\n\nUnlocks all 145 skills and sets each to its maximum level (the game caps each skill at its real max on next login). Existing progress preserved. Player must be offline.`,
     run: p => grantAllSkills(p.account_id) },
-  { id: 'grant-all-tech', group: 'Progression', label: 'Grant All Tech Recipes', icon: 'BookOpenCheck', offlineOnly: true,
-    rowNote: 'Purchase every buildable + recipe + starter group. Existing preserved. Tops Intel up to 5000 so recipes can be redeemed. Offline.',
-    confirm: p => `Grant every tech recipe to ${p.name}?\n\nMarks every buildable patent, crafting recipe, and starter group (449 total) as Purchased in the Intel terminal, and tops the character's Intel up to at least 5000 (a higher balance is left untouched) so the recipes can actually be redeemed on next login. Existing entries preserved. Player must be offline.`,
-    run: p => grantAllTech(p.account_id) },
+  // Grant All Tech Recipes — DISABLED pending rework. The DB write marks every
+  // recipe UnlockedState="Purchased", but in-game the items stay unclaimed/0-cost
+  // and Intel isn't consumed, so buildables are not actually usable. Backend
+  // (Invoke-DunePlayerGrantAllTech, the /grant-all-tech route, grantAllTech() in
+  // the API, and dune-tech-catalog.json) is intentionally left in place so this
+  // can be revisited once the correct "researched/usable" state is worked out.
+  // { id: 'grant-all-tech', group: 'Progression', label: 'Grant All Tech Recipes', icon: 'BookOpenCheck', offlineOnly: true,
+  //   rowNote: 'Purchase every buildable + recipe + starter group. Existing preserved. Tops Intel up to 5000 so recipes can be redeemed. Offline.',
+  //   confirm: p => `Grant every tech recipe to ${p.name}?\n\nMarks every buildable patent, crafting recipe, and starter group (449 total) as Purchased in the Intel terminal, and tops the character's Intel up to at least 5000 (a higher balance is left untouched) so the recipes can actually be redeemed on next login. Existing entries preserved. Player must be offline.`,
+  //   run: p => grantAllTech(p.account_id) },
 
   // ----- Items -----
   { id: 'give-item',      group: 'Items', label: 'Give Item', icon: 'PackagePlus', custom: 'give-item',


### PR DESCRIPTION
## What

Disables the **Grant All Tech Recipes** action by commenting out its UI button, and removes the Grant All Tech line from the v12.16.9 changelog.

## Why

The action marks every recipe `UnlockedState: "Purchased"`, but in-game the items stay **unclaimed / 0-cost** and **Intel isn't consumed**, so the buildables aren't actually usable (verified live: 421 recipes at "Purchased", still showing unresearched in the Research/Intel terminal). The "Purchased" DB state doesn't reliably translate to "researched/usable," and the behavior is inconsistent (worked in an earlier test, not now) — not shippable.

## Approach (kept for revisit)

Per request, the code is **commented/left intact**, not deleted:
- The `grant-all-tech` ActionDef in `sections.tsx` is commented out (with an explanatory note), and the now-unused `grantAllTech` import is dropped (`noUnusedLocals` would otherwise fail the build).
- **Backend is untouched and functional**: `Invoke-DunePlayerGrantAllTech`, the `POST /api/gameplay/players/grant-all-tech` route, the `grantAllTech()` API client, and `dune-tech-catalog.json` all remain. Re-enabling is just uncommenting the button + restoring the import once the correct usable-state is worked out.

Grant All Skills (validated, works) is unaffected and stays.

## Validation

- webui `tsc -b && vite build` passes (no unused-import error).