### PR TITLE
v12.18.12: VM file transfer over ssh (sudo cat / sudo tee) instead of scp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.8"
+      placeholder: "v12.18.12"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.12] - 2026-07-10
+
+### Fixed
+
+- **Local backup mirror (v12.18.10) actually copies files now.** Every mirror tick was silently failing: it enumerated the VM's backups correctly but every `scp` pull died with `bash: line 1: /usr/lib/ssh/sftp-server: No such file or directory` (rc=255). Since OpenSSH 9.0 the Windows `scp` client defaults to the SFTP subsystem for transfers, and the DST VM is Alpine minimal with no `sftp-server` and no `scp` binary at all. Adding `-O` (legacy SCP protocol) doesn't help either — there is nothing on the VM to receive it. DST no longer uses `scp`; all VM ↔ PC file transfers now stream over the existing `ssh` connection via `sudo cat` (VM → PC) or `sudo tee` (PC → VM), which uses the same key and toolset every other DST ↔ VM interaction already depends on. Same fix repairs the **Download** button on each backup row and the **Upload** button on the Database page, both of which were broken by the identical bug.
+- **Local backup mirror surfaces per-file copy failures.** The sidecar state only recorded top-level errors ("VM listing failed", "folder not writable"), so a run where every per-file copy failed reported `copied 0 file(s)` with no error banner — which is exactly how the scp bug above hid for a full release cycle. When any file fails, the mirror card now shows `Last error: N file(s) failed to copy - first: <first error>`.
+
 ## [12.18.11] - 2026-07-10
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.11'
+$script:DuneToolVersion = '12.18.12'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.11',
+    [string]$Version = '12.18.12',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.11</Version>
+    <Version>12.18.12</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.11"
+#define MyAppVersion "12.18.12"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"
@@ -97,9 +97,10 @@ Source: "..\..\webui\dist\*"; DestDir: "{app}\webui\dist"; Flags: ignoreversion 
 ; v11.0.1: Versioned copy of the remote partition-clear script.
 ; v11.0.3: Script is now staged inline to /tmp on the VM, run once with
 ; sudo, then removed — no /etc/local.d install, no /etc/periodic/15min cron.
-; DST scp's this file to /tmp/dune-cp-<id>.sh on every Start / Restart /
-; fix-on-demand-maps invocation. (Existing VMs that had the boot script +
-; cron installed by v11.0.1/v11.0.2 keep working harmlessly until rebuilt.)
+; v12.18.12: Staging uses base64-over-ssh (see Maps.ps1 / VmFileTransfer.ps1),
+; not scp — Alpine minimal has no sftp-server and modern OpenSSH scp needs it.
+; (Existing VMs that had the boot script + cron installed by v11.0.1/v11.0.2
+; keep working harmlessly until rebuilt.)
 Source: "..\resources\remote-scripts\*"; DestDir: "{app}\resources\remote-scripts"; Flags: ignoreversion recursesubdirs
 
 ; v6.1.24: Drop-in preflight checker users can run when something goes wrong.

--- a/app/server/lib/BackupMirror.ps1
+++ b/app/server/lib/BackupMirror.ps1
@@ -95,9 +95,11 @@ sudo find $script:DuneBackupDumpDir -maxdepth 3 -type f \( -name '*.backup' -o -
     return ,$out
 }
 
