### PR TITLE
Inline backup file-retention prune into every scheduled backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- **Backup file-retention prune now fires on every scheduled backup**, not on a separate daily line. Previously the crontab wrote the per-preset backup line PLUS a hard-coded `15 5 * * *` file-retention line, so an "Every hour" preset could accumulate up to 24 dump files before the daily sweep ran once — and if the VM was down at 05:15 UTC, the sweep was skipped entirely and files piled up until the next successful daily tick. The prune is now inline in each backup command, so "backup every hour" also prunes to keep-last-N every hour. `Keep last = 0` (keep forever) still emits no prune. No schedule change is required — but the new shape only lands when you next Save the schedule on the Database card, because DST only rewrites the DST-BACKUP crontab block on Save.
+
 ## [12.18.8] - 2026-07-10
 
 ### Changed

--- a/app/server/lib/BackupSchedule.ps1
+++ b/app/server/lib/BackupSchedule.ps1
@@ -81,6 +81,32 @@ function New-DuneBackupPodPruneSnippet {
     return "sudo kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.status.phase}{`"\n`"}{end}' 2>/dev/null | awk -F'|' '(`$3==`"Succeeded`" || `$3==`"Failed`") && `$2 ~ /-(dump|import)-[0-9]{8}-[0-9]{6}-pod`$/ { k=`$2; sub(/.*-(dump|import)-/,`"`",k); sub(/-pod`$/,`"`",k); print k`"|`"`$0 }' | sort -t'|' -k1 -r | cut -d'|' -f2- | tail -n +$skip | while IFS='|' read ns nm phase; do echo `"`$(date) dst: prune backup/restore pod `$ns/`$nm`" >> /var/log/dune-backup.log; sudo kubectl delete pod -n `"`$ns`" `"`$nm`" --ignore-not-found >> /var/log/dune-backup.log 2>&1; done"
 }
 
+# Build the cron-embedded file-retention prune snippet for a given keepLast.
+# Deletes /funcom/artifacts/database-dumps/*/ dump files beyond the newest N,
+# keying on filename (embedded UTC timestamp = newest-first). Two globs:
+#   (i)  Funcom/manual `-YYYYMMDD-HHMMSS.backup` files
+#   (ii) DST scheduled files (extension-less `dst-scheduled-<ts>`)
+# Both dump + its `.yaml` sidecar are deleted together. Manually named
+# snapshots like 'pre-patch-1_4_10_1.backup' (no timestamp tail) never match
+# either glob, so they're never pruned by accident.
+#
+# KeepLast=0 returns an empty string — the "keep forever" opt-out — so callers
+# can splice the result unconditionally.
+#
+# This snippet is spliced into New-DuneBackupCmd so file-retention fires on the
+# SAME tick as every backup (a bare `; find | rm` chain, sharing the parent's
+# restart-window guard). Historically DST wrote a separate `15 5 * * *` daily
+# line for this, which let an hourly preset accumulate up to 24 files between
+# sweeps and skipped the sweep entirely if the VM was off at 05:15 UTC.
+function New-DuneBackupFilePruneSnippet {
+    param([int]$KeepLast = 0)
+    if ($KeepLast -le 0) { return '' }
+    $namePat  = '*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].backup'
+    $schedPat = $script:DuneBackupScheduledFindGlob
+    $skip = $KeepLast + 1
+    return "ls -t $script:DuneBackupDumpDir/*/$namePat $script:DuneBackupDumpDir/*/$schedPat 2>/dev/null | tail -n +$skip | while IFS= read -r f; do rm -f `"`$f`" `"`$f.yaml`"; done"
+}
+
 # Build the full backup cron command for a given keepLast value.
 # The scheduled backup is wrapped in a guard that skips it when a DST-driven
 # battlegroup restart is in progress: RestartSchedule.ps1 touches
@@ -94,15 +120,28 @@ function New-DuneBackupPodPruneSnippet {
 # pruner is skipped during the restart window too: a kubectl-delete storm
 # while k3s is restarting would just compete for the API server.
 function New-DuneBackupCmd {
-    param([int]$KeepLastPods = 10)
-    $snippet = New-DuneBackupPodPruneSnippet -KeepLast $KeepLastPods
+    param(
+        [int]$KeepLastPods = 10,
+        [int]$KeepLast = 0
+    )
+    $podSnippet  = New-DuneBackupPodPruneSnippet -KeepLast $KeepLastPods
+    $fileSnippet = New-DuneBackupFilePruneSnippet -KeepLast $KeepLast
+    # File-retention prune (issue: hourly backups accumulated up to 24 files
+    # before the old daily `15 5 * * *` line ran once). Fire the prune on the
+    # SAME tick as the backup that just wrote the file, so keep-last-N is
+    # enforced continuously instead of once a day. KeepLast=0 emits an empty
+    # snippet, preserving the "keep forever" opt-out. The prune runs AFTER the
+    # backup + pod-prune succeed and shares the same restart-window guard, so
+    # a mid-restart tick still skips everything.
+    $tail = $podSnippet
+    if ($fileSnippet) { $tail = "$podSnippet; $fileSnippet" }
     # Pass a stable name to `battlegroup backup` so scheduled backups are
     # self-labeling in /funcom/artifacts/database-dumps/. A named backup makes
     # it obvious which snapshots were taken automatically by DST vs a manual
     # `battlegroup backup` on the command line — and it makes the pre-Funcom-
     # update-restore rollback path in the patch-compat routine easier to pick
     # out. Timestamp is UTC to match the rest of DST's log format.
-    return "if find /tmp/dst-restart-active -mmin -30 2>/dev/null | grep -q .; then echo `"`$(date) dst: backup skipped - BG restart window active`" >> /var/log/dune-backup.log; else /home/dune/.dune/bin/battlegroup backup `"dst-scheduled-`$(date -u +%Y%m%d-%H%M%S)`" >> /var/log/dune-backup.log 2>&1; $snippet; fi"
+    return "if find /tmp/dst-restart-active -mmin -30 2>/dev/null | grep -q .; then echo `"`$(date) dst: backup skipped - BG restart window active`" >> /var/log/dune-backup.log; else /home/dune/.dune/bin/battlegroup backup `"dst-scheduled-`$(date -u +%Y%m%d-%H%M%S)`" >> /var/log/dune-backup.log 2>&1; $tail; fi"
 }
 $script:DuneBackupBeginMarker = '# DST-BACKUP BEGIN'
 $script:DuneBackupEndMarker   = '# DST-BACKUP END'
@@ -250,7 +289,7 @@ function New-DuneBackupBlock {
     if ($null -eq $KeepDaysPods -or $KeepDaysPods -lt 0) { $KeepDaysPods = $script:DuneBackupPodPruneKeepDaysDefault }
     if ($KeepDaysPods -gt 365) { $KeepDaysPods = 365 }
 
-    $cmd = New-DuneBackupCmd -KeepLastPods $KeepLastPods
+    $cmd = New-DuneBackupCmd -KeepLastPods $KeepLastPods -KeepLast $KeepLast
 
     $lines = @()
     $lines += $script:DuneBackupBeginMarker
@@ -261,28 +300,8 @@ function New-DuneBackupBlock {
     foreach ($cronExpr in $script:DuneBackupPresets[$Preset].crons) {
         $lines += "$cronExpr $cmd"
     }
-    if ($KeepLast -gt 0) {
-        # Retention prune. Notes on the shape of this glob:
-        #   (i)  `battlegroup backup` writes to
-        #        /funcom/artifacts/database-dumps/<sh-hash-name>/<file>.backup,
-        #        so we need `/*/` to descend one level into the per-battlegroup
-        #        subdir. A shallow `$DumpDir/*.backup` matches nothing.
-        #   (ii) Each backup produces TWO files on disk: the dump itself and its
-        #        `<name>.yaml` sidecar. We count only the dump (never the
-        #        `*.yaml`) so keep-last=N means N real backups (not N/2), and
-        #        delete the matching `.yaml` sidecar alongside each pruned entry.
-        #   (iii)Two dump shapes are pruned: Funcom/manual `-YYYYMMDD-HHMMSS.backup`
-        #        files AND DST's own extension-less `dst-scheduled-<ts>` files
-        #        (Funcom writes the scheduled name verbatim, no `.backup`). Both
-        #        globs are fixed-shape, so a `.yaml` sidecar (longer) can't match
-        #        and manually named snapshots like 'pre-patch-1_4_10_1.backup'
-        #        (no timestamp tail) are never pruned by accident.
-        $namePat  = '*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].backup'
-        $schedPat = $script:DuneBackupScheduledFindGlob
-        $skip = $KeepLast + 1
-        $find = "ls -t $script:DuneBackupDumpDir/*/$namePat $script:DuneBackupDumpDir/*/$schedPat 2>/dev/null | tail -n +$skip | while IFS= read -r f; do rm -f `"`$f`" `"`$f.yaml`"; done"
-        $lines += "15 5 * * * $find"
-    }
+    # File-retention prune is spliced INTO $cmd (see New-DuneBackupCmd), so it
+    # fires on the same tick as each backup. No separate daily line is written.
     $lines += $script:DuneBackupEndMarker
     return (($lines -join "`n") + "`n")
 }

--- a/tests/BackupReturnShape.Tests.ps1
+++ b/tests/BackupReturnShape.Tests.ps1
@@ -259,4 +259,21 @@ Describe 'Scheduled backup (extension-less) recognition' -Tag 'Pure' {
         $block | Should -Match 'dst-scheduled-\?{8}-\?{6}'                                   # scheduled files pruned
         $block | Should -Match '\*-\[0-9\]\[0-9\]\[0-9\]\[0-9\]\[0-9\]\[0-9\]\[0-9\]\[0-9\]' # .backup timestamp files still pruned
     }
+
+    It 'file-retention prune fires on every backup tick, not a separate daily line' {
+        $block = New-DuneBackupBlock -Preset 'Hourly' -KeepLast 10
+        # No standalone `15 5 * * *` file-retention entry any more — it's
+        # spliced INTO each backup cron line so an hourly preset prunes hourly.
+        $block | Should -Not -Match '(?m)^15 5 \* \* \*'
+        # And every backup cron line ("0 * * * *" for Hourly) must contain the
+        # prune snippet body, so a schedule set to every hour prunes every hour.
+        $block | Should -Match '(?m)^0 \* \* \* \*.*rm -f'
+    }
+
+    It 'KeepLast=0 emits no file-retention prune anywhere in the block' {
+        $block = New-DuneBackupBlock -Preset 'Hourly' -KeepLast 0
+        # "Keep forever" opt-out: no ls|tail|rm chain, no 15 5 line.
+        $block | Should -Not -Match 'dst-scheduled-\?{8}-\?{6}'
+        $block | Should -Not -Match '(?m)^15 5 \* \* \*'
+    }
 }


### PR DESCRIPTION
## Why

Previously the DST-BACKUP crontab block wrote the per-preset backup line PLUS a separate hard-coded `15 5 * * *` file-retention line. Two consequences:

1. An **Every hour** preset accumulated up to 24 dump files before the daily sweep ran once.
2. If the VM was down / MQ was down / cron was skipped at 05:15 UTC, the sweep didn't fire at all until the next successful daily tick — files just piled up.

## What

`New-DuneBackupFilePruneSnippet -KeepLast $KeepLast` lifts the existing `ls -t $DumpDir/*/$namePat $DumpDir/*/$schedPat | tail -n +N | rm -f "$f" "$f.yaml"` chain into a reusable snippet. It's spliced into `New-DuneBackupCmd` right after the pod-prune snippet, inside the same restart-window guard. The standalone `15 5 * * *` line is removed.

- Per-backup command shape now: `[restart-guard] || { backup && pod-prune; file-prune }`
- `KeepLast=0` (keep forever) returns an empty snippet, so opt-out is preserved.
- No changes to `ConvertFrom-DuneBackupCrontab` — `# DST-BACKUP-KEEP-LAST: N` is still the parse source.

## Result

Backup cadence == file-prune cadence. Set the schedule to Hourly with keep-last=10 and after every hourly backup the oldest file is pruned. Same shape for Every6Hours, DailyUtc04, etc.

## Tests

- Existing `retention prune globs BOTH the .backup timestamp shape and the scheduled shape` — still passes (the globs are now inside the cmd instead of on a separate line).
- **New:** `file-retention prune fires on every backup tick, not a separate daily line` — asserts no `^15 5 \* \* \*` remains AND that the `0 * * * *` line contains `rm -f`.
- **New:** `KeepLast=0 emits no file-retention prune anywhere in the block` — no `dst-scheduled-????????-??????` glob and no `15 5` line.

All 18 tests pass.

## Op-note

Existing standing rule still applies: the new block only lands on the VM when the operator next hits **Save** on the Database → Backup Schedule card. DST only rewrites the DST-BACKUP crontab block on Save.

## Not shipped in this PR

No version bump / no release — batching with other pending work per Coastal's request. CHANGELOG entry is under `[Unreleased]`.