### PR TITLE
Battlegroup Info raw pane: rewrite drifted Status row from CRD JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Battlegroup Info "raw output" pane no longer shows a drifted Status column for multi-word / comma'd server names.** Funcom's `battlegroup status` script builds its Battlegroup Info table by awk-parsing a positional `kubectl get battlegroups --no-headers` row, so a server TITLE containing spaces or a comma (e.g. `Dune, my Arrakis`) shifts the Status cell — and every column after it — by one field per extra word, printing the second word of the name where the status belongs. The Info *panel* has read from the Battlegroup CRD JSON since v12.16.1 and was already correct; the raw-output pane still showed Funcom's drifted row verbatim. DST now rewrites just that one data row in the raw text from the same JSON-canonical values (Status / Database / Gateway / Director / Uptime) and tags it `(DST-corrected)`. Conservative: it only fires when the text row actually disagrees with the CRD (a correctly-columned single-word name is left untouched), and it no-ops when the CRD JSON is unavailable so the pane never renders worse than before. Reported by gd.py in `#hosting-help`.
+
 ## [12.16.12] - 2026-07-05
 
 ### Fixed

--- a/app/server/lib/Status.ps1
+++ b/app/server/lib/Status.ps1
@@ -263,6 +263,14 @@ function Get-DuneBattlegroupSnapshotFresh {
         if ($bgJsonInfo) {
             $result.info = $bgJsonInfo.info
             if ($bgJsonInfo.name -and -not $result.name) { $result.name = $bgJsonInfo.name }
+            # Funcom's `battlegroup status` script awk-parses a positional row,
+            # so a multi-word / comma'd server TITLE shifts the Status cell (and
+            # every column after it) in the raw-output pane. The Info panel is
+            # already rebuilt from JSON above; also rewrite the drifted row in
+            # the raw text from the same canonical values so the debug pane
+            # reads correctly. Only fires when the text row actually disagrees
+            # with JSON, and tags the repaired row so it's clear DST corrected it.
+            $result.output = Repair-DuneBgInfoRawOutput -Text $result.output -Info $bgJsonInfo.info
         }
         return $result
     } catch {
@@ -494,6 +502,61 @@ function Get-BgRowValues {
         }
     }
     return $values
+}
+
+# Lay out a table row so each value begins at its column's start offset (from
+# the dashes-row spans), reproducing the kubectl-style fixed-width alignment.
+# If a value overflows its column, the next value is separated by a single
+# space rather than being merged into it.
+function Format-BgRowFromSpans {
+    param([array]$Spans, [string[]]$Values)
+    $sb = New-Object System.Text.StringBuilder
+    for ($c = 0; $c -lt $Spans.Count -and $c -lt $Values.Count; $c++) {
+        $start = [int]$Spans[$c].start
+        if ($sb.Length -lt $start) {
+            [void]$sb.Append(' ', $start - $sb.Length)
+        } elseif ($c -gt 0) {
+            [void]$sb.Append(' ')
+        }
+        [void]$sb.Append([string]$Values[$c])
+    }
+    return $sb.ToString()
+}
+
+# Rewrite the single "Battlegroup Info" data row inside the raw `battlegroup
+# status` text using the canonical JSON-derived values, so the raw-output pane
+# no longer shows Funcom's positionally-drifted row for multi-word / comma'd
+# server names. Conservative: only rewrites when the text row's control-plane
+# fields (Status/Database/Gateway/Director) actually disagree with JSON, leaves
+# a correctly-columned name verbatim, and marks the repaired row "(DST-corrected)".
+# Returns the text unchanged when JSON is absent or the table isn't found.
+function Repair-DuneBgInfoRawOutput {
+    param([string]$Text, $Info)
+    if (-not $Text -or -not $Info) { return $Text }
+    $lines = $Text -split "`r?`n"
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        if ($lines[$i] -match '^\s*Battlegroup Info\s*$' -and $i + 3 -lt $lines.Length) {
+            $dashes = $lines[$i + 2]
+            if ($dashes -notmatch '-{3,}') { break }
+            $spans = Get-BgColumnSpans -Header $lines[$i + 1] -Dashes $dashes
+            if ($spans.Count -lt 5) { break }
+            $cur = @(Get-BgRowValues -Line $lines[$i + 3] -Cols $spans)
+            $jsonFour = @([string]$Info.status, [string]$Info.database, [string]$Info.gateway, [string]$Info.director)
+            $drift = $false
+            for ($c = 0; $c -lt 4; $c++) {
+                $have = if ($c -lt $cur.Count) { [string]$cur[$c] } else { '' }
+                if ($have -ne $jsonFour[$c]) { $drift = $true; break }
+            }
+            if (-not $drift) { break }
+            $row = Format-BgRowFromSpans -Spans $spans -Values @(
+                [string]$Info.status, [string]$Info.database, [string]$Info.gateway,
+                [string]$Info.director, [string]$Info.uptime
+            )
+            $lines[$i + 3] = "$row   (DST-corrected)"
+            break
+        }
+    }
+    return ($lines -join "`n")
 }
 
 # Parse a Game Servers table row by tokens from BOTH ends, NOT by fixed column

