### PR TITLE
release: v12.17.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.16.12"
+      placeholder: "v12.17.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.17.0] - 2026-07-05
+
 ### Fixed
 
 - **Battlegroup Info "raw output" pane no longer shows a drifted Status column for multi-word / comma'd server names.** Funcom's `battlegroup status` script builds its Battlegroup Info table by awk-parsing a positional `kubectl get battlegroups --no-headers` row, so a server TITLE containing spaces or a comma (e.g. `Dune, my Arrakis`) shifts the Status cell — and every column after it — by one field per extra word, printing the second word of the name where the status belongs. The Info *panel* has read from the Battlegroup CRD JSON since v12.16.1 and was already correct; the raw-output pane still showed Funcom's drifted row verbatim. DST now rewrites just that one data row in the raw text from the same JSON-canonical values (Status / Database / Gateway / Director / Uptime) and tags it `(DST-corrected)`. Conservative: it only fires when the text row actually disagrees with the CRD (a correctly-columned single-word name is left untouched), and it no-ops when the CRD JSON is unavailable so the pane never renders worse than before. Reported by gd.py in `#hosting-help`.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.16.12'
+$script:DuneToolVersion = '12.17.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.16.12',
+    [string]$Version = '12.17.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.16.12</Version>
+    <Version>12.17.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.16.12"
+#define MyAppVersion "12.17.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.16.12"
+$script:ToolVersion = "12.17.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Version bump for the **v12.17.0** release. Rolls `[Unreleased]` → `[12.17.0] - 2026-07-05`.

### Included since v12.16.12
- **#467** — Battlegroup Info raw-output pane: rewrite the drifted Status row from CRD JSON (headline fix, user-facing).
- **#468** — Links: use `snapshot.state` instead of re-parsing repaired BG output (internal, behavior-preserving hardening; rides under the #467 bullet).
- **#469** — retarget the stale `owner_account_id` schema test (test-only).

### Stamps bumped (all 5 + bug_report)
`app/DuneServer.ps1`, `dune-server.ps1`, `app/build/Build-Exe.ps1`, `app/installer/DuneServer.iss`, `app/desktop/DuneShell/DuneShell.csproj`, `.github/ISSUE_TEMPLATE/bug_report.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)