### PR TITLE
VM memory-pressure diagnostics (OOMKilled operators / low RAM)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,8 +22,11 @@ body:
         > SSH paths, Windows usernames, and config secrets are redacted before
         > the ZIP is written. The bundle includes a redacted **UserGame.ini /
         > UserEngine.ini snapshot** (with an automatic duplicate-section-header
-        > check) when the VM is reachable, and its `manifest.txt` lists what's
-        > inside and any sanitization warnings.
+        > check) and a **`vm-memory-pressure.txt`** probe (Funcom operator /
+        > Postgres restart counts + OOMKilled/exit-137 state and the VM's
+        > `free -h`) when the VM is reachable, and its `manifest.txt` lists
+        > what's inside, leads with any memory-pressure finding, and records any
+        > sanitization warnings.
 
         **✅ Do open an issue here** when the tool shows you a problem, e.g.:
         - The **Server Health** page shows the battlegroup as **Unknown** with
@@ -373,6 +376,32 @@ body:
         Gameplay Admin > Players: 5 rows, all names blank, all Unaligned
         Started after: character transfer to a separate game DB
         (Attached dst-diagnostics-*.zip — see gameplay-read-probe.txt)
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: mempressure_diag
+    attributes:
+      label: Battlegroup restarted off-schedule / ping surges under load (VM memory pressure)
+      description: |
+        If your battlegroup **restarted outside its scheduled time**, pods
+        cycle on their own, or you see **ping/lag spikes under load** even when
+        the host looks idle, this is usually the **VM running low on memory**:
+        the kubelet OOM-kills the Funcom operators (exit 137) and evicts
+        Postgres. DST now flags this itself — attach the diagnostic ZIP from
+        **Help → Create GitHub Issue + Save Logs** and see **`vm-memory-pressure.txt`**
+        (and the red banner at the top of **Server Health**).
+
+        In text, note: how much **RAM the VM has** (Hyper-V), whether Server
+        Health showed the red **"VM low on memory"** banner, and whether swap is
+        on (`free -h` in the bundle — `Swap: 0` is the pressure signature).
+
+        Leave blank if your bug isn't about off-schedule restarts / memory.
+      placeholder: |
+        Symptom: battlegroup restarted at ~06:09 and ~07:11 (schedule is 02:00)
+        Server Health banner: "VM low on memory — Funcom operators killed 34x"
+        VM RAM (Hyper-V): 24 GB. free -h in bundle showed Swap: 0
       render: shell
     validations:
       required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **VM memory-pressure diagnostics — DST now surfaces the "node is out of RAM" signature itself.** When a home-hosted VM runs low on memory the kubelet SIGKILLs whatever is using the most: the four Funcom operator controller-managers get exit-137 / OOMKilled with restart counts climbing into the 30s, the Postgres pod is evicted, and the nightly DB backup hangs for minutes while the node pages. The tell-tale is a tiny `MemAvailable` with `Swap: 0`. This has now bitten three times (murm ping-surge, Hagga per-map sizing, and a battlegroup restarting outside its 02:00 schedule) and could previously only be found by exporting logs and hand-reading them. A new read-only probe (`app/resources/remote-scripts/dune-mem-pressure-probe.sh`, run over the existing SSH path) reads operator/DB pod restart counts + last-terminated state and the VM's `free -h` / `/proc/meminfo`, and DST now:
+  - shows a red **"VM low on memory — Funcom operators killed N times; consider raising the VM's RAM"** banner at the top of **Server Health** (`GET /api/diagnostics/vm-memory`, cached 60s);
+  - prints the same warning after a **Start** / **Reboot** in the console (CLI `startup` / `reboot`); and
+  - adds a **`vm-memory-pressure.txt`** file to the diagnostics bundle (Help → Create GitHub Issue + Save Logs) and leads the bundle's `manifest.txt` with the finding when detected.
+  The probe never mutates the VM; an unreachable VM simply hides the banner. Prompted by Pat's report (v12.17.0) of his battlegroup restarting at ~06:09 / ~07:11 local — traced to node memory pressure on his `duneawakening` VM, not DST's scheduled restart.
+
 ### Fixed
 
 - **Save-guard no longer warns "N player(s) currently online" for a stale ghost row when nobody is connected.** The online-player check (`Get-V6OnlinePlayers`) counted any `encrypted_player_state` row whose `online_status` wasn't `Offline` — which since Funcom 1.4.10.0 also includes the new `LoggingOut` grace state, plus any stale/ghost row whose `server_id` points at a battlegroup that no longer exists after a restart. Such a row (its character name decrypts to blank, so it appears as a bare `id=N`) tripped the Game Config / Gameplay Admin save confirmation with no real player in-game. The query now mirrors Funcom's own `dune.is_player_offline()`: a row counts as online only when it isn't `Offline` **and** its `server_id` is in `dune.active_server_ids` (the currently-running servers). Guarded with `to_regclass()` so a DB predating that relation falls back to the previous behaviour instead of erroring. Reported by fargenbasteg in `#bug-reports` (confirmed: no player connected, and the phantom `id=3` persisted across a battlegroup restart).

