### PR TITLE
Release v12.18.4: prune Evicted/Failed dump pods

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.3"
+      placeholder: "v12.18.4"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The backup dump-pod cleanup now also clears Evicted/Failed dump pods.** DST already auto-prunes the `*-dump-*` pods Funcom's database-backup jobs leave behind (Database page → Backup schedule "keep last N pods", plus the manual **Prune** button), but it only removed **Succeeded** ones — so dump pods that were **Evicted** (e.g. OOM-killed during a VM memory-pressure event) were left behind, piled up in the Pods view, and survived every battlegroup/VM restart (they live in the k3s datastore, not as live processes, so a reboot just reloads them). Both the post-backup cron pruner and the manual Prune button now treat **all terminal dump pods** (Succeeded/Completed + Failed/Evicted) as prune candidates under the same keep-last / keep-days retention. In-progress dumps (Running/Pending) are still never touched.
+
 ## [12.18.3] - 2026-07-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.4] - 2026-07-09
+
 ### Fixed
 
 - **The backup dump-pod cleanup now also clears Evicted/Failed dump pods.** DST already auto-prunes the `*-dump-*` pods Funcom's database-backup jobs leave behind (Database page → Backup schedule "keep last N pods", plus the manual **Prune** button), but it only removed **Succeeded** ones — so dump pods that were **Evicted** (e.g. OOM-killed during a VM memory-pressure event) were left behind, piled up in the Pods view, and survived every battlegroup/VM restart (they live in the k3s datastore, not as live processes, so a reboot just reloads them). Both the post-backup cron pruner and the manual Prune button now treat **all terminal dump pods** (Succeeded/Completed + Failed/Evicted) as prune candidates under the same keep-last / keep-days retention. In-progress dumps (Running/Pending) are still never touched.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.3'
+$script:DuneToolVersion = '12.18.4'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.3',
+    [string]$Version = '12.18.4',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.3</Version>
+    <Version>12.18.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.3"
+#define MyAppVersion "12.18.4"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -62,7 +62,7 @@ $script:DuneBackupPodPruneKeepDaysDefault = 0
 # outpace the cron cadence (issue #363). One-line BusyBox-safe pipeline so
 # the whole backup command stays a single crontab entry:
 #   - kubectl jsonpath -> "ns|name|phase" per pod
-#   - awk filter to Succeeded dump-* pods
+#   - awk filter to terminal (Succeeded or Failed/Evicted) dump-* pods
 #   - sort by name (timestamp embedded, newest first), keep first N, delete rest
 # keepDays is intentionally NOT folded into the cron snippet — keeping the
 # crontab one-line + BusyBox-safe rules out the age math here. The cron tick
@@ -73,7 +73,7 @@ function New-DuneBackupPodPruneSnippet {
     if ($KeepLast -lt 0)   { $KeepLast = 0 }
     if ($KeepLast -gt 100) { $KeepLast = 100 }
     $skip = $KeepLast + 1
-    return "sudo kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.phase}{`"\n`"}{end}' 2>/dev/null | awk -F'|' '`$3==`"Succeeded`" && `$2 ~ /-dump-[0-9]{8}-[0-9]{6}-pod`$/' | sort -t'|' -k2 -r | tail -n +$skip | while IFS='|' read ns nm phase; do echo `"`$(date) dst: prune dump pod `$ns/`$nm`" >> /var/log/dune-backup.log; sudo kubectl delete pod -n `"`$ns`" `"`$nm`" --ignore-not-found >> /var/log/dune-backup.log 2>&1; done"
+    return "sudo kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.phase}{`"\n`"}{end}' 2>/dev/null | awk -F'|' '(`$3==`"Succeeded`" || `$3==`"Failed`") && `$2 ~ /-dump-[0-9]{8}-[0-9]{6}-pod`$/' | sort -t'|' -k2 -r | tail -n +$skip | while IFS='|' read ns nm phase; do echo `"`$(date) dst: prune dump pod `$ns/`$nm`" >> /var/log/dune-backup.log; sudo kubectl delete pod -n `"`$ns`" `"`$nm`" --ignore-not-found >> /var/log/dune-backup.log 2>&1; done"
 }
 
 # Build the full backup cron command for a given keepLast value.
