### PR TITLE
Default "Allow overflow" to ON for all player inventory give surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ here cover everything those tags shipped.
 
 ## [12.18.8] - 2026-07-10
 
+### Changed
+
+- **"Allow overflow" is now on by default on every player inventory give surface** — Give Item, Give Package, and Vehicle Kit. Overflow means the game drops any items that don't fit onto the ground next to the player instead of DST refusing the give when the inventory is full, so gives now succeed by default even when the recipient is at cap. This matches the server-side default (and the mobile app's behaviour) and stops "capacity exceeded" errors when the recipient hasn't cleared inventory. Uncheck the box on any of the three forms to opt back into the strict "must have room" behaviour for that give.
+
 ### Fixed
 
 - **Public IP / DDNS Apply no longer fails at the "Update VM network, settings.conf, K3s, NAT" step when the battlegroup is stopped.** The NAT sub-step queried the current `mq-game` service endpoint to install the RabbitMQ DNAT rule (`public:31982/tcp -> mq-game pod:5672`). When the battlegroup is stopped (or the MQ pod isn't Ready yet), `kubectl get endpoints` returns the literal string `<none>`, which was passed through the non-empty check and fed straight to `iptables` — producing `iptables v1.8.11 (nf_tables): Bad IP address "<none>"` and failing the whole Apply. The immediate rule install now skips gracefully in that case (logging a defer message) and the per-minute `dune-dnat-watch` cron installs the rule as soon as the MQ pod becomes Ready. The `/etc/local.d/dune-iptables.start` boot script that DST writes as part of the same step got the same `<none>` guard on its RabbitMQ DNAT install. No behaviour change on a running battlegroup — this only fixes the crash path when Apply is run while the BG is stopped.

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -579,7 +579,7 @@ export function giveSolari(controllerId: number, amount: number) {
   })
 }
 
-export function giveItem(pawnId: number, template: string, qty: number, quality: number, allowOverflow = false) {
+export function giveItem(pawnId: number, template: string, qty: number, quality: number, allowOverflow = true) {
   return api<WriteResult>('/api/gameplay/players/give-item', {
     method: 'POST', body: JSON.stringify({ pawn_id: pawnId, template, qty, quality, allow_overflow: allowOverflow }),
   })
@@ -1656,7 +1656,7 @@ export function getProgressionPresets() {
 // ---------------------------------------------------------------------------
 
 export interface GiveItemEntry { template: string; qty: number; quality?: number }
-export function giveItems(pawnId: number, items: GiveItemEntry[], allowOverflow = false) {
+export function giveItems(pawnId: number, items: GiveItemEntry[], allowOverflow = true) {
   return api<WriteResult>('/api/gameplay/players/give-items', {
     method: 'POST', body: JSON.stringify({ pawn_id: pawnId, items, allow_overflow: allowOverflow }),
   })

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -1393,7 +1393,7 @@ function GiveItemForm({ busy, submitLabel, onSubmit, onSubmitTierSet }: {
   const [giveQty, setGiveQty]   = useState('1')
   const [giveQual, setGiveQual] = useState('0')
   const [gradeable, setGradeable] = useState(false)
-  const [overflow, setOverflow] = useState(false)
+  const [overflow, setOverflow] = useState(true)
   return (
     <div className="space-y-3">
       <ItemPicker label="Item — type to search by name or template id"
@@ -1475,7 +1475,7 @@ export function GivePackageForm({ busy, playerName, targetLabel, showOverflow = 
   const [draftName, setDraftName] = useState('')
   const [draftRows, setDraftRows] = useState<PkgDraftRow[]>([])
   const [importText, setImportText] = useState('')
-  const [overflow, setOverflow] = useState(false)
+  const [overflow, setOverflow] = useState(true)
   const [saving, setSaving]     = useState(false)
 
   const load = useCallback(async (preferId?: string) => {
@@ -1742,7 +1742,7 @@ function VehicleKitForm({ busy, onSubmit }: {
   const [catErr, setCatErr] = useState(false)
   const [vid, setVid] = useState('')
   const [names, setNames] = useState<Record<string, string>>({})
-  const [overflow, setOverflow] = useState(false)
+  const [overflow, setOverflow] = useState(true)
   const selectCls = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50'
 
   // Fetch the shared vehicle-kit catalog once (single source of truth, served by


### PR DESCRIPTION
## Change

Default the **Allow overflow (drop to ground)** checkbox to **ON** across every player inventory give surface:

- **Give Item** (single item)
- **Give Package** (bulk items from a saved package)
- **Vehicle Kit** (all parts for a vehicle)

## Why

The server side (`GameplayPlayers.ps1` L131-133, `PlayersRmq.ps1` L90-93, `PlayersWrites.ps1` L17-19) has always defaulted `allow_overflow=$true` when the flag was omitted, and the mobile app (`mobile/app/index.tsx` L371, L415) sends `true` unconditionally. Only the desktop webui defaulted the checkbox to unchecked, which meant gives went down the strict capacity-guard path: DST refused the give when the recipient's inventory couldn't hold everything, instead of letting the game drop overflow onto the ground next to the player. Users had to remember to tick the box every time.

Flipping the three UI defaults to `true` aligns the desktop webui with the rest of the surface area, so gives just work by default even at cap. Users can still uncheck the box on any form to opt back into strict mode.

## Files

- `webui/src/pages/gameplay/players/sections.tsx` — 3× `useState(false)` → `useState(true)` in `GiveItemForm` (L1396), `GivePackageForm` (L1478), `VehicleKitForm` (L1745)
- `webui/src/api/gameplay.ts` — `giveItem` (L582) + `giveItems` (L1659) `allowOverflow` default `false` → `true` (defensive; matches server default)
- `CHANGELOG.md` — added Changed entry under `[12.18.8]`

## Verified

- `npm run build` in `webui/` passes (typecheck clean, 1859 modules transformed).
- Existing test `webui/tests/api/gameplay.test.ts` L100-102 passes an explicit `true` — unaffected by the default flip.

Rolling this into v12.18.8 (merge → rebuild installer → re-tag test1 → publish public).