### PR TITLE
VM memory-pressure banner: opt-in (off by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- **The VM memory-pressure warning banner is now opt-in (off by default).** Introduced in v12.18.0 and made dismissible in v12.18.2, the red Server Health banner still proved too intrusive shown-by-default. It no longer appears unless you turn it on under **Settings → Dashboard warnings → "Show VM memory-pressure warning."** When it's off (the default) the dashboard doesn't even poll the probe. Nothing else changed: the read-only `GET /api/diagnostics/vm-memory` probe still runs on demand, the Start/Reboot console still prints the warning, and `vm-memory-pressure.txt` is still included in the diagnostics bundle — so the signal is preserved for support without nagging every operator. Existing installs that had dismissed or shown the banner both land on the new off-by-default state.
+
 ### Fixed
 
 - **The Players → Tags panel no longer hides tags for heavily-tagged characters.** For a character with a large number of tags (200+), the Tags panel silently dropped whole alphabetically-later tag groups — most visibly the entire `Journey.*` group, which would "disappear on refresh" even though every tag was still present in the database. The cause was a read cap: the tag list was fetched with a 200-row limit and ordered alphabetically, so anything past ~row 200 (Contract.* alone can be 150+ rows) was truncated before it ever reached the UI. The cap is now high enough to return a mature character's full tag set, so all groups (Journey, and anything after it) show up correctly. This was a display-only bug — no tags were lost from the database, and the trigger-firing delta Save added in 12.18.2 already protected the hidden tags from being deleted.

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -188,7 +188,7 @@ export function Dashboard() {
         description="Live VM, battlegroup, and port status."
       />
 
-      <VmMemoryPressureBanner enabled={Boolean(vm?.running)} />
+      <VmMemoryPressureBanner vmRunning={Boolean(vm?.running)} />
 
       <section className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
         <div className="card card-hover p-4">

--- a/webui/src/pages/dashboard/VmMemoryPressureBanner.tsx
+++ b/webui/src/pages/dashboard/VmMemoryPressureBanner.tsx
@@ -6,41 +6,46 @@
 // could only be found by exporting logs and hand-reading them.
 //
 // Backed by GET /api/diagnostics/vm-memory, which is read-only and cached 60s
-// server-side, so polling here is cheap. Renders nothing unless the probe
+// server-side, so polling here is cheap. OPT-IN: hidden by default, shown only
+// when the operator enables it under Settings → Dashboard warnings. When off we
+// don't even poll the probe. Renders nothing unless enabled AND the probe
 // succeeded AND detected pressure.
 import { useCallback, useEffect, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import { getVmMemoryPressure, type VmMemoryPressure } from '../../api/diagnostics'
-import { useVmMemPressureHidden } from './vmMemoryPref'
+import { useVmMemPressureEnabled } from './vmMemoryPref'
 
 type Props = {
-  enabled: boolean   // gate on VM running — no point probing a stopped VM
+  vmRunning: boolean   // gate on VM running — no point probing a stopped VM
 }
 
-export function VmMemoryPressureBanner({ enabled }: Props) {
+export function VmMemoryPressureBanner({ vmRunning }: Props) {
   const [finding, setFinding] = useState<VmMemoryPressure | null>(null)
-  const [hidden, setHidden] = useVmMemPressureHidden()
+  const [show, setShow] = useVmMemPressureEnabled()
+
+  // Only active when the operator opted in AND the VM is running.
+  const active = show && vmRunning
 
   const load = useCallback(async () => {
-    if (!enabled) return
+    if (!active) return
     try {
       setFinding(await getVmMemoryPressure())
     } catch {
       // Best-effort — a probe hiccup must never break the dashboard. Leave the
       // last good finding in place.
     }
-  }, [enabled])
+  }, [active])
 
   useEffect(() => { void load() }, [load])
 
   // Poll on the same 60s cadence as the server-side cache TTL.
   useEffect(() => {
-    if (!enabled) return
+    if (!active) return
     const id = window.setInterval(() => { void load() }, 60_000)
     return () => window.clearInterval(id)
-  }, [enabled, load])
+  }, [active, load])
 
-  if (!enabled || hidden || !finding || !finding.ok || !finding.pressure) return null
+  if (!active || !finding || !finding.ok || !finding.pressure) return null
 
   const critical = finding.severity === 'critical'
   const tone = critical
@@ -65,10 +70,10 @@ export function VmMemoryPressureBanner({ enabled }: Props) {
         </div>
         <button
           type="button"
-          onClick={() => setHidden(true)}
+          onClick={() => setShow(false)}
           className="shrink-0 -mt-0.5 -mr-1 p-1 rounded hover:bg-current/10 text-current/70 hover:text-current transition-colors"
-          title="Dismiss this warning permanently. Re-enable it under Settings → Dashboard warnings."
-          aria-label="Dismiss VM memory-pressure warning permanently"
+          title="Hide this warning. Turn it back on under Settings → Dashboard warnings."
+          aria-label="Hide VM memory-pressure warning"
         >
           <Icon name="X" size={16} />
         </button>

--- a/webui/src/pages/dashboard/vmMemoryPref.ts
+++ b/webui/src/pages/dashboard/vmMemoryPref.ts
@@ -1,16 +1,18 @@
 // Persisted user preference for the VM memory-pressure dashboard banner.
 //
-// The banner is intentionally loud (it flags OOM-kills / Postgres eviction),
-// but operators who understand the risk asked to silence it permanently. This
-// stores a single "hidden" flag in localStorage and exposes a live-updating
-// hook so the banner (reader) and the Settings re-enable toggle (reader +
-// writer) stay in sync without a page reload.
+// The banner flags real trouble (OOM-kills / Postgres eviction), but it proved
+// too intrusive to show by default, so it is now OPT-IN: hidden unless the
+// operator explicitly enables it under Settings → Dashboard warnings. This
+// stores a single "enabled" flag in localStorage (absent = off) and exposes a
+// live-updating hook so the banner (reader) and the Settings toggle (reader +
+// writer) stay in sync without a page reload. The server-side probe and the
+// diagnostics-bundle entry are unchanged — this only governs the banner UI.
 import { useEffect, useState } from 'react'
 
-const KEY = 'dst.vmMemPressure.hidden'
+const KEY = 'dst.vmMemPressure.enabled'
 const EVENT = 'dst:vmMemPressurePref'
 
-export function isVmMemPressureHidden(): boolean {
+export function isVmMemPressureEnabled(): boolean {
   try {
     return localStorage.getItem(KEY) === '1'
   } catch {
@@ -18,9 +20,9 @@ export function isVmMemPressureHidden(): boolean {
   }
 }
 
-export function setVmMemPressureHidden(hidden: boolean): void {
+export function setVmMemPressureEnabled(enabled: boolean): void {
   try {
-    if (hidden) localStorage.setItem(KEY, '1')
+    if (enabled) localStorage.setItem(KEY, '1')
     else localStorage.removeItem(KEY)
   } catch {
     /* private mode / storage disabled — nothing we can do, fail quiet */
@@ -32,13 +34,13 @@ export function setVmMemPressureHidden(hidden: boolean): void {
   }
 }
 
-// Shared live-updating hook. Returns [hidden, setHidden]. Subscribes to same-tab
-// changes (custom event) and cross-tab changes (storage event).
-export function useVmMemPressureHidden(): [boolean, (hidden: boolean) => void] {
-  const [hidden, setHidden] = useState<boolean>(isVmMemPressureHidden)
+// Shared live-updating hook. Returns [enabled, setEnabled]. Subscribes to
+// same-tab changes (custom event) and cross-tab changes (storage event).
+export function useVmMemPressureEnabled(): [boolean, (enabled: boolean) => void] {
+  const [enabled, setEnabled] = useState<boolean>(isVmMemPressureEnabled)
 
   useEffect(() => {
-    const sync = () => setHidden(isVmMemPressureHidden())
+    const sync = () => setEnabled(isVmMemPressureEnabled())
     window.addEventListener(EVENT, sync)
     window.addEventListener('storage', sync)
     return () => {
@@ -47,5 +49,5 @@ export function useVmMemPressureHidden(): [boolean, (hidden: boolean) => void] {
     }
   }, [])
 
-  return [hidden, setVmMemPressureHidden]
+  return [enabled, setVmMemPressureEnabled]
 }

--- a/webui/src/pages/settings/DashboardAlertsCard.tsx
+++ b/webui/src/pages/settings/DashboardAlertsCard.tsx
@@ -1,11 +1,11 @@
 import { Icon } from '../../components/Icon'
-import { useVmMemPressureHidden } from '../dashboard/vmMemoryPref'
+import { useVmMemPressureEnabled } from '../dashboard/vmMemoryPref'
 
 // Settings → Dashboard warnings. Currently just the VM memory-pressure banner
-// toggle: operators who understand the risk can silence it from the banner's X,
-// and re-enable it here. Preference lives in localStorage (see vmMemoryPref.ts).
+// toggle. The banner is OPT-IN (off by default); operators who want to be
+// alerted turn it on here. Preference lives in localStorage (see vmMemoryPref.ts).
 export function DashboardAlertsCard() {
-  const [hidden, setHidden] = useVmMemPressureHidden()
+  const [show, setShow] = useVmMemPressureEnabled()
 
   return (
     <div className="card mb-4 p-6">
@@ -17,8 +17,8 @@ export function DashboardAlertsCard() {
       <label className="flex items-start gap-3 cursor-pointer select-none">
         <input
           type="checkbox"
-          checked={!hidden}
-          onChange={e => setHidden(!e.target.checked)}
+          checked={show}
+          onChange={e => setShow(e.target.checked)}
           className="h-4 w-4 mt-0.5"
         />
         <span className="min-w-0">
@@ -26,8 +26,8 @@ export function DashboardAlertsCard() {
           <span className="block text-xs text-text-dim mt-0.5">
             The red banner on the dashboard that fires when the game VM is low on
             memory (Funcom operators OOM-killed, Postgres evicted, or swap
-            exhausted). Turn this off to hide it permanently — you can also
-            dismiss it from the banner's <Icon name="X" size={11} className="inline align-[-1px]" /> button.
+            exhausted). Off by default; turn it on to be alerted. You can hide it
+            again from the banner's <Icon name="X" size={11} className="inline align-[-1px]" /> button or here.
           </span>
         </span>
       </label>


### PR DESCRIPTION
## What
Makes the VM memory-pressure warning banner **opt-in (off by default)**.

The red Server Health banner was added in v12.18.0 (#472) and made permanently dismissible in v12.18.2 (#482), but even dismissible it's too intrusive shown-by-default. This flips it to hidden unless the operator turns it on under **Settings → Dashboard warnings**.

## How
- `vmMemoryPref.ts`: invert the localStorage pref from a `hidden` flag (absent = shown) to an `enabled` flag (absent = **off**). New `useVmMemPressureEnabled()` hook.
- `VmMemoryPressureBanner.tsx`: gate rendering **and the 60s probe poll** on `enabled && vmRunning`, so a default install doesn't even call `GET /api/diagnostics/vm-memory`. The banner's X now turns it off. Prop renamed `enabled`→`vmRunning` for clarity.
- `DashboardAlertsCard.tsx`: toggle now enables (opt-in) instead of silencing; copy updated to "off by default."
- `Dashboard.tsx`: updated prop name.

## Unchanged (support signal preserved)
Server-side read-only probe, the Start/Reboot console warning, and the `vm-memory-pressure.txt` diagnostics-bundle entry all stay — so support can still spot memory pressure; operators just aren't nagged.

## Migration
Both prior states (dismissed or shown) resolve to the new off-by-default. No server changes.

webui builds clean (`tsc -b && vite build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)