### PR TITLE
Fix: scheduled backups missing from Database history + never pruned

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.6"
+      placeholder: "v12.18.7"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.7] - 2026-07-09
+
 ### Fixed
 
 - **Scheduled backups now appear in the Database page history (and get pruned by retention).** DST's scheduled backups run `battlegroup backup "dst-scheduled-<utc-ts>"`, and Funcom writes that name verbatim — with **no `.backup` extension**. The history listing, the retention prune, and the download/delete validators all matched only a trailing `.backup`, so every scheduled backup was silently skipped: only the manual/Funcom-default `*.backup` snapshots showed, and the scheduled files were never aged out. All of those paths now also recognize the extension-less `dst-scheduled-<ts>` shape (existing scheduled backups appear immediately after updating — no rename needed; `.yaml` sidecars stay excluded). The Save-As default when downloading a scheduled backup now adds `.backup`. *Re-save your backup schedule once after updating so the widened retention prune takes effect on the VM crontab.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Scheduled backups now appear in the Database page history (and get pruned by retention).** DST's scheduled backups run `battlegroup backup "dst-scheduled-<utc-ts>"`, and Funcom writes that name verbatim — with **no `.backup` extension**. The history listing, the retention prune, and the download/delete validators all matched only a trailing `.backup`, so every scheduled backup was silently skipped: only the manual/Funcom-default `*.backup` snapshots showed, and the scheduled files were never aged out. All of those paths now also recognize the extension-less `dst-scheduled-<ts>` shape (existing scheduled backups appear immediately after updating — no rename needed; `.yaml` sidecars stay excluded). The Save-As default when downloading a scheduled backup now adds `.backup`. *Re-save your backup schedule once after updating so the widened retention prune takes effect on the VM crontab.*
+
 ### Added
 
 - **New supporter in the "Thanks for the Coffee" menu.** Added gd.py (@gd.py).

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.6'
+$script:DuneToolVersion = '12.18.7'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.6',
+    [string]$Version = '12.18.7',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.6</Version>
+    <Version>12.18.7</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.6"
+#define MyAppVersion "12.18.7"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -108,6 +108,24 @@ $script:DuneBackupBeginMarker = '# DST-BACKUP BEGIN'
 $script:DuneBackupEndMarker   = '# DST-BACKUP END'
 $script:DuneBackupDumpDir     = '/funcom/artifacts/database-dumps'
 
+# Scheduled backups are written by `battlegroup backup "dst-scheduled-<utc-ts>"`
+# (see New-DuneBackupCmd). Funcom writes that name VERBATIM, with NO trailing
+# `.backup` extension, so a scheduled snapshot lands on disk as e.g.
+# `dst-scheduled-20260710-050000`. Every path that keyed on a trailing
+# `.backup` — the history listing, the retention prune, and the download/delete
+# validators — therefore silently skipped every scheduled backup, so only
+# manual / Funcom-default `*.backup` files ever showed in the Database page.
+# These two shared matchers widen those paths to ALSO recognize the extension-
+# less scheduled name, without pulling in each backup's `.yaml` sidecar:
+#   * a find(1) -name glob for listing + pruning. The `dst-scheduled-` prefix is
+#     followed by a FIXED 8-digit date, a dash, and 6 digits of time; the
+#     `<name>.yaml` sidecar is longer than the glob so it can never match.
+#   * a PowerShell regex for path validation on download/delete. `$` anchors to
+#     the bare scheduled name so the `.yaml` sidecar (and a `.backup.yaml`
+#     sidecar) are both rejected.
+$script:DuneBackupScheduledFindGlob = 'dst-scheduled-????????-??????'
+$script:DuneBackupPathRegex         = '(?:\.backup|/dst-scheduled-[0-9]{8}-[0-9]{6})$'
+
 function Get-DuneBackupPresetNames {
     return @($script:DuneBackupPresets.Keys | Sort-Object)
 }
