### PR TITLE
Reboot/Stop: note that Funcom's "did not report Stopped" warning is cosmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [Unreleased]
+
+### Fixed
+
+- **Reboot / Stop All no longer looks like it failed to stop the battlegroup.** Funcom's own `battlegroup stop` script waits for the battlegroup to report the "Stopped" phase by positionally parsing its status output, and mis-reads the phase when the server title contains spaces (e.g. "Dune Reapers - DST") — so it prints a cosmetic `WARNING: battlegroup … did not report Stopped within 90s` even though the stop succeeded. DST already verifies the real stop via its own pod-termination check; it now prints a short note after that confirmation explaining the Funcom warning is cosmetic when the server title has spaces. (Same root cause as the v12.16.1 Dashboard Battlegroup Info fix, but inside Funcom's script, which DST calls and does not modify.)
+
 ## [12.16.9] - 2026-07-05
 
 ### Changed

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -754,6 +754,30 @@ function Confirm-NoPlayersOnline {
     return ($proceed -eq "YES")
 }
 
+# Funcom's `battlegroup stop` waits for the BG CRD to report phase "Stopped" by
+# positionally parsing `kubectl get battlegroup --no-headers` (awk '{print $3}').
+# When the server title (spec.title) contains spaces, the title spans multiple
+# whitespace tokens and shifts the real PHASE column right, so Funcom reads a
+# title token as the phase, never matches "Stopped", and prints a cosmetic
+# "did not report Stopped within 90s" WARNING after its 90s timeout. The stop
+# still succeeds -- DST verifies that separately via the pod-termination check.
+# This note reassures the operator when their title would trigger the warning.
+# (Same root cause as the v12.16.1 Dashboard BG-Info fix, but inside Funcom's
+# stop script, which DST calls and must not modify.)
+function Show-DuneFuncomStopWarningNote {
+    param([string]$Ip, [string]$SshUser, [string]$SshKey)
+    try {
+        $title = ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$SshKey" "$SshUser@$Ip" `
+            "sudo k3s kubectl get battlegroups -A --no-headers -o custom-columns=T:.spec.title 2>/dev/null | head -1"
+        $title = ($title | Out-String).Trim()
+        if ($title -and ($title -match '\s')) {
+            Write-Host "  Note: any Funcom 'battlegroup ... did not report Stopped within 90s' warning above is" -ForegroundColor DarkGray
+            Write-Host "        cosmetic -- Funcom's stop script mis-reads the phase because your server title" -ForegroundColor DarkGray
+            Write-Host "        ('$title') contains spaces. DST confirmed the actual stop above (pods terminated)." -ForegroundColor DarkGray
+        }
+    } catch {}
+}
+
 # Returns $true if any battlegroup pod (sg/mq/sgw/tr/bgd) is currently
 # present on the VM. Used to short-circuit `battlegroup stop` calls when
 # nothing is running -- otherwise the VM-side helper script runs its own
@@ -1688,6 +1712,7 @@ while ($true) {
         if ($finalCount -eq 0) {
             Save-PhaseTiming 'pods-terminate' $elapsed
             Complete-WaitCounter -Message "All game/infra pods terminated after $(Format-Duration $elapsed)."
+            Show-DuneFuncomStopWarningNote -Ip $ip -SshUser $sshUser -SshKey $sshKey
         } else {
             Complete-WaitCounter -Message "$finalCount pod(s) still present after $(Format-Duration $elapsed). Proceeding with VM restart anyway." -Color Yellow
         }
@@ -1955,6 +1980,7 @@ while ($true) {
         if ($finalCount -eq 0) {
             Save-PhaseTiming 'pods-terminate' $elapsed
             Complete-WaitCounter -Message "All game/infra pods terminated after $(Format-Duration $elapsed)."
+            Show-DuneFuncomStopWarningNote -Ip $ip -SshUser $sshUser -SshKey $sshKey
         } else {
             Complete-WaitCounter -Message "$finalCount pod(s) still present after $(Format-Duration $elapsed). Proceeding with VM shutdown anyway." -Color Yellow
         }


### PR DESCRIPTION
## What

When rebooting or stopping the server, Funcom's `battlegroup stop` prints `WARNING: battlegroup … did not report Stopped within 90s` even though the stop succeeded — confusing operators into thinking something failed. This adds a short DST note explaining it's cosmetic.

## Root cause (Funcom-side, not DST)

DST's Reboot / Stop All flows call Funcom's `battlegroup stop` and stream its output. Funcom's `battlegroup.sh` waits for the BG to reach phase `Stopped` by positionally parsing its status:

```bash
phase=$(kubectl get battlegroup <name> -n <ns> --no-headers | awk '{print $3}')
```

When the server title (`spec.title`) contains spaces — e.g. **"Dune Reapers - DST"** — the title spans multiple whitespace tokens and shifts the real PHASE column right, so `$3` returns a **title token** ("Reapers") instead of the phase. It never matches "Stopped", so Funcom warns after its 90s timeout. **The stop actually succeeds** — DST verifies it independently via its own pod-termination check right after.

Same root cause as the v12.16.1 Dashboard Battlegroup Info fix, but this instance lives inside Funcom's stop script, which DST calls and must not modify (modding Funcom files is off-limits + gets overwritten on update).

## Change

- New helper `Show-DuneFuncomStopWarningNote` fetches the BG title (`spec.title`) and, **only if it contains spaces** (the exact trigger condition), prints a short dim note after DST's "all pods terminated" confirmation:
  > Note: any Funcom "did not report Stopped within 90s" warning above is cosmetic — Funcom's stop script mis-reads the phase because your server title contains spaces. DST confirmed the actual stop above.
- Called in **both** the Reboot and Stop All flows, in the success branch only.
- **The `battlegroup stop` call itself is unchanged** (no risk to the stop).

## Validation

- `dune-server.ps1` parses clean. Helper is pure ASCII; file encoding unchanged (launcher is pwsh-run, not PS2EXE-compiled).

Minor UX polish — no functional change to stop/reboot behavior. For the next release.