### PR TITLE
Release v12.18.1 — partition heal spin-up guard

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.0"
+      placeholder: "v12.18.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.1] - 2026-07-07
+
+### Fixed
+
+- **On-demand map partition self-heal no longer has a spin-up race.** The autonomous partition healer runs a conservative `*/15` cron pass that clears a drifted `igwsss.spec.partitions` pin so Deep Desert / Arrakeen / Harko Village can launch after an unclean host crash + VM reboot. It previously cycled **any** pinned on-demand map with no pod immediately — which left a ~1–3 second window during a manual spin-up (partition pinned and `replicas=1`, but k3s hasn't scheduled the pod yet) where a cron tick landing in that window could reset the in-progress spin-up. The cron pass now applies a **spin-up guard**: a pinned-but-pod-less map is recorded on first sighting and only cycled if it is *still* pod-less on a later tick. A legitimate spin-up gets its pod within seconds and clears the marker long before the next tick, so it is never disturbed. Unchanged: live sessions (Ready pods) are always skipped, demonstrably dead pods (`Terminating` / `CrashLoopBackOff` / image error) are still healed immediately, and the boot-time hook + the manual **Fix Partitions** button remain aggressive by design. A new `install-only` mode also lets DST refresh the on-VM automation without running the heal, so the update can be applied to a live server without touching any map.
+
 ## [12.18.0] - 2026-07-07
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.0'
+$script:DuneToolVersion = '12.18.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.0',
+    [string]$Version = '12.18.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.0</Version>
+    <Version>12.18.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.0"
+#define MyAppVersion "12.18.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.0"
+$script:ToolVersion = "12.18.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Release v12.18.1 — partition heal spin-up guard

Patch release. Bumps all 5 version stamps `12.18.0 → 12.18.1`, rolls the CHANGELOG, and bumps the bug-report template version placeholder.

### Ships (PR #478, already on main)

**On-demand map partition self-heal no longer has a spin-up race.** The `*/15` cron pass previously cycled any pinned on-demand map with no pod immediately, which could reset an in-progress manual spin-up during the ~1–3s window where the partition is pinned + `replicas=1` but k3s hasn't scheduled the pod yet. The cron pass now applies a **spin-up guard**: a pinned-but-pod-less map is recorded on first sighting and only cycled if it's *still* pod-less on a later tick. Unchanged: live sessions (Ready pods) always skipped; dead pods (`Terminating`/`CrashLoopBackOff`/image error) still healed immediately; boot hook + manual **Fix Partitions** button stay aggressive. New `install-only` mode lets DST refresh the on-VM automation without running the heal.

### Verification

- Installer built: `DuneServerSetup.exe` 46.09 MB (version parity check passed, updated script bundled).
- Guard already deployed to the live VM in `install-only` mode — no map cycled, players undisturbed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>