### PR TITLE
Backup cleanup: sweep import pods too + fix delete-error UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Backup cleanup now also sweeps restore (`import`) pods, not just backup (`dump`) pods.** Funcom's restore jobs leave a terminal `*-import-*-pod` behind on every restore, and — like the backup `*-dump-*` pods — Kubernetes never garbage-collects them, so they accumulated on the Pods page forever with no way to clear them from DST. The Database page's "keep last N pods" retention and the manual **Prune** button now manage the **combined** set of backup and restore job pods, keeping the most recent N by timestamp (regardless of which kind) and clearing the older ones. Live DB, util/mon/pghero, file-browser pods, and the `.backup` files are never touched.
+
+### Fixed
+
+- **Backup delete errors no longer show a doubled "Delete failed:" prefix.** A failed backup delete could surface as `Delete failed: Delete failed: …` because both the server and the web UI added the label. The server now returns just the reason and the UI adds the single "Delete failed:" prefix.
+- **A transient SSH hiccup during a multi-file backup delete or dump-pod prune no longer reports a false failure.** If the SSH connection to the VM dropped mid-command (e.g. a brief collision with the background health check), the action could report `SSH to VM failed (no exit code returned)` even though a second click worked immediately. DST now automatically retries the command once before surfacing that error, so the momentary drop recovers on its own.
+
 ## [12.18.5] - 2026-07-09
 
 ### Fixed

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -73,7 +73,12 @@ function New-DuneBackupPodPruneSnippet {
     if ($KeepLast -lt 0)   { $KeepLast = 0 }
     if ($KeepLast -gt 100) { $KeepLast = 100 }
     $skip = $KeepLast + 1
-    return "sudo kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.phase}{`"\n`"}{end}' 2>/dev/null | awk -F'|' '(`$3==`"Succeeded`" || `$3==`"Failed`") && `$2 ~ /-dump-[0-9]{8}-[0-9]{6}-pod`$/' | sort -t'|' -k2 -r | tail -n +$skip | while IFS='|' read ns nm phase; do echo `"`$(date) dst: prune dump pod `$ns/`$nm`" >> /var/log/dune-backup.log; sudo kubectl delete pod -n `"`$ns`" `"`$nm`" --ignore-not-found >> /var/log/dune-backup.log 2>&1; done"
+    # Emit "<embedded-timestamp>|ns|name|phase" so we can sort the COMBINED
+    # dump+import pool by real time (the pod-name prefix differs — 'dump' vs
+    # 'import' — so a plain name sort would group by type, not chronology and
+    # keep-last would cut the wrong ones). Sort by the extracted key desc, drop
+    # it, then keep the newest N.
+    return "sudo kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.phase}{`"\n`"}{end}' 2>/dev/null | awk -F'|' '(`$3==`"Succeeded`" || `$3==`"Failed`") && `$2 ~ /-(dump|import)-[0-9]{8}-[0-9]{6}-pod`$/ { k=`$2; sub(/.*-(dump|import)-/,`"`",k); sub(/-pod`$/,`"`",k); print k`"|`"`$0 }' | sort -t'|' -k1 -r | cut -d'|' -f2- | tail -n +$skip | while IFS='|' read ns nm phase; do echo `"`$(date) dst: prune backup/restore pod `$ns/`$nm`" >> /var/log/dune-backup.log; sudo kubectl delete pod -n `"`$ns`" `"`$nm`" --ignore-not-found >> /var/log/dune-backup.log 2>&1; done"
 }
 
 # Build the full backup cron command for a given keepLast value.
@@ -175,14 +180,26 @@ function Invoke-DuneBackupShell {
     $wrapped = "( $clean`n)`n__dst_rc=`$?`nprintf '\n__DST_RC:%s\n' `"`$__dst_rc`""
     $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($wrapped))
     $cmd = "echo $b64 | base64 -d | sudo bash 2>&1"
-    $out = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec
-    $joined = if ($null -eq $out) { '' } else { ($out -join "`n") }
+    # A missing __DST_RC sentinel (rc stays -1) means the SSH channel dropped or
+    # timed out before the wrapped script finished — usually a transient hiccup
+    # (a cold connection, or a collision with the ~60s background health poller
+    # that also SSHes to the VM). slowdesolation hit exactly this on a multi-file
+    # delete that then succeeded on the very next click. Retry once before giving
+    # up so callers don't surface a false failure for an action that would work.
     $rc = -1
-    $body = $joined
-    $m = [regex]::Match($joined, '(?ms)\r?\n?__DST_RC:(\d+)\r?\n?\s*$')
-    if ($m.Success) {
-        $rc = [int]$m.Groups[1].Value
-        $body = $joined.Substring(0, $m.Index)
+    $body = ''
+    for ($attempt = 1; $attempt -le 2; $attempt++) {
+        $out = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec
+        $joined = if ($null -eq $out) { '' } else { ($out -join "`n") }
+        $body = $joined
+        $m = [regex]::Match($joined, '(?ms)\r?\n?__DST_RC:(\d+)\r?\n?\s*$')
+        if ($m.Success) {
+            $rc = [int]$m.Groups[1].Value
+            $body = $joined.Substring(0, $m.Index)
+            break
+        }
+        $rc = -1
+        if ($attempt -lt 2) { Start-Sleep -Milliseconds 750 }
     }
     return @{ rc = $rc; out = $body }
 }
@@ -723,7 +740,7 @@ function Remove-DuneBackupFiles {
 # into the pod name (kubectl creationTimestamp would work too, but the embedded
 # timestamp is naturally sortable as a string and survives clock drift).
 # -----------------------------------------------------------------------------
-$script:DuneBackupDumpPodNameRegex = '^[a-z0-9.-]+-dump-[0-9]{8}-[0-9]{6}-pod$'
+$script:DuneBackupDumpPodNameRegex = '^[a-z0-9.-]+-(dump|import)-[0-9]{8}-[0-9]{6}-pod$'
 
 function Get-DuneBackupDumpPods {
     param([Parameter(Mandatory)][string]$Ip)
@@ -790,10 +807,12 @@ function Get-DuneBackupDumpPods {
             ownerIsController  = ($ownerCtrl -eq 'true')
         }) | Out-Null
     }
-    # Sort by the embedded YYYYMMDD-HHMMSS in the name (newest first). Falls
-    # back to name lexically — which for our regex is equivalent because the
-    # suffix is fixed-width.
-    return @($out | Sort-Object name -Descending)
+    # Sort by the embedded YYYYMMDD-HHMMSS timestamp (newest first). The pool
+    # mixes 'dump' and 'import' pods whose name PREFIX differs, so a plain name
+    # sort would order by type before time — sort on the parsed timestamp so
+    # keep-last-N is chronological across both. Pods with an unparseable name
+    # (shouldn't happen — the regex guarantees the suffix) sort last.
+    return @($out | Sort-Object -Property @{ Expression = { $_.nameTimestamp }; Descending = $true })
 }
 
 # -----------------------------------------------------------------------------
