### PR TITLE
test(schema): retarget stale owner_account_id assertion (fixes 393/1)

### DIFF
--- a/tests/Schema.Tests.ps1
+++ b/tests/Schema.Tests.ps1
@@ -23,9 +23,17 @@ Describe 'Schema: dune.actors column names' -Tag 'Schema' {
         $content = Get-LibContent 'PlayersWrites.ps1'
         $content | Should -Not -Match 'actors\.account_id\b'
     }
-    It 'PlayersAdmin.ps1 actually uses owner_account_id (the canonical column)' {
+    It 'PlayersAdmin.ps1 resolves accounts via accounts.id / player_state.account_id (never actors.account_id)' {
+        # Post-2235d00 (match Funcom's own delete flow, rip out DST's homegrown
+        # cleanup) PlayersAdmin no longer keys a homegrown delete cascade on
+        # actors.owner_account_id. It still must resolve accounts through the
+        # real columns: dune.accounts.id (raw funcom-id lookup) and
+        # dune.player_state.account_id (offline/account check). actors.account_id
+        # does not exist (see the negative guard above); owner_account_id lives
+        # on the read/roster path (PlayersRead.ps1), not here.
         $content = Get-LibContent 'PlayersAdmin.ps1'
-        $content | Should -Match '\bowner_account_id\b'
+        $content | Should -Match 'dune\.accounts WHERE id'
+        $content | Should -Match 'dune\.player_state WHERE account_id'
     }
 }
 


### PR DESCRIPTION
## What

`Schema.Tests.ps1` asserted `PlayersAdmin.ps1` references `owner_account_id`, but commit `2235d00` ("match Funcom's own delete flow, rip out DST's homegrown cleanup") intentionally removed the homegrown delete cascade that keyed on `actors.owner_account_id`. The positive-control test dated from v11.5.9 (`087291c`) and was never updated — so `main` has been shipping **393 passed / 1 failed**.

## Why it wasn't a test-isolation issue

The assertion is a pure `Get-Content … | Should -Match` file grep — no global closure can change what it reads. It fails **identically in isolation and in the full suite**. (Running `-Path ./PlayersAdmin.Tests.ps1` made it look green only because the failing test lives in `Schema.Tests.ps1`, not `PlayersAdmin.Tests.ps1`.)

## Fix

Retarget the assertion to what's true post-`2235d00`: `PlayersAdmin.ps1` resolves accounts via `dune.accounts.id` and `dune.player_state.account_id`, never `actors.account_id`. `owner_account_id` remains in use on the read/roster path (`PlayersRead.ps1:508`), which is unaffected.

Test-only change. No runtime/app code touched. Full suite: **394/394 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)