### PR TITLE
fix(bases): Release claim available whenever the battlegroup is off + indicator (v12.19.2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.19.1"
+      placeholder: "v12.19.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.19.2] - 2026-07-17
+
+### Changed
+
+- **Bases: Release claim now requires the battlegroup to be off, and is enabled whenever it is.** Releasing a claim deletes the base's totem actor, but a *running* map server keeps that claim in memory and rewrites it back to the database on its next flush — so a release done while the battlegroup is up silently gets restored (rebooting afterward does not help). The **Release claim** action is now gated on battlegroup state: it is **enabled whenever the battlegroup is stopped** and disabled while it is running/starting/stopping, with a clear indicator explaining that the battlegroup must be off for the release to persist. Once the battlegroup is off, release the claim and start it back up — the claim stays gone. No change to the underlying delete.
+
 ## [12.19.1] - 2026-07-13
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.19.1'
+$script:DuneToolVersion = '12.19.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.19.1',
+    [string]$Version = '12.19.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.19.1</Version>
+    <Version>12.19.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.19.1"
+#define MyAppVersion "12.19.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.19.1"
+$script:ToolVersion = "12.19.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/gameplay/BasesTab.tsx
+++ b/webui/src/pages/gameplay/BasesTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import { getBases, exportBase, destroyClaim, downloadBlueprintFile, type BaseRow, type DataSource } from '../../api/gameplay'
 import { fmtNum, SourceBadge, StatCard, DemoNotice } from './shared'
+import { useStatus } from '../../hooks/useStatus'
 
 type SortKey = 'id' | 'name' | 'owner' | 'pieces' | 'placeables'
 
@@ -19,6 +20,10 @@ export function BasesTab() {
   const [confirmBase, setConfirmBase] = useState<BaseRow | null>(null)
   const [ackBackup, setAckBackup] = useState(false)
   const [destroying, setDestroying] = useState(false)
+
+  const { status } = useStatus()
+  const bgState = status?.bg?.state ?? 'unknown'
+  const bgOff = bgState === 'stopped'
 
   const load = useCallback(async () => {
     setLoading(true); setError(null)
@@ -104,6 +109,16 @@ export function BasesTab() {
       {source === 'demo' && <DemoNotice liveError={liveError} what="base data" />}
       {flash && <div className="card p-3 mb-4 text-sm text-success break-words flex items-center gap-2"><Icon name="CheckCircle2" size={15} /> {flash}</div>}
       {error && <div className="card p-3 mb-4 text-sm text-danger break-words">{error}</div>}
+      {source !== 'demo' && !bgOff && (
+        <div className="card p-3 mb-4 text-sm text-warning break-words flex items-start gap-2">
+          <Icon name="AlertTriangle" size={15} className="mt-0.5 shrink-0" />
+          <span>
+            <span className="font-semibold">Release claim is available only while the battlegroup is off.</span>{' '}
+            The running map server keeps land claims in memory and restores any claim released while it is up, so Release claim
+            stays disabled until you stop the battlegroup{bgState !== 'unknown' ? <> (currently <span className="font-mono">{bgState}</span>)</> : null}.
+          </span>
+        </div>
+      )}
 
       <div className="card overflow-hidden">
         <table className="w-full text-sm">
@@ -140,9 +155,11 @@ export function BasesTab() {
                     onClick={() => { void handleExport(b) }} title="Download this base as a portable blueprint JSON file">
                     {busyId === b.id ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Download" size={13} />} Export
                   </button>
-                  <button className="btn-secondary py-1 px-2 text-xs text-danger ml-2" disabled={!b.totemId || source === 'demo'}
+                  <button className="btn-secondary py-1 px-2 text-xs text-danger ml-2" disabled={!b.totemId || source === 'demo' || !bgOff}
                     onClick={() => { setConfirmBase(b); setAckBackup(false) }}
-                    title={b.totemId ? "Release this base's land claim (removes ownership)" : 'No land claim on this base'}>
+                    title={!b.totemId ? 'No land claim on this base'
+                      : !bgOff ? 'Release claim requires the battlegroup to be OFF — stop the battlegroup first, or a running map server will restore the claim'
+                      : "Release this base's land claim (removes ownership)"}>
                     <Icon name="Trash2" size={13} /> Release claim
                   </button>
                 </td>
@@ -166,7 +183,8 @@ export function BasesTab() {
               <span className="text-text font-medium">{confirmBase.name || 'this unnamed base'}</span>
               {confirmBase.owner && <> owned by <span className="text-text font-medium">{confirmBase.owner}</span></>}.
               {' '}Ownership and all permission grants are removed. Building pieces stay in the world as unclaimed
-              structures and take effect after the next <span className="text-warning">battlegroup restart</span>.
+              structures. Because the battlegroup is off, the release will persist and takes effect the next time you
+              <span className="text-warning"> start the battlegroup</span>.
             </p>
 
             <div className="card p-3 mb-3 border-l-2 border-danger bg-danger/5 text-xs text-text-muted flex items-start gap-2">


### PR DESCRIPTION
## What
Gate the existing **Release claim** action on battlegroup state instead of running it any time.

## Why
Releasing a claim deletes the base's totem actor (the delete itself works and is unchanged). But a **running** map server holds the claim in RAM and rewrites it back to Postgres on its next flush, so a release performed while the battlegroup is up silently gets **restored** — rebooting afterward doesn't help. This is exactly what a user hit trying to free an abandoned base.

## Change
- **Release claim** (per-base button, Gameplay -> Bases) is now **enabled whenever the battlegroup is stopped**, and disabled while it is running/starting/stopping/updating.
- New **indicator banner + tooltip** explaining the battlegroup must be off for the release to persist (the running map server would restore it).
- Confirm dialog wording updated: the release persists because the BG is off and takes effect on next start.
- **No change** to the underlying totem-delete SQL (Invoke-DuneDestroyClaim).
- Bumps all 5 version stamps to **v12.19.2** (next canonical patch; 12.20.0 reserved for the hyperv/VMLAN feature), CHANGELOG + bug_report.yml.

## Workaround this enables for users
Stop the battlegroup -> Release claim on the base -> start the battlegroup. The claim stays gone and the base becomes accessible/re-claimable.

## Validation
- webui 
pm run build (tsc + vite) clean.
- Changed .ps1 parse-check clean (version-string edits only).
- DB mechanism (totem delete + RAM-cache re-hydrate behavior) verified live on UAT bases 1207/1444/1825 during investigation.

Merges to **main** to ride in the next release (parked, not a standalone release).