@@ -805,7 +824,7 @@ function Get-DuneBackupDumpPods {
 function Get-DuneBackupDumpPodTimestamp {
     param([string]$Name)
     if (-not $Name) { return $null }
-    if ($Name -notmatch '-dump-([0-9]{8})-([0-9]{6})-pod$') { return $null }
+    if ($Name -notmatch '-(?:dump|import)-([0-9]{8})-([0-9]{6})-pod$') { return $null }
     $date = $Matches[1]; $time = $Matches[2]
     try {
         return [datetime]::ParseExact("$date$time", 'yyyyMMddHHmmss', [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal)
@@ -876,7 +895,7 @@ function Remove-DuneBackupDumpPods {
             deleted   = @()
             kept      = @($kept.ToArray())
             remaining = @($kept.ToArray())
-            message   = "Found $total dump pod(s); nothing to prune ($why)."
+            message   = "Found $total backup/restore pod(s); nothing to prune ($why)."
             output    = ''
         }
     }
@@ -903,7 +922,7 @@ function Remove-DuneBackupDumpPods {
             deleted   = @()
             kept      = @($pods)
             remaining = @($pods)
-            message   = "Found $total dump pod(s); $($kept.Count) retained, $($toDelete.Count) skipped after name validation."
+            message   = "Found $total backup/restore pod(s); $($kept.Count) retained, $($toDelete.Count) skipped after name validation."
             output    = ''
         }
     }
@@ -967,7 +986,7 @@ function Remove-DuneBackupDumpPods {
         else                                      { $actuallyDeleted.Add($p) | Out-Null }
     }
 
-    $msg = "Deleted $($actuallyDeleted.Count) of $($toDelete.Count) dump pod(s); $($kept.Count) kept."
+    $msg = "Deleted $($actuallyDeleted.Count) of $($toDelete.Count) backup/restore pod(s); $($kept.Count) kept."
     if ($stillPresent.Count -gt 0) {
         $names = ($stillPresent | ForEach-Object { $_.name }) -join ', '
         $msg += " $($stillPresent.Count) survived both delete passes (likely owner-recreated or RBAC-denied): $names. Check kubectl describe."

--- a/app/server/routes/BackupTransfer.ps1
+++ b/app/server/routes/BackupTransfer.ps1
@@ -227,6 +227,9 @@ Register-DuneRoute -Method POST -Path '/api/db/backup-delete' -Handler {
         }
         Write-DuneJson -Response $res -Body $result
     } catch {
-        Write-DuneError -Response $res -Status 502 -Message "Delete failed: $($_.Exception.Message)"
+        # Return the bare reason — the web UI prepends its own "Delete failed:"
+        # action label, so prefixing here produced "Delete failed: Delete failed:
+        # …" in the toast (slowdesolation, v12.18.5).
+        Write-DuneError -Response $res -Status 502 -Message "$($_.Exception.Message)"
     }
 }

--- a/tests/BackupReturnShape.Tests.ps1
+++ b/tests/BackupReturnShape.Tests.ps1
@@ -111,3 +111,76 @@ Describe 'Remove-DuneBackupDumpPods return normalization' -Tag 'Pure' {
         @($r.survivors).Count  | Should -Be 0
     }
 }
