### PR TITLE
v12.18.8 — Public IP Apply: skip mq-game DNAT install when endpoint is `<none>`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.7"
+      placeholder: "v12.18.8"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.8] - 2026-07-10
+
+### Fixed
+
+- **Public IP / DDNS Apply no longer fails at the "Update VM network, settings.conf, K3s, NAT" step when the battlegroup is stopped.** The NAT sub-step queried the current `mq-game` service endpoint to install the RabbitMQ DNAT rule (`public:31982/tcp -> mq-game pod:5672`). When the battlegroup is stopped (or the MQ pod isn't Ready yet), `kubectl get endpoints` returns the literal string `<none>`, which was passed through the non-empty check and fed straight to `iptables` — producing `iptables v1.8.11 (nf_tables): Bad IP address "<none>"` and failing the whole Apply. The immediate rule install now skips gracefully in that case (logging a defer message) and the per-minute `dune-dnat-watch` cron installs the rule as soon as the MQ pod becomes Ready. The `/etc/local.d/dune-iptables.start` boot script that DST writes as part of the same step got the same `<none>` guard on its RabbitMQ DNAT install. No behaviour change on a running battlegroup — this only fixes the crash path when Apply is run while the BG is stopped.
+
 ## [12.18.7] - 2026-07-09
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.7'
+$script:DuneToolVersion = '12.18.8'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.7',
+    [string]$Version = '12.18.8',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.7</Version>
+    <Version>12.18.8</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.7"
+#define MyAppVersion "12.18.8"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -861,8 +861,10 @@ log() { echo "[$(ts)] boot: $*" >> "$LOG" 2>/dev/null; }
 sleep 30
 
 # RabbitMQ login: public:31982/tcp -> mq-game pod:5672 (idempotent).
+# kubectl prints the literal string "<none>" (not empty) when the service has no
+# endpoint yet -- that string must NOT be fed to iptables ("Bad IP address").
 POD_IP=$(k3s kubectl get endpoints --all-namespaces -o wide 2>/dev/null | grep mq-game | awk '{print $3}' | cut -d, -f1 | cut -d: -f1 | head -1)
-if [ -n "$POD_IP" ]; then
+if [ -n "$POD_IP" ] && [ "$POD_IP" != "<none>" ]; then
     iptables -t nat -C PREROUTING -d "$NEW_IP" -p tcp --dport "$RABBIT_PORT" -j DNAT --to-destination "${POD_IP}:5672" 2>/dev/null || \
       iptables -t nat -I PREROUTING 1 -d "$NEW_IP" -p tcp --dport "$RABBIT_PORT" -j DNAT --to-destination "${POD_IP}:5672"
 fi
@@ -900,8 +902,17 @@ DUNEBOOT
 sudo install -m 0755 /tmp/dune-iptables.start /etc/local.d/dune-iptables.start
 rm -f /tmp/dune-iptables.start
 sh -n /etc/local.d/dune-iptables.start
+# mq-game endpoint may be the literal string "<none>" when the BG is Stopped /
+# the pod hasn't come up yet -- skip the immediate install in that case, the
+# per-minute dune-dnat-watch cron installs it once the pod is Ready. Feeding
+# "<none>" to iptables errors "Bad IP address" and fails the whole Apply step.
 MQ_IP=$(sudo kubectl get endpoints --all-namespaces -o wide 2>/dev/null | grep mq-game | awk '{print $3}' | cut -d, -f1 | cut -d: -f1 | head -1)
-if [ -n "$MQ_IP" ]; then sudo iptables -t nat -C PREROUTING -d "$NEW_IP" -p tcp --dport 31982 -j DNAT --to-destination "${MQ_IP}:5672" 2>/dev/null || sudo iptables -t nat -I PREROUTING 1 -d "$NEW_IP" -p tcp --dport 31982 -j DNAT --to-destination "${MQ_IP}:5672"; fi
+if [ -n "$MQ_IP" ] && [ "$MQ_IP" != "<none>" ]; then
+  sudo iptables -t nat -C PREROUTING -d "$NEW_IP" -p tcp --dport 31982 -j DNAT --to-destination "${MQ_IP}:5672" 2>/dev/null || \
+    sudo iptables -t nat -I PREROUTING 1 -d "$NEW_IP" -p tcp --dport 31982 -j DNAT --to-destination "${MQ_IP}:5672"
+else
+  echo "mq-game endpoint not ready (got '${MQ_IP:-<empty>}'); rabbitmq DNAT deferred to dune-dnat-watch cron"
+fi
 # Game-UDP bridge (bind-detected; mirrors /etc/local.d/dune-iptables.start &
 # dune-dnat-watch.sh). Install <VM_IP>:7777-7810/udp -> NEW_IP ONLY when the game
 # binds the PUBLIC IP and NOT the LAN IP/wildcard, so a same-LAN / self join is

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.7"
+$script:ToolVersion = "12.18.8"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Bug

Public IP / DDNS **Apply** fails at the *"Update VM network, settings.conf, K3s, NAT"* step whenever the battlegroup is stopped (or the `mq-game` pod isn't Ready yet):

```
iptables v1.8.11 (nf_tables): Bad IP address "<none>"
```

## Root cause

The NAT sub-step queries the current `mq-game` service endpoint to install the RabbitMQ DNAT rule (`public:31982/tcp -> mq-game pod:5672`). When there's no ready endpoint, `kubectl get endpoints` prints the literal string `<none>` — not empty. The existing `[ -n "$MQ_IP" ]` guard passed that string through, and it went straight into an `iptables -t nat -A ... --to-destination <none>:5672` call, crashing the whole Apply.

Same trap existed in two places:

1. **Immediate rule install** (`app/server/lib/PublicIp.ps1` L903-908)
2. **Boot script** written to `/etc/local.d/dune-iptables.start` (L864)

The per-minute `dune-dnat-watch` cron (in `app/resources/remote-scripts/dune-dnat-watch-install.sh`) already guarded correctly with `is_ipv4` — that's the reference pattern.

## Fix

Both installs now check for the literal `<none>` in addition to the non-empty check, and log a defer message when skipping:

```sh
if [ -n "$MQ_IP" ] && [ "$MQ_IP" != "<none>" ]; then
    iptables -t nat -A ...
else
    echo "[dune-iptables] mq-game endpoint not ready (skipping — cron will install)"
fi
```

The per-minute `dune-dnat-watch` cron installs the rule automatically as soon as the MQ pod becomes Ready. No behaviour change on a running battlegroup — this only fixes the crash path when Apply is run while the BG is stopped.

## Verification

Bug reproduced live on UAT (`.219`) with BG stopped — Apply failed with exact `iptables: Bad IP address "<none>"` error at the NAT step. Fixed script is on-disk; installer with the fix is queued.

## Release checklist

- [x] Version bumped in all 5 stamp files (12.18.7 → 12.18.8)
- [x] `CHANGELOG.md` `[12.18.8]` entry describing the fix
- [x] `.github/ISSUE_TEMPLATE/bug_report.yml` `tool_version` placeholder bumped
- [x] Stale `[Unreleased]` gd.py line cleared (duplicate — already shipped in 12.18.7)
- [ ] Installer built + attached to release as sole asset (post-merge)
- [ ] Silent `v12.18.8-test1` mirror + Discord announce (post-merge)