### PR TITLE
Grant All Skills: partial unlock + skill-point buffer (fix NPE soft-lock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- **Grant All Skills no longer soft-locks the tutorial.** It previously maxed every skill, which left nothing to learn and made the New Player Experience step *"Learn a new Ability from the Skills menu"* impossible to complete. It now unlocks every skill but deliberately leaves **multi-level skills below max**, and grants a small **~20 skill-point buffer**, so the player can still spend a point to complete that step and finish leveling skills themselves.
+
 ### Fixed
 
 - **Reboot / Stop All no longer looks like it failed to stop the battlegroup.** Funcom's own `battlegroup stop` script waits for the battlegroup to report the "Stopped" phase by positionally parsing its status output, and mis-reads the phase when the server title contains spaces (e.g. "Dune Reapers - DST") — so it prints a cosmetic `WARNING: battlegroup … did not report Stopped within 90s` even though the stop succeeded. DST already verifies the real stop via its own pod-termination check; it now prints a short note after that confirmation explaining the Funcom warning is cosmetic when the server title has spaces. (Same root cause as the v12.16.1 Dashboard Battlegroup Info fix, but inside Funcom's script, which DST calls and does not modify.)

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1783,17 +1783,20 @@ function Invoke-DunePlayerMarkNpeCompleted {
     }
 }
 