+
+# Import-pod cleanup: the pruner pool was extended from dump-only to the combined
+# dump+import set (slowdesolation, 2026-07-09 — Funcom's restore jobs leave
+# `*-import-*-pod` behind too and DST never swept them). Because the two prefixes
+# differ, the pool must sort by the embedded timestamp, not the pod name.
+Describe 'Import-pod name/timestamp recognition' -Tag 'Pure' {
+
+    It 'name regex matches both dump and import pods, rejects others' {
+        'sh-x-dump-20260709-194654-pod'   | Should -Match $script:DuneBackupDumpPodNameRegex
+        'sh-x-import-20260701-034845-pod' | Should -Match $script:DuneBackupDumpPodNameRegex
+        'sh-x-db-dbdepl-sts-0'            | Should -Not -Match $script:DuneBackupDumpPodNameRegex
+        'sh-x-sg-overmap-pod-2'          | Should -Not -Match $script:DuneBackupDumpPodNameRegex
+    }
+
+    It 'timestamp parser reads the embedded date from an import pod name' {
+        $ts = Get-DuneBackupDumpPodTimestamp -Name 'sh-x-import-20260704-080843-pod'
+        $ts | Should -Not -BeNullOrEmpty
+        $ts.ToUniversalTime().ToString('yyyyMMdd-HHmmss') | Should -Be '20260704-080843'
+    }
+}
+
+Describe 'Get-DuneBackupDumpPods combined pool' -Tag 'Pure' {
+
+    It 'includes import pods, excludes non-terminal/non-matching, sorts newest-first across types' {
+        Mock -CommandName Invoke-V6Ssh -MockWith {
+            @(
+                'ns|sh-x-import-20260701-034845-pod|2026-07-01T03:48:45Z|Succeeded|Job|j1|true'
+                'ns|sh-x-dump-20260709-194654-pod|2026-07-09T19:46:54Z|Succeeded|Job|j2|true'
+                'ns|sh-x-import-20260708-205439-pod|2026-07-08T20:54:39Z|Failed|Job|j3|true'
+                'ns|sh-x-dump-20260704-080843-pod|2026-07-04T08:08:43Z|Succeeded|Job|j4|true'
+                'ns|sh-x-dump-20260710-010101-pod||Running|Job|j5|true'   # live dump: excluded
+                'ns|sh-x-db-dbdepl-sts-0|2026-01-01T00:00:00Z|Running|StatefulSet|s|true'  # not a backup pod
+            )
+        }
+        $pods = Get-DuneBackupDumpPods -Ip '10.0.0.1'
+        @($pods).Count | Should -Be 4
+        # Newest-first by embedded timestamp, regardless of dump/import prefix.
+        @($pods)[0].name | Should -Be 'sh-x-dump-20260709-194654-pod'
+        @($pods)[1].name | Should -Be 'sh-x-import-20260708-205439-pod'
+        @($pods)[2].name | Should -Be 'sh-x-dump-20260704-080843-pod'
+        @($pods)[3].name | Should -Be 'sh-x-import-20260701-034845-pod'
+    }
+}
+
+# Transient SSH resilience: a missing __DST_RC sentinel (channel dropped before
+# the wrapper finished) now retries once before returning rc=-1, so a multi-file
+# delete that would have surfaced a false "SSH to VM failed" now recovers when
+# the retry succeeds (slowdesolation, v12.18.5).
+Describe 'Invoke-DuneBackupShell transient retry' -Tag 'Pure' {
+
+    It 'retries once and succeeds when the first SSH attempt drops the sentinel' {
+        $script:sshCalls = 0
+        Mock -CommandName Invoke-V6Ssh -MockWith {
+            $script:sshCalls++
+            if ($script:sshCalls -eq 1) { @('partial output, connection dropped') }
+            else { @('done', '__DST_RC:0') }
+        }
+        $r = Invoke-DuneBackupShell -Ip '10.0.0.1' -Script 'echo hi'
+        $script:sshCalls | Should -Be 2
+        $r.rc | Should -Be 0
+    }
+
+    It 'returns rc=-1 after two attempts when the sentinel never appears' {
+        $script:sshCalls2 = 0
+        Mock -CommandName Invoke-V6Ssh -MockWith {
+            $script:sshCalls2++
+            @('still no sentinel')
+        }
+        $r = Invoke-DuneBackupShell -Ip '10.0.0.1' -Script 'echo hi'
+        $script:sshCalls2 | Should -Be 2
+        $r.rc | Should -Be -1
+    }
+}

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -902,7 +902,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
             ? `Deleted ${delCount}; ${survCount} survived both passes: ${detail}`
             : `0 deleted; ${survCount} survived both passes: ${detail}`)
       } else {
-        showToast('ok', r.message ?? (delCount > 0 ? `Deleted ${delCount} dump pod(s).` : 'Nothing to prune.'))
+        showToast('ok', r.message ?? (delCount > 0 ? `Deleted ${delCount} backup/restore pod(s).` : 'Nothing to prune.'))
       }
     } catch (e) {
       showToast('err', `Prune failed: ${e instanceof Error ? e.message : String(e)}`)
@@ -941,7 +941,7 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
       const exceededCount = draftKeepDumpPods > 0 && idx >= draftKeepDumpPods
       let exceededAge = false
       if (ageCutoffMs !== null) {
-        const m = p.name.match(/-dump-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})-pod$/)
+        const m = p.name.match(/-(?:dump|import)-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})-pod$/)
         if (m) {
           const ts = Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6])
           if (ts < ageCutoffMs) exceededAge = true
