### PR TITLE
Render action rowNote descriptions in the expanded row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [Unreleased]
+
+### Fixed
+
+- **Player action descriptions now show.** Each action under *Players → Progression / Items / etc.* has a short description (`rowNote`), but it was never rendered — so expanding an action (e.g. **Enable All Skills**) showed only the button with no explanation. The description now appears at the top of the expanded action.
+
 ## [12.16.10] - 2026-07-05
 
 ### Changed

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -948,6 +948,9 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
       </button>
       {open && (
         <div className="border-t border-border p-3">
+          {def.rowNote && (
+            <div className="text-xs text-text-dim italic mb-3 leading-relaxed">{def.rowNote}</div>
+          )}
           {def.custom === 'give-item' ? (
             <GiveItemForm busy={busy} submitLabel={def.label}
               onSubmit={(tpl, qty, qual, overflow) => runAction(def, () => giveItem(player.id, tpl, qty, qual, overflow))}


### PR DESCRIPTION
Player action defs carry a short rowNote description, but it was never rendered anywhere - expanding an action (e.g. Enable All Skills) showed only the button with no explanation. Renders rowNote as an italic dim note at the top of the expanded ActionRow content, so every action's description is visible. Shared ActionRow, so it applies to all action sections. webui build passes.