### PR TITLE
Add local backup mirror to Database page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Local backup mirror (Database → Backups).** New card lets you copy every VM database backup into a folder on this PC. Turn on the checkbox, pick a folder, and DST will SCP each new backup from the VM into that folder automatically (polled every ~30s, or click **Sync Now**). Filenames are preserved verbatim so mirrored files are drop-in compatible with the existing Restore / upload paths. **Copy-only by design** — DST never deletes files from your local mirror folder. The VM's auto-purge retention only trims the server side, so the mirror is a permanent local archive you can prune yourself when needed. Warning label on the card makes the "no local deletes" behaviour explicit.
+
 ## [12.18.9] - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.10] - 2026-07-10
+
 ### Added
 
-- **Local backup mirror (Database → Backups).** New card lets you copy every VM database backup into a folder on this PC. Turn on the checkbox, pick a folder, and DST will SCP each new backup from the VM into that folder automatically (polled every ~30s, or click **Sync Now**). Filenames are preserved verbatim so mirrored files are drop-in compatible with the existing Restore / upload paths. **Copy-only by design** — DST never deletes files from your local mirror folder. The VM's auto-purge retention only trims the server side, so the mirror is a permanent local archive you can prune yourself when needed. Warning label on the card makes the "no local deletes" behaviour explicit.
+- **Local backup mirror (Database → Backups).** New card lets you copy every VM database backup into a folder on this PC. Turn on the checkbox, pick a folder with **Browse…**, click **Save**, and DST will SCP each new backup from the VM into that folder automatically as new backups appear. **Open Folder** opens it in Explorer. Filenames are preserved verbatim so mirrored files are drop-in compatible with the existing Restore / upload paths. **Copy-only by design** — DST never deletes files from your local mirror folder. The VM's auto-purge retention only trims the server side, so the mirror is a permanent local archive you can prune yourself when needed.
 
 ## [12.18.9] - 2026-07-10
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.9'
+$script:DuneToolVersion = '12.18.10'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.9',
+    [string]$Version = '12.18.10',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.9</Version>
+    <Version>12.18.10</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Windows.Forms;
@@ -510,6 +511,31 @@ internal sealed class MainForm : Form
             catch { /* best-effort parse */ }
             BeginInvoke(new Action(() => ShowOpenDialog(id, filter)));
         }
+        else if (string.Equals(action, "pick-folder", StringComparison.OrdinalIgnoreCase))
+        {
+            // Show a native Folder Browser dialog and return the chosen path to
+            // the frontend. Used by the "Local Backup Mirror" card on the
+            // Database page.
+            string? id = null;
+            string? initialPath = null;
+            string? description = null;
+            try
+            {
+                string? json = e.WebMessageAsJson;
+                if (!string.IsNullOrWhiteSpace(json))
+                {
+                    using var doc2 = System.Text.Json.JsonDocument.Parse(json);
+                    var r2 = doc2.RootElement.ValueKind == System.Text.Json.JsonValueKind.String
+                        ? System.Text.Json.JsonDocument.Parse(doc2.RootElement.GetString()!).RootElement
+                        : doc2.RootElement;
+                    if (r2.TryGetProperty("id", out var idProp)) id = idProp.GetString();
+                    if (r2.TryGetProperty("initialPath", out var ipProp)) initialPath = ipProp.GetString();
+                    if (r2.TryGetProperty("description", out var dProp)) description = dProp.GetString();
+                }
+            }
+            catch { /* best-effort parse */ }
+            BeginInvoke(new Action(() => ShowFolderDialog(id, initialPath, description)));
+        }
     }
 
     // ----- Native file dialog bridge ------------------------------------------
@@ -533,6 +559,22 @@ internal sealed class MainForm : Form
         dlg.Title = "Select backup to upload";
         dlg.Filter = filter ?? "Database backups (*.backup)|*.backup|All files (*.*)|*.*";
         string? chosen = dlg.ShowDialog(this) == DialogResult.OK ? dlg.FileName : null;