@@ -1241,27 +1241,27 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
         )}
       </div>
 
-      {/* Completed backup pods — Funcom's database-backup job leaves a
-          `*-dump-YYYYMMDD-HHMMSS-pod` behind on every run. They terminate
-          Succeeded and are never garbage-collected, so they pile up on the
-          Pods page and in the VM's shell-pod picker. Retention is persisted
-          as part of the schedule (Save schedule above writes both); the
-          cron tick honors keepLast, the manual button honors both. The
-          .backup files on the PVC are handled by Keep last (count) above
-          (separate retention). */}
+      {/* Completed backup & restore pods — Funcom's database-backup and
+          restore jobs each leave a `*-dump-…-pod` / `*-import-…-pod` behind on
+          every run. They terminate Succeeded (or Failed after an OOM/eviction)
+          and are never garbage-collected, so they pile up on the Pods page and
+          in the VM's shell-pod picker. Retention is persisted as part of the
+          schedule (Save schedule above writes both); the cron tick honors
+          keepLast, the manual button honors both. The .backup files on the PVC
+          are handled by Keep last (count) above (separate retention). */}
       <div className="border-t border-border pt-3 mt-3">
         <div className="flex items-center justify-between gap-3 mb-2">
-          <div className="text-xs font-semibold text-text-muted">Completed backup pods</div>
+          <div className="text-xs font-semibold text-text-muted">Completed backup &amp; restore pods</div>
           <div className="text-xs text-text-dim">
             {dumpPods
-              ? <>Found <strong className="text-text">{dumpPods.count}</strong> Succeeded dump pod{dumpPods.count === 1 ? '' : 's'} on the cluster.</>
+              ? <>Found <strong className="text-text">{dumpPods.count}</strong> terminal backup/restore pod{dumpPods.count === 1 ? '' : 's'} on the cluster.</>
               : <span className="italic">{vmRunning ? 'Loading…' : 'VM not running.'}</span>}
           </div>
         </div>
         <p className="text-xs text-text-dim mb-2">
