### PR TITLE
Players Tags panel: raise tag read cap so heavily-tagged characters don't lose whole tag groups (Journey) from the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [Unreleased]
+
+### Fixed
+
+- **The Players → Tags panel no longer hides tags for heavily-tagged characters.** For a character with a large number of tags (200+), the Tags panel silently dropped whole alphabetically-later tag groups — most visibly the entire `Journey.*` group, which would "disappear on refresh" even though every tag was still present in the database. The cause was a read cap: the tag list was fetched with a 200-row limit and ordered alphabetically, so anything past ~row 200 (Contract.* alone can be 150+ rows) was truncated before it ever reached the UI. The cap is now high enough to return a mature character's full tag set, so all groups (Journey, and anything after it) show up correctly. This was a display-only bug — no tags were lost from the database, and the trigger-firing delta Save added in 12.18.2 already protected the hidden tags from being deleted.
+
 ## [12.18.2] - 2026-07-08
 
 ### Changed

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -871,7 +871,15 @@ function Invoke-DunePlayerResetAllKeystones {
 function Get-DunePlayerTagsLive {
     param([string]$Ip, [long]$AccountId)
     $sql = "SELECT tag FROM dune.player_tags WHERE character_id IN (SELECT id FROM dune.player_state WHERE account_id = $AccountId::bigint) ORDER BY tag;"
-    $soft = Invoke-DuneSqlSoft -Ip $Ip -Sql $sql -MaxRows 200 -TimeoutSec 30
+    # MaxRows 5000: player_tags is an unbounded per-character list — a mature
+    # character legitimately holds 200+ tags (Contract.* alone can be 150+, plus
+    # the 26-tag Journey.* group, BigMoments, Faction, etc.). The old MaxRows 200
+    # cap combined with ORDER BY tag truncated everything past ~position 200,
+    # silently hiding whole alphabetically-later groups (Journey and beyond) from
+    # the UI even though the tags exist in the DB. Rows are tiny text values, so a
+    # high cap is cheap. (Contrast Get-DunePlayerSpecsFullLive's MaxRows 200 read,
+    # which is safe because it returns a fixed small enum of spec track types.)
+    $soft = Invoke-DuneSqlSoft -Ip $Ip -Sql $sql -MaxRows 5000 -TimeoutSec 30
     if (-not $soft.ok) { return @{ ok = $false; error = $soft.error } }
     if ($soft.unsupported) { return @{ ok = $true; tags = @(); unsupported = $true } }
     $tags = @()


### PR DESCRIPTION
## Problem

The **Gameplay Admin → Players → Tags** panel silently truncates a character's tags for heavily-tagged characters, hiding entire tag groups (e.g. the whole `Journey.*` group) from the UI even though the tags are present in the database.

From a real Discord case (Juraki): his character has **245** `player_tags` rows including a full 26-tag `Journey.*` group with `Journey.LandsraadContractsUnlocked`, all confirmed present in the DB, but DST's UI only displayed the alphabetically-first groups (BigMoments / Character / Contract) and the Journey group "disappears on refresh".

## Root cause

`app/server/lib/GameplayPlayers.ps1` → `Get-DunePlayerTagsLive` read `player_tags` with:

```
... ORDER BY tag ...  -MaxRows 200
```

`player_tags` per character legitimately exceeds 200 on a mature character (`Contract.*` alone can be 150+), so `ORDER BY tag` alphabetically truncated everything past ~row 200 — dropping Journey (J) and all later groups before they ever reached the UI.

## Fix

- Raise the tag read cap from `-MaxRows 200` to `-MaxRows 5000` (keep `TimeoutSec 30`). Rows are tiny text values, so a high cap is cheap. Added an inline comment explaining why.

## Investigation (per the requested scope)

- **Line 778 (`Get-DunePlayerSpecsFullLive`, also `MaxRows 200`):** returns a fixed small enum of specialization track types + a single `keystones_total` row — genuinely bounded, **left as-is** and noted in the comment.
- **Other low caps** in the players read/lib paths (vehicle_modules per vehicle, specs/currency per player @111/113, Landsraad, market sales) are bounded lists, not unbounded per-character tag reads — out of scope.
- **Frontend** (`sections.tsx` / `TagPicker.tsx`): no display cap on the applied-tag list; the `slice(0, 300)` is the autocomplete suggestion catalog, unrelated. Backend cap was the confirmed cause.

## Not touched (by design)

- **Tag write path.** This is a display/read-only bug. The v12.18.2 delta Save (`dune.update_player_tags` add/remove vs baseline) is what prevented this truncation from becoming data loss and is preserved unchanged.
- No version bumps, no installer build, no release (the orchestrating session batches releases).
- The separate in-game "landsraad missions still locked" issue in the same Discord case is a cross-install-restore artifact and out of scope.

## Validation

- Parse-checked `GameplayPlayers.ps1` with `Parser::ParseFile` → OK.
- Encoding unchanged (added comment is ASCII-only).

## Changelog

Added an `[Unreleased] → Fixed` entry describing the fix.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>