+        PostFilePickResult(id, chosen);
+    }
+
+    private void ShowFolderDialog(string? id, string? initialPath, string? description)
+    {
+        using var dlg = new FolderBrowserDialog();
+        dlg.Description = string.IsNullOrWhiteSpace(description)
+            ? "Select a folder for local backup copies"
+            : description;
+        dlg.UseDescriptionForTitle = true;
+        dlg.ShowNewFolderButton = true;
+        if (!string.IsNullOrWhiteSpace(initialPath) && Directory.Exists(initialPath))
+        {
+            dlg.SelectedPath = initialPath;
+        }
+        string? chosen = dlg.ShowDialog(this) == DialogResult.OK ? dlg.SelectedPath : null;
         PostFilePickResult(id, chosen);
     }
 

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.9"
+#define MyAppVersion "12.18.10"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/BackupMirror.ps1
+++ b/app/server/lib/BackupMirror.ps1
@@ -1,0 +1,231 @@
+﻿# BackupMirror.ps1 — copy new VM database backups to a locally-chosen folder.
+#
+# The user turns this on from the Database page. When enabled, every time the
+# webui refreshes backup history, the frontend also POSTs to the mirror /sync
+# endpoint. This library does the actual work: enumerate DST-shape backups
+# on the VM (same set that appears in Get-DuneBackupHistory, i.e. `*.backup`
+# files AND `dst-scheduled-<utc-ts>` extension-less files), diff against
+# what's already in the local folder, and SCP any missing files down.
+#
+# Filenames are preserved verbatim (no rename) so downloaded files are drop-in
+# compatible with the existing Restore / upload paths.
+#
+# COPY-ONLY BY DESIGN. This mirror NEVER deletes from the local folder. The
+# VM's auto-retention prune (BackupSchedule.ps1 / New-DuneBackupFilePruneSnippet)
+# keeps the VM-side dump dir bounded, but any file that ever made it into the
+# local mirror folder stays there forever unless the user removes it manually.
+# Do NOT add a "prune local mirror" branch here — that's a deliberate product
+# decision.
+#
+# State (last mirrored time + last error message) lives in a sidecar JSON so
+# the INI-style dune-server.config stays a pure settings file.
+
+$script:DuneBackupMirrorStateFile = $null
+
+function Get-DuneBackupMirrorStatePath {
+    if ($script:DuneBackupMirrorStateFile) { return $script:DuneBackupMirrorStateFile }
+    $dir = if ($env:APPDATA) { Join-Path $env:APPDATA 'DuneServer' } else { $env:TEMP }
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+        try { New-Item -ItemType Directory -Path $dir -Force | Out-Null } catch {}
+    }
+    return (Join-Path $dir 'backup-mirror-state.json')
+}
+
+function Read-DuneBackupMirrorState {
+    $path = Get-DuneBackupMirrorStatePath
+    if (-not (Test-Path -LiteralPath $path)) {
+        return @{ lastMirroredAt = ''; lastError = ''; lastCopiedCount = 0 }
+    }
+    try {
+        $raw = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
+        $obj = $raw | ConvertFrom-Json -ErrorAction Stop
+        return @{
+            lastMirroredAt  = if ($obj.lastMirroredAt)  { [string]$obj.lastMirroredAt }  else { '' }
+            lastError       = if ($obj.lastError)       { [string]$obj.lastError }       else { '' }
+            lastCopiedCount = if ($obj.lastCopiedCount) { [int]$obj.lastCopiedCount }    else { 0 }
+        }
+    } catch {
+        return @{ lastMirroredAt = ''; lastError = ''; lastCopiedCount = 0 }
+    }
+}
+
+function Save-DuneBackupMirrorState {
+    param([hashtable]$State)
+    $path = Get-DuneBackupMirrorStatePath
+    try {
+        ($State | ConvertTo-Json -Depth 3) | Set-Content -LiteralPath $path -Encoding UTF8
+    } catch {
+        # Best-effort — state is informational only.
+    }
+}
+
+# Enumerate DST-recognized backup files on the VM's dump dir (mirrors the same
+# selection Get-DuneBackupHistory uses: `*.backup` OR `dst-scheduled-<ts>`).
+# Returns an array of hashtables { path; sizeBytes; mtimeEpoch }.
+function Get-DuneBackupMirrorVmFiles {
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [int]$Max = 5000
+    )
+    if ($Max -lt 1)    { $Max = 1 }
+    if ($Max -gt 5000) { $Max = 5000 }
+    $script = @"
+sudo find $script:DuneBackupDumpDir -maxdepth 3 -type f \( -name '*.backup' -o -name '$script:DuneBackupScheduledFindGlob' \) 2>/dev/null \
+  | head -$Max \
+  | xargs -r -I{} sudo stat -c '%Y|%s|%n' '{}' 2>/dev/null \
+  | sort -rn
+"@
+    $r = Invoke-DuneBackupShell -Ip $Ip -Script $script -TimeoutSec 30
+    if ($r.rc -lt 0) { throw 'SSH to VM failed (no exit code returned).' }
+    $out = @()
+    foreach ($ln in ($r.out -split "`n")) {
+        if (-not $ln) { continue }
+        $parts = $ln -split '\|', 3
+        if ($parts.Count -ne 3) { continue }
+        $epoch = 0
+        $size = 0
+        try { $epoch = [long]$parts[0] } catch { continue }
+        try { $size  = [long]$parts[1] } catch { $size = 0 }
+        $out += @{
+            path       = $parts[2]
+            sizeBytes  = $size
+            mtimeEpoch = $epoch
+        }
+    }
+    return ,$out
+}
+
+# SCP a single file from the VM to the local mirror folder. Preserves the
+# source filename. Returns @{ ok; localPath?; error? }.
+function Invoke-DuneBackupMirrorScpPull {
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [Parameter(Mandatory)][string]$KeyPath,
+        [Parameter(Mandatory)][string]$VmPath,
+        [Parameter(Mandatory)][string]$LocalFolder,
+        [int]$TimeoutSec = 300
+    )
+    $fileName = Split-Path -Leaf $VmPath
+    $localPath = Join-Path $LocalFolder $fileName
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName               = 'scp'
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute        = $false
+    $psi.CreateNoWindow         = $true
+    $psi.Arguments = "-o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i `"$KeyPath`" `"dune@$($Ip):$VmPath`" `"$localPath`""
+
+    $proc = [System.Diagnostics.Process]::new()
+    $proc.StartInfo = $psi
+    try {
+        [void]$proc.Start()
+        $errTask = $proc.StandardError.ReadToEndAsync()
+        $exited = $proc.WaitForExit($TimeoutSec * 1000)
+        if (-not $exited) {
+            try { $proc.Kill() } catch {}
+            return @{ ok = $false; error = "SCP timed out after ${TimeoutSec}s ($fileName)" }
+        }
+        [void]$proc.WaitForExit()
+        $stderr = $errTask.GetAwaiter().GetResult()
+        if ($proc.ExitCode -ne 0) {
+            return @{ ok = $false; error = "SCP failed rc=$($proc.ExitCode): $($stderr.Trim())" }
+        }
+    } finally {
+        try { $proc.Dispose() } catch {}
+    }
+    if (-not (Test-Path -LiteralPath $localPath)) {
+        return @{ ok = $false; error = "SCP reported success but $fileName not present locally." }
+    }
+    return @{ ok = $true; localPath = $localPath }
+}
+
+# Run one mirror pass. Fetches the VM file list, diffs against the local
+# folder (by filename), and SCPs anything missing. Returns a summary the
+# route handler can shape into JSON.
+function Invoke-DuneBackupMirrorTick {
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [Parameter(Mandatory)][string]$KeyPath,
+        [Parameter(Mandatory)][string]$LocalFolder,
+        [int]$MaxCopyPerTick = 20
+    )
+    $result = @{
+        ok          = $false
+        folder      = $LocalFolder
+        vmFileCount = 0
+        copied      = @()
+        skipped     = 0
+        failed      = @()
+        error       = ''
+    }
+
+    # Folder validation — the whole point of "silent skip + red status" is that
+    # this NEVER throws when the folder is unavailable.
+    if (-not $LocalFolder) {
+        $result.error = 'Mirror folder is not set.'
+        return $result
+    }
+    try {
+        if (-not (Test-Path -LiteralPath $LocalFolder)) {
+            New-Item -ItemType Directory -Path $LocalFolder -Force -ErrorAction Stop | Out-Null
+        }
+    } catch {
+        $result.error = "Mirror folder unavailable: $($_.Exception.Message)"
+        return $result
+    }
+
+    # Quick write-check by touching a probe file (removed immediately).
+    try {
+        $probe = Join-Path $LocalFolder ('.dst-mirror-probe-' + [guid]::NewGuid().ToString('N'))
+        Set-Content -LiteralPath $probe -Value '' -Encoding ASCII -ErrorAction Stop
+        Remove-Item -LiteralPath $probe -Force -ErrorAction SilentlyContinue
+    } catch {
+        $result.error = "Mirror folder not writable: $($_.Exception.Message)"
+        return $result
+    }
+
+    # Enumerate VM files
+    $vmFiles = @()
+    try {
+        $vmFiles = Get-DuneBackupMirrorVmFiles -Ip $Ip
+    } catch {
+        $result.error = "VM listing failed: $($_.Exception.Message)"
+        return $result
+    }
+    $result.vmFileCount = $vmFiles.Count
+
+    # Build local index by filename
+    $localNames = @{}
+    try {
+        Get-ChildItem -LiteralPath $LocalFolder -File -ErrorAction SilentlyContinue | ForEach-Object {
+            $localNames[$_.Name] = $true
+        }
+    } catch {}
+
+    # Copy any missing files (newest-first is already the sort order from
+    # Get-DuneBackupMirrorVmFiles). Cap per-tick to keep the request fast;
+    # subsequent ticks will pick up the rest.
+    $copied = 0
+    foreach ($vm in $vmFiles) {
+        $name = Split-Path -Leaf $vm.path
+        if ($localNames.ContainsKey($name)) {
+            $result.skipped++
+            continue
+        }
+        if ($copied -ge $MaxCopyPerTick) {
+            $result.skipped++
+            continue
+        }
+        $r = Invoke-DuneBackupMirrorScpPull -Ip $Ip -KeyPath $KeyPath -VmPath $vm.path -LocalFolder $LocalFolder
+        if ($r.ok) {
+            $result.copied += $name
+            $copied++
+        } else {
+            $result.failed += @{ name = $name; error = $r.error }
+        }
+    }
+
+    $result.ok = ($result.failed.Count -eq 0)
+    return $result
+}

