### PR TITLE
docs: mark compatible with Funcom Hotfix 1.4.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The current release is **v12.19.1**. The in-app version label and the
 website show plain semver tags (e.g. `v12.19.1`) — the previous
 Roman-numeral stylization has been removed.
 
-> ## ✅ Confirmed compatible with Dune: Awakening **1.4.10.1**
+> ## ✅ Confirmed compatible with Dune: Awakening **1.4.10.3**
 > DST **v12.19.x** is verified working against the **latest Funcom release** —
 > both the game **client** and the **self-hosted server** software — as of the
-> **1.4.10.1** patch. Compatibility was checked live against a running
+> **1.4.10.3** patch. Compatibility was checked live against a running
 > self-hosted server on that build, covering battlegroup management,
 > on-demand map spin-up, game-config and database editing, and backups.
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -9,7 +9,7 @@ const release = await getLatestRelease();
 const versionLabel = formatDisplayVersion(release.version);
 
 // Latest Funcom Dune: Awakening release this build is verified against.
-const funcomVersion = "1.4.10.1";
+const funcomVersion = "1.4.10.3";
 
 const features = [
   {
@@ -88,8 +88,8 @@ const features = [
         The current release ({versionLabel}) is verified against Funcom's
         latest update — both the game <strong class="text-dune-text">client</strong>
         and the <strong class="text-dune-text">self-hosted server</strong>
-        software — confirmed live on the 1.4.10.1 build (July 1, 2026,
-        including Funcom's follow-up server hotfix). No update to DST is required.
+        software — confirmed live on the 1.4.10.3 build (July 14, 2026).
+        No update to DST is required.
       </p>
     </div>
   </section>

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -82,8 +82,8 @@ import DownloadButton from "../components/DownloadButton.astro";
           >Dune: Awakening Self-Hosted Server</strong
         > installed via Steam (provides the battlegroup-management folder and
         the Hyper-V VM image). Verified against the latest <strong
-          class="text-dune-text">1.4.10.1</strong
-        > build (July 1, 2026).
+          class="text-dune-text">1.4.10.3</strong
+        > build (July 14, 2026).
       </li>
       <li>
         <strong class="text-dune-text">SSH private key</strong> for your VM —


### PR DESCRIPTION
Bumps the confirmed-compatible Funcom version from **1.4.10.1 → 1.4.10.3** across the README compatibility badge and the marketing site (`index.astro` + `install.astro`), matching the routine we run for every recent Funcom patch.

**Verification (live, post-patch):**
- Funcom Hotfix 1.4.10.3 applied to the self-hosted server (build `2019354` → `2036754`).
- `Verify-DstDbContract.ps1` against the running DB: **all 49 DST-referenced tables + 26 stored functions present.**
- Schema diff vs the 2026-07-01 baseline: tables 164→163, functions 525→525, columns 811→806 — the only drop is the non-DST `discord_links` table. **Zero DST-relevant schema drift.**
- No DST code change required.

All-clear announced to Discord #announcements.

Docs-only change; marketing site builds clean (`npm run build`).