### PR TITLE
Enable All Skills: level 7 + 100 Intel floor + rename & guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ here cover everything those tags shipped.
 
 ### Changed
 
-- **Grant All Skills no longer soft-locks the tutorial.** It previously maxed every skill, which left nothing to learn and made the New Player Experience step *"Learn a new Ability from the Skills menu"* impossible to complete. It now unlocks every skill but deliberately leaves **multi-level skills below max**, and grants a small **~20 skill-point buffer**, so the player can still spend a point to complete that step and finish leveling skills themselves.
+- **Grant All Skills no longer soft-locks the tutorial.** It previously maxed every skill, which left nothing to learn and made the New Player Experience step *"Learn a new Ability from the Skills menu"* impossible to complete. It now unlocks every skill but deliberately leaves **multi-level skills below max**, and grants a small **~20 skill-point buffer** plus a **100 Intel floor**, so the player can still spend a point to complete that step, finish leveling skills, and isn't blocked by anything that gates on Intel.
 
 ### Fixed
 

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1785,18 +1785,19 @@ function Invoke-DunePlayerMarkNpeCompleted {
 
 # Grant every skill in the bundled catalog on the target character, PARTIALLY.
 # Writes {"SkillPointsSpent":<val>} onto the pawn's FLevelComponent[1].ModuleData
-# for each catalog key. IMPORTANT: this uses a LOW value (2) on purpose, not a
-# max value. The game reconciles SkillPointsSpent -> skill level on login and
-# clamps it to each skill's real cap, so a low value maxes single-rank skills but
-# leaves MULTI-LEVEL skills BELOW max. That headroom is required: if every skill
-# is maxed, the New Player Experience journey step "Learn a new Ability from the
-# Skills menu" can never complete (nothing left to learn/upgrade) and the player
-# is soft-stuck. Leaving multi-level skills unmaxed keeps that step completable.
-# The action also grants a small spendable skill-point buffer (UnspentSkillPoints)
-# so the player can actually spend points to finish the step and level skills up.
-# Offline-only. Same catalog for every character.
-$script:DuneGrantAllSkillsLevelValue = 2
+# for each catalog key. IMPORTANT: this uses an INTERMEDIATE value (7) on purpose,
+# not a max value. The game reconciles SkillPointsSpent -> skill level on login and
+# clamps it to each skill's real cap, so this value fills single-rank skills and
+# brings multi-level skills up several levels but leaves MULTI-LEVEL skills BELOW
+# max. That headroom is required: if every skill is maxed, the New Player Experience
+# journey step "Learn a new Ability from the Skills menu" can never complete
+# (nothing left to learn/upgrade) and the player is soft-stuck. Leaving multi-level
+# skills unmaxed keeps that step completable. The action also grants a small
+# spendable skill-point buffer (UnspentSkillPoints) plus an Intel floor so the
+# player can finish the step and nothing gates on Intel. Offline-only.
+$script:DuneGrantAllSkillsLevelValue = 7
 $script:DuneGrantAllSkillsPointBuffer = 20
+$script:DuneGrantAllSkillsIntelFloor = 100
 function Invoke-DunePlayerGrantAllSkills {
     param([string]$Ip, [long]$AccountId)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
@@ -1809,6 +1810,7 @@ function Invoke-DunePlayerGrantAllSkills {
     }
     $levelVal = [int]$script:DuneGrantAllSkillsLevelValue
     $buffer   = [int]$script:DuneGrantAllSkillsPointBuffer
+    $intelFloor = [int]$script:DuneGrantAllSkillsIntelFloor
     # Target TotalSkillPoints so the grant's spend leaves ~$buffer unspent
     # regardless of whether the game trusts the stored UnspentSkillPoints or
     # recomputes it as Total - spent.
@@ -1859,6 +1861,21 @@ WHERE fe.entity_id = (
     WHERE actor_id = $pawnID::bigint AND slot_name = 'DuneCharacter'
 );
 "@)
+    # Intel floor: raise the Intel balance (m_TechKnowledgePoints on the pawn
+    # actor) to at least $intelFloor so nothing that gates on Intel blocks the
+    # player. GREATEST never lowers a higher balance.
+    [void]$sb.AppendLine(@"
+UPDATE dune.actors
+SET properties = jsonb_set(
+    COALESCE(properties, '{}'::jsonb),
+    '{TechKnowledgePlayerComponent}',
+    COALESCE(properties -> 'TechKnowledgePlayerComponent', '{}'::jsonb)
+        || jsonb_build_object('m_TechKnowledgePoints',
+            to_jsonb(GREATEST(
+                COALESCE((properties #>> '{TechKnowledgePlayerComponent,m_TechKnowledgePoints}')::int, 0),
+                $intelFloor))))
+WHERE id = $pawnID::bigint;
+"@)
     [void]$sb.AppendLine('COMMIT;')
 
     # -Bulk streams SQL through ssh stdin so the ~60 KB payload (145 UPDATEs)
@@ -1871,9 +1888,10 @@ WHERE fe.entity_id = (
     }
     return @{
         ok = $true
-        message = "Granted every skill ($($keys.Count) total) plus a $buffer skill-point buffer. Multi-level skills are left below max on purpose so the 'Learn a new Ability' step stays completable; spend the granted points to finish leveling. Takes effect on next login."
+        message = "Granted every skill ($($keys.Count) total) plus a $buffer skill-point buffer and topped Intel to at least $intelFloor. Multi-level skills are left below max on purpose so the 'Learn a new Ability' step stays completable; spend the granted points to finish leveling. Takes effect on next login."
         catalog_size = $keys.Count
         point_buffer = $buffer
+        intel_floor = $intelFloor
     }
 }
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -667,9 +667,9 @@ const ACTIONS: ActionDef[] = [
   { id: 'fresh-start', group: 'Progression', label: 'Fresh Start (keep purchases)', icon: 'Sunrise', custom: 'fresh-start',
     rowNote: 'Snapshot cosmetics, delete + recreate character in-game (same name), then restore. Offline to restore.',
     run: () => Promise.resolve({ message: '' }) },
-  { id: 'grant-all-skills', group: 'Progression', label: 'Grant All Skills', icon: 'Sparkles', offlineOnly: true,
-    rowNote: 'Unlock every skill (multi-level ones left below max) + a ~20 skill-point buffer to finish. Keeps the tutorial "Learn a new Ability" step completable. Offline.',
-    confirm: p => `Grant all skills to ${p.name}?\n\nUnlocks all 145 skills, but leaves multi-level skills BELOW max on purpose so the tutorial step "Learn a new Ability from the Skills menu" stays completable (maxing everything soft-locks it). Also grants a small (~20) spendable skill-point buffer so ${p.name} can finish leveling. Existing progress preserved. Player must be offline.`,
+  { id: 'grant-all-skills', group: 'Progression', label: 'Enable All Skills', icon: 'Sparkles', offlineOnly: true,
+    rowNote: 'Only do this AFTER applying "Unlock Trainers" above. Do NOT use this if you plan to level some skill trainer trees yourself. Enables every skill (multi-level left below max) + a ~20 skill-point buffer + 100 Intel. Offline.',
+    confirm: p => `Enable all skills for ${p.name}?\n\nOnly do this AFTER applying "Unlock Trainers". Do NOT use this if you plan to level some skill trainer trees yourself.\n\nUnlocks all 145 skills but leaves multi-level skills BELOW max on purpose so the tutorial step "Learn a new Ability from the Skills menu" stays completable (maxing everything soft-locks it). Also grants a small (~20) spendable skill-point buffer and tops Intel to 100 so nothing gates. Existing progress preserved. Player must be offline.`,
     run: p => grantAllSkills(p.account_id) },
   // Grant All Tech Recipes — DISABLED pending rework. The DB write marks every
   // recipe UnlockedState="Purchased", but in-game the items stay unclaimed/0-cost


### PR DESCRIPTION
## What

Live-tuned follow-up to the Grant All Skills redesign (partial-unlock + skill-point buffer), plus a rename and guidance.

## Changes

- **`SkillPointsSpent = 7`** (was 2) — live-tuned on a real character: 7 fills skills to a good level while still leaving multi-level skills **below max**, so the NPE *"Learn a new Ability"* step stays completable. (Verified in-game: "this is perfect".)
- **100 Intel floor** — Enable All Skills now also raises the character's Intel (`m_TechKnowledgePoints`) to at least 100 (raise-only), so nothing that gates on Intel blocks the player. Applied in the same transaction as the skill grant + skill-point buffer.
- **Renamed** the action **"Grant All Skills" → "Enable All Skills"**.
- **Added guidance** to the row note + confirm dialog: run it **after "Unlock Trainers"**, and **don't use it if you plan to level some skill trainer trees yourself**.

## Live validation

Applied the exact generated SQL (SPS=7 + 20-point buffer + 100 Intel) to a live character: `UnspentSkillPoints=20`, `TotalSkillPoints=310→1035`, `Intel=100`, and the maintainer confirmed in-game the result is correct and the quest completes.

- `PlayersWrites.ps1` parses clean; UTF-8 BOM retained.
- webui `tsc -b && vite build` passes.

For the next release, alongside the reboot/stop cosmetic-warning note.