### PR TITLE
Release v12.18.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.2"
+      placeholder: "v12.18.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.3] - 2026-07-09
+
 ### Changed
 
 - **The VM memory-pressure warning banner is now opt-in (off by default).** Introduced in v12.18.0 and made dismissible in v12.18.2, the red Server Health banner still proved too intrusive shown-by-default. It no longer appears unless you turn it on under **Settings → Dashboard warnings → "Show VM memory-pressure warning."** When it's off (the default) the dashboard doesn't even poll the probe. Nothing else changed: the read-only `GET /api/diagnostics/vm-memory` probe still runs on demand, the Start/Reboot console still prints the warning, and `vm-memory-pressure.txt` is still included in the diagnostics bundle — so the signal is preserved for support without nagging every operator. Existing installs that had dismissed or shown the banner both land on the new off-by-default state.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.2'
+$script:DuneToolVersion = '12.18.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.2',
+    [string]$Version = '12.18.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.2</Version>
+    <Version>12.18.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.2"
+#define MyAppVersion "12.18.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.2"
+$script:ToolVersion = "12.18.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Rolls `[Unreleased]` → **[12.18.3]** and bumps the 5 version stamps + `bug_report.yml`.

Bundles three already-merged PRs:
- **#489** — VM memory-pressure banner opt-in (off by default)
- **#487** — Players → Tags panel read-cap fix
- **#474** — Public IP → Apply verify backoff (no false FAILED)

Sole-asset `DuneServerSetup.exe` built at v12.18.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)