@@ -249,16 +267,20 @@ function New-DuneBackupBlock {
         #        /funcom/artifacts/database-dumps/<sh-hash-name>/<file>.backup,
         #        so we need `/*/` to descend one level into the per-battlegroup
         #        subdir. A shallow `$DumpDir/*.backup` matches nothing.
-        #   (ii) Each backup produces TWO files on disk: `<name>.backup` and
-        #        its `<name>.backup.yaml` sidecar. We match only `.backup` for
-        #        counting so keep-last=N means N real backups (not N/2), and
-        #        delete the `.yaml` sidecar alongside each pruned entry.
-        #   (iii)The `-YYYYMMDD-HHMMSS.backup` shape gate preserves manually
-        #        named snapshots like 'pre-patch-1_4_10_1.backup' -- they
-        #        never match this pattern, so we can't prune them by accident.
-        $namePat = '*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].backup'
+        #   (ii) Each backup produces TWO files on disk: the dump itself and its
+        #        `<name>.yaml` sidecar. We count only the dump (never the
+        #        `*.yaml`) so keep-last=N means N real backups (not N/2), and
+        #        delete the matching `.yaml` sidecar alongside each pruned entry.
+        #   (iii)Two dump shapes are pruned: Funcom/manual `-YYYYMMDD-HHMMSS.backup`
+        #        files AND DST's own extension-less `dst-scheduled-<ts>` files
+        #        (Funcom writes the scheduled name verbatim, no `.backup`). Both
+        #        globs are fixed-shape, so a `.yaml` sidecar (longer) can't match
+        #        and manually named snapshots like 'pre-patch-1_4_10_1.backup'
+        #        (no timestamp tail) are never pruned by accident.
+        $namePat  = '*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].backup'
+        $schedPat = $script:DuneBackupScheduledFindGlob
         $skip = $KeepLast + 1
-        $find = "ls -t $script:DuneBackupDumpDir/*/$namePat 2>/dev/null | tail -n +$skip | while IFS= read -r f; do rm -f `"`$f`" `"`$f.yaml`"; done"
+        $find = "ls -t $script:DuneBackupDumpDir/*/$namePat $script:DuneBackupDumpDir/*/$schedPat 2>/dev/null | tail -n +$skip | while IFS= read -r f; do rm -f `"`$f`" `"`$f.yaml`"; done"
         $lines += "15 5 * * * $find"
     }
     $lines += $script:DuneBackupEndMarker
