### PR TITLE
release: v12.18.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.9] - 2026-07-10
+
 ### Fixed
 
 - **Give Faction Rep and Set Faction Tier no longer refuse when the character is already in the target faction.** Both actions were checking whether the character was aligned to _any_ faction, and errored out (`"already a member of X. Use Reset Faction first..."`) even when the target faction _was_ that same faction — making it impossible to bump or set a Harkonnen player's Harkonnen rep without first Reset-ing them and re-recruiting through the ceremony. The guard now fires only when the character is aligned to the _other_ faction (where a reset is genuinely required to avoid stacking two memberships). Same-faction calls take a minimal rep-only path: **Give Faction Rep** reads the current rep, adds the Delta, and writes it back (allowing negative Deltas to drop rep, clamped to 0..cap); **Set Faction Tier** writes the tier-threshold rep directly. Both dual-write the `player_faction_reputation` table and the pawn's `FactionPlayerComponent`, matching how Reset Faction / Progression Unlock persist rep. Changes take effect on the character's next login.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.8'
+$script:DuneToolVersion = '12.18.9'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.8',
+    [string]$Version = '12.18.9',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.8</Version>
+    <Version>12.18.9</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.8"
+#define MyAppVersion "12.18.9"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.8"
+$script:ToolVersion = "12.18.9"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Rolls `[Unreleased]` into **v12.18.9**:

- **Fixed:** Give Faction Rep / Set Faction Tier now allow same-faction passthrough (PR #501)
- **Changed:** Backup file-retention prune fires inline on every scheduled backup (PR #500)

Version bumped in the 5 canonical spots. Installer will be built + attached after merge.