--- a/app/resources/remote-scripts/dune-mem-pressure-probe.sh
+++ b/app/resources/remote-scripts/dune-mem-pressure-probe.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+# dune-mem-pressure-probe.sh
+#
+# VM memory-pressure probe for the Dune Server Tool.
+#
+# Staged over SSH and executed as root via `sudo bash`. It NEVER mutates the
+# VM - it only reads memory + pod state and prints stable key=value lines.
+# The same output contract is parsed by BOTH callers, so keep it stable:
+#   - app/server/lib/VmMemoryPressure.ps1  (Diagnostics bundle + status banner)
+#   - dune-server.ps1                      (CLI Start-All WARNINGS)
+#
+# Why this exists: three real cases (murm ping-surge, Hagga per-map sizing, and
+# Pat's off-schedule battlegroup restarts, 2026-07-07) were all the home-hosted
+# VM thrashing for memory. The kubelet SIGKILLs the Funcom operators
+# (*-controller-manager-*, exit 137 / OOMKilled, restart counts in the 30s) and
+# evicts the Postgres pod when the node runs low on memory with Swap: 0. Today
+# that can only be found by exporting logs and hand-reading them; this probe
+# surfaces it in DST itself.
+#
+# Emitted keys:
+#   probe=dune-mem-pressure/1
+#   mem_total_k / mem_avail_k / swap_total_k / swap_free_k   (KiB, from /proc)
+#   __FREE_H_BEGIN__ ... __FREE_H_END__                       (human free -h)
+#   ns_operators=<ns|empty>   ns_seabass=<ns|empty>
+#   op=<record>   (one per *-controller-manager-* operator pod)
+#   db=<record>   (one per Postgres/database statefulset pod)
+#   probe_done=1
+#
+# Pod record shape (~ is the field separator; lists are space-joined so a
+# multi-container pod - manager + kube-rbac-proxy - is fully covered):
+#   <name>~P:<phase>~PR:<podReason>~R:<restarts >~E:<exitCodes >~X:<termReasons >~W:<waitReasons >
+# ---------------------------------------------------------------------------
+set -u
+
+KUBECTL=/usr/local/bin/kubectl
+[ -x "$KUBECTL" ] || KUBECTL=kubectl
+
+echo "probe=dune-mem-pressure/1"
+
+# --- Node memory ----------------------------------------------------------
+# /proc/meminfo is authoritative and universal (MemAvailable is present on
+# every modern kernel); free -h is only for human display in the bundle.
+if [ -r /proc/meminfo ]; then
+  awk '
+    /^MemTotal:/     { print "mem_total_k="$2 }
+    /^MemAvailable:/ { print "mem_avail_k="$2 }
+    /^SwapTotal:/    { print "swap_total_k="$2 }
+    /^SwapFree:/     { print "swap_free_k="$2 }
+  ' /proc/meminfo
+else
+  echo "meminfo_missing=1"
+fi
+
+echo "__FREE_H_BEGIN__"
+free -h 2>/dev/null || free 2>/dev/null || echo "(free unavailable)"
+echo "__FREE_H_END__"
+
+# --- Pod records ----------------------------------------------------------
+# jsonpath emits one line per pod; per-container fields are space-joined inside
+# each field so the PS side can take the max restart count and scan the
+# exit-code / termination-reason lists for 137 / OOMKilled / Error / Evicted.
+JPATH='{range .items[*]}{.metadata.name}{"~P:"}{.status.phase}{"~PR:"}{.status.reason}{"~R:"}{range .status.containerStatuses[*]}{.restartCount}{" "}{end}{"~E:"}{range .status.containerStatuses[*]}{.lastState.terminated.exitCode}{" "}{end}{"~X:"}{range .status.containerStatuses[*]}{.lastState.terminated.reason}{" "}{end}{"~W:"}{range .status.containerStatuses[*]}{.state.waiting.reason}{" "}{end}{"\n"}{end}'
+
+# Funcom operators live in a fixed namespace; only the four
+# *-controller-manager-* pods matter (battlegroup / database / server /
+# utilities controller-managers).
+OPNS=funcom-operators
+if "$KUBECTL" get ns "$OPNS" >/dev/null 2>&1; then
+  echo "ns_operators=$OPNS"
+  "$KUBECTL" get pods -n "$OPNS" -o jsonpath="$JPATH" 2>/dev/null | while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      *controller-manager*) echo "op=$line" ;;
+    esac
+  done
+else
+  echo "ns_operators="
+fi
+
+# The game/DB workloads live in funcom-seabass-<world>. The database pod is the
+# Postgres statefulset member; exclude the transient dump/backup/util pods
+# (terminal by design - a non-zero exit there is not a memory-pressure signal).
+DBNS=$("$KUBECTL" get ns --no-headers -o custom-columns=N:.metadata.name 2>/dev/null | grep -m1 '^funcom-seabass-')
+if [ -n "$DBNS" ]; then
+  echo "ns_seabass=$DBNS"
+  "$KUBECTL" get pods -n "$DBNS" -o jsonpath="$JPATH" 2>/dev/null | while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    name=${line%%~*}
+    case "$name" in
+      *dump*|*backup*|*dbdepl-util*) continue ;;
+    esac
+    case "$name" in
+      *-db-*|*-db|*database*) echo "db=$line" ;;
+    esac
+  done
+else
+  echo "ns_seabass="
+fi
+
+echo "probe_done=1"