@@ -582,9 +604,9 @@ function Get-DuneBackupHistory {
     # emit the true total so the UI can show "showing N of M".
     $script = @"
 echo '__DST_SECTION:COUNT'
-sudo find $script:DuneBackupDumpDir -maxdepth 3 -type f -name '*.backup' 2>/dev/null | wc -l
+sudo find $script:DuneBackupDumpDir -maxdepth 3 -type f \( -name '*.backup' -o -name '$script:DuneBackupScheduledFindGlob' \) 2>/dev/null | wc -l
 echo '__DST_SECTION:FILES'
-sudo find $script:DuneBackupDumpDir -maxdepth 3 -type f -name '*.backup' 2>/dev/null \
+sudo find $script:DuneBackupDumpDir -maxdepth 3 -type f \( -name '*.backup' -o -name '$script:DuneBackupScheduledFindGlob' \) 2>/dev/null \
   | head -5000 \
   | xargs -r -I{} sudo stat -c '%Y|%s|%n' '{}' 2>/dev/null \
   | sort -rn \
@@ -682,8 +704,8 @@ function Remove-DuneBackupFiles {
         if ($path -notlike "$root/*") {
             $failed.Add(@{ path = $path; reason = "Path must be inside $root." }); continue
         }
-        if ($path -notmatch '\.backup$') {
-            $failed.Add(@{ path = $path; reason = 'Path must end in .backup.' }); continue
+        if ($path -notmatch $script:DuneBackupPathRegex) {
+            $failed.Add(@{ path = $path; reason = 'Path must be a .backup file or a dst-scheduled-<ts> backup.' }); continue
         }
         $valid.Add($path) | Out-Null
     }

--- a/app/server/routes/BackupTransfer.ps1
+++ b/app/server/routes/BackupTransfer.ps1
@@ -33,9 +33,12 @@ Register-DuneRoute -Method POST -Path '/api/db/backup-download' -Handler {
         Write-DuneError -Response $res -Status 400 -Message 'Body must include vmPath and localPath.'
         return
     }
-    # Validate the VM path looks like a backup file (safety)
-    if ($vmPath -notmatch '\.backup$') {
-        Write-DuneError -Response $res -Status 400 -Message 'vmPath must end in .backup'
+    # Validate the VM path looks like a backup file (safety). Accept both a
+    # trailing `.backup` (manual / Funcom-default / uploaded) and DST's own
+    # extension-less `dst-scheduled-<ts>` scheduled backups — see the shared
+    # matcher in BackupSchedule.ps1.
+    if ($vmPath -notmatch $script:DuneBackupPathRegex) {
+        Write-DuneError -Response $res -Status 400 -Message 'vmPath must be a .backup file or a dst-scheduled-<ts> backup.'
         return
     }
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.6"
+$script:ToolVersion = "12.18.7"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/BackupReturnShape.Tests.ps1
+++ b/tests/BackupReturnShape.Tests.ps1
@@ -215,3 +215,48 @@ Describe 'Remove-DuneBackupFiles delete script' -Tag 'Pure' {
         $script:capturedScript | Should -Match 'rm -f'
     }
 }
+
+# Scheduled backups land as `dst-scheduled-<utc-ts>` with NO `.backup` extension
+# (Funcom writes the name verbatim), so the history listing, retention prune, and
+# download/delete validators — all of which keyed on a trailing `.backup` — used
+# to skip every scheduled backup. Only the manual one showed (Coastal, 2026-07-10:
+# "all my db backups dont appear to be showing"). These tests lock in the widened
+# matchers so both file shapes are first-class while `.yaml` sidecars stay excluded.
+Describe 'Scheduled backup (extension-less) recognition' -Tag 'Pure' {
+
+    It 'path regex accepts both .backup and dst-scheduled-<ts>, rejects sidecars/others' {
+        '/funcom/artifacts/database-dumps/x/sh-x-20260709-193817.backup' | Should -Match $script:DuneBackupPathRegex
+        '/funcom/artifacts/database-dumps/x/dst-scheduled-20260710-050000' | Should -Match $script:DuneBackupPathRegex
+        # sidecars and non-backups must NOT validate
+        '/funcom/artifacts/database-dumps/x/dst-scheduled-20260710-050000.yaml' | Should -Not -Match $script:DuneBackupPathRegex
+        '/funcom/artifacts/database-dumps/x/sh-x-20260709-193817.backup.yaml'   | Should -Not -Match $script:DuneBackupPathRegex
+        '/etc/passwd' | Should -Not -Match $script:DuneBackupPathRegex
+    }
+
+    It 'Remove-DuneBackupFiles now accepts an extension-less dst-scheduled path' {
+        Mock -CommandName Invoke-DuneBackupShell -MockWith {
+            @{ rc = 0; out = '__DEL_OK:/funcom/artifacts/database-dumps/x/dst-scheduled-20260710-050000' }
+        }
+        $p = '/funcom/artifacts/database-dumps/x/dst-scheduled-20260710-050000'
+        $r = Remove-DuneBackupFiles -Ip '10.0.0.1' -Paths @($p)
+        $r.ok               | Should -BeTrue
+        @($r.deleted).Count | Should -Be 1
+        @($r.failed).Count  | Should -Be 0   # not rejected by the extension gate
+    }
+
+    It 'Get-DuneBackupHistory find matches both .backup and the scheduled glob' {
+        $script:capturedHistScript = $null
+        Mock -CommandName Invoke-DuneBackupShell -MockWith {
+            $script:capturedHistScript = $Script
+            @{ rc = 0; out = "__DST_SECTION:COUNT`n0`n__DST_SECTION:FILES`n__DST_SECTION:LOG`n__DST_SECTION:DISK`n0" }
+        }
+        Get-DuneBackupHistory -Ip '10.0.0.1' | Out-Null
+        $script:capturedHistScript | Should -Match "-name '\*\.backup' -o -name 'dst-scheduled-\?{8}-\?{6}'"
+    }
+
+    It 'retention prune globs BOTH the .backup timestamp shape and the scheduled shape' {
+        $block = New-DuneBackupBlock -Preset 'Hourly' -KeepLast 10
+        $block | Should -Match 'dst-scheduled-\?{8}-\?{6}'                                   # scheduled files pruned
+        $block | Should -Match '\*-\[0-9\]\[0-9\]\[0-9\]\[0-9\]\[0-9\]\[0-9\]\[0-9\]\[0-9\]' # .backup timestamp files still pruned
+    }
+}

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -751,7 +751,11 @@ function BackupScheduleCard({ vmRunning, showToast }: BackupScheduleCardProps) {
   }
 
   async function handleDownload(vmPath: string) {
-    const fileName = vmPath.split('/').pop() ?? 'backup.backup'
+    const baseName = vmPath.split('/').pop() ?? 'backup.backup'
+    // Scheduled backups land on the VM without a `.backup` extension
+    // (dst-scheduled-<ts>); give the Save-As dialog a `.backup` default so the
+    // downloaded copy is named like every other backup on the user's PC.
+    const fileName = baseName.includes('.') ? baseName : `${baseName}.backup`
     const localPath = await pickFileFromShell('pick-save-file', { id: 'backup-download', defaultName: fileName })
     if (!localPath) return  // cancelled
     setTransferring(vmPath)


### PR DESCRIPTION
## Problem

On the Database page, **only manually-taken backups showed** — every scheduled backup was missing from the "All backups" history, even though the files are on disk and restorable (the Commands-page restore picker lists them fine).

## Root cause

The scheduled cron runs `battlegroup backup "dst-scheduled-<utc-ts>"` (`BackupSchedule.ps1` `New-DuneBackupCmd`). Funcom writes that name **verbatim, with no `.backup` extension** → files land as `dst-scheduled-20260710-050000`. Four code paths keyed on a trailing `.backup` and silently skipped them:

1. `Get-DuneBackupHistory` — `find … -name '*.backup'` (COUNT + FILES) → history showed "1 of 1".
2. `New-DuneBackupBlock` retention prune glob (`*-<ts>.backup`) → scheduled files **never aged out**.
3. `Remove-DuneBackupFiles` path validation (`\.backup$`) → delete would reject them.
4. `backup-download` route validation (`\.backup$`) → download would reject them.

## Fix

Two shared matchers in `BackupSchedule.ps1` (script-scoped, reused by the `BackupTransfer.ps1` route via the shared scope):

- `$script:DuneBackupScheduledFindGlob = 'dst-scheduled-????????-??????'` — fixed 8-4-6 shape for `find`/`ls` listing + pruning. A `.yaml` sidecar is longer, so it can't match.
- `$script:DuneBackupPathRegex = '(?:\.backup|/dst-scheduled-[0-9]{8}-[0-9]{6})$'` — path validation on download/delete; anchored so `.yaml` / `.backup.yaml` sidecars are rejected.

All four paths widened to accept **both** shapes. Existing scheduled backups appear immediately after updating — **no rename or VM surgery needed**. The download Save-As default now appends `.backup` for extension-less files.

⚠️ **After updating, re-save your backup schedule once** — the widened retention prune only rewrites the VM crontab on the next "Save schedule".

## Tests

`tests/BackupReturnShape.Tests.ps1` **16/0** (+4): path regex accept/reject (incl. sidecars), `Remove-DuneBackupFiles` accepts an extension-less scheduled path, `Get-DuneBackupHistory` find + retention prune both widened. webui builds clean (tsc); installer rebuilt → `app/installer/output/DuneServerSetup.exe` (46.09 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