@@ -709,8 +709,10 @@ function Remove-DuneBackupFiles {
 
 # -----------------------------------------------------------------------------
 # Public: list `*-dump-YYYYMMDD-HHMMSS-pod` pods left behind by Funcom's database-
-# backup jobs. They finish Succeeded but are never garbage-collected, so they
-# pile up over time (issue #363). Returned newest-first by the timestamp baked
+# backup jobs. They finish Succeeded (or Failed/Evicted when the node was low on
+# memory) but are never garbage-collected by k8s, so they pile up over time
+# (issue #363) — and survive restarts/reboots because they live in the k3s
+# datastore, not as live processes. Returned newest-first by the timestamp baked
 # into the pod name (kubectl creationTimestamp would work too, but the embedded
 # timestamp is naturally sortable as a string and survives clock drift).
 # -----------------------------------------------------------------------------
@@ -720,8 +722,8 @@ function Get-DuneBackupDumpPods {
     param([Parameter(Mandatory)][string]$Ip)
     # Stream namespace|name|startTime|phase|ownerKind|ownerName|controller via
     # jsonpath. Avoids needing jq on the VM. We filter by phase + name regex
-    # here so callers always get a canonical list (Completed/Succeeded dump-*
-    # pods only).
+    # here so callers always get a canonical list (terminal dump-* pods only:
+    # Completed/Succeeded plus Failed/Evicted).
     #
     # Owner reference info is included because "pod survives a force-delete"
     # means an owner controller is re-creating it with the same name — we
@@ -756,7 +758,13 @@ function Get-DuneBackupDumpPods {
         $ownerName = if ($parts.Count -gt 5) { [string]$parts[5] } else { '' }
         $ownerCtrl = if ($parts.Count -gt 6) { [string]$parts[6] } else { '' }
         if ($name -notmatch $script:DuneBackupDumpPodNameRegex) { continue }
-        if ($phase -ne 'Succeeded' -and $phase -ne 'Completed') { continue }
+        # Terminal dump-job pods only. "Succeeded"/"Completed" = the dump ran
+        # cleanly; "Failed" = the dump pod was Evicted or errored (e.g. OOM-killed
+        # during a VM memory-pressure event) — those are the leftovers that pile
+        # up worst and were previously left behind by this pruner. Running/Pending
+        # (an in-progress backup) are deliberately excluded so we never delete a
+        # live dump.
+        if ($phase -ne 'Succeeded' -and $phase -ne 'Completed' -and $phase -ne 'Failed') { continue }
 
         # Parse the timestamp baked into the name (authoritative — survives
         # status.startTime being cleared on terminal pods) and compute age.
@@ -800,7 +808,8 @@ function Get-DuneBackupDumpPodTimestamp {
 }
 
 # -----------------------------------------------------------------------------
-# Public: prune Succeeded/Completed dump-* pods. Two independent thresholds:
+# Public: prune terminal dump-* pods (Succeeded/Completed + Failed/Evicted).
+# Two independent thresholds:
 #   -KeepLast N   : keep at most the N most-recent pods (0 = no count cap)
 #   -KeepDays D   : also delete anything older than D days (0 = no age cap)
 # A pod survives only if it passes BOTH filters — exceeding either threshold

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.3"
+$script:ToolVersion = "12.18.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## What
The backup dump-pod cleanup now also removes **Evicted/Failed** `*-dump-*` pods, not just Succeeded ones.

## Why
DST already auto-prunes the dump pods Funcom's DB-backup jobs leave behind (Database page → keep-last N + manual Prune), but it filtered `Succeeded`/`Completed` only. Dump pods **Evicted** during a VM memory-pressure event (OOM, exit 137) were left behind, piled up in the Pods view, and survived every battlegroup/VM restart — they live in the k3s datastore, so a reboot just reloads them. (Surfaced by slowdesolation in #hosting-help.)

## How
- `New-DuneBackupPodPruneSnippet` (cron): awk filter `$3=="Succeeded"` → `($3=="Succeeded" || $3=="Failed")`.
- `Get-DuneBackupDumpPods` (list, drives the manual Prune): phase filter now also allows `Failed`.
- Both keep the `-dump-YYYYMMDD-HHMMSS-pod` name regex and exclude Running/Pending, so an in-progress dump is never deleted. Same keep-last / keep-days retention applies.

Parses clean; BOM preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)