-# SCP a single file from the VM to the local mirror folder. Preserves the
-# source filename. Returns @{ ok; localPath?; error? }.
-function Invoke-DuneBackupMirrorScpPull {
+# Pull a single file from the VM to the local mirror folder. Preserves the
+# source filename. Wraps the shared Copy-DuneVmFileToLocal helper (which
+# streams via `ssh + sudo cat` because Alpine minimal has no scp/sftp — see
+# lib/VmFileTransfer.ps1). Returns @{ ok; localPath?; error? }.
+function Invoke-DuneBackupMirrorFilePull {
     param(
         [Parameter(Mandatory)][string]$Ip,
         [Parameter(Mandatory)][string]$KeyPath,
@@ -105,37 +107,11 @@ function Invoke-DuneBackupMirrorScpPull {
         [Parameter(Mandatory)][string]$LocalFolder,
         [int]$TimeoutSec = 300
     )
-    $fileName = Split-Path -Leaf $VmPath
+    $fileName  = Split-Path -Leaf $VmPath
     $localPath = Join-Path $LocalFolder $fileName
-
-    $psi = [System.Diagnostics.ProcessStartInfo]::new()
-    $psi.FileName               = 'scp'
-    $psi.RedirectStandardOutput = $true
-    $psi.RedirectStandardError  = $true
-    $psi.UseShellExecute        = $false
-    $psi.CreateNoWindow         = $true
-    $psi.Arguments = "-o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i `"$KeyPath`" `"dune@$($Ip):$VmPath`" `"$localPath`""
-
-    $proc = [System.Diagnostics.Process]::new()
-    $proc.StartInfo = $psi
-    try {
-        [void]$proc.Start()
-        $errTask = $proc.StandardError.ReadToEndAsync()
-        $exited = $proc.WaitForExit($TimeoutSec * 1000)
-        if (-not $exited) {
-            try { $proc.Kill() } catch {}
-            return @{ ok = $false; error = "SCP timed out after ${TimeoutSec}s ($fileName)" }
-        }
-        [void]$proc.WaitForExit()
-        $stderr = $errTask.GetAwaiter().GetResult()
-        if ($proc.ExitCode -ne 0) {
-            return @{ ok = $false; error = "SCP failed rc=$($proc.ExitCode): $($stderr.Trim())" }
-        }
-    } finally {
-        try { $proc.Dispose() } catch {}
-    }
-    if (-not (Test-Path -LiteralPath $localPath)) {
-        return @{ ok = $false; error = "SCP reported success but $fileName not present locally." }
+    $r = Copy-DuneVmFileToLocal -Ip $Ip -KeyPath $KeyPath -VmPath $VmPath -LocalPath $localPath -TimeoutSec $TimeoutSec
+    if (-not $r.ok) {
+        return @{ ok = $false; error = "$($r.error) ($fileName)" }
     }
     return @{ ok = $true; localPath = $localPath }
 }
@@ -217,7 +193,7 @@ function Invoke-DuneBackupMirrorTick {
             $result.skipped++
             continue
         }
-        $r = Invoke-DuneBackupMirrorScpPull -Ip $Ip -KeyPath $KeyPath -VmPath $vm.path -LocalFolder $LocalFolder
+        $r = Invoke-DuneBackupMirrorFilePull -Ip $Ip -KeyPath $KeyPath -VmPath $vm.path -LocalFolder $LocalFolder
         if ($r.ok) {
             $result.copied += $name
             $copied++

--- a/app/server/lib/DuneAdminCache.ps1
+++ b/app/server/lib/DuneAdminCache.ps1
@@ -28,7 +28,8 @@
 # accidentally clearing, walk them through:
 #   1. zip the timestamped folder under the path above,
 #   2. send it back,
-#   3. scp the wanted yaml(s) back into ~/.dune/ on the VM,
+#   3. stream the wanted yaml(s) back into ~/.dune/ on the VM (Copy-DuneLocalFileToVm
+#      in lib/VmFileTransfer.ps1 already handles this shape),
 #   4. chown dune:dune them.
 # Pruning is not automatic; files are ~70 KB each and clears are rare.
 # ----------------------------------------------------------------------

--- a/app/server/lib/VmFileTransfer.ps1
+++ b/app/server/lib/VmFileTransfer.ps1
@@ -1,0 +1,167 @@
+﻿# VmFileTransfer.ps1 — stream files between the DST VM and this PC over ssh.
+#
+# The DST VM (Alpine minimal) has no `scp` binary and no `sftp-server`
+# subsystem installed. Since OpenSSH 9.0 the Windows `scp` client defaults to
+# the SFTP protocol for the actual transfer, so every `scp dune@vm:...` call
+# dies with `bash: line 1: /usr/lib/ssh/sftp-server: No such file or directory`
+# followed by `scp: Connection closed` (rc=255). That broke the manual
+# Database → Download button, the manual Upload button, and every tick of the
+# v12.18.10 Local Backup Mirror. Adding scp `-O` (legacy SCP protocol) doesn't
+# help either — the VM has no `scp` executable to receive the transfer.
+#
+# So DST no longer uses scp at all. This module wraps `ssh + sudo cat` for
+# pulls and `ssh + sudo tee` for pushes, streaming raw bytes through the
+# process's redirected stdio. That's the same ssh key + toolset every other
+# VM interaction already uses (Invoke-DuneBackupShell, etc.), so there is no
+# new VM-side requirement — if a user can reach their VM at all, transfers
+# work.
+#
+# Callers:
+#   * lib/BackupMirror.ps1  — Invoke-DuneBackupMirrorTick per-file pull
+#   * routes/BackupTransfer.ps1 — Download + Upload
+
+# Pull a file from the VM into a local path. Streams raw bytes over
+# `ssh dune@vm sudo cat <path>` into a local FileStream so binary backups
+# survive intact. Returns @{ ok; localPath?; error? }.
+function Copy-DuneVmFileToLocal {
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [Parameter(Mandatory)][string]$KeyPath,
+        [Parameter(Mandatory)][string]$VmPath,
+        [Parameter(Mandatory)][string]$LocalPath,
+        [int]$TimeoutSec = 300
+    )
+    # Refuse anything that isn't an absolute posix path so an accidental
+    # $null / relative path can't turn into `sudo cat` of the ssh CWD.
+    if ($VmPath -notmatch '^/') {
+        return @{ ok = $false; error = "VM path must be absolute: $VmPath" }
+    }
+
+    $localDir = Split-Path -Parent $LocalPath
+    if ($localDir -and -not (Test-Path -LiteralPath $localDir)) {
+        try { New-Item -ItemType Directory -Path $localDir -Force -ErrorAction Stop | Out-Null }
+        catch { return @{ ok = $false; error = "Cannot create local directory: $($_.Exception.Message)" } }
+    }
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName               = 'ssh'
+    # Single-quoted VmPath because it's already validated to start with '/'
+    # and Alpine's find never emits characters that need escaping (posix
+    # dump-dir paths only). Wrapping in single quotes stops the local
+    # shell + remote shell from re-interpreting whitespace or globs.
+    $psi.Arguments = "-o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i `"$KeyPath`" `"dune@$Ip`" sudo cat '$VmPath'"
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute        = $false
+    $psi.CreateNoWindow         = $true
+
+    $fs = $null
+    $proc = [System.Diagnostics.Process]::new()
+    $proc.StartInfo = $psi
+    try {
+        [void]$proc.Start()
+        $errTask = $proc.StandardError.ReadToEndAsync()
+        try {
+            $fs = [System.IO.File]::Create($LocalPath)
+        } catch {
+            try { $proc.Kill() } catch {}
+            return @{ ok = $false; error = "Cannot open local file for write: $($_.Exception.Message)" }
+        }
+        # CopyTo blocks until ssh closes stdout (EOF) or the process dies.
+        $proc.StandardOutput.BaseStream.CopyTo($fs)
+        $fs.Flush()
+        $fs.Close()
+        $fs = $null
+
+        $exited = $proc.WaitForExit($TimeoutSec * 1000)
+        if (-not $exited) {
+            try { $proc.Kill() } catch {}
+            return @{ ok = $false; error = "ssh cat timed out after ${TimeoutSec}s" }
+        }
+        [void]$proc.WaitForExit()
+        $stderr = $errTask.GetAwaiter().GetResult()
+        if ($proc.ExitCode -ne 0) {
+            # Clean up the partial file — a 0-byte or half-written backup
+            # would poison the local mirror folder / the local target.
+            try { Remove-Item -LiteralPath $LocalPath -Force -ErrorAction SilentlyContinue } catch {}
+            $tail = if ($stderr) { ": $($stderr.Trim())" } else { '' }
+            return @{ ok = $false; error = "ssh cat failed rc=$($proc.ExitCode)$tail" }
+        }
+    } finally {
+        if ($fs) { try { $fs.Close() } catch {} }
+        try { $proc.Dispose() } catch {}
+    }
+
+    if (-not (Test-Path -LiteralPath $LocalPath)) {
+        return @{ ok = $false; error = 'ssh cat reported success but local file not present.' }
+    }
+    return @{ ok = $true; localPath = $LocalPath }
+}
+
+# Push a local file to the VM. Streams raw bytes into `ssh dune@vm sudo tee
+# <path> > /dev/null` so the remote file is written with root ownership +
+# perms directly at $VmPath. Returns @{ ok; vmPath?; error? }.
+function Copy-DuneLocalFileToVm {
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [Parameter(Mandatory)][string]$KeyPath,
+        [Parameter(Mandatory)][string]$LocalPath,
+        [Parameter(Mandatory)][string]$VmPath,
+        [int]$TimeoutSec = 600
+    )
+    if ($VmPath -notmatch '^/') {
+        return @{ ok = $false; error = "VM path must be absolute: $VmPath" }
+    }
+    if (-not (Test-Path -LiteralPath $LocalPath -PathType Leaf)) {
+        return @{ ok = $false; error = "Local file not found: $LocalPath" }
+    }
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName               = 'ssh'
+    # `sudo tee` writes stdin to the target; `> /dev/null` suppresses tee's
+    # stdout copy so the ssh stdout stays quiet. `sudo chmod 644` follows so
+    # the file is world-readable (matches how `battlegroup backup` writes it).
+    $psi.Arguments = "-o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i `"$KeyPath`" `"dune@$Ip`" `"sudo tee '$VmPath' > /dev/null && sudo chmod 644 '$VmPath'`""
+    $psi.RedirectStandardInput  = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute        = $false
+    $psi.CreateNoWindow         = $true
+
+    $inFs = $null
+    $proc = [System.Diagnostics.Process]::new()
+    $proc.StartInfo = $proc.StartInfo = $psi
+    try {
+        [void]$proc.Start()
+        $outTask = $proc.StandardOutput.ReadToEndAsync()
+        $errTask = $proc.StandardError.ReadToEndAsync()
+        try {
+            $inFs = [System.IO.File]::OpenRead($LocalPath)
+        } catch {
+            try { $proc.Kill() } catch {}
+            return @{ ok = $false; error = "Cannot open local file for read: $($_.Exception.Message)" }
+        }
+        # Pump the file into ssh stdin. Close stdin so `tee` sees EOF.
+        $inFs.CopyTo($proc.StandardInput.BaseStream)
+        $proc.StandardInput.BaseStream.Flush()
+        $proc.StandardInput.Close()
+        $inFs.Close()
+        $inFs = $null
+
+        $exited = $proc.WaitForExit($TimeoutSec * 1000)
+        if (-not $exited) {
+            try { $proc.Kill() } catch {}
+            return @{ ok = $false; error = "ssh tee timed out after ${TimeoutSec}s" }
+        }
+        [void]$proc.WaitForExit()
+        $stderr = $errTask.GetAwaiter().GetResult()
+        if ($proc.ExitCode -ne 0) {
+            $tail = if ($stderr) { ": $($stderr.Trim())" } else { '' }
+            return @{ ok = $false; error = "ssh tee failed rc=$($proc.ExitCode)$tail" }
+        }
+    } finally {
+        if ($inFs) { try { $inFs.Close() } catch {} }
+        try { $proc.Dispose() } catch {}
+    }
+    return @{ ok = $true; vmPath = $VmPath }
+}

--- a/app/server/routes/BackupMirror.ps1
+++ b/app/server/routes/BackupMirror.ps1
@@ -168,10 +168,24 @@ Register-DuneRoute -Method POST -Path '/api/db/backup-mirror/sync' -Handler {
 
     $tick = Invoke-DuneBackupMirrorTick -Ip $ctx.ip -KeyPath $keyPath -LocalFolder $folder
 
+    # Surface per-file failures in lastError so the UI can flag them. Without
+    # this the sidecar only ever recorded $tick.error (top-level "VM listing
+    # failed" / "folder not writable" errors), so a run where every single
+    # SCP/ssh-cat died would silently report "copied 0 file(s)" with a green
+    # banner — how the pre-v12.18.12 scp bug hid for a full release cycle.
+    $errMsg = ''
+    if ($tick.error) {
+        $errMsg = [string]$tick.error
+    } elseif ($tick.failed -and @($tick.failed).Count -gt 0) {
+        $failed = @($tick.failed)
+        $first  = if ($failed[0] -and $failed[0].error) { [string]$failed[0].error } else { 'unknown error' }
+        $errMsg = "$($failed.Count) file(s) failed to copy - first: $first"
+    }
+
     $now = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     $newState = @{
         lastMirroredAt  = $now
-        lastError       = if ($tick.error) { [string]$tick.error } else { '' }
+        lastError       = $errMsg
         lastCopiedCount = @($tick.copied).Count
     }
     Save-DuneBackupMirrorState -State $newState

--- a/app/server/routes/BackupTransfer.ps1
+++ b/app/server/routes/BackupTransfer.ps1
@@ -57,34 +57,13 @@ Register-DuneRoute -Method POST -Path '/api/db/backup-download' -Handler {
         }
     }
 
-    # SCP from VM to local path
-    $psi = [System.Diagnostics.ProcessStartInfo]::new()
-    $psi.FileName               = 'scp'
-    $psi.RedirectStandardOutput = $true
-    $psi.RedirectStandardError  = $true
-    $psi.UseShellExecute        = $false
-    $psi.CreateNoWindow         = $true
-    $psi.Arguments = "-o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i `"$key`" `"dune@$($ctx.ip):$vmPath`" `"$localPath`""
-
-    $proc = [System.Diagnostics.Process]::new()
-    $proc.StartInfo = $psi
-    try {
-        [void]$proc.Start()
-        $errTask = $proc.StandardError.ReadToEndAsync()
-        $exited = $proc.WaitForExit(120000)  # 2 min timeout for large files
-        if (-not $exited) {
-            try { $proc.Kill() } catch {}
-            Write-DuneError -Response $res -Status 504 -Message 'SCP timed out after 120s.'
-            return
-        }
-        [void]$proc.WaitForExit()
-        $stderr = $errTask.GetAwaiter().GetResult()
-        if ($proc.ExitCode -ne 0) {
-            Write-DuneError -Response $res -Status 502 -Message "SCP failed (rc=$($proc.ExitCode)): $($stderr.Trim())"
-            return
-        }
-    } finally {
-        try { $proc.Dispose() } catch {}
+    # Stream from VM to local via `ssh + sudo cat` (see lib/VmFileTransfer.ps1
+    # for why not scp). Copy-DuneVmFileToLocal handles binary safely and
+    # cleans up a partial file on failure.
+    $r = Copy-DuneVmFileToLocal -Ip $ctx.ip -KeyPath $key -VmPath $vmPath -LocalPath $localPath -TimeoutSec 300
+    if (-not $r.ok) {
+        Write-DuneError -Response $res -Status 502 -Message $r.error
+        return
     }
 
     # Verify file landed
@@ -146,41 +125,12 @@ Register-DuneRoute -Method POST -Path '/api/db/backup-upload' -Handler {
     $fileName = Split-Path -Leaf $localPath
     $remotePath = "$dumpSubdir/$fileName"
 
-    # SCP local file to VM (upload to a temp path, then sudo mv to dump dir)
-    $tmpRemote = "/tmp/dst-upload-$fileName"
-    $psi = [System.Diagnostics.ProcessStartInfo]::new()
-    $psi.FileName               = 'scp'
-    $psi.RedirectStandardOutput = $true
-    $psi.RedirectStandardError  = $true
-    $psi.UseShellExecute        = $false
-    $psi.CreateNoWindow         = $true
-    $psi.Arguments = "-o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i `"$key`" `"$localPath`" `"dune@$($ctx.ip):$tmpRemote`""
-
-    $proc = [System.Diagnostics.Process]::new()
-    $proc.StartInfo = $psi
-    try {
-        [void]$proc.Start()
-        $errTask = $proc.StandardError.ReadToEndAsync()
-        $exited = $proc.WaitForExit(120000)
-        if (-not $exited) {
-            try { $proc.Kill() } catch {}
-            Write-DuneError -Response $res -Status 504 -Message 'SCP upload timed out after 120s.'
-            return
-        }
-        [void]$proc.WaitForExit()
-        $stderr = $errTask.GetAwaiter().GetResult()
-        if ($proc.ExitCode -ne 0) {
-            Write-DuneError -Response $res -Status 502 -Message "SCP upload failed (rc=$($proc.ExitCode)): $($stderr.Trim())"
-            return
-        }
-    } finally {
-        try { $proc.Dispose() } catch {}
-    }
-
-    # Move the uploaded file from /tmp to the dump directory (needs sudo)
-    $mvResult = Invoke-DuneBackupShell -Ip $ctx.ip -Script "sudo mv `"$tmpRemote`" `"$remotePath`" && sudo chmod 644 `"$remotePath`"" -TimeoutSec 10
-    if ($mvResult.rc -ne 0) {
-        Write-DuneError -Response $res -Status 502 -Message "File uploaded but move to dump dir failed: $($mvResult.out)"
+    # Stream local file to VM via `ssh + sudo tee` (see lib/VmFileTransfer.ps1
+    # for why not scp). Copy-DuneLocalFileToVm writes with root ownership
+    # + 644 directly at $remotePath — no intermediate /tmp step needed.
+    $r = Copy-DuneLocalFileToVm -Ip $ctx.ip -KeyPath $key -LocalPath $localPath -VmPath $remotePath -TimeoutSec 600
+    if (-not $r.ok) {
+        Write-DuneError -Response $res -Status 502 -Message $r.error
         return
     }
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.11"
+$script:ToolVersion = "12.18.12"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## The bug

Reported by Coastal: the **Local Backup Mirror** (v12.18.10 feature) was showing `Last sync: <timestamp> · copied 0 file(s)` with no error banner, but the mirror folder stayed empty even though 12 scheduled backups were sitting on the VM.

Root cause: every per-file `scp` pull was dying with

```
bash: line 1: /usr/lib/ssh/sftp-server: No such file or directory
scp: Connection closed
```

(rc=255). Since OpenSSH 9.0 the Windows `scp` client defaults to the SFTP subsystem for the actual transfer, and the DST VM (Alpine minimal) has no `sftp-server` and no `scp` binary at all. Adding `scp -O` (legacy SCP protocol) doesn't help — the VM has no `scp` executable to receive it either.

Silent-failure UX bug compounding it: `Save-DuneBackupMirrorState` only recorded `$tick.error` (top-level "VM listing failed" / "folder not writable"). Per-file failures landed in `$tick.failed` and were dropped on the floor, so the UI cheerfully reported "copied 0 file(s)" every 30 seconds.

Same scp code is used by the per-row **Download** button and the manual **Upload** button, so both were broken by the identical bug.

## The fix

New `app/server/lib/VmFileTransfer.ps1` exposes two helpers that stream raw bytes via the ssh key + tools DST already depends on everywhere else:

- `Copy-DuneVmFileToLocal`: `ssh dune@vm sudo cat '<vmPath>'` → local `FileStream`
- `Copy-DuneLocalFileToVm`: local `FileStream` → `ssh dune@vm sudo tee '<vmPath>' > /dev/null && sudo chmod 644`

Both handle binary safely, honor the caller's timeout, and clean up a partial file if ssh dies mid-transfer. No VM-side install needed — every DST VM already runs ssh + sudo.

Callers rewritten:
- `lib/BackupMirror.ps1` — `Invoke-DuneBackupMirrorScpPull` renamed to `Invoke-DuneBackupMirrorFilePull`, delegates to the shared helper.
- `routes/BackupTransfer.ps1` — Download and Upload both drop their scp `ProcessStartInfo` blocks and call the shared helpers.
- `routes/BackupMirror.ps1` `/sync` — `$tick.failed.Count` is now surfaced in `lastError` so the UI can't silently hide per-file failures again.

Also swept the whole repo for other `scp`/`sftp` usage — `dune-server.ps1` (Public IP install), `Maps.ps1` (partition-clear staging), and `DuneAdminCache.ps1` (yaml cache backup) already use base64-over-ssh from earlier releases. Only two stale prose comments (in `DuneAdminCache.ps1` and `DuneServer.iss`) still said "scp"; those are corrected here.

## Verification

Roundtrip on Coastal's live server (`192.168.23.219`):

```
PULL: {"ok":true,"localPath":"C:\\Users\\Coastal\\AppData\\Local\\Temp\\dst-fix-test.backup"}; local=1798678B
PUSH: {"ok":true,"vmPath":"/tmp/dst-transfer-roundtrip-test"}
VM MD5:    d8e50147a28dedfa0d64a78195d66046
LOCAL MD5: d8e50147a28dedfa0d64a78195d66046
MATCH ✓
```

## Version stamps

All 5 bumped to 12.18.12 (`Build-Installer.ps1` parity check passes). CHANGELOG rolled. `bug_report.yml` `tool_version` placeholder bumped.