### PR TITLE
docs: refresh README + marketing site for v12.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 
 **🌐 Website & feature tour: [coastal-ms.github.io/DST-DuneServerTool](https://coastal-ms.github.io/DST-DuneServerTool/)** — screenshots, install guide, and the full changelog.
 
-The current release is **v12.14.7**. The in-app version label and the
-website show plain semver tags (e.g. `v12.14.7`) — the previous
+The current release is **v12.18.1**. The in-app version label and the
+website show plain semver tags (e.g. `v12.18.1`) — the previous
 Roman-numeral stylization has been removed.
 
-> ## ✅ Confirmed compatible with Dune: Awakening **1.4.10.0**
-> DST **v12.14.x** is verified working against the **latest Funcom release** —
+> ## ✅ Confirmed compatible with Dune: Awakening **1.4.10.1**
+> DST **v12.18.x** is verified working against the **latest Funcom release** —
 > both the game **client** and the **self-hosted server** software — as of the
-> **1.4.10.0** patch. Compatibility was checked live against a running
+> **1.4.10.1** patch. Compatibility was checked live against a running
 > self-hosted server on that build, covering battlegroup management,
 > on-demand map spin-up, game-config and database editing, and backups.
 
@@ -28,6 +28,71 @@ the sidebar's **Web Portal** button hands the portal off to your default
 browser and keeps the server running in the background.
 
 ![Server Health](docs/img/server-health.png)
+
+### New in v12.15–v12.18
+
+- **VM memory-pressure diagnostics** (v12.18.0, Server Health). When a
+  home-hosted VM runs low on RAM the kubelet OOM-kills Funcom's operator
+  pods and Postgres, and the nightly backup stalls — a signature that
+  previously took a log export to spot. A read-only probe now reads
+  operator/DB pod restart counts and the VM's `free -h` / `/proc/meminfo`,
+  and DST surfaces a red **"VM low on memory"** banner on Server Health,
+  prints the same warning after Start / Reboot, and adds
+  `vm-memory-pressure.txt` to the diagnostics bundle.
+- **Remote-player game-UDP bridge — no more P34 on public-IP-only servers**
+  (v12.18.0, Settings → Public IP / DDNS). Funcom's game pods bind the
+  **public IP only**, so a router forwarding game UDP (7777–7810) to the
+  VM's LAN IP hits no listener and remote players time out with P34. DST
+  now installs and *persists* an iptables DNAT bridge
+  (`LAN-IP:7777-7810/udp → public IP`) across the Public IP apply, the boot
+  script, and the every-minute self-heal watchdog. It is **bind-detected**
+  so it can't reintroduce the same-LAN black-hole removed in v12.16.9 —
+  installed only when the game binds public-only, removed when it binds the
+  LAN IP/wildcard. Live-verified by `tcpdump`.
+- **Grant Cosmetics surfaces the full skin-variant catalog** (v12.18.0,
+  Players → Items). The picker now buckets the entire `*_Variant` cosmetic
+  family — **22 vehicle skins**, **37 weapon skins** (previously zero), and
+  armor/suit variants — not just the three sandbike meshes it used to match.
+- **Save-guard no longer false-fires on stale ghost rows** (v12.18.0). The
+  online-player check now mirrors Funcom's own `dune.is_player_offline()`
+  (online only when the row isn't `Offline` **and** its `server_id` is in
+  `dune.active_server_ids`), so the new `LoggingOut` grace state and orphan
+  rows after a restart no longer warn "N player(s) online" with nobody
+  connected.
+- **Update Tags gets the real catalog typeahead** (v12.18.0, Players →
+  Update Tags). The add-tag box now uses the catalog-backed picker instead
+  of a hardcoded 5-item list, so real gameplay tags (e.g.
+  `Journey.LandsraadContractsUnlocked`) autocomplete. The write path still
+  posts the add/remove **delta** so the game's server-side unlock triggers
+  fire.
+- **On-demand map partition self-heal — spin-up race fixed** (v12.18.1).
+  The autonomous `*/15` partition healer no longer resets an in-progress
+  manual map spin-up: a pinned-but-pod-less map is recorded on first
+  sighting and only cycled if it is *still* pod-less on a later tick. Dead
+  pods are still healed immediately; live sessions are always skipped. A new
+  `install-only` mode lets the on-VM automation refresh without touching any
+  map, so a live server can update mid-session.
+- **Battlegroup Info raw pane: no more drifted Status column** (v12.17.0).
+  A server title with spaces or a comma (e.g. `Dune, my Arrakis`) used to
+  shift the Status cell in Funcom's positionally-parsed raw output. DST now
+  rewrites just that row from the Battlegroup CRD JSON, tagged
+  `(DST-corrected)`, only when the text actually disagrees.
+- **VM header + Public IP card no longer crash on multi-adapter VMs**
+  (v12.16.12). `Get-DuneVmStatus` coerces the VM IP to a string, so a
+  wrapping PSObject on multi-adapter hosts no longer renders `[object
+  Object]` or throws React error #31.
+- **SteamCMD orphan-workdir pre-flight** (v12.16.11, Commands →
+  Battlegroup → `update`). An interrupted SteamCMD update leaves a
+  root-owned download workdir that fails every retry with `state is 0x206`;
+  DST now cleans it before invoking `battlegroup update`.
+- **Restore Backup no longer needs the battlegroup stopped** (v12.16.11).
+  Funcom's `battlegroup import` handles the full stop/swap/recover cycle
+  itself, so both the Database page and the Commands `import` entry now
+  require only that the VM is running.
+- **Grant All Skills reworked** (v12.16.9–v12.16.10). Now grants every
+  skill at its real max level (EXPERIMENTAL badge removed), while leaving a
+  small skill-point buffer and a 100 Intel floor so the tutorial's "learn
+  an ability" step isn't soft-locked.
 
 ### New in v12.14.x
 
@@ -922,7 +987,7 @@ so it can be tracked and fixed:
 
 The bug report form asks for:
 
-- **Tool version** — shown in the portal footer (e.g. `v12.14.7 · coastal-ms`).
+- **Tool version** — shown in the portal footer (e.g. `v12.18.1 · coastal-ms`).
 - **Surface** — which portal page (Server Health, Commands, PowerShell,
   Game Config, DD Map, Map SpinUp, Database, Sietches, Settings, Setup
   Wizard) or whether it was the CLI / installer / auto-updater.

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -10,7 +10,7 @@ const sections = [
     id: "health",
     title: "Server Health",
     img: "server-health.png",
-    body: "Default landing page. Combined battlegroup + VM state, live TCP port verdicts, per-pod game-server status, active spice-field counts pulled live from Postgres, and Map SpinUp loading diagnostics with restart actions and clear failure reasons when a map will not come up.",
+    body: "Default landing page. Combined battlegroup + VM state, live TCP port verdicts, per-pod game-server status, active spice-field counts pulled live from Postgres, and Map SpinUp loading diagnostics with restart actions and clear failure reasons when a map will not come up. A read-only probe also surfaces a VM low-on-memory banner when a home-hosted VM starts OOM-killing Funcom's operator pods, so the 'node is out of RAM' signature is caught without a log export.",
   },
   {
     id: "commands",
@@ -28,13 +28,13 @@ const sections = [
     id: "gameplay",
     title: "Gameplay Admin",
     img: "gameplay-admin.png",
-    body: "The Gameplay Admin portal is a full in-tree port with 54 player-management endpoints and a bucketed Actions panel. Recent additions include a Landsraad Houses tab for editing house reward milestones, inline stack-quantity editing in Storage and player inventory, and Duke's market-bot pricing modes — formula, market-follow, and over-market buy guard — plus the built-in Cheat Scripts and Landsraad contribution controls.",
+    body: "The Gameplay Admin portal is a full in-tree port with 54 player-management endpoints and a bucketed Actions panel. It covers a Landsraad Houses tab for editing house reward milestones, inline stack-quantity editing in Storage and player inventory, Grant Cosmetics with the full skin-variant catalog (vehicle and weapon skins, not just sandbikes), an Update Tags box with catalog typeahead that fires the game's server-side unlock triggers, and Duke's market-bot pricing modes — formula, market-follow, and over-market buy guard — plus the built-in Cheat Scripts and Landsraad contribution controls. Save actions are guarded by a real online-player check so they don't false-warn on stale ghost rows after a restart.",
   },
   {
     id: "give-package",
     title: "Give Package",
     img: "give-package.png",
-    body: "New in v12.0.19 — build and reuse your own item packages. Create named bundles of any items (each with a quantity and tier Mk1–Mk6), then hand a whole package to any player in one click from their Inventory section. Packages are created, edited, and deleted right from the form and saved server-side (item-packages.json), so they persist across restarts and are shared between the desktop app and the remote portal. Delivery uses the normal give-items path, so it works online or offline as long as there's inventory space.",
+    body: "Build and reuse your own item packages. Create named bundles of any items (each with a quantity and tier Mk1–Mk6), then hand a whole package to any player in one click from their Inventory section. Packages are created, edited, and deleted right from the form and saved server-side (item-packages.json), so they persist across restarts and are shared between the desktop app and the remote portal. Delivery uses the normal give-items path, so it works online or offline as long as there's inventory space.",
   },
   {
     id: "give-vehicle-kit",
@@ -46,7 +46,7 @@ const sections = [
     id: "cheat-scripts",
     title: "Cheat Scripts (Players → Live)",
     img: "gameplay-cheat-scripts.png",
-    body: "New in v12.2.1 — one-click buttons fire the named server cheat scripts for an online player: Playtest Setup, Award Player XP, Unlock All Skills / Abilities, and Leave Me Alone, plus a freeform box for any other script name. Developer performance harnesses (Start / Stop Hitch Test) sit on a separate Dev / Perf Scripts row. Both carry a disclaimer that the scripts originate from the Playtest server and may have no effect on a retail server.",
+    body: "One-click buttons fire the named server cheat scripts for an online player: Playtest Setup, Award Player XP, Unlock All Skills / Abilities, and Leave Me Alone, plus a freeform box for any other script name. Developer performance harnesses (Start / Stop Hitch Test) sit on a separate Dev / Perf Scripts row. Both carry a disclaimer that the scripts originate from the Playtest server and may have no effect on a retail server.",
   },
   {
     id: "landsraad",
@@ -64,7 +64,7 @@ const sections = [
     id: "settings",
     title: "Settings",
     img: "settings.png",
-    body: "The Settings page reflects the same choices the Setup Wizard makes, plus the newer remote-access and appearance controls. It covers the two-path installer experience, Steam path and SSH-key selection, Windows username, port-check provider, themes, remote-access policy, and auto-updater preferences.",
+    body: "The Settings page reflects the same choices the Setup Wizard makes, plus the newer remote-access and appearance controls. It covers the two-path installer experience, Steam path and SSH-key selection, Windows username, port-check provider, themes, remote-access policy, and auto-updater preferences. The Public IP / DDNS card applies your public IP across the battlegroup and installs a persistent game-UDP DNAT bridge so remote players don't hit P34 on a server whose game pods bind the public IP only.",
   },
 ];
 ---

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -9,7 +9,7 @@ const release = await getLatestRelease();
 const versionLabel = formatDisplayVersion(release.version);
 
 // Latest Funcom Dune: Awakening release this build is verified against.
-const funcomVersion = "1.4.10.0";
+const funcomVersion = "1.4.10.1";
 
 const features = [
   {
@@ -88,7 +88,7 @@ const features = [
         The current release ({versionLabel}) is verified against Funcom's
         latest update — both the game <strong class="text-dune-text">client</strong>
         and the <strong class="text-dune-text">self-hosted server</strong>
-        software — confirmed live on the 1.4.10.0 build (June 24, 2026,
+        software — confirmed live on the 1.4.10.1 build (July 1, 2026,
         including Funcom's follow-up server hotfix). No update to DST is required.
       </p>
     </div>

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -82,8 +82,8 @@ import DownloadButton from "../components/DownloadButton.astro";
           >Dune: Awakening Self-Hosted Server</strong
         > installed via Steam (provides the battlegroup-management folder and
         the Hyper-V VM image). Verified against the latest <strong
-          class="text-dune-text">1.4.10.0</strong
-        > build (June 24, 2026).
+          class="text-dune-text">1.4.10.1</strong
+        > build (July 1, 2026).
       </li>
       <li>
         <strong class="text-dune-text">SSH private key</strong> for your VM —


### PR DESCRIPTION
## What

Brings the README and the marketing site (`site/`) current with the latest public release and Funcom compatibility.

### README.md
- Current-release string `v12.14.7 → v12.18.1` (intro + footer version example)
- Compat banner `1.4.10.0 / v12.14.x → 1.4.10.1 / v12.18.x`
- New **"New in v12.15–v12.18"** highlights block: VM memory-pressure diagnostics, remote-player game-UDP DNAT bridge, Grant Cosmetics skin-variant catalog, save-guard ghost-row fix, Update Tags catalog typeahead, partition-heal spin-up race fix, BG-info raw-pane repair, multi-adapter VM `[object Object]` fix, SteamCMD orphan-workdir pre-flight, Restore ungate, Grant All Skills rework. Older `New in v12.14.x`/`v12.13.x` sections kept as historical.

### Marketing site
- `index.astro` + `install.astro`: Funcom compat `1.4.10.0 (June 24) → 1.4.10.1 (July 1, 2026)`
- `features.astro`: page-tour bodies enriched (Server Health mem-pressure banner; Gameplay Admin cosmetics variants + tag typeahead + save-guard; Settings Public IP game-UDP bridge); dropped stale `New in v12.0.19 / v12.2.1 —` date prefixes
- Changelog page and download button already auto-resolve from `CHANGELOG.md` / the Releases API at build time — no change needed

## Verification
- `cd site && npm run build` → **9 pages built, clean** (Node 22.18)
- Remaining `v12.14.7` / `1.4.10.0` refs are intentional historical attributions inside the older "New in" sections

Docs/site content only — no code or release version bump.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>