--- a/app/server/lib/VmMemoryPressure.ps1
+++ b/app/server/lib/VmMemoryPressure.ps1
@@ -1,0 +1,315 @@
+# -----------------------------------------------------------------------------
+# VmMemoryPressure.ps1
+#
+# Detects the "home-hosted VM is thrashing for memory" signature that has now
+# bitten three times in the wild (murm ping-surge 2026-07-01, Hagga per-map
+# sizing 2026-07-06, and Pat's off-schedule battlegroup restarts 2026-07-07).
+#
+# When the appliance VM (Alpine + k3s + Postgres + the Funcom operators) runs
+# low on memory the kubelet SIGKILLs whatever is using the most: the four
+# Funcom operator controller-managers get exit-137 / OOMKilled with restart
+# counts climbing into the 30s, the Postgres statefulset pod gets evicted, and
+# the nightly DB-backup psql hangs for minutes because the node is paging. The
+# tell-tale is a tiny MemAvailable with `Swap: 0` (no cushion). Until now this
+# could only be found by exporting logs and hand-reading them.
+#
+# This module surfaces it in DST itself. It NEVER mutates the VM - it stages
+# the read-only probe (app/resources/remote-scripts/dune-mem-pressure-probe.sh)
+# over SSH, runs it as root, and parses its stable key=value output into a
+# structured finding with red-banner-ready warning strings.
+#
+# Public entry points:
+#   - Get-DuneVmMemoryPressure     -> context + probe + parse (+ 60s cache).
+#   - ConvertFrom-DuneMemPressureProbe -> PURE parser (unit-testable, no SSH).
+#   - Format-DuneMemKiB            -> KiB -> "12.3 GiB" for display.
+# -----------------------------------------------------------------------------
+
+# A container restart count above this is "elevated" and worth a warning even
+# without a captured OOMKill (the OOM lastState is overwritten once the pod
+# stabilises, but the cumulative restart count persists). Healthy = 0.
+$script:DuneMemHighRestartThreshold = 5
+
+# "Low memory" gate for the free-h signal: flag when MemAvailable is under 1 GiB
+# OR under 8% of total. Paired with Swap:0 this is the pressure signature.
+$script:DuneMemLowAvailKiB    = 1048576   # 1 GiB in KiB
+$script:DuneMemLowAvailPct    = 8
+
+# Short-lived cache so a Dashboard mount + its 60s poll (and a concurrent
+# Diagnostics bundle) don't each pay a fresh SSH round-trip.
+$script:DuneMemPressureCache     = $null
+$script:DuneMemPressureCacheAt   = [datetime]::MinValue
+$script:DuneMemPressureCacheTtlS = 60
+
+function Get-DuneMemPressureProbePath {
+    # Mirror the resource-path resolution used by Maps.ps1 / FlsToken.ps1:
+    # installed layout first, dev layout second.
+    $candidates = @(
+        (Join-Path $PSScriptRoot '..\..\resources\remote-scripts\dune-mem-pressure-probe.sh')                   # installed layout
+        (Join-Path (Split-Path -Parent $PSScriptRoot) '..\resources\remote-scripts\dune-mem-pressure-probe.sh')  # dev layout fallback
+    )
+    foreach ($p in $candidates) { if (Test-Path -LiteralPath $p) { return $p } }
+    return $null
+}
+
+# KiB -> human string. Pure; safe for tests.
+function Format-DuneMemKiB {
+    param([Nullable[long]]$KiB)
+    if ($null -eq $KiB -or $KiB -lt 0) { return '?' }
+    $units = @('KiB','MiB','GiB','TiB')
+    $v = [double]$KiB
+    $i = 0
+    while ($v -ge 1024 -and $i -lt ($units.Count - 1)) { $v /= 1024; $i++ }
+    if ($i -eq 0) { return ("{0:0} {1}" -f $v, $units[$i]) }
+    return ("{0:0.0} {1}" -f $v, $units[$i])
+}
+
+# -----------------------------------------------------------------------------
+# ConvertFrom-DuneMemPressureProbe : parse the probe's stdout into a structured
+# finding. PURE - no SSH, no I/O - so the wiring is unit-testable from a fixture.
+#
+# Returns @{ ok; mem; operators; db; signals; pressure; severity; headline;
+#            warnings; raw }.
+# -----------------------------------------------------------------------------
+function ConvertFrom-DuneMemPressureProbe {
+    param([string]$Raw)
+
+    $result = @{
+        ok        = $true
+        mem       = @{ totalK=$null; availK=$null; swapTotalK=$null; swapFreeK=$null;
+                       availPct=$null; lowAvailable=$false; swapZero=$false; freeH='' }
+        operators = @()
+        db        = @()
+        signals   = @{ oomKills=0; highRestartPods=0; maxRestarts=0; lowMemory=$false }
+        pressure  = $false
+        severity  = 'none'
+        headline  = ''
+        warnings  = @()
+        raw       = $Raw
+    }
+    if ([string]::IsNullOrWhiteSpace($Raw)) {
+        $result.ok = $false
+        return $result
+    }
+
+    $lines = $Raw -split "`r?`n"
+
+    # --- k=v scalars + free -h block ---------------------------------------
+    $inFreeH = $false
+    $freeH   = New-Object System.Collections.Generic.List[string]
+    $opRecords = New-Object System.Collections.Generic.List[string]
+    $dbRecords = New-Object System.Collections.Generic.List[string]
+    foreach ($line in $lines) {
+        if ($line -eq '__FREE_H_BEGIN__') { $inFreeH = $true;  continue }
+        if ($line -eq '__FREE_H_END__')   { $inFreeH = $false; continue }
+        if ($inFreeH) { $freeH.Add($line); continue }
+
+        $t = $line.Trim()
+        if (-not $t) { continue }
+        $eq = $t.IndexOf('=')
+        if ($eq -lt 1) { continue }
+        $k = $t.Substring(0, $eq)
+        $v = $t.Substring($eq + 1)
+        switch ($k) {
+            'mem_total_k'  { [long]$tmp = 0; if ([long]::TryParse($v, [ref]$tmp)) { $result.mem.totalK = $tmp } }
+            'mem_avail_k'  { [long]$tmp = 0; if ([long]::TryParse($v, [ref]$tmp)) { $result.mem.availK = $tmp } }
+            'swap_total_k' { [long]$tmp = 0; if ([long]::TryParse($v, [ref]$tmp)) { $result.mem.swapTotalK = $tmp } }
+            'swap_free_k'  { [long]$tmp = 0; if ([long]::TryParse($v, [ref]$tmp)) { $result.mem.swapFreeK = $tmp } }
+            'op'           { $opRecords.Add($v) }
+            'db'           { $dbRecords.Add($v) }
+        }
+    }
+    $result.mem.freeH = ($freeH -join "`n").Trim()
+
+    # --- memory signal -----------------------------------------------------
+    $mt = $result.mem.totalK
+    $ma = $result.mem.availK
+    if ($null -ne $mt -and $mt -gt 0 -and $null -ne $ma -and $ma -ge 0) {
+        $result.mem.availPct = [math]::Round(($ma * 100.0 / $mt), 1)
+        $lowByAbs = $ma -lt $script:DuneMemLowAvailKiB
+        $lowByPct = $result.mem.availPct -lt $script:DuneMemLowAvailPct
+        $result.mem.lowAvailable = ($lowByAbs -or $lowByPct)
+    }
+    if ($null -ne $result.mem.swapTotalK) {
+        $result.mem.swapZero = ($result.mem.swapTotalK -eq 0)
+    }
+    $result.signals.lowMemory = ($result.mem.lowAvailable -and $result.mem.swapZero)
+
+    # --- pod records -------------------------------------------------------
+    $result.operators = @(foreach ($r in $opRecords) { _ConvertFrom-DuneMemPodRecord -Record $r })
+    $result.db        = @(foreach ($r in $dbRecords) { _ConvertFrom-DuneMemPodRecord -Record $r })
+
+    $allPods = @($result.operators) + @($result.db)
+    foreach ($p in $allPods) {
+        if ($p.oom) { $result.signals.oomKills++ }
+        if ($p.restarts -gt $script:DuneMemHighRestartThreshold) { $result.signals.highRestartPods++ }
+        if ($p.restarts -gt $result.signals.maxRestarts) { $result.signals.maxRestarts = $p.restarts }
+    }
+
+    # --- compose warnings + severity --------------------------------------
+    $warn = New-Object System.Collections.Generic.List[string]
+
+    if ($result.signals.lowMemory) {
+        $warn.Add(("VM low on memory: only {0} available ({1}% of {2}) with Swap: 0. Postgres and the Funcom operators get OOM-killed under load." -f `
+            (Format-DuneMemKiB $result.mem.availK), $result.mem.availPct, (Format-DuneMemKiB $result.mem.totalK)))
+    } elseif ($result.mem.lowAvailable) {
+        $warn.Add(("VM memory is tight: {0} available ({1}% of {2})." -f `
+            (Format-DuneMemKiB $result.mem.availK), $result.mem.availPct, (Format-DuneMemKiB $result.mem.totalK)))
+    }
+
+    $oomOps = @($result.operators | Where-Object { $_.oom })
+    if ($oomOps.Count -gt 0) {
+        $names = ($oomOps | ForEach-Object { "$($_.shortName) x$($_.restarts)" }) -join ', '
+        $warn.Add(("Funcom operators OOM-killed (memory pressure): $names. Restart count should be 0 on a healthy VM."))
+    }
+    $oomDb = @($result.db | Where-Object { $_.oom })
+    if ($oomDb.Count -gt 0) {
+        $names = ($oomDb | ForEach-Object { "$($_.shortName) x$($_.restarts)" }) -join ', '
+        $warn.Add(("Database (Postgres) pod OOM-killed / evicted: $names. The nightly DB backup will hang or fail while the node is paging."))
+    }
+
+    # High restarts that aren't already flagged as an OOM (elevated churn).
+    $churn = @($allPods | Where-Object { -not $_.oom -and $_.restarts -gt $script:DuneMemHighRestartThreshold })
+    if ($churn.Count -gt 0) {
+        $names = ($churn | ForEach-Object { "$($_.shortName) x$($_.restarts)" }) -join ', '
+        $warn.Add(("Elevated pod restarts (possible memory pressure): $names."))
+    }
+
+    $result.pressure = ($result.signals.oomKills -gt 0 -or $result.signals.lowMemory -or $result.signals.highRestartPods -gt 0)
+
+    if ($result.signals.oomKills -gt 0 -or ($result.signals.lowMemory -and $result.signals.maxRestarts -gt $script:DuneMemHighRestartThreshold)) {
+        $result.severity = 'critical'
+    } elseif ($result.pressure) {
+        $result.severity = 'warn'
+    } else {
+        $result.severity = 'none'
+    }
+
+    if ($result.pressure) {
+        $killN = $result.signals.maxRestarts
+        if ($result.signals.oomKills -gt 0 -and $killN -gt 0) {
+            $result.headline = "VM low on memory - Funcom operators killed ${killN}x; consider raising the VM's RAM"
+        } elseif ($result.signals.lowMemory) {
+            $result.headline = "VM low on memory (Swap: 0) - consider raising the VM's RAM or lowering per-map memory limits"
+        } else {
+            $result.headline = "Possible VM memory pressure - operators/DB have elevated restarts"
+        }
+        # Remediation tail is always useful when we're flagging pressure.
+        $warn.Add("Fix: raise the VM's RAM in Hyper-V, or lower per-map memory limits (Hagga/Deep Desert). See vm-memory-pressure.txt in the diagnostics bundle.")
+    }
+
+    $result.warnings = @($warn)
+    return $result
+}
+
+# Parse ONE pod record:
+#   <name>~P:<phase>~PR:<podReason>~R:<restarts >~E:<exits >~X:<termReasons >~W:<waits >
+function _ConvertFrom-DuneMemPodRecord {
+    param([string]$Record)
+    $pod = @{
+        name=''; shortName=''; phase=''; podReason=''
+        restarts=0; exitCodes=@(); termReasons=@(); waitReasons=@()
+        oom=$false
+    }
+    if ([string]::IsNullOrWhiteSpace($Record)) { return $pod }
+    $parts = $Record -split '~'
+    $pod.name = $parts[0].Trim()
+    foreach ($seg in ($parts | Select-Object -Skip 1)) {
+        $colon = $seg.IndexOf(':')
+        if ($colon -lt 1) { continue }
+        $tag = $seg.Substring(0, $colon)
+        $val = $seg.Substring($colon + 1)
+        switch ($tag) {
+            'P'  { $pod.phase = $val.Trim() }
+            'PR' { $pod.podReason = $val.Trim() }
+            'R'  {
+                $nums = @($val -split '\s+' | Where-Object { $_ -match '^\d+$' } | ForEach-Object { [int]$_ })
+                if ($nums.Count -gt 0) { $pod.restarts = ($nums | Measure-Object -Maximum).Maximum }
+            }
+            'E'  { $pod.exitCodes   = @($val -split '\s+' | Where-Object { $_ -ne '' }) }
+            'X'  { $pod.termReasons = @($val -split '\s+' | Where-Object { $_ -ne '' }) }
+            'W'  { $pod.waitReasons = @($val -split '\s+' | Where-Object { $_ -ne '' }) }
+        }
+    }
+    # Short name: drop the battlegroup hash prefix (sh-<hash>-<rand>-) for
+    # readability in the banner; fall back to the full name.
+    $pod.shortName = ($pod.name -replace '^sh-[a-z0-9]+-[a-z0-9]+-', '')
+    if (-not $pod.shortName) { $pod.shortName = $pod.name }
+
+    $exit137 = @($pod.exitCodes | Where-Object { $_ -eq '137' }).Count -gt 0
+    $evicted = ($pod.podReason -match '(?i)Evicted|OOMKilled')
+    # Exit 137 (SIGKILL) or an OOMKilled/Evicted reason is the memory-pressure
+    # fingerprint; a bare "Error" reason without 137 is NOT treated as OOM
+    # (avoids false positives from ordinary crash-restarts).
+    $pod.oom = ($exit137 -or ($pod.termReasons -contains 'OOMKilled') -or $evicted)
+    return $pod
+}
+
+# -----------------------------------------------------------------------------
+# _Invoke-DuneMemPressureProbe : stage + run the read-only probe over SSH,
+# return its raw stdout (or ''). Uses Invoke-DuneBackupShell when available
+# (base64 + `sudo bash` + rc marker, same path DbUtilAutoheal uses); falls back
+# to a direct Invoke-V6Ssh stream if not.
+# -----------------------------------------------------------------------------
+function _Invoke-DuneMemPressureProbe {
+    param([Parameter(Mandatory)][string]$Ip, [int]$TimeoutSec = 45)
+    $path = Get-DuneMemPressureProbePath
+    if (-not $path) { return @{ ok=$false; raw=''; message='dune-mem-pressure-probe.sh not found in install dir.' } }
+    $raw = [System.IO.File]::ReadAllText($path)
+    $lf  = $raw -replace "`r`n", "`n" -replace "`r", "`n"
+
+    if (Get-Command Invoke-DuneBackupShell -ErrorAction SilentlyContinue) {
+        $r = Invoke-DuneBackupShell -Ip $Ip -Script $lf -TimeoutSec $TimeoutSec
+        return @{ ok=($r.rc -ge 0); raw=[string]$r.out; message='' }
+    }
+    if (Get-Command Invoke-V6Ssh -ErrorAction SilentlyContinue) {
+        $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($lf))
+        $out = Invoke-V6Ssh -Ip $Ip -Cmd 'base64 -d | sudo -n bash' -StdinData $b64 -TimeoutSec $TimeoutSec
+        return @{ ok=$true; raw=(($out -join "`n")); message='' }
+    }
+    return @{ ok=$false; raw=''; message='No SSH helper available (Invoke-DuneBackupShell / Invoke-V6Ssh).' }
+}
+
+# -----------------------------------------------------------------------------
+# Get-DuneVmMemoryPressure : the public observability entry. Resolves the VM
+# context, runs the probe, parses it, and returns the finding. Cached for
+# $script:DuneMemPressureCacheTtlS seconds unless -Force. Never throws.
+#
+# Returns the ConvertFrom-DuneMemPressureProbe shape plus:
+#   ok=$false; message=...   when the VM is unreachable / probe failed.
+# -----------------------------------------------------------------------------
+function Get-DuneVmMemoryPressure {
+    param([switch]$Force)
+    try {
+        if (-not $Force -and $script:DuneMemPressureCache) {
+            $age = ((Get-Date) - $script:DuneMemPressureCacheAt).TotalSeconds
+            if ($age -lt $script:DuneMemPressureCacheTtlS) { return $script:DuneMemPressureCache }
+        }
+
+        # Resolve a reachable VM IP the same way the diagnostics bundle does.
+        $ip = $null
+        foreach ($getter in 'Get-DuneBackupContext', 'Get-DuneGameConfigContext', 'Get-DuneDbContext') {
+            if (Get-Command $getter -ErrorAction SilentlyContinue) {
+                try { $c = & $getter; if ($c.ok -and $c.ip) { $ip = $c.ip; break } } catch {}
+            }
+        }
+        if (-not $ip -and (Get-Command Get-DuneVmStatus -ErrorAction SilentlyContinue)) {
+            try { $vm = Get-DuneVmStatus; if ($vm.running -and $vm.ip) { $ip = $vm.ip } } catch {}
+        }
+        if (-not $ip) {
+            return @{ ok=$false; pressure=$false; severity='none'; warnings=@(); message='VM not reachable.' }
+        }
+
+        $probe = _Invoke-DuneMemPressureProbe -Ip $ip
+        if (-not $probe.ok -or [string]::IsNullOrWhiteSpace($probe.raw)) {
+            return @{ ok=$false; pressure=$false; severity='none'; warnings=@(); message=($probe.message -or 'Probe returned no output.') }
+        }
+
+        $parsed = ConvertFrom-DuneMemPressureProbe -Raw $probe.raw
+        $parsed.ok = $true
+        $script:DuneMemPressureCache   = $parsed
+        $script:DuneMemPressureCacheAt = Get-Date
+        return $parsed
+    } catch {
+        return @{ ok=$false; pressure=$false; severity='none'; warnings=@(); message=$_.Exception.Message }
+    }
+}

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -445,6 +445,84 @@ done
         $warnings.Add('Game-server pod logs skipped: SSH helper not loaded.')
     }
 
