### PR TITLE
Links: use snapshot.state instead of re-parsing repaired BG output

### DIFF
--- a/app/server/lib/Links.ps1
+++ b/app/server/lib/Links.ps1
@@ -84,8 +84,14 @@ function Get-DuneLinks {
             $snap = Get-DuneBattlegroupSnapshot
         }
         if ($snap -and $snap.available) {
-            $state = $null
-            if (Get-Command Get-BgStateFromStatusText -ErrorAction SilentlyContinue) {
+            # Use the snapshot's authoritative state, computed once from the raw
+            # `battlegroup status` text when the snapshot is built. Do NOT re-parse
+            # $snap.output here: that field is post-processed for display (the
+            # Battlegroup Info row is rewritten from the CRD JSON so multi-word /
+            # comma'd server names don't drift the Status column), so re-parsing it
+            # would couple director-link resolution to a display transform.
+            $state = $snap.state
+            if (-not $state -and (Get-Command Get-BgStateFromStatusText -ErrorAction SilentlyContinue)) {
                 $state = Get-BgStateFromStatusText $snap.output
             }
             if ($state -eq 'Running') { $bgRunning = $true }


### PR DESCRIPTION
## Why

Follow-up to #467. That PR made the Battlegroup Info **raw-output pane** rewrite its drifted Status row from the CRD JSON (so multi-word / comma'd server names no longer shift the columns). While verifying it against the **Server Health** page (the Dashboard), I traced every consumer of the status snapshot:

- The Server Health page renders `state` / `info` / `gameServers` — all derived from the **pre-repair** text or JSON, so they're unaffected.
- `bg.output` is display-only (a single `<pre>` behind "Show raw output"), **except** one backend caller: `Get-DuneWebLinks` re-parsed `$snap.output` with `Get-BgStateFromStatusText` to decide `bgRunning` (which gates Director-link resolution).

That last one couples link resolution to the display transform. It doesn't regress today (the repaired row preserves the `Running`/`Ready` keywords the classifier matches on, and the `(DST-corrected)` marker contains no state keyword), but it's fragile.

## Change

Use the snapshot's authoritative `.state` — computed once from the raw text when the snapshot is built ([Status.ps1:248](../blob/main/app/server/lib/Status.ps1#L248)) — instead of re-parsing the post-processed `$snap.output`. Keeps a fallback to the old parse for any snapshot shape without `.state`.

Behavior-preserving (`.state` is the same value the re-parse produced), removes a redundant parse, and de-risks the coupling.

## Tests

Full suite: 397 passed / 1 pre-existing unrelated failure (`PlayersAdmin owner_account_id`, a full-suite-only harness global-state leak already being fixed separately). Links.ps1 parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)