### PR TITLE
Give Faction Rep / Set Faction Tier: allow same-faction bumps without Reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Give Faction Rep and Set Faction Tier no longer refuse when the character is already in the target faction.** Both actions were checking whether the character was aligned to _any_ faction, and errored out (`"already a member of X. Use Reset Faction first..."`) even when the target faction _was_ that same faction — making it impossible to bump or set a Harkonnen player's Harkonnen rep without first Reset-ing them and re-recruiting through the ceremony. The guard now fires only when the character is aligned to the _other_ faction (where a reset is genuinely required to avoid stacking two memberships). Same-faction calls take a minimal rep-only path: **Give Faction Rep** reads the current rep, adds the Delta, and writes it back (allowing negative Deltas to drop rep, clamped to 0..cap); **Set Faction Tier** writes the tier-threshold rep directly. Both dual-write the `player_faction_reputation` table and the pawn's `FactionPlayerComponent`, matching how Reset Faction / Progression Unlock persist rep. Changes take effect on the character's next login.
+
 ### Changed
 
 - **Backup file-retention prune now fires on every scheduled backup**, not on a separate daily line. Previously the crontab wrote the per-preset backup line PLUS a hard-coded `15 5 * * *` file-retention line, so an "Every hour" preset could accumulate up to 24 dump files before the daily sweep ran once — and if the VM was down at 05:15 UTC, the sweep was skipped entirely and files piled up until the next successful daily tick. The prune is now inline in each backup command, so "backup every hour" also prunes to keep-last-N every hour. `Keep last = 0` (keep forever) still emits no prune. No schedule change is required — but the new shape only lands when you next Save the schedule on the Database card, because DST only rewrites the DST-BACKUP crontab block on Save.

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -161,12 +161,55 @@ function Invoke-DunePlayerGiveFactionRep {
     $accountID = if ($amaps.Count -ge 1) { [int64](ConvertTo-DuneInt $amaps[0]['aid']) } else { 0 }
     if ($accountID -le 0) { return @{ ok = $false; error = "no account for controller $ActorId." } }
 
-    # An already-aligned member must be reset before re-applying standing — otherwise
-    # we would stack a fresh recruitment on top of an existing membership.
     $aligned = Get-DunePlayerAlignedFaction -Ip $Ip -ControllerId $ActorId
-    if ($aligned -ne 0) {
+
+    # Cross-faction case is the only real problem: switching factions mid-stream
+    # would leave the old faction's tags / journey-node state behind. Force a
+    # Reset Faction first so the switch goes through the recruitment ceremony
+    # cleanly on the next Give Faction Rep call.
+    if ($aligned -ne 0 -and $aligned -ne $FactionId) {
         $an = Get-DuneFactionDisplayName $aligned
         return @{ ok = $false; error = "This character is already a member of $an. Use Players -> Progression -> Reset Faction first, then set the standing again." }
+    }
+
+    if ($aligned -eq $FactionId) {
+        # Already in the target faction — this is a delta bump on an existing
+        # membership. Read current rep, add Delta (allowing negative for a
+        # tactical drop), clamp to [0..cap], then write BOTH the reputation
+        # table and the runtime-read FactionPlayerComponent so the change is
+        # visible on next login (matches Reset Faction's dual-write pattern).
+        # No journey-node / tag ceremony — those are already applied.
+        $factionName = Get-DuneFactionDisplayName $FactionId
+        $curSql = "SELECT COALESCE(reputation_amount, 0)::text AS rep FROM dune.player_faction_reputation WHERE actor_id = $ActorId::bigint AND faction_id = $FactionId::smallint LIMIT 1;"
+        $cr = Invoke-DuneSqlQuery -Ip $Ip -Sql $curSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+        if (-not $cr.ok) { return @{ ok = $false; error = "lookup current rep: $($cr.error)" } }
+        $cmaps = ConvertTo-DuneRowMaps -Result $cr
+        $current = if ($cmaps.Count -ge 1) { [int](ConvertTo-DuneInt $cmaps[0]['rep']) } else { 0 }
+        $newRep = $current + $Delta
+        if ($newRep -lt 0) { $newRep = 0 }
+        if ($newRep -gt $script:DuneFactionRepCap) { $newRep = $script:DuneFactionRepCap }
+        $compSql = Get-DuneFactionComponentUpsertSql -ActorId $ActorId -FactionName $factionName -Rep $newRep
+        $tx = @"
+BEGIN;
+SELECT dune.set_player_faction_reputation($ActorId::bigint, $FactionId::smallint, $newRep::integer);
+$compSql
+COMMIT;
+"@
+        $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $tx -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+        if (-not $r.ok) {
+            Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
+            return @{ ok = $false; error = "give-faction-rep tx: $($r.error)" }
+        }
+        $tier = Convert-DuneRepToTier $newRep
+        $tierName = Get-DuneFactionTierName $FactionId $tier
+        return @{
+            ok = $true
+            faction = $factionName; faction_id = $FactionId
+            rep = $newRep; previous_rep = $current; delta = ($newRep - $current)
+            tier = $tier; tier_name = $tierName
+            controller_id = $ActorId
+            message = "Adjusted $factionName rep by $($newRep - $current) ($current -> $newRep, tier $tier / $tierName) - takes effect on next login."
+        }
     }
 
     # Unaligned: establish full membership at the requested standing (Delta from 0).
@@ -192,13 +235,43 @@ function Invoke-DunePlayerSetFactionTier {
     if ($accountID -le 0) { return @{ ok = $false; error = "no account for controller $ActorId." } }
 
     $aligned = Get-DunePlayerAlignedFaction -Ip $Ip -ControllerId $ActorId
-    if ($aligned -ne 0) {
+
+    if ($aligned -ne 0 -and $aligned -ne $FactionId) {
         $an = Get-DuneFactionDisplayName $aligned
         return @{ ok = $false; error = "This character is already a member of $an. Use Players -> Progression -> Reset Faction first, then set the tier again." }
     }
 
     $rep = $script:DuneFactionTierThresholds[$Tier]
     if ($Tier -gt 0) { $rep = $rep + 1 }
+
+    if ($aligned -eq $FactionId) {
+        # Already in the target faction — Set Faction Tier is an absolute
+        # write, so just update the rep table + FactionPlayerComponent to the
+        # tier threshold. No recruitment ceremony (nodes / tags / alignment
+        # are already applied).
+        $factionName = Get-DuneFactionDisplayName $FactionId
+        $compSql = Get-DuneFactionComponentUpsertSql -ActorId $ActorId -FactionName $factionName -Rep $rep
+        $tx = @"
+BEGIN;
+SELECT dune.set_player_faction_reputation($ActorId::bigint, $FactionId::smallint, $rep::integer);
+$compSql
+COMMIT;
+"@
+        $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $tx -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+        if (-not $r.ok) {
+            Invoke-DuneSqlQuery -Ip $Ip -Sql 'ROLLBACK;' -ReadOnly $false -MaxRows 1 -TimeoutSec 5 | Out-Null
+            return @{ ok = $false; error = "set-faction-tier tx: $($r.error)" }
+        }
+        $tierName = Get-DuneFactionTierName $FactionId $Tier
+        return @{
+            ok = $true
+            faction = $factionName; faction_id = $FactionId
+            rep = $rep; tier = $Tier; tier_name = $tierName
+            controller_id = $ActorId
+            message = "Set $factionName tier to $Tier ($tierName), rep $rep - takes effect on next login."
+        }
+    }
+
     return Invoke-DuneEstablishFactionMembership -Ip $Ip -ControllerId $ActorId -AccountId $accountID -FactionId $FactionId -Rep $rep
 }
 

--- a/tests/FactionMembership.Tests.ps1
+++ b/tests/FactionMembership.Tests.ps1
@@ -101,11 +101,15 @@ Describe 'Invoke-DuneEstablishFactionMembership' -Tag 'Establish' {
 Describe 'Invoke-DunePlayerSetFactionTier / GiveFactionRep alignment guard' -Tag 'Establish' {
     BeforeEach {
         $script:aligned = @()          # ConvertTo-DuneRowMaps-style maps for player_faction
+        $script:currentRep = @()       # ConvertTo-DuneRowMaps-style maps for player_faction_reputation
         $script:establishArgs = $null
+        $script:capturedTx = $null
         function global:Invoke-DuneSqlQuery {
             param([string]$Ip, [string]$Sql, [bool]$ReadOnly, [int]$MaxRows, [int]$TimeoutSec)
-            if ($Sql -match 'AS aid')        { return @{ ok = $true; maps = @(@{ aid = 19 }) } }
-            if ($Sql -match 'player_faction') { return @{ ok = $true; maps = $script:aligned } }
+            if ($Sql -match '^\s*BEGIN;')                              { $script:capturedTx = $Sql; return @{ ok = $true } }
+            if ($Sql -match 'AS aid')                                  { return @{ ok = $true; maps = @(@{ aid = 19 }) } }
+            if ($Sql -match 'FROM dune\.player_faction_reputation')    { return @{ ok = $true; maps = $script:currentRep } }
+            if ($Sql -match 'FROM dune\.player_faction\b')             { return @{ ok = $true; maps = $script:aligned } }
             return @{ ok = $true; maps = @(); message = 'SELECT 1' }
         }
         function global:Invoke-DuneEstablishFactionMembership {
@@ -119,32 +123,69 @@ Describe 'Invoke-DunePlayerSetFactionTier / GiveFactionRep alignment guard' -Tag
         Remove-Item function:global:Invoke-DuneEstablishFactionMembership -ErrorAction SilentlyContinue
     }
 
-    It 'blocks Set Faction Tier on an already-aligned character' {
-        $script:aligned = @(@{ fid = 2 })
+    # -- Set Faction Tier ---------------------------------------------------
+
+    It 'Set Faction Tier: blocks when aligned to a DIFFERENT faction' {
+        $script:aligned = @(@{ fid = 2 })  # Harkonnen, but target is Atreides
         $r = Invoke-DunePlayerSetFactionTier -Ip '1.2.3.4' -ActorId 227 -FactionId 1 -Tier 5
         $r.ok    | Should -BeFalse
         $r.error | Should -Match 'already a member'
         $script:establishArgs | Should -BeNullOrEmpty
     }
-    It 'establishes membership for an unaligned character at the tier reputation' {
+    It 'Set Faction Tier: establishes membership for an unaligned character at the tier reputation' {
         $script:aligned = @()
         $r = Invoke-DunePlayerSetFactionTier -Ip '1.2.3.4' -ActorId 227 -FactionId 1 -Tier 5
         $r.ok | Should -BeTrue
         $script:establishArgs.FactionId | Should -Be 1
         $script:establishArgs.Rep       | Should -Be 2000   # tier 5 threshold 1999 + 1
     }
-    It 'blocks Give Faction Rep on an aligned character' {
-        $script:aligned = @(@{ fid = 1 })
+    It 'Set Faction Tier: same-faction bypasses Establish and does a rep-only tx' {
+        $script:aligned = @(@{ fid = 1 })  # already Atreides
+        $r = Invoke-DunePlayerSetFactionTier -Ip '1.2.3.4' -ActorId 227 -FactionId 1 -Tier 10
+        $r.ok            | Should -BeTrue
+        $r.rep           | Should -Be 3875   # tier 10 threshold 3874 + 1
+        $r.tier          | Should -Be 10
+        $script:establishArgs | Should -BeNullOrEmpty      # NO recruitment ceremony
+        $script:capturedTx    | Should -Match 'set_player_faction_reputation\(227::bigint, 1::smallint, 3875::integer\)'
+        $script:capturedTx    | Should -Match "jsonb_build_object\('Name', 'Atreides'\)"
+    }
+
+    # -- Give Faction Rep ---------------------------------------------------
+
+    It 'Give Faction Rep: blocks when aligned to a DIFFERENT faction' {
+        $script:aligned = @(@{ fid = 2 })  # Harkonnen, but target is Atreides
         $r = Invoke-DunePlayerGiveFactionRep -Ip '1.2.3.4' -ActorId 227 -FactionId 1 -Delta 500
         $r.ok    | Should -BeFalse
         $r.error | Should -Match 'already a member'
+        $script:establishArgs | Should -BeNullOrEmpty
     }
-    It 'establishes membership for unaligned Give Faction Rep at the delta standing' {
+    It 'Give Faction Rep: establishes membership for unaligned at the delta standing' {
         $script:aligned = @()
         $r = Invoke-DunePlayerGiveFactionRep -Ip '1.2.3.4' -ActorId 227 -FactionId 1 -Delta 500
         $r.ok | Should -BeTrue
         $script:establishArgs.Rep | Should -Be 500
     }
+    It 'Give Faction Rep: same-faction adds Delta to CURRENT rep (not a fresh recruitment)' {
+        $script:aligned    = @(@{ fid = 2 })
+        $script:currentRep = @(@{ rep = 3000 })   # tier ~9
+        $r = Invoke-DunePlayerGiveFactionRep -Ip '1.2.3.4' -ActorId 227 -FactionId 2 -Delta 15000
+        $r.ok           | Should -BeTrue
+        $r.previous_rep | Should -Be 3000
+        $r.rep          | Should -Be 12474        # clamped to cap
+        $r.delta        | Should -Be 9474
+        $script:establishArgs | Should -BeNullOrEmpty
+        $script:capturedTx    | Should -Match 'set_player_faction_reputation\(227::bigint, 2::smallint, 12474::integer\)'
+        $script:capturedTx    | Should -Match "jsonb_build_object\('Name', 'Harkonnen'\)"
+    }
+    It 'Give Faction Rep: same-faction with negative Delta drops rep, clamped to 0' {
+        $script:aligned    = @(@{ fid = 1 })
+        $script:currentRep = @(@{ rep = 100 })
+        $r = Invoke-DunePlayerGiveFactionRep -Ip '1.2.3.4' -ActorId 227 -FactionId 1 -Delta -500
+        $r.ok  | Should -BeTrue
+        $r.rep | Should -Be 0
+        $script:capturedTx | Should -Match 'set_player_faction_reputation\(227::bigint, 1::smallint, 0::integer\)'
+    }
+
     It 'rejects non-house factions' {
         Invoke-DunePlayerSetFactionTier -Ip '1.2.3.4' -ActorId 227 -FactionId 4 -Tier 5 | Select-Object -ExpandProperty ok | Should -BeFalse
         Invoke-DunePlayerGiveFactionRep -Ip '1.2.3.4' -ActorId 227 -FactionId 3 -Delta 500 | Select-Object -ExpandProperty ok | Should -BeFalse


### PR DESCRIPTION
## Bug

From Coastal's Reapers server: character already Harkonnen-aligned, tried Give Faction Rep +15000 Harkonnen — refused with `"already a member of Harkonnen. Use Reset Faction first..."`. Same error on Set Faction Tier when the char is already in the target faction.

## Cause

`Invoke-DunePlayerGiveFactionRep` and `Invoke-DunePlayerSetFactionTier` both call `Get-DunePlayerAlignedFaction` and reject whenever the returned faction is non-zero — regardless of whether that faction _is_ the target. So it's impossible to bump / set rep on an already-aligned member of the same faction without first Reset Faction'ing them.

## Fix

Split the guard into three cases:

- **Aligned to a different faction** → keep the block (real problem: would stack two memberships).
- **Aligned to the target faction** → NEW: minimal rep-only path. No recruitment ceremony (nodes / tags / alignment are already applied).
  - `Give Faction Rep`: read current rep from `player_faction_reputation`, add `Delta` (negative allowed for a rep drop), clamp `[0..cap]`, write.
  - `Set Faction Tier`: write the tier-threshold rep directly.
  - Both dual-write `player_faction_reputation` + the pawn's `FactionPlayerComponent` (via existing `Get-DuneFactionComponentUpsertSql`), matching Reset Faction / Progression Unlock so it survives login.
- **Unaligned** → unchanged, falls through to `Invoke-DuneEstablishFactionMembership` (recruitment ceremony from scratch).

## Tests

Reworked the `Invoke-DunePlayerSetFactionTier / GiveFactionRep alignment guard` describe block in `FactionMembership.Tests.ps1`:

- Kept: cross-faction still blocks, unaligned still Establishes, non-house factions still rejected.
- New: same-faction Set Faction Tier bypasses Establish and emits `set_player_faction_reputation(..., 3875)` + `Name=Atreides` in the component upsert.
- New: same-faction Give Faction Rep adds Delta to CURRENT rep (3000 + 15000 → clamped to cap 12474) with `delta=9474`, `previous_rep=3000`.
- New: negative Delta clamps to 0.

Also tightened the mock SQL router: `set_player_faction_reputation` contains `player_faction_reputation` as a substring, so the previous broad `player_faction_reputation` match was capturing the tx SQL instead of routing it through the `BEGIN;` handler. Router now uses `FROM dune.player_faction_reputation` / `FROM dune.player_faction` and checks `^\s*BEGIN;` first.

All **19 tests pass**.

## Not shipped in this PR

Batching with the backup file-prune change under `[Unreleased]` — no version bump yet.