+    # 6c-4) VM memory-pressure probe (OOMKilled operators / DB, free -h) -----
+    # The "battlegroup restarted outside its schedule" / "ping surges under
+    # load" class of report is decided at the VM memory layer: when the
+    # home-hosted node runs low on memory the kubelet SIGKILLs the Funcom
+    # operators (exit 137 / OOMKilled, restart counts in the 30s) and evicts
+    # Postgres, and the nightly DB backup hangs. Nothing else in this bundle
+    # sees it. Pull the read-only probe (operator/DB restart + lastState, plus
+    # `free -h`) so a future log export leads with the memory finding instead
+    # of burying it. Best-effort over SSH; never fatal.
+    $memFinding = $null
+    if (Get-Command Get-DuneVmMemoryPressure -ErrorAction SilentlyContinue) {
+        try {
+            $memFinding = Get-DuneVmMemoryPressure -Force
+            $memLines = [System.Collections.Generic.List[string]]::new()
+            $memLines.Add('# VM memory-pressure probe')
+            $memLines.Add("# Generated $(Get-Date -Format 'o')")
+            $memLines.Add('# Detects OOMKilled/exit-137 Funcom operators + Postgres and low MemAvailable with Swap:0.')
+            $memLines.Add('')
+            if (-not $memFinding.ok) {
+                $memLines.Add("Probe unavailable: $($memFinding.message)")
+                $warnings.Add("VM memory-pressure probe skipped: $($memFinding.message)")
+            } else {
+                if ($memFinding.pressure) {
+                    $memLines.Add("RESULT: MEMORY PRESSURE DETECTED (severity: $($memFinding.severity))")
+                    $memLines.Add(">> $($memFinding.headline)")
+                } else {
+                    $memLines.Add('RESULT: no memory-pressure signals (operators healthy, memory has headroom).')
+                }
+                $memLines.Add('')
+                $m = $memFinding.mem
+                $memLines.Add('Node memory:')
+                $memLines.Add(("  MemTotal     : {0}" -f (Format-DuneMemKiB $m.totalK)))
+                $memLines.Add(("  MemAvailable : {0}{1}" -f (Format-DuneMemKiB $m.availK), $(if ($null -ne $m.availPct) { " ($($m.availPct)%)" } else { '' })))
+                $memLines.Add(("  Swap total   : {0}{1}" -f (Format-DuneMemKiB $m.swapTotalK), $(if ($m.swapZero) { '  << no swap cushion' } else { '' })))
+                $memLines.Add('')
+                if ($m.freeH) {
+                    $memLines.Add('free -h:')
+                    foreach ($fl in ($m.freeH -split "`n")) { $memLines.Add("  $fl") }
+                    $memLines.Add('')
+                }
+                $memLines.Add('Funcom operator pods (controller-managers) - RestartCount should be 0:')
+                if (@($memFinding.operators).Count -eq 0) {
+                    $memLines.Add('  (none found)')
+                } else {
+                    foreach ($p in $memFinding.operators) {
+                        $flag = if ($p.oom) { '  << OOMKilled/137' } elseif ($p.restarts -gt 5) { '  << elevated' } else { '' }
+                        $memLines.Add(("  {0,-46} restarts={1} phase={2} lastExit={3} reason={4}{5}" -f `
+                            $p.shortName, $p.restarts, $p.phase, ((@($p.exitCodes) -join ',')), ((@($p.termReasons) -join ',')), $flag))
+                    }
+                }
+                $memLines.Add('')
+                $memLines.Add('Database (Postgres) pod:')
+                if (@($memFinding.db).Count -eq 0) {
+                    $memLines.Add('  (none found)')
+                } else {
+                    foreach ($p in $memFinding.db) {
+                        $flag = if ($p.oom) { '  << OOMKilled/137/evicted' } elseif ($p.restarts -gt 5) { '  << elevated' } else { '' }
+                        $memLines.Add(("  {0,-46} restarts={1} phase={2} lastExit={3} reason={4}{5}" -f `
+                            $p.shortName, $p.restarts, $p.phase, ((@($p.exitCodes) -join ',')), ((@($p.termReasons) -join ',')), $flag))
+                    }
+                }
+                if (@($memFinding.warnings).Count -gt 0) {
+                    $memLines.Add('')
+                    $memLines.Add('Findings:')
+                    foreach ($w in $memFinding.warnings) { $memLines.Add("  - $w") }
+                }
+            }
+            $memText = Invoke-DstRedaction -Text ($memLines -join "`r`n") @redactArgs
+            $memOut  = Join-Path $stageDir 'vm-memory-pressure.txt'
+            Set-Content -LiteralPath $memOut -Value $memText -Encoding UTF8
+            $included.Add(@{ name = 'vm-memory-pressure.txt'; bytes = (Get-Item -LiteralPath $memOut).Length })
+        } catch {
+            $warnings.Add("VM memory-pressure probe failed: $($_.Exception.Message)")
+        }
+    } else {
+        $warnings.Add('VM memory-pressure helper not loaded - probe skipped.')
+    }
+
     # 6d) Gameplay Admin read-path probe ------------------------------------
     # The "Players/Bases show top-level rows but blank names / unaligned
     # factions / 0 pieces" class of bug (e.g. after a character transfer)
