### PR TITLE
Fix VM header [object Object] + Public IP card crash on multi-adapter VMs (v12.16.12)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.16.11"
+      placeholder: "v12.16.12"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.16.12] - 2026-07-05
+
+### Fixed
+
+- **VM header no longer shows `[object Object]`, and the Public IP card no longer crashes on VMs with multiple network adapters.** `Get-DuneVmStatus` now coerces the discovered VM IP to a string before returning it. Previously, on VMs where `Get-VMNetworkAdapter` yields multiple adapters, the pipeline chain could return a wrapping PSObject that JSON-serialized as `{}`; the webui then rendered `VM · [object Object]` in the header, and the *Settings → Public IP / DDNS* card threw React error #31 (`Objects are not valid as a React child`) and displayed "Public IP couldn't be displayed". Also added defensive `typeof === 'string'` guards on both surfaces so a future backend regression can't crash the app.
+
 ## [12.16.11] - 2026-07-05
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.16.11'
+$script:DuneToolVersion = '12.16.12'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.16.11',
+    [string]$Version = '12.16.12',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.16.11</Version>
+    <Version>12.16.12</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.16.11"
+#define MyAppVersion "12.16.12"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -306,7 +306,7 @@ function Get-DunePublicIpStatus {
         lastResolvedPublicIp= [string]$cfg.LastResolvedPublicIp
         lastAppliedPublicIp = [string]$cfg.LastAppliedPublicIp
         currentPublicIp     = $null
-        vmIp                = if ($vm) { $vm.ip } else { $null }
+        vmIp                = if ($vm) { [string]$vm.ip } else { '' }
         k3sExternalIp       = ''
     }
     try { $status.currentPublicIp = Get-DunePublicIp } catch {}

--- a/app/server/lib/Status.ps1
+++ b/app/server/lib/Status.ps1
@@ -56,6 +56,13 @@ function Get-DuneVmStatus {
         $vm = Get-VM -Name $script:DuneVmName -ErrorAction Stop
         $ip = ($vm | Get-VMNetworkAdapter).IPAddresses |
               Where-Object { $_ -match '^\d+\.\d+\.\d+\.\d+$' } | Select-Object -First 1
+        # Coerce to string. On VMs with multiple network adapters the pipeline
+        # can hand back a PSObject wrapping the IP; without the cast, ConvertTo-Json
+        # serializes it as `{}` and the webui renders `VM · [object Object]` +
+        # crashes the Public IP card with React error #31 (`Objects are not valid
+        # as a React child`). See dst-vm-ip-object-render-bug on Infinate Scaled
+        # host, 2026-07-05.
+        $ip = if ($null -ne $ip) { [string]$ip } else { '' }
         return @{
             exists  = $true
             name    = $script:DuneVmName
@@ -70,7 +77,7 @@ function Get-DuneVmStatus {
             name    = $script:DuneVmName
             state   = 'NotFound'
             running = $false
-            ip      = $null
+            ip      = ''
             uptime  = 0
             error   = $_.Exception.Message
         }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.16.11"
+$script:ToolVersion = "12.16.12"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/layout/StatusBar.tsx
+++ b/webui/src/layout/StatusBar.tsx
@@ -19,7 +19,14 @@ function portPillClass(ports: PortStatus | null | undefined, port: number, proto
 function vmPillText(vm: VmStatus | undefined | null): string {
   if (!vm) return '—'
   if (!vm.exists) return 'Not found'
-  if (vm.running) return vm.ip ? `Running · ${vm.ip}` : 'Running'
+  // Defensive stringification: if the backend hands back a non-string ip
+  // (seen 2026-07-05 when Get-DuneVmStatus returned a wrapping PSObject on a
+  // multi-adapter VM), rendering `${ip}` in the pill text yields
+  // `[object Object]`. Coerce to string and reject anything that isn't a
+  // proper dotted IPv4.
+  const rawIp = (vm as unknown as { ip?: unknown }).ip
+  const ip = typeof rawIp === 'string' && /^\d{1,3}(\.\d{1,3}){3}$/.test(rawIp) ? rawIp : ''
+  if (vm.running) return ip ? `Running · ${ip}` : 'Running'
   return vm.state || 'Stopped'
 }
 

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -378,7 +378,7 @@ export function PublicIpCard() {
           </p>
           <div className="mt-2 flex flex-wrap gap-2 text-xs">
             {status?.currentPublicIp && <span className="pill-muted">internet · {status.currentPublicIp}</span>}
-            {status?.vmIp && <span className="pill-muted">VM · {status.vmIp}</span>}
+            {status?.vmIp && typeof status.vmIp === 'string' && <span className="pill-muted">VM · {status.vmIp}</span>}
             {status?.k3sExternalIp && <span className="pill-muted">K3s ExternalIP · {status.k3sExternalIp}</span>}
             {status?.lastAppliedPublicIp && <span className="pill-success">last applied · {status.lastAppliedPublicIp}</span>}
           </div>


### PR DESCRIPTION
Real-world repro on Coastal's **Infinate Scaled** host right after installing v12.16.11: header showed `VM · Running · [object Object]`, the *Settings → Public IP / DDNS* card crashed with "Public IP couldn't be displayed" (Minified React error #31: *Objects are not valid as a React child (found: object with keys {})*), and the BG badge fell to `Unknown` because downstream code that assumed `vm.ip` is a string choked.

**Root cause:** `Get-DuneVmStatus`'s IP-discovery pipeline:
```powershell
($vm | Get-VMNetworkAdapter).IPAddresses | Where-Object {...} | Select-Object -First 1
```
returns a plain string on VMs with a single adapter, but on VMs with multiple adapters PowerShell can hand back a wrapping `PSObject` that JSON-serializes as `{}`. React then tries to render that object directly as text and throws #31.

**Fix (belt and suspenders across both layers):**
- Coerce `$ip` to `[string]` before returning from `Get-DuneVmStatus`
- Coerce `Get-DunePublicIpStatus.vmIp` to `[string]` too (defensive; reads `$vm.ip`)
- `StatusBar.vmPillText`: `typeof === 'string'` guard + IPv4 regex validate before interpolating — won't render an object even if a future backend regression leaks one
- `PublicIpCard`'s VM pill: `typeof === 'string'` guard

Version stamps 12.16.11 → 12.16.12 across all 5 files; CHANGELOG rolled; bug-report template placeholder bumped. Installer at `app/installer/output/DuneServerSetup.exe` (46.07 MB), webui build clean, PS parse-check clean.