--- a/tests/BgStatusRawRepair.Tests.ps1
+++ b/tests/BgStatusRawRepair.Tests.ps1
@@ -1,0 +1,73 @@
+# Regression coverage for the "Battlegroup Info" raw-output pane column drift.
+#
+# Funcom's `battlegroup status` script awk-parses a positional row, so a server
+# TITLE containing spaces or a comma (e.g. "Dune, my Arrakis") shifts the Status
+# cell (and every column after it) — the raw-output pane then shows the second
+# word of the name where the status should be. The Info *panel* is already
+# rebuilt from the Battlegroup CRD JSON (v12.16.1); Repair-DuneBgInfoRawOutput
+# also rewrites the drifted row in the raw text from those canonical values so
+# the debug pane reads correctly, tagging it "(DST-corrected)".
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'Status.ps1'
+
+    $script:Info = @{ status = 'Healthy'; database = 'Healthy'; gateway = 'Running'; director = 'Ready'; uptime = '3d4h' }
+
+    # Extract the single data row under the "Battlegroup Info" header.
+    function Get-InfoRow {
+        param([string] $Text)
+        $lines = $Text -split "`r?`n"
+        for ($i = 0; $i -lt $lines.Length; $i++) {
+            if ($lines[$i] -match '^\s*Battlegroup Info\s*$') { return $lines[$i + 3] }
+        }
+        return $null
+    }
+}
+
+Describe 'Repair-DuneBgInfoRawOutput' {
+    It 'rewrites a drifted row from JSON and marks it corrected' {
+        # Multi-word title "Dune, my Arrakis" -> Funcom puts "my" in the Status cell.
+        $drifted = @"
+Battlegroup: sh-abc123
+Battlegroup Info
+Status     Database   Gateway    Director   Uptime
+---------- ---------- ---------- ---------- --------
+my         Healthy    Running    Ready      3d4h
+Game Servers
+"@
+        $out = Repair-DuneBgInfoRawOutput -Text $drifted -Info $script:Info
+        $row = Get-InfoRow -Text $out
+
+        $row | Should -Match 'DST-corrected'
+        # Each canonical value lands under its own column header.
+        $vals = @(Get-BgRowValues -Line $row -Cols (Get-BgColumnSpans -Header 'Status     Database   Gateway    Director   Uptime' -Dashes '---------- ---------- ---------- ---------- --------'))
+        $vals[0] | Should -Be 'Healthy'
+        $vals[1] | Should -Be 'Healthy'
+        $vals[2] | Should -Be 'Running'
+        $vals[3] | Should -Be 'Ready'
+    }
+
+    It 'leaves an already-correct row verbatim (no marker)' {
+        $clean = @"
+Battlegroup: sh-abc123
+Battlegroup Info
+Status     Database   Gateway    Director   Uptime
+---------- ---------- ---------- ---------- --------
+Healthy    Healthy    Running    Ready      3d4h
+"@
+        $out = Repair-DuneBgInfoRawOutput -Text $clean -Info $script:Info
+        $out | Should -Be ($clean -replace "`r`n", "`n")
+        $out | Should -Not -Match 'DST-corrected'
+    }
+
+    It 'returns text unchanged when JSON info is absent' {
+        $drifted = "Battlegroup Info`nStatus     Database`n---------- ----------`nmy         Healthy"
+        Repair-DuneBgInfoRawOutput -Text $drifted -Info $null | Should -Be $drifted
+    }
+
+    It 'does nothing when there is no Battlegroup Info table' {
+        $text = "Battlegroup: sh-abc123`nNo resources found in namespace"
+        Repair-DuneBgInfoRawOutput -Text $text -Info $script:Info | Should -Be $text
+    }
+}


### PR DESCRIPTION
## What

The **Battlegroup Info** section of the raw-output pane (`battlegroup status` text) shows a **drifted Status column** when the server title has spaces or a comma (e.g. `Dune, my Arrakis`) — the Status cell prints the second word of the name instead of the actual status, and every column after it shifts right by one field per extra word.

Root cause is Funcom's own `battlegroup status` script: it builds the table by awk-parsing a positional `kubectl get battlegroups --no-headers` row, so a multi-word TITLE pushes PHASE (and the rest) out of position.

The Info **panel** has read from the Battlegroup CRD JSON since v12.16.1 and is already correct; only the verbatim raw-output pane still showed Funcom's drifted row.

## Fix

`Repair-DuneBgInfoRawOutput` rewrites just the one Battlegroup Info data row in the raw text using the same JSON-canonical values the panel uses (Status / Database / Gateway / Director / Uptime), tagged `(DST-corrected)`.

- **Conservative:** only fires when the text row's control-plane fields actually disagree with the CRD — a correctly-columned single-word name is left verbatim.
- **Safe fallback:** no-ops when the CRD JSON is unavailable, so the pane never renders worse than before.
- Backend-only; no UI change.

Before:
```
Status     Database   Gateway    Director   Uptime
---------- ---------- ---------- ---------- --------
my         Healthy    Running    Ready      3d4h
```
After:
```
Status     Database   Gateway    Director   Uptime
---------- ---------- ---------- ---------- --------
Healthy    Healthy    Running    Ready      3d4h   (DST-corrected)
```

## Tests

New `tests/BgStatusRawRepair.Tests.ps1` (4 cases: drift rewrite, verbatim-when-clean, null-JSON no-op, no-table no-op) — all pass. Full suite: 397 passed / 1 pre-existing unrelated failure (`PlayersAdmin owner_account_id`, fails on clean `main` in full-suite runs due to a cross-file harness global-state leak; passes in isolation).

Reported by gd.py in `#hosting-help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)