### PR TITLE
v12.18.13: backup mirror auto-copy runs from backend scheduler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.12"
+      placeholder: "v12.18.13"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.13] - 2026-07-11
+
+### Fixed
+
+- **Local backup mirror actually runs on schedule now.** In v12.18.10-v12.18.12 the auto-copy only ticked while the **Database** page was open in the DST window — the 30-second poll lived in the React component's `useEffect`, so navigating away or minimizing to tray stopped it. A backup that landed on the VM at 00:00 sat there until the next time the user opened the Database page (e.g., copied at 00:11 when the user checked). DST now runs the mirror sync inside the same background scheduler runspace that fires scheduled restarts, gated to every ~10 minutes so a hourly backup shows up in the mirror folder within one tick without pinging the VM every 30 seconds. The mirror runs whether or not any page is open, as long as DST is running — same "only while DST is running" caveat as scheduled restarts. The Database page's in-page poll stays as a fast catch-up when the page is opened, and the **Sync now** button still forces an immediate tick.
+
 ## [12.18.12] - 2026-07-10
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.12'
+$script:DuneToolVersion = '12.18.13'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.12',
+    [string]$Version = '12.18.13',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.12</Version>
+    <Version>12.18.13</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.12"
+#define MyAppVersion "12.18.13"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/BackupMirror.ps1
+++ b/app/server/lib/BackupMirror.ps1
@@ -205,3 +205,90 @@ function Invoke-DuneBackupMirrorTick {
     $result.ok = ($result.failed.Count -eq 0)
     return $result
 }
+
+# Scheduler tick: called every ~30s by the restart-scheduler loop in
+# lib/RestartSchedule.ps1 so the mirror keeps copying even when the Database
+# page isn't open in the webui. This is the ONLY auto-copy path — the webui's
+# in-page /sync poll (`syncBackupMirror` in Database.tsx) only ticks while the
+# component is mounted, so before v12.18.13 a scheduled backup that landed at
+# 00:00 sat on the VM until the next time the user opened the Database page.
+#
+# Gated to every 20th iteration of the 30s scheduler loop = ~10 minute
+# effective cadence. Plenty for hourly backups and avoids pinging the VM every
+# 30 seconds solely for the mirror. The scheduler-runspace-scoped counter
+# advances even when the tick returns early (mirror disabled etc.), so a user
+# who flips the checkbox on doesn't wait an extra ~9 minutes for the first
+# tick after enabling — they wait at most ~10 minutes, and the /sync route
+# still lets them force one immediately from the UI.
+#
+# Silent no-op when the feature is disabled or no folder is set, so a user who
+# hasn't turned the mirror on doesn't get any VM traffic. Writes the same
+# sidecar state ($env:APPDATA\DuneServer\backup-mirror-state.json) the /sync
+# route writes, so the UI's Last sync / Last error labels stay accurate no
+# matter which path did the tick.
+$script:DuneBackupMirrorTickCounter = 0
+$script:DuneBackupMirrorTickEvery = 20
+
+function Invoke-DuneBackupMirrorSchedulerTick {
+    $script:DuneBackupMirrorTickCounter++
+    if (($script:DuneBackupMirrorTickCounter % $script:DuneBackupMirrorTickEvery) -ne 0) {
+        return
+    }
+
+    $enabled = $false
+    $folder  = ''
+    try { $enabled = Get-DuneLocalBackupMirrorEnabled } catch { return }
+    if (-not $enabled) { return }
+    try { $folder = Get-DuneLocalBackupMirrorFolder } catch { return }
+    if (-not $folder) { return }
+
+    # VM context — silently skip when VM is down / paused / SSH not ready.
+    # The user will see stale lastMirroredAt in the UI and (if the last error
+    # was VM-unavailable) that message; nothing else surfaces.
+    $ctx = $null
+    try { $ctx = Get-DuneBackupContext } catch { return }
+    if (-not $ctx -or -not $ctx.ok) { return }
+
+    $keyPath = $null
+    try { $keyPath = Get-V6SshKeyPath } catch { return }
+    if (-not $keyPath -or -not (Test-Path -LiteralPath $keyPath)) { return }
+
+    $tick = $null
+    try {
+        $tick = Invoke-DuneBackupMirrorTick -Ip $ctx.ip -KeyPath $keyPath -LocalFolder $folder
+    } catch {
+        # Persist the failure so the UI can surface it next time the page
+        # renders, even without the user forcing a /sync.
+        $prev = Read-DuneBackupMirrorState
+        $prev.lastError = "scheduler tick error: $($_.Exception.Message)"
+        Save-DuneBackupMirrorState -State $prev
+        return
+    }
+
+    # Same lastError-shape rule as the /sync route: prefer $tick.error, else
+    # count $tick.failed so a silent per-file-scp-fails-across-the-board bug
+    # can't hide again.
+    $errMsg = ''
+    if ($tick.error) {
+        $errMsg = [string]$tick.error
+    } elseif ($tick.failed -and @($tick.failed).Count -gt 0) {
+        $failed = @($tick.failed)
+        $first  = if ($failed[0] -and $failed[0].error) { [string]$failed[0].error } else { 'unknown error' }
+        $errMsg = "$($failed.Count) file(s) failed to copy - first: $first"
+    }
+    $now = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    Save-DuneBackupMirrorState -State @{
+        lastMirroredAt  = $now
+        lastError       = $errMsg
+        lastCopiedCount = @($tick.copied).Count
+    }
+    if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+        $copiedCount = @($tick.copied).Count
+        $failedCount = @($tick.failed).Count
+        if ($copiedCount -gt 0 -or $failedCount -gt 0) {
+            try {
+                Write-DuneLog "backup mirror tick: copied=$copiedCount failed=$failedCount vmFiles=$($tick.vmFileCount)"
+            } catch {}
+        }
+    }
+}

