### PR TITLE
Boot-time force-clear for stuck core maps after hard VM crash (v12.18.16)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.15"
+      placeholder: "v12.18.16"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.16] - 2026-07-12
+
+### Fixed
+
+- **Core maps now auto-recover faster after a hard VM crash / power loss.** When the host is hard-reset while the battlegroup was still running, a core map (Overmap, Survival_1/Hagga) could come back up but sit unavailable for a while — players saw it stuck in a "preshutdown" state. The cause is the server operator draining the stale pre-crash server pod through its full 120s grace window before recreating a fresh one. The VM-side self-heal now includes a **boot-only stuck-server force-clear** pass: for any map that should be up (serverset replicas ≥ 1) whose backing pod is demonstrably stuck — terminating, or in the draining `Stopping` phase — it force-deletes that pod so the operator recreates it immediately, skipping the drain. It runs at boot only (no players are online), never during live play, so it can't interrupt a legitimate scheduled-restart drain. Ready pods and normally-starting pods are left untouched, and cleanly shut-down maps (replicas = 0) are never restarted. This complements the existing on-demand-map partition self-heal (which is unchanged and still only touches on-demand map partitions).
+
 ## [12.18.15] - 2026-07-11
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.15'
+$script:DuneToolVersion = '12.18.16'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.15',
+    [string]$Version = '12.18.16',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.15</Version>
+    <Version>12.18.16</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.15"
+#define MyAppVersion "12.18.16"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/resources/remote-scripts/dune-clear-partitions-install.sh
+++ b/app/resources/remote-scripts/dune-clear-partitions-install.sh
@@ -14,16 +14,30 @@
 #   force-close the map -> clear partitions -> let spin-up restore it. This
 #   installs that fix as an autonomous VM-side heal so it works WITH DST CLOSED.
 #
+#   The SAME crash class also strands the CORE maps (Overmap / Survival_1 Hagga):
+#   their pre-crash pod comes back as a stale server the operator DRAINS through
+#   terminationGracePeriodSeconds (120s) before recreating it -- game phase
+#   "Stopping" (players see "preshutdown"), or the k8s pod stuck Terminating --
+#   so the map is unavailable for the whole grace window. A BOOT-only pass here
+#   force-clears such a stale pod so the operator recreates it immediately. Core
+#   maps keep a legitimate partition pin, so that pass evicts the POD only and
+#   never touches partitions (that stays the on-demand pass's job).
+#
 # WHAT IT DOES
-#   1. Writes the heal script to /usr/local/bin/dune-clear-partitions.sh. The
-#      heal cycles a map (patch {replicas:0, partitions:[]}, which evicts the
-#      zombie pod AND clears the pin; the director then restores a warm floor)
-#      ONLY when the partition is pinned AND no pod is Ready -- so a live player
-#      session (Ready pod) is never kicked.
+#   1. Writes the heal script to /usr/local/bin/dune-clear-partitions.sh. It has
+#      two passes: (a) BOOT-only stuck-server force-clear for any map that should
+#      be up (replicas>=1) whose pod is stuck Terminating or draining "Stopping",
+#      force-deleting that pod so the operator recreates it without the 120s
+#      drain -- a Ready pod is never touched; and (b) the on-demand/warm map
+#      partition heal that cycles a map (patch {replicas:0, partitions:[]}, which
+#      evicts the zombie pod AND clears the pin; the director then restores a warm
+#      floor) ONLY when the partition is pinned AND no pod is Ready.
 #   2. Installs it as the OpenRC boot hook /etc/local.d/dune-clear-partitions.start
 #      (mode=boot: aggressive, since no players can exist right after boot).
 #   3. Installs a */15 cron entry (mode=cron: conservative, only cycles a clearly
-#      stuck/zombie or pod-less map so it never races a legitimate spin-up).
+#      stuck/zombie or pod-less map so it never races a legitimate spin-up; the
+#      stuck-server force-clear runs in BOOT mode ONLY, never cron/manual, so it
+#      cannot interrupt a legitimate scheduled-restart drain during live play).
 #   4. Runs the heal once now in the mode given by $1 (default: cron). DST passes
 #      'cron' for the automatic app-start sync (conservative -- never disturbs a
 #      map that is only mid-spin-up while the app is launched during live play)