@@ -524,6 +602,16 @@ done
     $manLines.Add("Dune Server Tool diagnostic bundle")
     $manLines.Add("Generated $(Get-Date -Format 'o') by v$script:DuneToolVersion")
     $manLines.Add('')
+    # Lead with the memory-pressure finding so a triager sees it first - it is
+    # the root cause of the "battlegroup restarted off-schedule" / "ping surge"
+    # class of report and is otherwise buried in per-pod logs.
+    if ($memFinding -and $memFinding.ok -and $memFinding.pressure) {
+        $manLines.Add('*** VM MEMORY PRESSURE DETECTED ***')
+        $manLines.Add("  $($memFinding.headline)")
+        foreach ($w in @($memFinding.warnings)) { $manLines.Add("  - $w") }
+        $manLines.Add('  (full detail: vm-memory-pressure.txt)')
+        $manLines.Add('')
+    }
     $manLines.Add('Sanitization applied to every text file in this bundle:')
     $manLines.Add('  - IPv4 / IPv6 addresses (except loopback) -> <ip> / <ipv6>')
     $manLines.Add('  - C:\Users\<anyone>\... paths              -> C:\Users\<user>\...')
@@ -538,6 +626,12 @@ done
     $manLines.Add('gameplay-read-probe.txt re-runs the Players/Bases list queries and records')
     $manLines.Add('COUNTS ONLY (no player names or ids) so "rows but blank detail" bugs are')
     $manLines.Add('triageable; absent when the DB is unreachable (see Warnings).')
+    $manLines.Add('')
+    $manLines.Add('vm-memory-pressure.txt probes the VM for the OOMKilled-operators / low-memory')
+    $manLines.Add('signature (Funcom controller-manager restart counts + lastState, Postgres pod')
+    $manLines.Add('state, and free -h / MemAvailable vs Swap). It is the root cause of the')
+    $manLines.Add('"battlegroup restarted outside its schedule" and "ping surges under load"')
+    $manLines.Add('reports; when detected it is also called out at the top of this manifest.')
     $manLines.Add('')
     $manLines.Add('game-pods.txt + game-server-logs.txt are pulled live over SSH: a pod/serverset')
     $manLines.Add('snapshot plus the recent logs of the connection-path pods (game servers, server')
