### PR TITLE
Remove mis-targeted Legacy Admin Cache card from Settings (v12.18.17)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.18.16"
+      placeholder: "v12.18.17"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.18.17] - 2026-07-12
+
+### Removed
+
+- **Removed the "Legacy Admin Cache" card from Settings.** The standalone Legacy Admin Tool (dune-admin) was sunset months ago, and the card that offered to "clear its VM cache" was mis-targeted: it globbed `~/.dune/sh-*.yaml`, which on a live server only ever matches Funcom's own database backup/restore operation manifests (`sh-<bg>-dump-<timestamp>.yaml`, one written per scheduled backup) — never dune-admin's actual cache (which was always the client-side `~/.dune-admin/config.yaml`). So the card could never do its stated job and only surfaced Funcom's backup bookkeeping as if it were tool cache. It has been removed from the UI. No data was ever at risk: every clear snapshotted the files locally first, and the manifests it listed were spent, already-applied Kubernetes operation specs, not live backups (those live in `/funcom/artifacts/database-dumps/`).
+
 ## [12.18.16] - 2026-07-12
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.18.16'
+$script:DuneToolVersion = '12.18.17'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.18.16',
+    [string]$Version = '12.18.17',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.18.16</Version>
+    <Version>12.18.17</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.18.16"
+#define MyAppVersion "12.18.17"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.18.16"
+$script:ToolVersion = "12.18.17"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -81,48 +81,6 @@ export function Settings() {
   const [dbTestMsg, setDbTestMsg] = useState<string | null>(null)
   const [dbTestOk, setDbTestOk] = useState<boolean | null>(null)
   const [dbSuggestedPort, setDbSuggestedPort] = useState<number | null>(null)
-  // dune-admin VM cache: companion admin tool caches a stale BG snapshot
-  // on the VM at ~/.dune/sh-<bg-id>*.yaml; clearing it forces its setup
-  // wizard to re-discover the live DB password etc.
-  const [daCache, setDaCache] = useState<{ count: number; totalBytes: number; files: { path: string; size: number }[] } | null>(null)
-  const [daLoading, setDaLoading] = useState(false)
-  const [daClearing, setDaClearing] = useState(false)
-  const [daMsg, setDaMsg] = useState<string | null>(null)
-  const [daErr, setDaErr] = useState<string | null>(null)
-  async function loadDaCache() {
-    setDaLoading(true)
-    setDaErr(null)
-    try {
-      const r = await api<{ ok: boolean; count: number; totalBytes: number; files: { path: string; size: number }[]; message?: string }>(
-        '/api/dune-admin-cache',
-      )
-      setDaCache({ count: r.count, totalBytes: r.totalBytes, files: r.files ?? [] })
-    } catch (e) {
-      setDaErr(e instanceof Error ? e.message : String(e))
-      setDaCache(null)
-    } finally {
-      setDaLoading(false)
-    }
-  }
-  async function onClearDaCache() {
-    if (!window.confirm('Delete the Legacy Admin Tool cache on the VM?\n\nThis removes ~/.dune/sh-*.yaml on the VM. Nothing else is touched. The Legacy Admin Tool will re-run its setup discovery (and pick up the current DB password) the next time you launch it with -setup.')) return
-    setDaClearing(true)
-    setDaMsg(null)
-    setDaErr(null)
-    try {
-      const r = await api<{ ok: boolean; cleared: number; message?: string }>(
-        '/api/dune-admin-cache/clear',
-        { method: 'POST' },
-      )
-      setDaMsg(r.message ?? (r.ok ? `Cleared ${r.cleared}.` : 'Clear did not complete.'))
-      await loadDaCache()
-    } catch (e) {
-      setDaErr(e instanceof Error ? e.message : String(e))
-    } finally {
-      setDaClearing(false)
-    }
-  }
-  useEffect(() => { void loadDaCache() }, [])
 
   async function onOpenBattlegroupBat() {
     if (!window.confirm('Open Funcom\'s original battlegroup.bat?\n\nThis launches the battlegroup.bat in the root of your Steam install folder in an ELEVATED (administrator) window. Approve the Windows UAC prompt if it appears.')) return
@@ -791,68 +749,10 @@ export function Settings() {
         </div>
       </div>
 
-      {/* --- dune-admin VM cache (companion admin tool, decoupled in 12.x) --- */}
-      <div className="card mb-4 p-6">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <Icon name="Trash2" size={18} className="text-text-muted" />
-              <h2 className="text-lg font-semibold">Legacy Admin Cache</h2>
-            </div>
-            <p className="text-sm text-text-dim">
-              The Legacy Admin Tool caches a per-battlegroup snapshot on the VM
-              at <span className="font-mono">~/.dune/sh-&lt;bg-id&gt;*.yaml</span> and reads the DB password from it. After
-              Funcom rotates the DB password on a reconcile, that cache goes stale and the tool keeps
-              presenting the old password on its next <span className="font-mono">-setup</span> run. Clearing the cache forces
-              a fresh discovery from the live cluster.
-            </p>
-            {daCache && (
-              <p className="mt-2 text-xs text-text-dim">
-                {daCache.count === 0 ? (
-                  <span>No Legacy Admin Tool cache files present on the VM.</span>
-                ) : (
-                  <span>
-                    {daCache.count} file{daCache.count === 1 ? '' : 's'} on the VM
-                    {daCache.totalBytes > 0 && ` · ${(daCache.totalBytes / 1024).toFixed(0)} KB`}
-                  </span>
-                )}
-              </p>
-            )}
-            {daMsg && (
-              <p className="mt-2 text-xs text-success flex items-center gap-1.5">
-                <Icon name="CheckCircle2" size={13} /> {daMsg}
-              </p>
-            )}
-            {daErr && (
-              <p className="mt-2 text-xs text-danger flex items-center gap-1.5">
-                <Icon name="AlertCircle" size={13} /> {daErr}
-              </p>
-            )}
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <button
-              type="button"
-              onClick={() => void loadDaCache()}
-              disabled={daLoading || daClearing}
-              title="Re-check the VM"
-              className="btn-secondary"
-            >
-              <Icon name={daLoading ? 'Loader2' : 'RefreshCw'} size={15} className={daLoading ? 'animate-spin' : ''} />
-              {daLoading ? 'Checking…' : 'Refresh'}
-            </button>
-            <button
-              type="button"
-              onClick={() => void onClearDaCache()}
-              disabled={daClearing || daLoading || (daCache?.count ?? 0) === 0}
-              title="Delete ~/.dune/sh-*.yaml on the VM"
-              className="btn-danger"
-            >
-              <Icon name={daClearing ? 'Loader2' : 'Trash2'} size={15} className={daClearing ? 'animate-spin' : ''} />
-              {daClearing ? 'Clearing…' : 'Clear cache'}
-            </button>
-          </div>
-        </div>
-      </div>
+      {/* --- dune-admin VM cache card removed (12.18.17): companion tool was
+           sunset months ago; the card globbed ~/.dune/sh-*.yaml which only
+           ever matched Funcom's own backup/restore operation manifests, never
+           dune-admin's real client-side cache. Backend route + lib retained. --- */}
 
       <form onSubmit={onSubmit} className="card p-6 space-y-5">
         {FIELDS.filter(f => !f.showWhen || f.showWhen(values)).map(f => (


### PR DESCRIPTION
## Summary

Removes the **"Legacy Admin Cache"** card from the Settings page. The standalone Legacy Admin Tool (`dune-admin`) was sunset months ago, and the card was **mis-targeted from the start**.

## Why

The card offered to "clear the Legacy Admin Tool's VM cache" by deleting `~/.dune/sh-*.yaml`. But that glob is wrong:

- **What the card deleted:** `~/.dune/sh-<bg>-dump-<ts>.yaml` / `sh-<bg>-import-<ts>.yaml` — Funcom's own Kubernetes `DatabaseOperation` manifests, one written per DB backup/restore. On an Hourly backup schedule these pile up (e.g. 22 = ~22h of backups) and the card surfaced them as if they were "tool cache."
- **What dune-admin's real cache actually was:** the **client-side** `~/.dune-admin/config.yaml` (`%USERPROFILE%\.dune-admin\`), confirmed from the dune-admin source (`SETUP_KUBECTL.md`: reads `~/.dune/<bg>.yaml` on the VM → writes `~/.dune-admin/config.yaml`). The card never touched that path — the `-admin` was dropped.

So the card could **never** do its stated job (clear the stale dune-admin cache) and only ever churned Funcom's backup bookkeeping. With dune-admin retired and zero reports about it, it's dead UI.

## What changed

- Removed the card JSX from `webui/src/pages/Settings.tsx` plus its now-orphaned React state, `loadDaCache`/`onClearDaCache` handlers, and the `useEffect` that auto-loaded it on mount.
- **Backend intentionally retained** per request: the route (`/api/dune-admin-cache` + `/clear`, `routes/DuneAdminCache.ps1`) and lib (`lib/DuneAdminCache.ps1`) are left in place — only the card is cut.

## Safety note

No data was ever at risk from the old card: every clear snapshotted the files locally to `%APPDATA%\DuneServer\legacy-admin-backups\<ts>\` before deleting, and the files it removed were **spent, already-applied** operation specs — the real backups live in `/funcom/artifacts/database-dumps/` and were never touched.

## Release

- 5 version stamps bumped 12.18.16 → 12.18.17.
- `CHANGELOG.md` `[Unreleased]` → `[12.18.17]` (Removed).
- `bug_report.yml` `tool_version` placeholder bumped.
- Web UI builds clean (`tsc -b` + vite); installer builds clean (version-check passes at 12.18.17).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>