### PR TITLE
Release v12.18.5: fix backup delete/prune false failure ("Argument types do not match") + clearer UX

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.4"
+      placeholder: "v12.18.5"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.5] - 2026-07-09
+
+### Fixed
+
+- **Backup delete and dump-pod Prune no longer report a false failure ("Argument types do not match").** On the Database page, deleting a backup file or clicking **Prune** would flash a red error — `Delete failed: Argument types do not match` / `Prune failed: …` — even though the file (or pods) had in fact been removed, which is why the item vanished on the next refresh but the error still appeared. The cause was a PowerShell quirk on the server: wrapping an internal result list with the array operator `@(…)` throws `Argument types do not match` for that particular collection type, and the throw happened *after* the delete/prune had already run on the VM — so the action succeeded but the response came back as an error. Both `Remove-DuneBackupFiles` and `Remove-DuneBackupDumpPods` now normalize their result lists safely, so a successful delete/prune reports success and a real failure reports the real reason. Added a regression test covering every return path.
+
+### Changed
+
+- **Clearer feedback when deleting backups or pruning dump pods.** A single-file delete now shows a spinner on that row's trash button while it runs (not just the bulk "Delete" button), and error messages from a delete or prune now stay pinned on screen with a dismiss (✕) button instead of auto-clearing after a few seconds — so a failure can't scroll past or vanish before you read it. Successful actions still self-dismiss.
+
 ## [12.18.4] - 2026-07-09
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.4'
+$script:DuneToolVersion = '12.18.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.4',
+    [string]$Version = '12.18.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.4</Version>
+    <Version>12.18.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.4"
+#define MyAppVersion "12.18.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -634,6 +634,13 @@ function Remove-DuneBackupFiles {
         [Parameter(Mandatory)][string]$Ip,
         [Parameter(Mandatory)][string[]]$Paths
     )
+    # NOTE: $failed is List[object] (holds @{path;reason} hashtables). Do NOT
+    # wrap a List[object] variable with @(...) — the array-subexpression operator
+    # throws `ArgumentException: Argument types do not match` on a bare
+    # List[object] (both Windows PowerShell 5.1 and PS7). `rm`/`kubectl delete`
+    # would already have run, so the caller sees a 502 while the file/pod was in
+    # fact deleted. Always normalize via .ToArray() before returning. Same rule
+    # applies to every List[object] in Remove-DuneBackupDumpPods below.
     $deleted = New-Object System.Collections.Generic.List[string]
     $failed  = New-Object System.Collections.Generic.List[object]
     $valid   = New-Object System.Collections.Generic.List[string]
@@ -657,7 +664,7 @@ function Remove-DuneBackupFiles {
     }
 
     if ($valid.Count -eq 0) {
-        return @{ ok = $false; status = 400; deleted = @(); failed = @($failed); message = 'No valid backup paths to delete.' }
+        return @{ ok = $false; status = 400; deleted = @(); failed = @($failed.ToArray()); message = 'No valid backup paths to delete.' }
     }
 
     # Build a shell script that removes each validated file + its sidecar and
@@ -675,7 +682,7 @@ function Remove-DuneBackupFiles {
     }
 
     if ($sb.Length -eq 0) {
-        return @{ ok = $false; status = 400; deleted = @(); failed = @($failed); message = 'No valid backup paths to delete.' }
+        return @{ ok = $false; status = 400; deleted = @(); failed = @($failed.ToArray()); message = 'No valid backup paths to delete.' }
     }
 
     $r = Invoke-DuneBackupShell -Ip $Ip -Script $sb.ToString() -TimeoutSec 60
@@ -704,7 +711,7 @@ function Remove-DuneBackupFiles {
     } else {
         "Delete failed for all $($failed.Count) file(s)."
     }
-    return @{ ok = $ok; deleted = @($deleted); failed = @($failed); message = $msg }
+    return @{ ok = $ok; deleted = @($deleted.ToArray()); failed = @($failed.ToArray()); message = $msg }
 }
 
 # -----------------------------------------------------------------------------