@@ -100,6 +114,83 @@ done
 if ! $KUBE get igwsss --all-namespaces >/dev/null 2>&1; then
   log "k3s API / igwsss CRD not reachable, nothing to do (mode=$MODE)"
   exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# BOOT-ONLY: stuck-server pod force-clear (core maps Overmap/Hagga + any map
+# that is supposed to be up). After a hard host crash + VM reboot, the
+# pre-crash server pod comes back as a stale server that the Funcom
+# server-operator DRAINS through terminationGracePeriodSeconds (120s on the
+# serverset) before it recreates a fresh pod -- the game phase shows "Stopping"
+# (what players see as "preshutdown"), or the k8s pod is stuck Terminating
+# (deletionTimestamp set because the node was NotReady). Either way the map is
+# unavailable for the whole grace window. This does NOT overlap the partition
+# pass below: core maps keep a legitimate partition pin that must never be
+# cleared -- the fix here is to evict the STALE POD, not touch partitions.
+#
+# At BOOT no players can be online, so force-deleting a demonstrably-stuck pod
+# (--force --grace-period=0) is safe and lets the operator recreate immediately,
+# skipping the drain. A normally-starting pod (Initializing / Starting, no
+# deletion mark) is LEFT ALONE so a legitimate world-load is never interrupted.
+# Boot mode ONLY -- never cron/manual, because during live play a "Stopping" pod
+# may be a legitimate scheduled-restart drain we must not kill.
+force_clear_stuck_pods() {
+  $KUBE get serverset --all-namespaces --no-headers 2>/dev/null | awk '{print $1"\t"$2}' \
+    | while IFS="$(printf '\t')" read -r ns ss; do
+    { [ -z "$ns" ] || [ -z "$ss" ]; } && continue
+    # Only maps that are SUPPOSED to be up (replicas>=1). A cleanly shut-down
+    # BG has every serverset at replicas=0 -> skipped -> we never start a map
+    # the operator intends to keep down.
+    rep=$($KUBE -n "$ns" get serverset "$ss" -o jsonpath='{.spec.replicas}' 2>/dev/null)
+    case "$rep" in ''|*[!0-9]*) continue ;; esac
+    [ "$rep" -ge 1 ] || continue
+    rdyN=$($KUBE -n "$ns" get serverset "$ss" -o jsonpath='{.status.readyReplicas}' 2>/dev/null)
+    case "$rdyN" in ''|*[!0-9]*) rdyN=0 ;; esac
+    # Fully ready -> healthy, nothing to do.
+    [ "$rdyN" -ge "$rep" ] && continue
+
+    pods=$($KUBE -n "$ns" get pods --no-headers -o custom-columns=':metadata.name' 2>/dev/null | grep "^${ss}-pod-" || true)
+    for p in $pods; do
+      [ -z "$p" ] && continue
+      # Never disturb a live/Ready pod (belt-and-braces; no players at boot).
+      rdy=$($KUBE -n "$ns" get pod "$p" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+      [ "$rdy" = "True" ] && continue
+      del=$($KUBE -n "$ns" get pod "$p" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null)
+      idx="${p##*-pod-}"
+      gphase=""
+      case "$idx" in
+        ''|*[!0-9]*) : ;;
+        *) gphase=$($KUBE -n "$ns" get serverset "$ss" -o jsonpath="{.status.pods[?(@.ordinalIndex==$idx)].phase}" 2>/dev/null) ;;
+      esac
+
+      # Only force a DEMONSTRABLY-stuck pod: stuck Terminating (deletionTimestamp)
+      # or draining (game phase "Stopping"). Initializing / Starting / not-yet-
+      # Ready-but-healthy pods are left to load normally.
+      if [ -n "$del" ] || [ "$gphase" = "Stopping" ]; then
+        reason="phase=${gphase:-?}${del:+,terminating}"
+        if $KUBE -n "$ns" delete pod "$p" --force --grace-period=0 >>"$LOG" 2>&1; then
+          log "$ns/$ss: force-cleared stuck pod $p ($reason) -> operator will recreate a fresh pod (skipped drain)"
+        else
+          log "$ns/$ss: ERROR force-deleting stuck pod $p ($reason)"
+        fi
+      else
+        log "$ns/$ss: pod $p not Ready (phase=${gphase:-?}) but not stuck (likely starting) -- leaving to load"
+      fi
+    done
+  done
+  return 0
+}
+
+if [ "$MODE" = "boot" ]; then
+  # The operator can take a short while after boot to surface a stale pod as
+  # Terminating/Stopping, so probe a few times over ~2 min. Idempotent: each
+  # pass is a cheap no-op when nothing is stuck.
+  fc=1
+  while [ "$fc" -le 6 ]; do
+    force_clear_stuck_pods
+    [ "$fc" -lt 6 ] && sleep 20
+    fc=$((fc + 1))
+  done
 fi
 
 # Return non-empty if at least one igwsss matches one of our map suffixes.

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.15"
+$script:ToolVersion = "12.18.16"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Problem