-# Grant every skill in the bundled catalog on the target character, at MAX level.
-# Writes jsonb_set for each catalog key with {"SkillPointsSpent":<max>} onto the
-# pawn's FLevelComponent[1].ModuleData (keyed via actor_fgl_entities.slot_name=
-# 'DuneCharacter'). The game reconciles SkillPointsSpent -> skill level on login
-# and CLAMPS an over-max value down to each skill's real cap, so writing a single
-# comfortably-high value (10) maxes every skill regardless of how many levels it
-# has (live-verified: 10 -> 3/3 on multi-level perks/abilities/keystones/capstones
-# and the single-rank attributes cap cleanly, no breakage, pool not overdrawn).
-# Entries already at >= the max value are skipped (idempotent). Does NOT touch the
-# character's skill-point pool. Offline-only. Same catalog for every character.
-$script:DuneGrantAllSkillsMaxValue = 10
+# Grant every skill in the bundled catalog on the target character, PARTIALLY.
+# Writes {"SkillPointsSpent":<val>} onto the pawn's FLevelComponent[1].ModuleData
+# for each catalog key. IMPORTANT: this uses a LOW value (2) on purpose, not a
+# max value. The game reconciles SkillPointsSpent -> skill level on login and
+# clamps it to each skill's real cap, so a low value maxes single-rank skills but
+# leaves MULTI-LEVEL skills BELOW max. That headroom is required: if every skill
+# is maxed, the New Player Experience journey step "Learn a new Ability from the
+# Skills menu" can never complete (nothing left to learn/upgrade) and the player
+# is soft-stuck. Leaving multi-level skills unmaxed keeps that step completable.
+# The action also grants a small spendable skill-point buffer (UnspentSkillPoints)
+# so the player can actually spend points to finish the step and level skills up.
+# Offline-only. Same catalog for every character.
+$script:DuneGrantAllSkillsLevelValue = 2
+$script:DuneGrantAllSkillsPointBuffer = 20
 function Invoke-DunePlayerGrantAllSkills {
     param([string]$Ip, [long]$AccountId)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
@@ -1804,13 +1807,16 @@ function Invoke-DunePlayerGrantAllSkills {
     if ($keys.Count -eq 0) {
         return @{ ok = $false; error = 'skills catalog is empty (app/data/dune-skills-catalog.json missing?).' }
     }
-    $maxVal = [int]$script:DuneGrantAllSkillsMaxValue
+    $levelVal = [int]$script:DuneGrantAllSkillsLevelValue
+    $buffer   = [int]$script:DuneGrantAllSkillsPointBuffer
+    # Target TotalSkillPoints so the grant's spend leaves ~$buffer unspent
+    # regardless of whether the game trusts the stored UnspentSkillPoints or
+    # recomputes it as Total - spent.
+    $totalTarget = ($keys.Count * $levelVal) + $buffer
 
     # Build one transaction that jsonb_set each catalog key onto the character's
-    # ModuleData at the max value. The guard `SkillPointsSpent < $maxVal` makes
-    # each UPDATE idempotent and also UPGRADES any prior level-1 grants to max,
-    # without lowering a skill a player legitimately leveled (the game clamps
-    # anyway, so an already-max skill is untouched).
+    # ModuleData at the low value. The guard `SkillPointsSpent < $levelVal` makes
+    # each UPDATE idempotent and does not lower a skill already at/above it.
     $sb = [System.Text.StringBuilder]::new()
     [void]$sb.AppendLine('BEGIN;')
     foreach ($sk in $keys) {
@@ -1822,7 +1828,7 @@ UPDATE dune.fgl_entities fe
 SET components = jsonb_set(
     fe.components,
     ARRAY['FLevelComponent','1','ModuleData','$safeKey'],
-    '{"SkillPointsSpent": $maxVal}'::jsonb,
+    '{"SkillPointsSpent": $levelVal}'::jsonb,
     true)
 WHERE fe.entity_id = (
     SELECT entity_id FROM dune.actor_fgl_entities
@@ -1831,9 +1837,28 @@ WHERE fe.entity_id = (
 AND COALESCE(
     (fe.components->'FLevelComponent'->1->'ModuleData'->'$safeKey'->>'SkillPointsSpent')::int,
     0
-) < $maxVal;
+) < $levelVal;
 "@)
     }
+    # Grant a spendable skill-point buffer: set UnspentSkillPoints to the buffer,
+    # and raise TotalSkillPoints (never lower it) so the pool stays positive even
+    # if the game recomputes unspent = total - spent on login.
+    [void]$sb.AppendLine(@"
+UPDATE dune.fgl_entities fe
+SET components = jsonb_set(
+    jsonb_set(
+        fe.components,
+        ARRAY['FLevelComponent','1','UnspentSkillPoints'],
+        to_jsonb($buffer::int), true),
+    ARRAY['FLevelComponent','1','TotalSkillPoints'],
+    to_jsonb(GREATEST(
+        COALESCE((fe.components #>> '{FLevelComponent,1,TotalSkillPoints}')::int, 0),
+        $totalTarget::int)), true)
+WHERE fe.entity_id = (
+    SELECT entity_id FROM dune.actor_fgl_entities
+    WHERE actor_id = $pawnID::bigint AND slot_name = 'DuneCharacter'
+);
+"@)
     [void]$sb.AppendLine('COMMIT;')
 
     # -Bulk streams SQL through ssh stdin so the ~60 KB payload (145 UPDATEs)
@@ -1846,8 +1871,9 @@ AND COALESCE(
     }
     return @{
         ok = $true
-        message = "Granted every skill ($($keys.Count) total) at max level on the character. The game caps each skill at its real max on next login. Takes effect on next login."
+        message = "Granted every skill ($($keys.Count) total) plus a $buffer skill-point buffer. Multi-level skills are left below max on purpose so the 'Learn a new Ability' step stays completable; spend the granted points to finish leveling. Takes effect on next login."
         catalog_size = $keys.Count
+        point_buffer = $buffer
     }
 }
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -668,8 +668,8 @@ const ACTIONS: ActionDef[] = [
     rowNote: 'Snapshot cosmetics, delete + recreate character in-game (same name), then restore. Offline to restore.',
     run: () => Promise.resolve({ message: '' }) },
   { id: 'grant-all-skills', group: 'Progression', label: 'Grant All Skills', icon: 'Sparkles', offlineOnly: true,
-    rowNote: 'Unlock every skill at max level. The game caps each skill at its real max on login. Offline.',
-    confirm: p => `Grant every skill to ${p.name} at max level?\n\nUnlocks all 145 skills and sets each to its maximum level (the game caps each skill at its real max on next login). Existing progress preserved. Player must be offline.`,
+    rowNote: 'Unlock every skill (multi-level ones left below max) + a ~20 skill-point buffer to finish. Keeps the tutorial "Learn a new Ability" step completable. Offline.',
+    confirm: p => `Grant all skills to ${p.name}?\n\nUnlocks all 145 skills, but leaves multi-level skills BELOW max on purpose so the tutorial step "Learn a new Ability from the Skills menu" stays completable (maxing everything soft-locks it). Also grants a small (~20) spendable skill-point buffer so ${p.name} can finish leveling. Existing progress preserved. Player must be offline.`,
     run: p => grantAllSkills(p.account_id) },
   // Grant All Tech Recipes — DISABLED pending rework. The DB write marks every
   // recipe UnlockedState="Purchased", but in-game the items stay unclaimed/0-cost


### PR DESCRIPTION
## What

Grant All Skills previously maxed every skill, which left nothing to learn and made the New Player Experience step **"Learn a new Ability from the Skills menu"** impossible to complete — soft-locking the player's tutorial journey.

## Change

- Writes `SkillPointsSpent = 2` instead of `10`. The game clamps this to each skill's cap, so single-rank skills still max but **multi-level skills stay below max** — there's always something left to learn/upgrade, keeping the NPE step completable.
- Grants a small **~20 spendable skill-point buffer**: sets `UnspentSkillPoints = 20` and raises `TotalSkillPoints` (never lowers it) to `catalogCount*2 + 20`, so the pool stays positive whether the game trusts the stored unspent value or recomputes it as `total - spent` on login.
- UI row note + confirm dialog updated to explain the partial-unlock + buffer behavior.

## Notes

- Idempotent guard preserved (`SkillPointsSpent < 2`), so it won't lower a skill already at/above the value.
- Skill-point fields discovered live on the character: `TotalSkillPoints`, `UnspentSkillPoints`, `KeystoneBonusSkillPoints` under `FLevelComponent[1]`.
- The exact pool-reconciliation behavior (game trusts vs. recomputes unspent) is being verified on a live character; the double-write approach covers both cases.

## Validation

- `PlayersWrites.ps1` parses clean; UTF-8 BOM retained.
- webui `tsc -b && vite build` passes.

For the next release, alongside the reboot/stop cosmetic-warning note.