### PR TITLE
docs: refresh README + site + bug template for v12.19.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.19.0"
+      placeholder: "v12.19.1"
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 **🌐 Website & feature tour: [coastal-ms.github.io/DST-DuneServerTool](https://coastal-ms.github.io/DST-DuneServerTool/)** — screenshots, install guide, and the full changelog.
 
-The current release is **v12.18.1**. The in-app version label and the
-website show plain semver tags (e.g. `v12.18.1`) — the previous
+The current release is **v12.19.1**. The in-app version label and the
+website show plain semver tags (e.g. `v12.19.1`) — the previous
 Roman-numeral stylization has been removed.
 
 > ## ✅ Confirmed compatible with Dune: Awakening **1.4.10.1**
-> DST **v12.18.x** is verified working against the **latest Funcom release** —
+> DST **v12.19.x** is verified working against the **latest Funcom release** —
 > both the game **client** and the **self-hosted server** software — as of the
 > **1.4.10.1** patch. Compatibility was checked live against a running
 > self-hosted server on that build, covering battlegroup management,
@@ -28,6 +28,24 @@ the sidebar's **Web Portal** button hands the portal off to your default
 browser and keeps the server running in the background.
 
 ![Server Health](docs/img/server-health.png)
+
+### New in v12.19
+
+- **Landsraad contributions now grant guild Voting Power** (v12.19.1, Players →
+  Landsraad). Setting a player's House contribution now drives the game's own
+  contribution pipeline instead of writing the totals directly, so the points
+  cascade to the player's guild, refresh **Voting Power** live, and attribute
+  to the guild's real faction — exactly like retail. This fixes guilds that led
+  a House but stayed at 0 Voting Power and couldn't place a decree vote. (Once a
+  guild casts its decree vote the game locks its Voting Power in — later
+  contributions still complete Houses on the board but won't change a vote
+  already cast; that's Funcom's own rule.)
+- **Bases: Release / Destroy claim** (v12.19.0, Gameplay Admin → Bases). A new
+  **Owner** column plus a guarded **Release claim** action (with a backup
+  warning) frees a base's land claim by removing the totem; Funcom's cascade
+  strips the claim, land segments, and every ownership grant in one
+  transaction, and the building pieces remain as unclaimed structures. Restart
+  the battlegroup for it to take effect in-game.
 
 ### New in v12.15–v12.18
 

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -52,7 +52,7 @@ const sections = [
     id: "landsraad",
     title: "Players → Landsraad",
     img: "gameplay-landsraad.png",
-    body: "Set any player's contribution to any Great House to an arbitrary amount, term by term — faction and guild totals recompute automatically. On the Game Config side, Landsraad edits seed and preserve Funcom's full nested settings struct: v12.2.1 fixed a bug where editing a single Landsraad value could strip the board layouts, messages, and contract settings the game needs, heals stripped struct boxes written by older builds, and warns when your client's copy of the block is incomplete.",
+    body: "Set any player's contribution to any Great House to an arbitrary amount, term by term. As of v12.19.1 the contribution routes through the game's own pipeline, so it cascades to the player's guild and refreshes the guild's Voting Power live — attributing to the guild's real faction, exactly like retail (an admin edit finally moves Voting Power, not just the leaderboard). On the Game Config side, Landsraad edits seed and preserve Funcom's full nested settings struct: v12.2.1 fixed a bug where editing a single Landsraad value could strip the board layouts, messages, and contract settings the game needs, heals stripped struct boxes written by older builds, and warns when your client's copy of the block is incomplete.",
   },
   {
     id: "database",


### PR DESCRIPTION
Post-release docs refresh for **v12.19.1** (follow-up to #513).

- **README**: current-release line and Funcom-verified banner bumped to v12.19.1 / v12.19.x; new **"New in v12.19"** section covering the Landsraad guild Voting Power cascade and the Bases Release/Destroy claim.
- **site/features.astro**: Landsraad card rewritten to describe the v12.19.1 cascade (contributions now move guild Voting Power live, like retail) instead of the old "totals recompute automatically" copy. Merging to main re-triggers `deploy-site.yml`.
- **bug_report.yml**: `tool_version` placeholder bumped to v12.19.1 (the base-claim + Landsraad surfaces were already present).

Docs-only; no code or version-stamp changes.