### PR TITLE
Add gd.py to the Thanks for the Coffee supporter list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **New supporter in the "Thanks for the Coffee" menu.** Added gd.py (@gd.py).
+
 ## [12.18.6] - 2026-07-09
 
 ### Added

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -497,6 +497,10 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <Icon name="Heart" size={14} className="text-ibad shrink-0" />
               <span className="flex-1">Derkuli (@ichbinderkuli)</span>
             </div>
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">gd.py (@gd.py)</span>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Adds **gd.py (@gd.py)** to the "Thanks for the Coffee" supporter menu (`MenuBar.tsx`), appended after the last entry. CHANGELOG `[Unreleased]` noted.

webui build clean (tsc typecheck passes). Staged for the next release.