### PR TITLE
Release v12.18.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.1"
+      placeholder: "v12.18.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
-## [Unreleased]
+## [12.18.2] - 2026-07-08
 
 ### Changed
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.1'
+$script:DuneToolVersion = '12.18.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.1',
+    [string]$Version = '12.18.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.1</Version>
+    <Version>12.18.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.1"
+#define MyAppVersion "12.18.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.1"
+$script:ToolVersion = "12.18.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Release **v12.18.2** — bundles the following already-merged changes and stamps the version.

**Included (merged to main):**
- #482 — Permanent **Dismiss (X)** for the VM memory-pressure banner + Settings → Dashboard warnings re-enable toggle
- #483 — Friend Helper bridge no longer flashes a console window every ~2 min
- #484 — Player **Tags** panel Save now fires the game's trigger-firing delta path (Journey/Landsraad unlocks apply for real); removed redundant Update Tags row
- #485 — Tag editor's off-catalog **Add** button is now a real clickable button

**This PR:**
- Bumps all 5 version files 12.18.1 → 12.18.2
- Rolls CHANGELOG `[Unreleased]` → `[12.18.2] - 2026-07-08`
- Bumps bug_report.yml tool_version placeholder to v12.18.2