### PR TITLE
Fix: make off-catalog tags addable via a real Add button in TagPicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ here cover everything those tags shipped.
 
 ### Fixed
 
+- **The tag editor's "Add" button now works for custom tags not in the built-in catalog.** When you typed a tag the catalog didn't recognise, the picker said *"No known tags match … Press Add to use it anyway"* — but "Add" was just static text with nothing to click, so the only way to actually add a custom tag was to press Enter (undiscoverable). The picker now shows a real, clickable **Add "&lt;your tag&gt;"** row whenever your text matches no catalog entry, so off-catalog tags (e.g. a one-off `Cosmetic.*` marker) can be added the same way as catalogued ones.
+
 - **The mobile/remote "Friend Helper" bridge no longer flashes a console window on the desktop every couple of minutes.** The bridge's background service is kept alive by a self-healing supervisor loop plus an at-sign-in task trigger, but the installer *also* registered a **2-minute keepalive** trigger as a backstop in case the supervisor process itself was killed. In an interactive Windows session, each keepalive fire relaunched the hidden `wscript -> pwsh` helper, and even the window-hidden shim briefly allocates a console host that could momentarily flash on screen. That keepalive trigger has been removed: the supervisor still relaunches the bridge daemon within a few seconds if it crashes, and the at-sign-in trigger re-establishes the supervisor after every reboot / re-login, so the bridge stays just as reliable — without the periodic flash. Existing installs pick up the fix on their next update; the live scheduled task can also be corrected in place.
 
 ## [12.18.1] - 2026-07-07

--- a/webui/src/components/TagPicker.tsx
+++ b/webui/src/components/TagPicker.tsx
@@ -3,8 +3,10 @@
 // on every keystroke against the friendly label OR the raw tag, then GROUPS the
 // matches by their parent breadcrumb (everything except the final segment) so
 // related tags read as a set. Each group shows an "Add all (N)" button; each
-// leaf tag is an explicit "+ Add" row. Results render inline (not a floating
-// popup) and paginate by group. Tags the player already has are excluded.
+// leaf tag is an explicit "+ Add" row. When the typed text matches no catalog
+// tag, an "Add "<text>"" row lets you commit it as a custom (off-catalog) tag.
+// Results render inline (not a floating popup) and paginate by group. Tags the
+// player already has are excluded.
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { Icon } from './Icon'
@@ -109,6 +111,14 @@ export function TagPicker({
   const goPage = (p: number) => setPage(Math.max(0, Math.min(p, pageCount - 1)))
 
   const addOne = (tag: string) => onPick(tag)
+  // Commit the raw typed text as a custom (off-catalog) tag. Mirrors the Enter
+  // key: prefer the consumer's onEnterRaw handler, fall back to onPick.
+  const addRaw = () => {
+    const t = value.trim()
+    if (!t) return
+    if (onEnterRaw) onEnterRaw()
+    else onPick(t)
+  }
   const addGroup = (g: TagGroup) => {
     const tags = g.entries.map(e => e.tag)
     if (onPickMany) onPickMany(tags)
@@ -172,11 +182,23 @@ export function TagPicker({
               <div className="px-3 py-2 text-xs text-danger">{catalogError}</div>
             )}
             {!catalogLoading && !catalogError && matches.length === 0 && (
-              <div className="px-3 py-2 text-xs text-text-dim">
-                {value.trim().length > 0
-                  ? <>No known tags match "{value}". Press <span className="text-text">Add</span> to use it anyway.</>
-                  : 'No more tags to add.'}
-              </div>
+              value.trim().length > 0 ? (
+                <button
+                  type="button"
+                  onMouseDown={ev => { ev.preventDefault(); addRaw() }}
+                  className="w-full text-left px-3 py-2 flex items-center gap-2 hover:bg-surface-2 group"
+                >
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-sm text-text">Add "{value.trim()}"</span>
+                    <span className="block text-[11px] text-text-dim">No catalog match — add it as a custom tag.</span>
+                  </span>
+                  <span className="shrink-0 inline-flex items-center gap-1 text-[11px] text-text-dim group-hover:text-text">
+                    <Icon name="Plus" size={12} /> Add
+                  </span>
+                </button>
+              ) : (
+                <div className="px-3 py-2 text-xs text-text-dim">No more tags to add.</div>
+              )
             )}
             {visibleGroups.map(g => (
               <div key={g.key || '__ungrouped__'} className="border-b border-border/60 last:border-b-0">


### PR DESCRIPTION
## What & why

From Juraki''s support thread: when you type a tag the catalog doesn''t recognise, the picker says *"No known tags match … Press **Add** to use it anyway"* — but "Add" was just static text (`<span>`), nothing to click. The only working path was the **Enter** key, which is undiscoverable. So custom / off-catalog tags (e.g. a one-off `Cosmetic.Test.RemoveMe` marker) looked impossible to add.

## Change

`webui/src/components/TagPicker.tsx`: when the typed text matches no catalog entry (and is non-empty), render a real clickable **Add "&lt;text&gt;"** row instead of the dead hint. It commits the raw value via the consumer''s `onEnterRaw` handler (same path as the Enter key), falling back to `onPick`. The empty-input case still shows "No more tags to add."

## Verification

- `cd webui && npm run build` — `tsc -b` clean, vite build succeeds.

CHANGELOG `[Unreleased]` → **Fixed** entry added.

## Note

Independent of #484 (tag-editing unify) — different file, no overlap. Both ride the next release.