### PR TITLE
fix(site): repair broken border on the "What's in the box" card

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -145,6 +145,9 @@ const features = [
           Browse the code →
         </a>
       </div>
+    </div>
+  </section>
+
   <section class="mx-auto max-w-6xl px-6 pb-20">
     <div
       class="rounded-xl border border-dune-accent/40 bg-dune-accent/5 p-8 sm:p-12 sm:flex sm:items-center sm:justify-between gap-8"


### PR DESCRIPTION
## Problem

On the homepage, the **"What's in the box"** card rendered with a broken, overlapping border — the community CTA was drawn *inside* the bordered box (see report screenshot).

## Cause

The section's wrapper `<div>` and `<section>` were never closed before the **"Join the DST community"** `<section>` opened, so the community section was nested inside the "What's in the box" card. Pre-existing markup bug.

## Fix

Add the two missing closing tags (`</div></section>`) after the Install-guide / Browse-the-code links row, so the two sections are proper siblings again.

## Verification

- `npm run build` → 9 pages, clean
- Visually confirmed in `astro preview`: the "What's in the box" card now fully encloses its content, and "Join the DST community" is a separate bordered card below it

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>