### PR TITLE
Reword v12.18.18 changelog: don't name the supporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ here cover everything those tags shipped.
 
 ### Changed
 
-- **Added Chumdizzle (@chumdizzle) to the "Thanks for the Coffee" supporter credits.**
+- **Supporter added to list.**
 
 ## [12.18.17] - 2026-07-12
 


### PR DESCRIPTION
Rewords the v12.18.18 CHANGELOG entry from naming the supporter to just **"Supporter added to list."** per standing preference. The in-app "Thanks for the Coffee" dropdown still credits them by name — this only changes the public changelog wording.

Companion to the already-updated GitHub release notes and Discord #releases/#changelog embeds.