--- a/app/server/lib/RestartSchedule.ps1
+++ b/app/server/lib/RestartSchedule.ps1
@@ -1021,6 +1021,19 @@ function Start-DuneRestartScheduler {
                         try { Write-DuneLog "db-util autoheal tick error (outer): $($_.Exception.Message)" 'WARN' } catch {}
                     }
                 }
+                # v12.18.13: local backup mirror auto-copy. The restart
+                # scheduler loop sleeps 30s per iteration; this tick internally
+                # gates to every 20th call (~10 minutes) which is plenty for
+                # hourly backups. Runs whether or not the Database page is open
+                # in the webui, so a scheduled backup landing at 00:00 gets
+                # copied within ~10 min without the user touching DST. Silent
+                # no-op unless the user has turned the mirror on (Database →
+                # Local Backup Mirror card).
+                try { Invoke-DuneBackupMirrorSchedulerTick } catch {
+                    if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                        try { Write-DuneLog "backup mirror tick error (outer): $($_.Exception.Message)" 'WARN' } catch {}
+                    }
+                }
                 Start-Sleep -Seconds 30
             }
         })

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.12"
+$script:ToolVersion = "12.18.13"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Fixes

**Local backup mirror actually runs on schedule now.** In v12.18.10-v12.18.12 the auto-copy only ticked while the **Database** page was mounted in the webui - the 30s poll lived in a React `useEffect` so navigating away, minimizing to tray, or closing the window silently stopped the copy loop. A backup landing on the VM at 00:00 sat there until the user next opened the Database page (Coastal saw this: hourly 00:00 backup, mirror folder Date modified `12:11 AM` = when he checked, not when the backup fired).

## Changes

- New `Invoke-DuneBackupMirrorSchedulerTick` in `app/server/lib/BackupMirror.ps1`. Reads mirror settings + VM context + ssh key path, runs the same `Invoke-DuneBackupMirrorTick` the `/sync` route does, writes the same sidecar state file (`backup-mirror-state.json`) so the UI's `Last sync` / `Last error` labels stay accurate regardless of which path did the tick. Silent no-op when the mirror is disabled or the VM is unavailable.
- Wired into the existing scheduler runspace loop in `app/server/lib/RestartSchedule.ps1` (the one that already runs restart / discord / db-util ticks). No new thread — piggybacks on the existing 30s cadence.
- Gated internally to every 20th iteration = **~10 minute effective cadence**. Hourly backups will show up in the mirror folder within 10 minutes without pinging the VM every 30 seconds.

## Caveats

- Same "only while DST is running" caveat as scheduled restarts — the mirror does not run when DST is closed.
- The in-page `useEffect` poll in `BackupMirrorCard` stays as a fast catch-up when the Database page is opened.
- The **Sync now** button still forces an immediate tick.

## Test

Installed locally, closed the Database page, waited ~10 min past the next hourly backup, mirror folder had the new file without opening Database first. Confirmed working.