### PR TITLE
Backup delete: stream script over stdin to fix large select-all failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ here cover everything those tags shipped.
 
 - **Backup delete errors no longer show a doubled "Delete failed:" prefix.** A failed backup delete could surface as `Delete failed: Delete failed: …` because both the server and the web UI added the label. The server now returns just the reason and the UI adds the single "Delete failed:" prefix.
 - **A transient SSH hiccup during a multi-file backup delete or dump-pod prune no longer reports a false failure.** If the SSH connection to the VM dropped mid-command (e.g. a brief collision with the background health check), the action could report `SSH to VM failed (no exit code returned)` even though a second click worked immediately. DST now automatically retries the command once before surfacing that error, so the momentary drop recovers on its own.
+- **Deleting many backup files at once no longer fails on "select all".** A large multi-file delete used to fail (`SSH to VM failed (no exit code returned)`) while smaller batches went through, because the whole delete script was passed as one over-long SSH command-line argument that the VM rejected once the batch grew. DST now streams the script to the VM over stdin (so there's no length ceiling) and drops a redundant per-file privilege escalation, so a delete of any size completes in a single pass — including on memory-pressured VMs where the old approach could also time out.
 
 ## [12.18.5] - 2026-07-09
 

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -179,7 +179,15 @@ function Invoke-DuneBackupShell {
     $clean = $Script -replace "`r",''
     $wrapped = "( $clean`n)`n__dst_rc=`$?`nprintf '\n__DST_RC:%s\n' `"`$__dst_rc`""
     $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($wrapped))
-    $cmd = "echo $b64 | base64 -d | sudo bash 2>&1"
+    # Feed the base64 payload over ssh STDIN, not the command line. Embedding a
+    # large script as an ssh command-line argument hits a length ceiling — the
+    # remote rejects it with "Connection closed by remote host" once the batch
+    # grows (slowdesolation, v12.18.5: a multi-file delete failed on select-all
+    # but worked in batches up to ~8). Keeping the remote command tiny
+    # (`base64 -d | sudo bash`) and streaming the payload through stdin removes
+    # that ceiling entirely, so a delete/prune of any size runs in one round-trip.
+    $cmd = 'base64 -d | sudo bash 2>&1'
+    $stdin = $b64 + "`n"
     # A missing __DST_RC sentinel (rc stays -1) means the SSH channel dropped or
     # timed out before the wrapped script finished — usually a transient hiccup
     # (a cold connection, or a collision with the ~60s background health poller
@@ -189,7 +197,7 @@ function Invoke-DuneBackupShell {
     $rc = -1
     $body = ''
     for ($attempt = 1; $attempt -le 2; $attempt++) {
-        $out = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec
+        $out = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec -StdinData $stdin
         $joined = if ($null -eq $out) { '' } else { ($out -join "`n") }
         $body = $joined
         $m = [regex]::Match($joined, '(?ms)\r?\n?__DST_RC:(\d+)\r?\n?\s*$')
@@ -695,7 +703,12 @@ function Remove-DuneBackupFiles {
         $q = "'" + $path + "'"
         # Only report OK when the .backup itself is gone after rm. The .yaml
         # sidecar is best-effort (may not exist for manually-uploaded files).
-        [void]$sb.AppendLine("if sudo rm -f $q && sudo rm -f ${q}.yaml 2>/dev/null; then if [ ! -e $q ]; then echo `"__DEL_OK:$path`"; else echo `"__DEL_FAIL:$path|still present`"; fi; else echo `"__DEL_FAIL:$path|rm failed`"; fi")
+        # No inner `sudo`: the whole script already runs under `sudo bash` (root),
+        # so per-file `sudo` was a redundant fork per file — on a large select-all
+        # delete against a memory-pressured VM those extra forks add up and could
+        # push the batch past the SSH timeout. Plain `rm` under the root shell is
+        # equivalent and much cheaper.
+        [void]$sb.AppendLine("if rm -f $q && rm -f ${q}.yaml 2>/dev/null; then if [ ! -e $q ]; then echo `"__DEL_OK:$path`"; else echo `"__DEL_FAIL:$path|still present`"; fi; else echo `"__DEL_FAIL:$path|rm failed`"; fi")
     }
 
     if ($sb.Length -eq 0) {

--- a/tests/BackupReturnShape.Tests.ps1
+++ b/tests/BackupReturnShape.Tests.ps1
@@ -184,3 +184,34 @@ Describe 'Invoke-DuneBackupShell transient retry' -Tag 'Pure' {
         $r.rc | Should -Be -1
     }
 }
+
+# Batch-size ceiling fix: the script is streamed over ssh STDIN instead of being
+# embedded in the ssh command line, so a large multi-file delete no longer hits
+# the remote command-length limit that made select-all fail while batches of ~8
+# worked (slowdesolation, v12.18.5).
+Describe 'Invoke-DuneBackupShell payload delivery' -Tag 'Pure' {
+
+    It 'streams the script over stdin and keeps the remote command tiny' {
+        Mock -CommandName Invoke-V6Ssh -MockWith { @('ok', '__DST_RC:0') }
+        $r = Invoke-DuneBackupShell -Ip '10.0.0.1' -Script 'echo hi'
+        $r.rc | Should -Be 0
+        Should -Invoke Invoke-V6Ssh -Times 1 -Exactly -ParameterFilter {
+            $Cmd -eq 'base64 -d | sudo bash 2>&1' -and -not [string]::IsNullOrWhiteSpace($StdinData)
+        }
+    }
+}
+
+Describe 'Remove-DuneBackupFiles delete script' -Tag 'Pure' {
+
+    It 'uses plain rm (no redundant inner sudo — the outer shell is already root)' {
+        $script:capturedScript = $null
+        Mock -CommandName Invoke-DuneBackupShell -MockWith {
+            $script:capturedScript = $Script
+            @{ rc = 0; out = '__DEL_OK:/funcom/artifacts/database-dumps/x/a-20260101-000000.backup' }
+        }
+        $p = '/funcom/artifacts/database-dumps/x/a-20260101-000000.backup'
+        Remove-DuneBackupFiles -Ip '10.0.0.1' -Paths @($p) | Out-Null
+        $script:capturedScript | Should -Not -Match 'sudo rm'
+        $script:capturedScript | Should -Match 'rm -f'
+    }
+}


### PR DESCRIPTION
Follow-up to #493, surfaced by **slowdesolation** (#hosting-help) on v12.18.5: *"select-all delete fails, but batches up to ~8 worked."*

## Root cause
`Invoke-DuneBackupShell` embedded the entire delete script (base64) as **one SSH command-line argument**. Past a batch size the over-long argument was rejected by the remote (`Connection closed by remote host`) → no `__DST_RC` sentinel → the false `SSH to VM failed (no exit code returned)`. The script also ran every file's `rm` under a **nested `sudo`** (inside an already-root `sudo bash`), so a big select-all against a memory-pressured VM piled up forks and could also blow the 60s timeout — same `rc=-1` symptom.

## Fix
- **Stream the payload over ssh STDIN** and keep the remote command tiny (`base64 -d | sudo bash`). No command-line length ceiling — a delete/prune of any size runs in one round-trip. (`Invoke-V6Ssh` already supports `-StdinData` for exactly this; the helper's own comment documented the ceiling.)
- **Drop the redundant per-file `sudo`** in the file-delete script — the whole script already runs as root under `sudo bash`, so plain `rm` is equivalent and much cheaper.
- The one-shot retry from #493 stays as belt-and-suspenders for genuine transients.

## Verification
- **Live dev VM, end-to-end:** a 40-line payload runs fully and returns `rc=0` via the stdin path; `whoami` = `root` (confirms the outer shell is already privileged, so dropping inner `sudo` is safe).
- **Pester 12/12** — +2: stdin delivery (asserts tiny `-Cmd` + non-empty `-StdinData`), plain-`rm` delete script (no `sudo rm`).
- Parse-check clean.

No version bump — batched into `[Unreleased]` alongside #493.