--- a/app/server/lib/Config.ps1
+++ b/app/server/lib/Config.ps1
@@ -26,7 +26,9 @@ $script:DuneConfigKeys = @(
     'UpdateChannel',
     'UpdatePreReleaseTag',
     'UpdateInstalledPrerelease',
-    'UpdateInstalledTag'
+    'UpdateInstalledTag',
+    'LocalBackupMirrorEnabled',
+    'LocalBackupMirrorFolder'
 )
 
 # Default in-pod PostgreSQL port. All DST DB access runs as
@@ -151,6 +153,22 @@ function Get-DuneUpdateInstalledPrerelease {
         return ($v -match '^(?i:true|1|yes)$')
     } catch {}
     return $false
+}
+
+# Local backup mirror — resolved settings for the "copy each new backup to a
+# local folder" feature (see BackupMirror.ps1 route + lib). Enabled is boolean-
+# ish (falsy unless explicitly '1'/'true'/'yes'/'on'); folder is a plain path
+# or empty.
+function Get-DuneLocalBackupMirrorEnabled {
+    $raw = Read-DuneConfigRaw
+    $v = if ($raw.Contains('LocalBackupMirrorEnabled')) { [string]$raw['LocalBackupMirrorEnabled'] } else { '' }
+    return ($v -match '^(?i:true|1|yes|on)$')
+}
+
+function Get-DuneLocalBackupMirrorFolder {
+    $raw = Read-DuneConfigRaw
+    $v = if ($raw.Contains('LocalBackupMirrorFolder')) { [string]$raw['LocalBackupMirrorFolder'] } else { '' }
+    return $v.Trim()
 }
 
 function Save-DuneConfig {

--- a/app/server/routes/BackupMirror.ps1
+++ b/app/server/routes/BackupMirror.ps1
@@ -1,0 +1,193 @@
+﻿# BackupMirror.ps1 — routes for the "Local Backup Mirror" feature.
+#
+# The Database page exposes a card that lets the user pick a local folder;
+# every backup that appears on the VM is SCP'd there. See lib/BackupMirror.ps1
+# for the actual copy logic. Copy-only: this route never deletes local files.
+#
+# GET  /api/db/backup-mirror         → current settings + last sync state
+# POST /api/db/backup-mirror         body { enabled?, folder? }  save settings
+# POST /api/db/backup-mirror/open    body { folder? }            open in Explorer
+# POST /api/db/backup-mirror/sync                                run one mirror pass
+
+Register-DuneRoute -Method GET -Path '/api/db/backup-mirror' -Handler {
+    param($req, $res, $routeParams, $body)
+    $state = Read-DuneBackupMirrorState
+    Write-DuneJson -Response $res -Body @{
+        enabled         = (Get-DuneLocalBackupMirrorEnabled)
+        folder          = (Get-DuneLocalBackupMirrorFolder)
+        lastMirroredAt  = $state.lastMirroredAt
+        lastError       = $state.lastError
+        lastCopiedCount = $state.lastCopiedCount
+    }
+}
+
+Register-DuneRoute -Method POST -Path '/api/db/backup-mirror' -Handler {
+    param($req, $res, $routeParams, $body)
+
+    $enabledSpecified = $false
+    $folderSpecified  = $false
+    $enabled = $false
+    $folder  = ''
+
+    if ($body -is [hashtable] -or $body -is [System.Collections.IDictionary]) {
+        if ($body.ContainsKey('enabled')) { $enabledSpecified = $true; $enabled = [bool]$body['enabled'] }
+        if ($body.ContainsKey('folder'))  { $folderSpecified  = $true; $folder  = [string]$body['folder'] }
+    } elseif ($body) {
+        if ($null -ne $body.enabled) { $enabledSpecified = $true; $enabled = [bool]$body.enabled }
+        if ($null -ne $body.folder)  { $folderSpecified  = $true; $folder  = [string]$body.folder }
+    }
+
+    if (-not $enabledSpecified -and -not $folderSpecified) {
+        Write-DuneError -Response $res -Status 400 -Message 'Body must include enabled and/or folder.'
+        return
+    }
+
+    $updates = @{}
+    if ($enabledSpecified) {
+        $updates['LocalBackupMirrorEnabled'] = if ($enabled) { 'true' } else { 'false' }
+    }
+    if ($folderSpecified) {
+        $updates['LocalBackupMirrorFolder'] = ($folder.Trim())
+    }
+    Save-DuneConfig -Config $updates | Out-Null
+
+    $state = Read-DuneBackupMirrorState
+    Write-DuneJson -Response $res -Body @{
+        ok              = $true
+        enabled         = (Get-DuneLocalBackupMirrorEnabled)
+        folder          = (Get-DuneLocalBackupMirrorFolder)
+        lastMirroredAt  = $state.lastMirroredAt
+        lastError       = $state.lastError
+        lastCopiedCount = $state.lastCopiedCount
+    }
+}
+
+Register-DuneRoute -Method POST -Path '/api/db/backup-mirror/open' -Handler {
+    param($req, $res, $routeParams, $body)
+    $folder = $null
+    if ($body -is [hashtable] -or $body -is [System.Collections.IDictionary]) {
+        if ($body.ContainsKey('folder')) { $folder = [string]$body['folder'] }
+    } elseif ($body -and $body.folder) {
+        $folder = [string]$body.folder
+    }
+    if (-not $folder) {
+        $folder = Get-DuneLocalBackupMirrorFolder
+    }
+    if (-not $folder) {
+        Write-DuneError -Response $res -Status 400 -Message 'No mirror folder set.'
+        return
+    }
+    if (-not (Test-Path -LiteralPath $folder)) {
+        try {
+            New-Item -ItemType Directory -Path $folder -Force -ErrorAction Stop | Out-Null
+        } catch {
+            Write-DuneError -Response $res -Status 400 -Message "Folder unavailable: $($_.Exception.Message)"
+            return
+        }
+    }
+    try {
+        Start-Process -FilePath 'explorer.exe' -ArgumentList "`"$folder`"" | Out-Null
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Failed to open folder: $($_.Exception.Message)"
+        return
+    }
+    Write-DuneJson -Response $res -Body @{ ok = $true; folder = $folder }
+}
+
+Register-DuneRoute -Method POST -Path '/api/db/backup-mirror/sync' -Handler {
+    param($req, $res, $routeParams, $body)
+
+    $enabled = Get-DuneLocalBackupMirrorEnabled
+    $folder  = Get-DuneLocalBackupMirrorFolder
+    $state   = Read-DuneBackupMirrorState
+
+    if (-not $enabled) {
+        Write-DuneJson -Response $res -Body @{
+            ok              = $true
+            skipped         = $true
+            reason          = 'disabled'
+            enabled         = $false
+            folder          = $folder
+            lastMirroredAt  = $state.lastMirroredAt
+            lastError       = $state.lastError
+            lastCopiedCount = $state.lastCopiedCount
+        }
+        return
+    }
+    if (-not $folder) {
+        $errMsg = 'No mirror folder set.'
+        $state.lastError = $errMsg
+        Save-DuneBackupMirrorState -State $state
+        Write-DuneJson -Response $res -Body @{
+            ok              = $false
+            enabled         = $true
+            folder          = ''
+            error           = $errMsg
+            lastMirroredAt  = $state.lastMirroredAt
+            lastError       = $errMsg
+            lastCopiedCount = $state.lastCopiedCount
+        }
+        return
+    }
+
+    $ctx = Get-DuneBackupContext
+    if (-not $ctx.ok) {
+        $errMsg = "VM unavailable: $($ctx.message)"
+        $state.lastError = $errMsg
+        Save-DuneBackupMirrorState -State $state
+        Write-DuneJson -Response $res -Body @{
+            ok              = $false
+            skipped         = $true
+            reason          = 'vm-unavailable'
+            enabled         = $true
+            folder          = $folder
+            error           = $errMsg
+            lastMirroredAt  = $state.lastMirroredAt
+            lastError       = $errMsg
+            lastCopiedCount = $state.lastCopiedCount
+        }
+        return
+    }
+
+    $keyPath = Get-V6SshKeyPath
+    if (-not $keyPath -or -not (Test-Path -LiteralPath $keyPath)) {
+        $errMsg = 'SSH key not available (VM v6 key missing).'
+        $state.lastError = $errMsg
+        Save-DuneBackupMirrorState -State $state
+        Write-DuneJson -Response $res -Body @{
+            ok              = $false
+            enabled         = $true
+            folder          = $folder
+            error           = $errMsg
+            lastMirroredAt  = $state.lastMirroredAt
+            lastError       = $errMsg
+            lastCopiedCount = $state.lastCopiedCount
+        }
+        return
+    }
+
+    $tick = Invoke-DuneBackupMirrorTick -Ip $ctx.ip -KeyPath $keyPath -LocalFolder $folder
+
+    $now = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $newState = @{
+        lastMirroredAt  = $now
+        lastError       = if ($tick.error) { [string]$tick.error } else { '' }
+        lastCopiedCount = @($tick.copied).Count
+    }
+    Save-DuneBackupMirrorState -State $newState
+
+    Write-DuneJson -Response $res -Body @{
+        ok              = [bool]$tick.ok
+        enabled         = $true
+        folder          = $folder
+        vmFileCount     = $tick.vmFileCount
+        copied          = @($tick.copied)
+        copiedCount     = @($tick.copied).Count
+        skipped         = $tick.skipped
+        failed          = @($tick.failed)
+        error           = $newState.lastError
+        lastMirroredAt  = $newState.lastMirroredAt
+        lastError       = $newState.lastError
+        lastCopiedCount = $newState.lastCopiedCount
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.9"
+$script:ToolVersion = "12.18.10"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/api/database.ts
+++ b/webui/src/api/database.ts
@@ -107,3 +107,50 @@ export function pruneBackupDumpPods(opts: { keepLast: number; keepDays: number }
     body: JSON.stringify({ keepLast: opts.keepLast, keepDays: opts.keepDays }),
   })
 }
+
+// Local backup mirror — copies each new VM backup into a user-chosen folder.
+// Copy-only: the mirror never deletes local files (VM auto-purge is scoped
+// to the VM only).
+export type BackupMirrorState = {
+  enabled: boolean
+  folder: string
+  lastMirroredAt: string
+  lastError: string
+  lastCopiedCount: number
+}
+
+export type BackupMirrorSyncResult = BackupMirrorState & {
+  ok: boolean
+  skipped?: boolean
+  reason?: string
+  vmFileCount?: number
+  copied?: string[]
+  copiedCount?: number
+  failed?: { name: string; error: string }[]
+  error?: string
+}
+
+export function getBackupMirror() {
+  return api<BackupMirrorState>('/api/db/backup-mirror')
+}
+
+export function setBackupMirror(opts: { enabled?: boolean; folder?: string }) {
+  return api<BackupMirrorState & { ok: boolean }>('/api/db/backup-mirror', {
+    method: 'POST',
+    body: JSON.stringify(opts),
+  })
+}
+
+export function openBackupMirrorFolder(opts: { folder?: string } = {}) {
+  return api<{ ok: boolean; folder: string }>('/api/db/backup-mirror/open', {
+    method: 'POST',
+    body: JSON.stringify(opts),
+  })
+}
+
+export function syncBackupMirror() {
+  return api<BackupMirrorSyncResult>('/api/db/backup-mirror/sync', {
+    method: 'POST',
+    body: JSON.stringify({}),
+  })
+}

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -14,6 +14,11 @@ import {
   deleteBackups,
   getBackupDumpPods,
   pruneBackupDumpPods,
+  getBackupMirror,
+  setBackupMirror,
+  openBackupMirrorFolder,
+  syncBackupMirror,
+  type BackupMirrorState,
 } from '../api/database'
 import type {
   DbInfo,
@@ -49,6 +54,26 @@ function pickFileFromShell(action: 'pick-save-file' | 'pick-open-file', opts: { 
     wv.addEventListener('message', handler)
     wv.postMessage({ action, ...opts })
     // Timeout: if the dialog is cancelled or shell doesn't respond within 5 min
+    setTimeout(() => { wv.removeEventListener('message', handler); resolve(null) }, 300_000)
+  })
+}
+
+// Sibling of pickFileFromShell for the native folder-browser dialog. The shell
+// posts back with the same "file-picked" action so the id-scoped listener can
+// stay in sync with the file variants.
+function pickFolderFromShell(opts: { id: string; initialPath?: string; description?: string }): Promise<string | null> {
+  return new Promise(resolve => {
+    const wv = (window as any).chrome?.webview
+    if (!wv) { resolve(null); return }
+    function handler(e: MessageEvent) {
+      const data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data
+      if (data?.action === 'file-picked' && data?.id === opts.id) {
+        wv.removeEventListener('message', handler)
+        resolve(data.path ?? null)
+      }
+    }
+    wv.addEventListener('message', handler)
+    wv.postMessage({ action: 'pick-folder', ...opts })
     setTimeout(() => { wv.removeEventListener('message', handler); resolve(null) }, 300_000)
   })
 }
@@ -320,6 +345,9 @@ export function Database() {
 
       {/* Configurable backup schedule (writes the VM's root crontab) */}
       <BackupScheduleCard vmRunning={vmRunning} showToast={showToast} />
+
+      {/* Local backup mirror — copies each new VM backup into a user-chosen folder. */}
+      <BackupMirrorCard vmRunning={vmRunning} showToast={showToast} />
 
       {/* Fix on-demand maps — captured output */}
       <div className="card p-5 flex flex-col mb-6">
@@ -1425,4 +1453,241 @@ function relativeFromNow(epochSeconds: number): string {
   if (deltaSec < 86400)     return `${Math.floor(deltaSec / 3600)}h ago`
   if (deltaSec < 86400 * 7) return `${Math.floor(deltaSec / 86400)}d ago`
   return `${Math.floor(deltaSec / 86400)}d ago`
+}
+
+// ---------- Local Backup Mirror card ----------------------------------------
+// Copy-only mirror of the VM's DST-recognized backup files into a folder the
+// user picks. Every history refresh also fires a mirror /sync so any new
+// backup gets copied down within a poll cycle. Never deletes local files.
+
+type BackupMirrorCardProps = {
+  vmRunning: boolean
+  showToast: (kind: 'ok' | 'err', msg: string) => void
+}
+
+function BackupMirrorCard({ vmRunning, showToast }: BackupMirrorCardProps) {
+  const [state, setState] = useState<BackupMirrorState | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [syncing, setSyncing] = useState(false)
+  const [folderDraft, setFolderDraft] = useState('')
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const s = await getBackupMirror()
+      setState(s)
+      setFolderDraft(s.folder ?? '')
+      setErr(null)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void load() }, [load])
+
+  // Poll a mirror sync on the same cadence as backup history (~30s) when
+  // enabled and the VM is running. This is how new backups get pulled down
+  // without any user action.
+  const enabled = state?.enabled === true
+  useEffect(() => {
+    if (!enabled || !vmRunning) return
+    let cancelled = false
+    const tick = async () => {
+      try {
+        const r = await syncBackupMirror()
+        if (!cancelled) {
+          setState(prev => prev ? {
+            ...prev,
+            lastMirroredAt: r.lastMirroredAt,
+            lastError: r.lastError,
+            lastCopiedCount: r.lastCopiedCount,
+          } : prev)
+        }
+      } catch { /* silent — status line in card shows any surfaced error */ }
+    }
+    void tick()
+    const h = window.setInterval(() => { void tick() }, 30_000)
+    return () => { cancelled = true; window.clearInterval(h) }
+  }, [enabled, vmRunning])
+
+  const toggleEnabled = useCallback(async (next: boolean) => {
+    if (next && !folderDraft.trim()) {
+      showToast('err', 'Pick a folder before enabling the mirror.')
+      return
+    }
+    setSaving(true)
+    try {
+      const r = await setBackupMirror({ enabled: next, folder: folderDraft.trim() })
+      setState({
+        enabled: r.enabled,
+        folder: r.folder,
+        lastMirroredAt: r.lastMirroredAt,
+        lastError: r.lastError,
+        lastCopiedCount: r.lastCopiedCount,
+      })
+      showToast('ok', next ? 'Local backup mirror enabled.' : 'Local backup mirror disabled.')
+    } catch (e) {
+      showToast('err', e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }, [folderDraft, showToast])
+
+  const saveFolder = useCallback(async (folder: string) => {
+    setSaving(true)
+    try {
+      const r = await setBackupMirror({ folder })
+      setState({
+        enabled: r.enabled,
+        folder: r.folder,
+        lastMirroredAt: r.lastMirroredAt,
+        lastError: r.lastError,
+        lastCopiedCount: r.lastCopiedCount,
+      })
+      showToast('ok', 'Mirror folder saved.')
+    } catch (e) {
+      showToast('err', e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }, [showToast])
+
+  const browse = useCallback(async () => {
+    const chosen = await pickFolderFromShell({
+      id: 'backup-mirror-folder',
+      initialPath: folderDraft || undefined,
+      description: 'Select a folder for local backup copies',
+    })
+    if (!chosen) return
+    setFolderDraft(chosen)
+    void saveFolder(chosen)
+  }, [folderDraft, saveFolder])
+
+  const openFolder = useCallback(async () => {
+    if (!folderDraft.trim()) {
+      showToast('err', 'No folder set.')
+      return
+    }
+    try {
+      await openBackupMirrorFolder({ folder: folderDraft.trim() })
+    } catch (e) {
+      showToast('err', e instanceof Error ? e.message : String(e))
+    }
+  }, [folderDraft, showToast])
+
+  const syncNow = useCallback(async () => {
+    setSyncing(true)
+    try {
+      const r = await syncBackupMirror()
+      setState(prev => prev ? {
+        ...prev,
+        lastMirroredAt: r.lastMirroredAt,
+        lastError: r.lastError,
+        lastCopiedCount: r.lastCopiedCount,
+      } : prev)
+      if (r.ok) {
+        showToast('ok', r.copiedCount ? `Mirrored ${r.copiedCount} new file(s).` : 'Mirror up to date.')
+      } else if (r.error) {
+        showToast('err', r.error)
+      }
+    } catch (e) {
+      showToast('err', e instanceof Error ? e.message : String(e))
+    } finally {
+      setSyncing(false)
+    }
+  }, [showToast])
+
+  const lastError = state?.lastError ?? ''
+  const lastMirroredAt = state?.lastMirroredAt ?? ''
+
+  return (
+    <div className="card p-5 flex flex-col mb-6">
+      <div className="flex items-center gap-3 mb-3">
+        <Icon name="FolderSync" size={22} className="text-primary" />
+        <h2 className="text-base font-semibold tracking-tight">Local backup mirror</h2>
+      </div>
+      <p className="text-sm text-text-muted mb-3">
+        Automatically copy every DST-taken database backup into a folder on this PC.
+        Copies are added as new backups appear on the VM — files in the mirror folder are never
+        deleted by DST, even if the VM's auto-purge trims older backups on the server side.
+      </p>
+
+      <label className="flex items-center gap-3 mb-3 select-none cursor-pointer">
+        <input
+          type="checkbox"
+          checked={enabled}
+          disabled={loading || saving}
+          onChange={e => void toggleEnabled(e.target.checked)}
+        />
+        <span className="text-sm">Mirror new backups to a local folder</span>
+      </label>
+
+      {enabled && (
+        <div className="flex flex-col gap-3">
+          <div className="text-xs text-warning">
+            ⚠ Copies every backup that appears in backup history (scheduled, manual, and Funcom's auto-backups).
+            Files are never deleted from your local folder — VM auto-purge only trims the server side.
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              className="input flex-1 font-mono text-xs"
+              placeholder="C:\Path\To\Backup\Folder"
+              value={folderDraft}
+              onChange={e => setFolderDraft(e.target.value)}
+              onBlur={() => {
+                if (folderDraft.trim() !== (state?.folder ?? '')) {
+                  void saveFolder(folderDraft.trim())
+                }
+              }}
+              disabled={saving}
+            />
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => void browse()}
+              disabled={saving}
+            >
+              Browse…
+            </button>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => void openFolder()}
+              disabled={!folderDraft.trim()}
+              title="Open folder in Explorer"
+            >
+              Open Folder
+            </button>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => void syncNow()}
+              disabled={syncing || !folderDraft.trim() || !vmRunning}
+              title="Copy any missing backups now"
+            >
+              {syncing ? 'Syncing…' : 'Sync Now'}
+            </button>
+          </div>
+
+          <div className="text-xs text-text-dim">
+            {lastError ? (
+              <span className="text-danger">Last error: {lastError}</span>
+            ) : lastMirroredAt ? (
+              <span>Last sync: {lastMirroredAt} · copied {state?.lastCopiedCount ?? 0} file(s).</span>
+            ) : (
+              <span>Not yet synced.</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {err && <div className="text-xs text-danger mt-2">{err}</div>}
+    </div>
+  )
 }

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -1469,7 +1469,6 @@ function BackupMirrorCard({ vmRunning, showToast }: BackupMirrorCardProps) {
   const [state, setState] = useState<BackupMirrorState | null>(null)
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
-  const [syncing, setSyncing] = useState(false)
   const [folderDraft, setFolderDraft] = useState('')
   const [err, setErr] = useState<string | null>(null)
 
@@ -1515,13 +1514,9 @@ function BackupMirrorCard({ vmRunning, showToast }: BackupMirrorCardProps) {
   }, [enabled, vmRunning])
 
   const toggleEnabled = useCallback(async (next: boolean) => {
-    if (next && !folderDraft.trim()) {
-      showToast('err', 'Pick a folder before enabling the mirror.')
-      return
-    }
     setSaving(true)
     try {
-      const r = await setBackupMirror({ enabled: next, folder: folderDraft.trim() })
+      const r = await setBackupMirror({ enabled: next })
       setState({
         enabled: r.enabled,
         folder: r.folder,
@@ -1529,13 +1524,17 @@ function BackupMirrorCard({ vmRunning, showToast }: BackupMirrorCardProps) {
         lastError: r.lastError,
         lastCopiedCount: r.lastCopiedCount,
       })
-      showToast('ok', next ? 'Local backup mirror enabled.' : 'Local backup mirror disabled.')
+      if (next && !r.folder) {
+        showToast('ok', 'Mirror enabled — pick a folder to start copying backups.')
+      } else {
+        showToast('ok', next ? 'Local backup mirror enabled.' : 'Local backup mirror disabled.')
+      }
     } catch (e) {
       showToast('err', e instanceof Error ? e.message : String(e))
     } finally {
       setSaving(false)
     }
-  }, [folderDraft, showToast])
+  }, [showToast])
 
   const saveFolder = useCallback(async (folder: string) => {
     setSaving(true)
@@ -1564,8 +1563,7 @@ function BackupMirrorCard({ vmRunning, showToast }: BackupMirrorCardProps) {
     })
     if (!chosen) return
     setFolderDraft(chosen)
-    void saveFolder(chosen)
-  }, [folderDraft, saveFolder])
+  }, [folderDraft])
 
   const openFolder = useCallback(async () => {
     if (!folderDraft.trim()) {
@@ -1579,27 +1577,7 @@ function BackupMirrorCard({ vmRunning, showToast }: BackupMirrorCardProps) {
     }
   }, [folderDraft, showToast])
 
-  const syncNow = useCallback(async () => {
-    setSyncing(true)
-    try {
-      const r = await syncBackupMirror()
-      setState(prev => prev ? {
-        ...prev,
-        lastMirroredAt: r.lastMirroredAt,
-        lastError: r.lastError,
-        lastCopiedCount: r.lastCopiedCount,
-      } : prev)
-      if (r.ok) {
-        showToast('ok', r.copiedCount ? `Mirrored ${r.copiedCount} new file(s).` : 'Mirror up to date.')
-      } else if (r.error) {
-        showToast('err', r.error)
-      }
-    } catch (e) {
-      showToast('err', e instanceof Error ? e.message : String(e))
-    } finally {
-      setSyncing(false)
-    }
-  }, [showToast])
+  const folderDirty = (folderDraft.trim() !== (state?.folder ?? ''))
 
   const lastError = state?.lastError ?? ''
   const lastMirroredAt = state?.lastMirroredAt ?? ''
@@ -1607,8 +1585,8 @@ function BackupMirrorCard({ vmRunning, showToast }: BackupMirrorCardProps) {
   return (
     <div className="card p-5 flex flex-col mb-6">
       <div className="flex items-center gap-3 mb-3">
-        <Icon name="FolderSync" size={22} className="text-primary" />
-        <h2 className="text-base font-semibold tracking-tight">Local backup mirror</h2>
+        <Icon name="FolderSync" size={22} className="text-info" />
+        <h2 className="text-base font-semibold tracking-tight text-info">Local backup mirror</h2>
       </div>
       <p className="text-sm text-text-muted mb-3">
         Automatically copy every DST-taken database backup into a folder on this PC.
@@ -1640,11 +1618,6 @@ function BackupMirrorCard({ vmRunning, showToast }: BackupMirrorCardProps) {
               placeholder="C:\Path\To\Backup\Folder"
               value={folderDraft}
               onChange={e => setFolderDraft(e.target.value)}
-              onBlur={() => {
-                if (folderDraft.trim() !== (state?.folder ?? '')) {
-                  void saveFolder(folderDraft.trim())
-                }
-              }}
               disabled={saving}
             />
             <button
@@ -1657,21 +1630,20 @@ function BackupMirrorCard({ vmRunning, showToast }: BackupMirrorCardProps) {
             </button>
             <button
               type="button"
+              className="btn btn-primary"
+              onClick={() => void saveFolder(folderDraft.trim())}
+              disabled={saving || !folderDirty}
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+            <button
+              type="button"
               className="btn btn-secondary"
               onClick={() => void openFolder()}
               disabled={!folderDraft.trim()}
               title="Open folder in Explorer"
             >
               Open Folder
-            </button>
-            <button
-              type="button"
-              className="btn btn-secondary"
-              onClick={() => void syncNow()}
-              disabled={syncing || !folderDraft.trim() || !vmRunning}
-              title="Copy any missing backups now"
-            >
-              {syncing ? 'Syncing…' : 'Sync Now'}
             </button>
           </div>
 


### PR DESCRIPTION
## Summary

Adds a checkbox on the **Database → Backups** section that copies every VM database backup into a user-picked folder on this PC. Filenames are preserved verbatim so mirrored files stay drop-in compatible with the existing Restore / upload paths. Polls every ~30s while enabled, and there's a **Sync Now** button.

**Copy-only by design.** DST never deletes files from the local mirror folder. VM auto-purge retention only trims the server side — the mirror is a permanent local archive the user prunes themselves when needed. The card's warning label makes this explicit.

## Files

**Backend**
- `app/server/lib/Config.ps1` — adds `LocalBackupMirrorEnabled` + `LocalBackupMirrorFolder` keys and `Get-` helpers
- `app/server/lib/BackupMirror.ps1` *(new)* — enumerates DST-recognized backup files on the VM, diffs against local folder by filename, SCPs missing files. Sidecar JSON state at `%APPDATA%\DuneServer\backup-mirror-state.json` holds `lastMirroredAt` / `lastError` / `lastCopiedCount`
- `app/server/routes/BackupMirror.ps1` *(new)* — `GET/POST /api/db/backup-mirror` + `/open` + `/sync`

**Shell**
- `app/desktop/DuneShell/MainForm.cs` — new `pick-folder` WebView2 bridge action using `FolderBrowserDialog` so the Browse button opens a native dialog

**Frontend**
- `webui/src/api/database.ts` — `BackupMirrorState` + `getBackupMirror` / `setBackupMirror` / `openBackupMirrorFolder` / `syncBackupMirror` clients
- `webui/src/pages/Database.tsx` — `BackupMirrorCard` mounted next to `BackupScheduleCard`, wires the folder picker, Open Folder in Explorer, and polls sync while enabled

**Docs**
- `CHANGELOG.md` — `[Unreleased]` Added entry

## Design decisions

- **State file:** sidecar JSON, not extra config keys — timestamps and error strings don't belong in the INI-style config.
- **Filter:** mirror every backup the history endpoint reports (both `dst-scheduled-*` extension-less files AND `*.backup` files, including Funcom-default names). Avoids the "how do we tell which `.backup` came from a DST-manual" ambiguity.
- **Cap per tick:** 20 files max per sync to keep the request fast; subsequent ticks pick up the rest.
- **Folder unavailable:** silent skip on the server, red status line in the card — never throws.

## Testing

- webui `npm run build` — passes (typecheck + Vite build clean)
- PowerShell parse-check on all new/modified `.ps1` files — clean
- BOM check on new `.ps1` files — both have UTF-8 BOM (required for PS2EXE)

Pester tests and installer smoke-test to follow before batching into the next release.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>