-          Funcom's <span className="font-mono">battlegroup backup</span> job creates a one-shot pod per run that finishes
+          Funcom's <span className="font-mono">battlegroup backup</span> and restore (<span className="font-mono">import</span>) jobs each create a one-shot pod per run that finishes
           Succeeded and is never cleaned up. The scheduled cleanup runs after every backup tick using <strong>Keep last (count)</strong> below;
-          the manual button honors both thresholds. Only terminal <span className="font-mono">*-dump-*-pod</span> objects are touched —
+          the manual button honors both thresholds. Only terminal <span className="font-mono">*-dump-*-pod</span> / <span className="font-mono">*-import-*-pod</span> objects are touched —
           live DB, util/mon/pghero, file-browser, and the <span className="font-mono">.backup</span> files are never affected.
         </p>
         <div className="flex flex-wrap items-end gap-3">


### PR DESCRIPTION
Surfaced by **slowdesolation** (#hosting-help) on v12.18.5. Three bundled fixes to the Database-page backup cleanup.

## 1. Import-pod cleanup (combined dump+import pool)
Funcom's restore jobs leave a terminal `*-import-*-pod` behind on every restore, and — like the backup `*-dump-*` pods — Kubernetes never garbage-collects them, so they piled up on the Pods page with **no way to clear them from DST** (the pruner was `-dump-`-only). The "keep last N pods" retention and the manual **Prune** button now manage the **combined** backup + restore job-pod set, keeping the most recent N **by embedded timestamp** (a name-prefix sort would group by type, `import` before `dump`, and cut the wrong ones). Live DB, util/mon/pghero, file-browser pods, and the `.backup` files are never touched.

- `BackupSchedule.ps1`: `DuneBackupDumpPodNameRegex`, `Get-DuneBackupDumpPodTimestamp`, and the cron-embedded awk now match `-(dump|import)-`; `Get-DuneBackupDumpPods` sorts the pool by embedded timestamp.
- `Database.tsx`: candidate regex matches import pods; user-facing labels → "backup & restore pods".

## 2. Doubled `Delete failed: Delete failed:` prefix
Both the server (`BackupTransfer.ps1`) and the UI (`Database.tsx`) prepended "Delete failed:". The server now returns the bare reason; the UI owns the single prefix.

## 3. Transient-SSH false failure on multi-delete
A dropped SSH channel mid-command (e.g. a brief collision with the ~60s health poller) surfaced `SSH to VM failed (no exit code returned)` even though the next click worked. `Invoke-DuneBackupShell` now retries once on a missing `__DST_RC` sentinel before surfacing the error.

## Verification
- PowerShell parse-check clean (`BackupSchedule.ps1`, `BackupTransfer.ps1`)
- **Pester 10/10** — 5 new: import name-regex/timestamp, combined-pool sort across dump+import, retry-succeeds and gives-up-after-2
- webui `npm run build` clean (tsc typecheck passes)
- CHANGELOG `[Unreleased]` rolled

No version bump — staged for the next batched release.