@@ -599,6 +693,44 @@ Register-DuneRoute -Method POST -Path '/api/diagnostics/bundle' -Handler {
     try {
         $result = New-DstDiagnosticBundle
         Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+# GET /api/diagnostics/vm-memory — the VM memory-pressure finding, for the
+# Server Health red banner. Read-only + cached (60s) in the lib, so the
+# Dashboard can poll it cheaply. Returns a compact JSON-friendly view; the
+# full per-pod detail lives in the diagnostics bundle. Never 500s on an
+# unreachable VM — it reports ok=false so the banner just stays hidden.
+Register-DuneRoute -Method GET -Path '/api/diagnostics/vm-memory' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        if (-not (Get-Command Get-DuneVmMemoryPressure -ErrorAction SilentlyContinue)) {
+            Write-DuneJson -Response $res -Body @{ ok=$false; pressure=$false; message='memory-pressure helper not loaded' }
+            return
+        }
+        $f = Get-DuneVmMemoryPressure
+        $body = @{
+            ok       = [bool]$f.ok
+            pressure = [bool]$f.pressure
+            severity = [string]($f.severity)
+            headline = [string]($f.headline)
+            warnings = @($f.warnings)
+            message  = [string]($f.message)
+        }
+        if ($f.ok -and $f.mem) {
+            $body.mem = @{
+                availK       = $f.mem.availK
+                totalK       = $f.mem.totalK
+                availPct     = $f.mem.availPct
+                swapZero     = [bool]$f.mem.swapZero
+                lowAvailable = [bool]$f.mem.lowAvailable
+            }
+            $body.maxRestarts = [int]$f.signals.maxRestarts
+            $body.oomKills    = [int]$f.signals.oomKills
+        }
+        Write-DuneJson -Response $res -Body $body
     } catch {
         Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
     }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -858,6 +858,126 @@ function Get-DuneRemotePartitionScriptPath {
     return $null
 }
 
+function Get-DuneMemPressureProbePath {
+    $candidates = @(
+        (Join-Path $scriptDir 'resources\remote-scripts\dune-mem-pressure-probe.sh')
+        (Join-Path $scriptDir 'app\resources\remote-scripts\dune-mem-pressure-probe.sh')
+    )
+    foreach ($p in $candidates) {
+        if (Test-Path -LiteralPath $p) { return $p }
+    }
+    return $null
+}
+
+function Show-DuneVmMemoryPressureWarning {
+    # Run the read-only VM memory-pressure probe over SSH and print a red
+    # warning if the node is thrashing for memory: Funcom operators OOM-killed
+    # (exit 137 / OOMKilled, high restart counts), Postgres evicted, or a tiny
+    # MemAvailable with Swap: 0. This is the root cause of the "battlegroup
+    # restarted outside its schedule" / "ping surge under load" reports and is
+    # otherwise invisible without hand-reading exported logs.
+    #
+    # Uses the SAME bundled probe the web backend uses
+    # (app/server/lib/VmMemoryPressure.ps1 + dune-mem-pressure-probe.sh) so the
+    # CLI Start-All and the Server Health banner never disagree. Read-only and
+    # best-effort - never throws, never blocks a good start on a probe hiccup.
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [string]$SshUser = $sshUser,
+        [string]$SshKey  = $sshKey
+    )
+    try {
+        $local = Get-DuneMemPressureProbePath
+        if (-not $local) { return }
+        $raw = [System.IO.File]::ReadAllText($local)
+        $lf  = $raw -replace "`r`n", "`n" -replace "`r", "`n"
+        $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($lf))
+
+        # Stream the base64 payload over stdin, decode, run as root. Mirrors the
+        # partition-clear staging path (no scp/sftp dependency).
+        $out = $b64 | & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -o ConnectTimeout=8 `
+                    -i "$SshKey" "${SshUser}@${Ip}" 'base64 -d | sudo -n bash' 2>$null
+        if (-not $out) { return }
+        $lines = @($out)
+
+        # --- lightweight parse (mirrors ConvertFrom-DuneMemPressureProbe) -----
+        $memTotalK = $null; $memAvailK = $null; $swapTotalK = $null
+        $records = New-Object System.Collections.Generic.List[object]
+        foreach ($line in $lines) {
+            $t = ([string]$line).Trim()
+            if (-not $t) { continue }
+            if ($t -like 'mem_total_k=*')  { $memTotalK  = [long]($t.Substring(12)); continue }
+            if ($t -like 'mem_avail_k=*')  { $memAvailK  = [long]($t.Substring(12)); continue }
+            if ($t -like 'swap_total_k=*') { $swapTotalK = [long]($t.Substring(13)); continue }
+            if ($t -like 'op=*' -or $t -like 'db=*') {
+                $kind = $t.Substring(0, 2)
+                $rec  = $t.Substring(3)
+                $parts = $rec -split '~'
+                $name = $parts[0]
+                $restarts = 0; $exits = @(); $reasons = @(); $podReason = ''
+                foreach ($seg in ($parts | Select-Object -Skip 1)) {
+                    $c = $seg.IndexOf(':'); if ($c -lt 1) { continue }
+                    $tag = $seg.Substring(0, $c); $val = $seg.Substring($c + 1)
+                    switch ($tag) {
+                        'PR' { $podReason = $val.Trim() }
+                        'R'  { $nums = @($val -split '\s+' | Where-Object { $_ -match '^\d+$' } | ForEach-Object { [int]$_ }); if ($nums.Count) { $restarts = ($nums | Measure-Object -Maximum).Maximum } }
+                        'E'  { $exits   = @($val -split '\s+' | Where-Object { $_ -ne '' }) }
+                        'X'  { $reasons = @($val -split '\s+' | Where-Object { $_ -ne '' }) }
+                    }
+                }
+                $oom = ($exits -contains '137') -or ($reasons -contains 'OOMKilled') -or ($podReason -match '(?i)Evicted|OOMKilled')
+                $short = $name -replace '^sh-[a-z0-9]+-[a-z0-9]+-', ''
+                $records.Add([pscustomobject]@{ kind=$kind; name=$short; restarts=$restarts; oom=$oom })
+            }
+        }
+
+        $lowMem = $false; $swapZero = ($null -ne $swapTotalK -and $swapTotalK -eq 0)
+        $availPct = $null
+        if ($null -ne $memTotalK -and $memTotalK -gt 0 -and $null -ne $memAvailK) {
+            $availPct = [math]::Round(($memAvailK * 100.0 / $memTotalK), 1)
+            $lowMem = ($memAvailK -lt 1048576 -or $availPct -lt 8)
+        }
+        $oomPods = @($records | Where-Object { $_.oom })
+        $churn   = @($records | Where-Object { -not $_.oom -and $_.restarts -gt 5 })
+        $memPressure = ($oomPods.Count -gt 0) -or ($lowMem -and $swapZero) -or ($churn.Count -gt 0)
+        if (-not $memPressure) { return }
+
+        function _fmtKiB($k) {
+            if ($null -eq $k) { return '?' }
+            $u = @('KiB','MiB','GiB','TiB'); $v = [double]$k; $i = 0
+            while ($v -ge 1024 -and $i -lt 3) { $v /= 1024; $i++ }
+            if ($i -eq 0) { return ('{0:0} {1}' -f $v, $u[$i]) }
+            return ('{0:0.0} {1}' -f $v, $u[$i])
+        }
+
+        $maxRestarts = 0
+        if ($records.Count -gt 0) { $maxRestarts = ($records | Measure-Object -Property restarts -Maximum).Maximum }
+        $headline = if ($oomPods.Count -gt 0 -and $maxRestarts -gt 0) {
+            "VM low on memory - Funcom operators killed ${maxRestarts}x; consider raising the VM's RAM"
+        } elseif ($lowMem -and $swapZero) {
+            "VM low on memory (Swap: 0) - consider raising the VM's RAM or lowering per-map memory limits"
+        } else {
+            "Possible VM memory pressure - operators/DB have elevated restarts"
+        }
+
+        Write-Host ""
+        Write-Host "  WARNING: $headline" -ForegroundColor Red
+        if ($lowMem) {
+            Write-Host ("    MemAvailable {0} ({1}%) with Swap: {2}." -f (_fmtKiB $memAvailK), $availPct, $(if ($swapZero) { '0 (no cushion)' } else { (_fmtKiB $swapTotalK) })) -ForegroundColor Yellow
+        }
+        foreach ($p in $oomPods) {
+            $label = if ($p.kind -eq 'db') { 'database' } else { 'operator' }
+            Write-Host ("    {0} '{1}' OOM-killed x{2} (exit 137 / OOMKilled)." -f $label, $p.name, $p.restarts) -ForegroundColor Yellow
+        }
+        foreach ($p in $churn) {
+            Write-Host ("    pod '{0}' restarted x{1} (elevated)." -f $p.name, $p.restarts) -ForegroundColor Yellow
+        }
+        Write-Host "    Fix: raise the VM's RAM in Hyper-V, or lower per-map memory limits. Full detail: Help > Create GitHub Issue + Save Logs (vm-memory-pressure.txt)." -ForegroundColor DarkGray
+    } catch {
+        # Best-effort only - a probe hiccup must never fail a good start.
+    }
+}
+
 function Invoke-DuneRemotePartitionScript {
     # Stages the bundled dune-clear-partitions.start to /tmp on the VM via an
     # ssh exec + base64 stream (no scp/sftp dependency), runs it once with sudo,
@@ -1653,6 +1773,10 @@ while ($true) {
             Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
         }
 
+        # Surface VM memory-pressure (OOMKilled operators / low RAM+Swap:0) as a
+        # red warning after the summary - the root cause of off-schedule restarts.
+        Show-DuneVmMemoryPressureWarning -Ip $ip
+
         $directorPort = $null
         continue
     }
@@ -1926,6 +2050,10 @@ while ($true) {
         } else {
             Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
         }
+
+        # Same memory-pressure surfacing as startup (a reboot ends by starting
+        # the battlegroup, so the OOM signature is just as relevant here).
+        Show-DuneVmMemoryPressureWarning -Ip $ip
         continue
     }
 

--- a/tests/VmMemoryPressure.Tests.ps1
+++ b/tests/VmMemoryPressure.Tests.ps1
@@ -1,0 +1,133 @@
+# Tests the pure parser in app/server/lib/VmMemoryPressure.ps1: it turns the
+# read-only probe's key=value output into a memory-pressure finding. No SSH /
+# IO - the live probe is exercised only on a real VM.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'VmMemoryPressure.ps1'
+}
+
+Describe 'Format-DuneMemKiB' -Tag 'Pure' {
+    It 'scales KiB up to the right unit' {
+        Format-DuneMemKiB 512        | Should -Be '512 KiB'
+        Format-DuneMemKiB 71060      | Should -Be '69.4 MiB'
+        Format-DuneMemKiB 24671232   | Should -Be '23.5 GiB'
+    }
+    It 'returns ? for null / negative' {
+        Format-DuneMemKiB $null | Should -Be '?'
+        Format-DuneMemKiB -5    | Should -Be '?'
+    }
+}
+
+Describe 'ConvertFrom-DuneMemPressureProbe' -Tag 'Pure' {
+
+    # Mirrors Pat's case (2026-07-07): 23.5 GiB VM, 69 MiB available, Swap: 0,
+    # two operators OOM-killed (exit 137) with restart counts in the 30s.
+    # Defined in BeforeAll (with $script: scope) so it survives Pester v5's
+    # discovery -> run phase split and is visible inside the It blocks.
+    BeforeAll {
+        $script:patFixture = @'
+probe=dune-mem-pressure/1
+mem_total_k=24671232
+mem_avail_k=71060
+swap_total_k=0
+swap_free_k=0
+__FREE_H_BEGIN__
+              total        used        free
+Mem:           23Gi        22Gi       200Mi
+Swap:            0B          0B          0B
+__FREE_H_END__
+ns_operators=funcom-operators
+op=battlegroup-operator-controller-manager-abc~P:Running~PR:~R:34 0 ~E:137  ~X:Error  ~W:
+op=database-operator-controller-manager-xyz~P:Running~PR:~R:32 0 ~E:137  ~X:OOMKilled  ~W:
+ns_seabass=funcom-seabass-sh-abc-def
+db=sh-abc-def-db-dbdepl-sts-0~P:Running~PR:~R:5 0 ~E:  ~X:  ~W:
+probe_done=1
+'@
+    }
+
+    It 'detects critical memory pressure on the Pat case' {
+        $r = ConvertFrom-DuneMemPressureProbe -Raw $patFixture
+        $r.pressure          | Should -BeTrue
+        $r.severity          | Should -Be 'critical'
+        $r.signals.oomKills  | Should -Be 2
+        $r.signals.maxRestarts | Should -Be 34
+        $r.mem.swapZero      | Should -BeTrue
+        $r.mem.lowAvailable  | Should -BeTrue
+        $r.headline          | Should -Match 'killed 34x'
+    }
+
+    It 'captures the free -h block and per-pod detail' {
+        $r = ConvertFrom-DuneMemPressureProbe -Raw $patFixture
+        $r.mem.freeH         | Should -Match 'Swap:'
+        @($r.operators).Count | Should -Be 2
+        # short name drops the sh-<hash>-<rand>- prefix on the DB pod
+        ($r.db[0].shortName) | Should -Be 'db-dbdepl-sts-0'
+        ($r.db[0].oom)       | Should -BeFalse   # restarts=5, no 137
+    }
+
+    It 'reports no pressure on a healthy VM' {
+        $healthy = @'
+mem_total_k=24671232
+mem_avail_k=12000000
+swap_total_k=4194304
+swap_free_k=4194304
+ns_operators=funcom-operators
+op=x-controller-manager-a~P:Running~PR:~R:0 0 ~E:  ~X:  ~W:
+probe_done=1
+'@
+        $r = ConvertFrom-DuneMemPressureProbe -Raw $healthy
+        $r.pressure           | Should -BeFalse
+        $r.severity           | Should -Be 'none'
+        @($r.warnings).Count  | Should -Be 0
+    }
+
+    It 'does NOT flag low available when swap provides a cushion' {
+        $lowButSwap = @'
+mem_total_k=24671232
+mem_avail_k=200000
+swap_total_k=8388608
+swap_free_k=8000000
+op=x-controller-manager-a~P:Running~PR:~R:1 ~E:  ~X:  ~W:
+probe_done=1
+'@
+        $r = ConvertFrom-DuneMemPressureProbe -Raw $lowButSwap
+        $r.mem.lowAvailable    | Should -BeTrue
+        $r.signals.lowMemory   | Should -BeFalse   # swap present -> not the signature
+        $r.pressure            | Should -BeFalse
+    }
+
+    It 'treats a bare Error exit (no 137) as a crash, not an OOM' {
+        $churn = @'
+mem_total_k=24671232
+mem_avail_k=9000000
+swap_total_k=0
+op=x-controller-manager-a~P:Running~PR:~R:9 0 ~E:1  ~X:Error  ~W:
+probe_done=1
+'@
+        $r = ConvertFrom-DuneMemPressureProbe -Raw $churn
+        $r.signals.oomKills       | Should -Be 0
+        $r.signals.highRestartPods | Should -Be 1
+        $r.severity               | Should -Be 'warn'
+    }
+
+    It 'flags an Evicted pod-level reason as OOM' {
+        $evicted = @'
+mem_total_k=24671232
+mem_avail_k=50000
+swap_total_k=0
+db=sh-a-b-db-0~P:Failed~PR:Evicted~R:0 ~E:  ~X:  ~W:
+probe_done=1
+'@
+        $r = ConvertFrom-DuneMemPressureProbe -Raw $evicted
+        ($r.db[0].oom)      | Should -BeTrue
+        $r.signals.oomKills | Should -Be 1
+        $r.pressure         | Should -BeTrue
+    }
+
+    It 'returns ok=false for empty input' {
+        $r = ConvertFrom-DuneMemPressureProbe -Raw ''
+        $r.ok       | Should -BeFalse
+        $r.pressure | Should -BeFalse
+    }
+}

--- a/webui/src/api/diagnostics.ts
+++ b/webui/src/api/diagnostics.ts
@@ -17,3 +17,28 @@ export function buildDiagnosticBundle() {
     body: '{}',
   })
 }
+
+// VM memory-pressure finding for the Server Health red banner. Read-only,
+// cached 60s server-side. `ok=false` (VM unreachable / probe failed) or
+// `pressure=false` (healthy) => the banner stays hidden.
+export interface VmMemoryPressure {
+  ok: boolean
+  pressure: boolean
+  severity: 'none' | 'warn' | 'critical'
+  headline: string
+  warnings: string[]
+  message?: string
+  maxRestarts?: number
+  oomKills?: number
+  mem?: {
+    availK: number | null
+    totalK: number | null
+    availPct: number | null
+    swapZero: boolean
+    lowAvailable: boolean
+  }
+}
+
+export function getVmMemoryPressure() {
+  return api<VmMemoryPressure>('/api/diagnostics/vm-memory')
+}

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { Icon } from '../components/Icon'
 import { useStatus } from '../hooks/useStatus'
 import { BgSpiceSummary } from './dashboard/BgSpiceSummary'
 import { ScheduledRestarts } from './dashboard/ScheduledRestarts'
+import { VmMemoryPressureBanner } from './dashboard/VmMemoryPressureBanner'
 import type { BgState, BgGameServer } from '../api/types'
 import { getLinks, type LinksResponse } from '../api/links'
 import { api, ApiError } from '../api/client'
@@ -186,6 +187,8 @@ export function Dashboard() {
         icon="LayoutDashboard"
         description="Live VM, battlegroup, and port status."
       />
+
+      <VmMemoryPressureBanner enabled={Boolean(vm?.running)} />
 
       <section className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
         <div className="card card-hover p-4">

--- a/webui/src/pages/dashboard/VmMemoryPressureBanner.tsx
+++ b/webui/src/pages/dashboard/VmMemoryPressureBanner.tsx
@@ -1,0 +1,67 @@
+// VmMemoryPressureBanner — red Server Health banner that fires when the VM is
+// low on memory: Funcom operators OOM-killed (exit 137 / high restart counts),
+// Postgres evicted, or a tiny MemAvailable with Swap: 0. This is the root cause
+// of the "battlegroup restarted outside its schedule" / "ping surge under load"
+// class of report (murm, Hagga per-map sizing, Pat 2026-07-07), and until now
+// could only be found by exporting logs and hand-reading them.
+//
+// Backed by GET /api/diagnostics/vm-memory, which is read-only and cached 60s
+// server-side, so polling here is cheap. Renders nothing unless the probe
+// succeeded AND detected pressure.
+import { useCallback, useEffect, useState } from 'react'
+import { Icon } from '../../components/Icon'
+import { getVmMemoryPressure, type VmMemoryPressure } from '../../api/diagnostics'
+
+type Props = {
+  enabled: boolean   // gate on VM running — no point probing a stopped VM
+}
+
+export function VmMemoryPressureBanner({ enabled }: Props) {
+  const [finding, setFinding] = useState<VmMemoryPressure | null>(null)
+
+  const load = useCallback(async () => {
+    if (!enabled) return
+    try {
+      setFinding(await getVmMemoryPressure())
+    } catch {
+      // Best-effort — a probe hiccup must never break the dashboard. Leave the
+      // last good finding in place.
+    }
+  }, [enabled])
+
+  useEffect(() => { void load() }, [load])
+
+  // Poll on the same 60s cadence as the server-side cache TTL.
+  useEffect(() => {
+    if (!enabled) return
+    const id = window.setInterval(() => { void load() }, 60_000)
+    return () => window.clearInterval(id)
+  }, [enabled, load])
+
+  if (!enabled || !finding || !finding.ok || !finding.pressure) return null
+
+  const critical = finding.severity === 'critical'
+  const tone = critical
+    ? 'border-danger/50 bg-danger/10 text-danger'
+    : 'border-warning/50 bg-warning/10 text-warning'
+
+  return (
+    <section className={`card p-4 mb-6 ${tone}`} role="alert">
+      <div className="flex items-start gap-3">
+        <Icon name="AlertTriangle" size={20} className="shrink-0 mt-0.5" />
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold">
+            {finding.headline || 'VM memory pressure detected'}
+          </h2>
+          {finding.warnings.length > 0 && (
+            <ul className="mt-2 space-y-1 text-xs text-text-muted list-disc pl-4">
+              {finding.warnings.map((w, i) => (
+                <li key={i} className="break-words">{w}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Why (real case, 2026-07-07)
Pat (v12.17.0) reported his battlegroup restarting **outside** its 02:00 schedule (~06:09 and ~07:11 local). Log forensics showed the true cause was **node memory pressure** on his home-hosted VM (`duneawakening`), not DST's scheduled restart:
- The nightly 04:00 DB backup's first `psql` hung 861s (normally instant) and aborted at the 600s limit (exit 50) because the VM was thrashing for memory.
- All four Funcom operator controller-managers were SIGKILLed simultaneously — `Terminated / Error / Exit Code 137`, cumulative `Restart Count: 32–36` over ~1 month.
- Kubelet: `The node was low on resource: memory ... available: 71060Ki. Container database was using 16971996Ki` (Postgres ≈16.2 GB).

This is the **third** memory-pressure case (murm ping-surge, Hagga per-map sizing, now Pat). Until now it could only be found by exporting logs and hand-reading them.

## What this adds
A read-only probe (`app/resources/remote-scripts/dune-mem-pressure-probe.sh`, run over the existing SSH path — never mutates the VM) reads the four `*-controller-manager-*` operator pods + the Postgres pod (RestartCount + last-terminated state: exit 137 / OOMKilled / Evicted) and the VM's `/proc/meminfo` + `free -h` (low `available` + `Swap: 0` is the signature). Surfaced in three places, from one shared detector:

- **Server Health** — red **"VM low on memory — Funcom operators killed N times; consider raising the VM's RAM"** banner (`GET /api/diagnostics/vm-memory`, cached 60s). Lib `app/server/lib/VmMemoryPressure.ps1`; webui `VmMemoryPressureBanner.tsx`.
- **CLI Start-All / Reboot** — the same warning printed after the startup summary (`Show-DuneVmMemoryPressureWarning`).
- **Diagnostics bundle** — new `vm-memory-pressure.txt`, and `manifest.txt` now **leads** with the finding when detected. `bug_report.yml` refreshed (bundle description + a targeted "off-schedule restart / memory pressure" section).

## Detection rules
Exit 137 (SIGKILL) / `OOMKilled` / `Evicted` = the OOM fingerprint; a bare `Error` without 137 is treated as an ordinary crash (no false positive). Low-memory banner needs low `MemAvailable` **and** `Swap: 0` (swap present = cushion, not flagged). RestartCount > 5 flags elevated churn.

## Tests / verification
- `tests/VmMemoryPressure.Tests.ps1` — 9 passing (Pat case, healthy, swap-cushion, crash-vs-OOM, evicted, empty). Pure parser, no SSH.
- Existing `tests/Diagnostics.Tests.ps1` — 8 passing.
- `webui` `tsc -b` + `eslint` clean.
- All touched `.ps1` parse clean; new `.ps1` are pure ASCII (no BOM needed); `dune-server.ps1` additions kept ASCII (no encoding change).

## Notes
- **Held per Coastal.** PR-only — no release/tag/merge. No version bump; changelog entry under **[Unreleased] → Added**.
- Live-fire against a real VM is the one thing not covered here (probe output shape is fixtured, not hit against Pat's box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)