@@ -867,8 +874,8 @@ function Remove-DuneBackupDumpPods {
         return @{
             ok        = $true
             deleted   = @()
-            kept      = @($kept)
-            remaining = @($kept)
+            kept      = @($kept.ToArray())
+            remaining = @($kept.ToArray())
             message   = "Found $total dump pod(s); nothing to prune ($why)."
             output    = ''
         }
@@ -967,11 +974,11 @@ function Remove-DuneBackupDumpPods {
     }
     return @{
         ok              = $true
-        deleted         = @($actuallyDeleted)
-        attempted       = @($toDelete)
-        kept            = @($kept)
+        deleted         = @($actuallyDeleted.ToArray())
+        attempted       = @($toDelete.ToArray())
+        kept            = @($kept.ToArray())
         remaining       = @($remaining)
-        survivors       = @($stillPresent)
+        survivors       = @($stillPresent.ToArray())
         message         = $msg
         output          = ($firstPassOutput + "`n" + $forceOutput).Trim()
     }

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.4"
+$script:ToolVersion = "12.18.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/BackupReturnShape.Tests.ps1
+++ b/tests/BackupReturnShape.Tests.ps1
@@ -1,0 +1,113 @@
+# Regression test for the `@(<List[object]>)` footgun in BackupSchedule.ps1.
+#
+# Wrapping a bare System.Collections.Generic.List[object] variable with the
+# array-subexpression operator `@(...)` throws
+#   System.ArgumentException: Argument types do not match
+# on BOTH Windows PowerShell 5.1 and PS7 (a covariance quirk of the operator;
+# List[string] is unaffected). Remove-DuneBackupFiles and Remove-DuneBackupDumpPods
+# both build List[object] results and used to `@($that)` on return -- so the
+# rm / kubectl-delete would run on the VM and THEN the return threw, surfacing as
+# a 502 "Delete failed: Argument types do not match" / "Prune failed: ..." even
+# though the file/pod was actually gone (slowdesolation, 2026-07-09, on v12.18.4).
+# The fix normalizes every List[object] via .ToArray() before returning. These
+# tests drive the real functions with the SSH layer mocked and assert they never
+# throw and hand back well-formed arrays.
+
+BeforeAll {
+    # Import-DstLib promotes only single-file libs cleanly; BackupSchedule.ps1
+    # nested-dot-sources Db-Postgres.ps1 at load, which trips its promotion
+    # filter. Dot-source both directly into the BeforeAll scope instead — Pester
+    # v5 makes these visible to the It blocks below, and mocking works the same.
+    $repo = Split-Path $PSScriptRoot -Parent
+    . (Join-Path $repo 'app\lib\Db-Postgres.ps1')
+    . (Join-Path $repo 'app\server\lib\BackupSchedule.ps1')
+}
+
+Describe 'Remove-DuneBackupFiles return normalization' -Tag 'Pure' {
+
+    It 'does not throw on the all-invalid early return (empty failed list)' {
+        # /etc/passwd fails the "inside dump dir" gate -> nothing valid ->
+        # early 400 return that wraps the (populated) failed list.
+        { Remove-DuneBackupFiles -Ip '10.0.0.1' -Paths @('/etc/passwd') } | Should -Not -Throw
+        $r = Remove-DuneBackupFiles -Ip '10.0.0.1' -Paths @('/etc/passwd')
+        $r.ok        | Should -BeFalse
+        $r.status    | Should -Be 400
+        @($r.failed).Count | Should -Be 1
+    }
+
+    It 'does not throw and returns arrays on a fully successful delete (empty failed list)' {
+        Mock -CommandName Invoke-DuneBackupShell -MockWith {
+            @{ rc = 0; out = "__DEL_OK:/funcom/artifacts/database-dumps/x/a-20260101-000000.backup" }
+        }
+        $p = '/funcom/artifacts/database-dumps/x/a-20260101-000000.backup'
+        { Remove-DuneBackupFiles -Ip '10.0.0.1' -Paths @($p) } | Should -Not -Throw
+        $r = Remove-DuneBackupFiles -Ip '10.0.0.1' -Paths @($p)
+        $r.ok              | Should -BeTrue
+        @($r.deleted).Count | Should -Be 1
+        @($r.failed).Count  | Should -Be 0   # <-- the empty List[object] that used to throw
+    }
+
+    It 'does not throw on a partial failure (both lists populated)' {
+        Mock -CommandName Invoke-DuneBackupShell -MockWith {
+            @{ rc = 0; out = @(
+                '__DEL_OK:/funcom/artifacts/database-dumps/x/a-20260101-000000.backup',
+                '__DEL_FAIL:/funcom/artifacts/database-dumps/x/b-20260102-000000.backup|still present'
+            ) -join "`n" }
+        }
+        $paths = @(
+            '/funcom/artifacts/database-dumps/x/a-20260101-000000.backup',
+            '/funcom/artifacts/database-dumps/x/b-20260102-000000.backup'
+        )
+        { Remove-DuneBackupFiles -Ip '10.0.0.1' -Paths $paths } | Should -Not -Throw
+        $r = Remove-DuneBackupFiles -Ip '10.0.0.1' -Paths $paths
+        $r.ok               | Should -BeFalse
+        @($r.deleted).Count | Should -Be 1
+        @($r.failed).Count  | Should -Be 1
+    }
+}
+
+Describe 'Remove-DuneBackupDumpPods return normalization' -Tag 'Pure' {
+
+    It 'does not throw on nothing-to-prune (populated kept list)' {
+        Mock -CommandName Get-DuneBackupDumpPods -MockWith {
+            @(
+                [pscustomobject]@{ namespace='ns'; name='sh-x-dump-20260102-000000-pod'; phase='Succeeded' }
+                [pscustomobject]@{ namespace='ns'; name='sh-x-dump-20260101-000000-pod'; phase='Failed' }
+            )
+        }
+        { Remove-DuneBackupDumpPods -Ip '10.0.0.1' -KeepLast 5 -KeepDays 0 } | Should -Not -Throw
+        $r = Remove-DuneBackupDumpPods -Ip '10.0.0.1' -KeepLast 5 -KeepDays 0
+        $r.ok              | Should -BeTrue
+        @($r.deleted).Count | Should -Be 0
+        @($r.kept).Count    | Should -Be 2   # <-- populated List[object] that used to throw
+    }
+
+    It 'does not throw on an actual prune (populated deleted/attempted/kept lists)' {
+        # First read: 3 terminal dump pods. After the (mocked) delete succeeds,
+        # a re-read returns only the 1 we keep -> deleted=2, kept=1, no survivors.
+        $script:podReads = 0
+        Mock -CommandName Get-DuneBackupDumpPods -MockWith {
+            $script:podReads++
+            if ($script:podReads -eq 1) {
+                @(
+                    [pscustomobject]@{ namespace='ns'; name='sh-x-dump-20260103-000000-pod'; phase='Succeeded' }
+                    [pscustomobject]@{ namespace='ns'; name='sh-x-dump-20260102-000000-pod'; phase='Succeeded' }
+                    [pscustomobject]@{ namespace='ns'; name='sh-x-dump-20260101-000000-pod'; phase='Failed' }
+                )
+            } else {
+                @( [pscustomobject]@{ namespace='ns'; name='sh-x-dump-20260103-000000-pod'; phase='Succeeded' } )
+            }
+        }
+        Mock -CommandName Invoke-DuneBackupShell -MockWith {
+            @{ rc = 0; out = '__DST_POD_DEL__:0:ns/sh-x-dump-20260102-000000-pod:pod deleted' }
+        }
+        { Remove-DuneBackupDumpPods -Ip '10.0.0.1' -KeepLast 1 -KeepDays 0 } | Should -Not -Throw
+        $script:podReads = 0
+        $r = Remove-DuneBackupDumpPods -Ip '10.0.0.1' -KeepLast 1 -KeepDays 0
+        $r.ok                  | Should -BeTrue
+        @($r.deleted).Count    | Should -Be 2
+        @($r.kept).Count       | Should -Be 1
+        @($r.attempted).Count  | Should -Be 2
+        @($r.survivors).Count  | Should -Be 0
+    }
+}

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -76,7 +76,13 @@ export function Database() {
 
   const showToast = useCallback((kind: 'ok' | 'err', msg: string) => {
     setToast({ kind, msg })
-    window.setTimeout(() => setToast(t => (t?.msg === msg ? null : t)), 4000)
+    // Success messages self-dismiss; errors stay pinned until the user closes
+    // them (or the next action replaces them). A delete/prune failure that
+    // vanished after 4s while the list re-rendered was exactly the "errors
+    // don't bubble to the final state" complaint (slowdesolation, 2026-07-09).
+    if (kind === 'ok') {
+      window.setTimeout(() => setToast(t => (t?.msg === msg ? null : t)), 4000)
+    }
   }, [])
 
   async function runMaint(name: 'backup' | 'import') {
@@ -254,11 +260,19 @@ export function Database() {
       />
 
       {toast && (
-        <div className={`card p-3 mb-4 text-sm flex items-center gap-2 ${toast.kind === 'ok'
+        <div role="alert" className={`card p-3 mb-4 text-sm flex items-start gap-2 ${toast.kind === 'ok'
           ? 'border-success/40 bg-success/10 text-success'
           : 'border-danger/40 bg-danger/10 text-danger'}`}>
-          <Icon name={toast.kind === 'ok' ? 'CheckCircle2' : 'AlertCircle'} size={14} />
-          {toast.msg}
+          <Icon name={toast.kind === 'ok' ? 'CheckCircle2' : 'AlertCircle'} size={14} className="mt-0.5 shrink-0" />
+          <span className="flex-1 whitespace-pre-wrap break-words">{toast.msg}</span>
+          <button
+            type="button"
+            onClick={() => setToast(null)}
+            title="Dismiss"
+            className="shrink-0 opacity-70 hover:opacity-100"
+          >
+            <Icon name="X" size={14} />
+          </button>
         </div>
       )}
 
@@ -652,6 +666,9 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
   const [sortBy, setSortBy]     = useState<'date-desc' | 'date-asc' | 'size-desc' | 'size-asc' | 'name'>('date-desc')
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [deleting, setDeleting] = useState(false)
+  // Paths currently being deleted — drives the per-row spinner so a single-file
+  // delete shows visible progress on its own row (not just the header button).
+  const [deletingPaths, setDeletingPaths] = useState<Set<string>>(new Set())
 
   // Draft state — initialised from `schedule` when it loads, then locally
   // editable so the user can preview their choice before clicking Save.
@@ -823,6 +840,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
   async function runDelete(paths: string[]) {
     if (paths.length === 0) return
     setDeleting(true)
+    setDeletingPaths(new Set(paths))
     try {
       const r = await deleteBackups({ paths })
       const del = r.deleted?.length ?? 0
@@ -834,12 +852,16 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
         showToast('ok', r.message ?? `Deleted ${del} backup${del === 1 ? '' : 's'}.`)
       }
       setSelected(new Set())
-      void getBackupHistory({ recent: 200, logLines: 50 }).then(setHistory).catch(() => {})
     } catch (e) {
       showToast('err', `Delete failed: ${e instanceof Error ? e.message : String(e)}`)
     } finally {
       setDeleting(false)
+      setDeletingPaths(new Set())
     }
+    // Reload OUTSIDE the try/finally — awaiting a state-reload inside the handler
+    // chain doesn't flush the render in the DST WebView2 host; a top-level
+    // fire-and-forget does (mirrors handlePruneDumpPods + the Refresh button).
+    void loadAll()
   }
 
   function handleDeleteOne(path: string) {
@@ -1141,7 +1163,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
               title="Delete selected backups"
             >
               <Icon name={deleting ? 'Loader2' : 'Trash2'} size={12} className={deleting ? 'animate-spin' : ''} />
-              Delete{selected.size > 0 ? ` (${selected.size})` : ''}
+              {deleting ? 'Deleting…' : `Delete${selected.size > 0 ? ` (${selected.size})` : ''}`}
             </button>
           </div>
         )}
@@ -1200,9 +1222,9 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
                           onClick={() => handleDeleteOne(f.path)}
                           disabled={!!transferring || deleting}
                           className="text-danger hover:text-danger-bright disabled:opacity-40 shrink-0"
-                          title="Delete from server"
+                          title={deletingPaths.has(f.path) ? 'Deleting…' : 'Delete from server'}
                         >
-                          <Icon name="Trash2" size={12} />
+                          <Icon name={deletingPaths.has(f.path) ? 'Loader2' : 'Trash2'} size={12} className={deletingPaths.has(f.path) ? 'animate-spin' : ''} />
                         </button>
                       </div>
                     </td>


### PR DESCRIPTION
## What

Fixes a confirmed regression on **v12.18.4**: on the Database page, deleting a backup file or clicking **Prune** flashed a red error — `Delete failed: Argument types do not match` / `Prune failed: …` — even though the file/pods were actually removed (item vanished on the next refresh, but the error still showed).

### Root cause
`Remove-DuneBackupFiles` and `Remove-DuneBackupDumpPods` returned their result collections as `@($listObject)`. Wrapping a bare `System.Collections.Generic.List[object]` with the array-subexpression operator `@(…)` throws `System.ArgumentException: Argument types do not match` on **both** Windows PowerShell 5.1 and PS7 (a covariance quirk — `List[string]` is unaffected). The throw happens **after** the `rm` / `kubectl delete` has already run on the VM, so the action succeeds but the HTTP handler catches the exception and returns 502.

Reported by **slowdesolation**: single deletes vanished on reload yet still errored; Prune left the pods.

### Fix
- Normalize every `List[object]` return via `.ToArray()` before wrapping (`app/server/lib/BackupSchedule.ps1`).
- Blast-radius scan: no other server file uses the `@($localListObjectVar)` pattern — contained to these two functions.
- New `tests/BackupReturnShape.Tests.ps1` — 5 cases covering empty + populated return paths for both functions.

### UX (his 2nd report: "unclear if anything is happening; errors don't bubble to the final state")
- A single-file delete now spins **that row's** trash button (not just the bulk Delete button).
- Delete/prune **error** toasts now stay pinned with a dismiss (✕) button instead of auto-clearing after 4s; success toasts still self-dismiss.

## Verification
- Reproduced the throw against the dev VM, then confirmed delete + prune both return cleanly after the fix (dev VM `192.168.23.219`).
- `tests/Run-Tests.ps1`: **418/0**.
- `npm run build` (webui): clean.
- Installer built: `DuneServerSetup.exe` 46.09 MB, version preflight (12.18.5) passed.

Bumps the 5 version stamps + `bug_report.yml`, rolls CHANGELOG `[Unreleased]` → `[12.18.5]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