When the host is hard-reset / loses power while the battlegroup is still running, a **core map** (Overmap, Survival_1/Hagga) can come back up but sit unavailable for a while — players see it stuck in a "preshutdown" state.

Root cause: after an unclean crash, the pre-crash server pod returns as a stale server that the Funcom server-operator **drains through `terminationGracePeriodSeconds` (120s, operator-set) before recreating** a fresh pod. During that window the per-pod game phase is `Stopping`, or the k8s pod is stuck `Terminating` (deletionTimestamp set because the node was NotReady). The map is unavailable for the whole grace window.

This is **not** the existing on-demand-map partition auto-heal — that path is unchanged and only touches on-demand map *partitions*. Core maps keep a legitimate partition pin that must never be cleared.

## Fix

Add a **boot-mode-only** stuck-server force-clear pass to the VM-side self-heal (`dune-clear-partitions.sh`, installed by `dune-clear-partitions-install.sh`):

- Enumerates serversets that **should be up** (`.spec.replicas >= 1`) and aren't fully ready.
- For a backing pod that is **demonstrably stuck** — `deletionTimestamp` set (Terminating) **or** game phase `== Stopping` (draining) — it `kubectl delete pod --force --grace-period=0` so the operator recreates a fresh pod immediately, **skipping the 120s drain**.
- Loops ~6× over ~2 min (idempotent) because the operator can take a moment to surface a stale pod after boot.

### Safety
- **Boot mode only** — never cron/manual — so a legitimate scheduled-restart drain during live play is never killed. No players are online right after boot.
- **Evicts the POD only** — core-map partitions are never touched (partition clearing stays the on-demand pass's job, filtered by `MAP_SUFFIXES`).
- **Ready pods and normally-starting** (Initializing/Starting, no deletion mark) pods are left alone.
- **Cleanly shut-down maps** (`replicas == 0`) are skipped, so a BG the operator intends to keep down is never restarted (respects the "BG was shut down before the crash" condition).

## Validation
- Outer installer + extracted inner heal script both pass `sh -n` on the live VM (real POSIX sh).
- Detection jsonpath queries validated **read-only against the live UAT cluster**: `.spec.replicas`, `.status.readyReplicas`, pod Ready condition, `.metadata.deletionTimestamp`, ordinalIndex extraction, and the `.status.pods[?(@.ordinalIndex==N)].phase` filter all resolve correctly (both core maps returned `phase=Running`, correctly no-op'd; all rep=0 serversets skipped).
- Installer builds clean; 5-stamp version check passes at 12.18.16; updated heal script is bundled.

## Release
- Bumped all 5 version stamps 12.18.15 → 12.18.16.
- Rolled `CHANGELOG.md` `[Unreleased]` → `[12.18.16]`.
- Bumped `bug_report.yml` `tool_version` placeholder.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>