### PR TITLE
fix: bound ssh post-exit stream drains so a held pipe can't hang the backend

### DIFF
--- a/app/lib/Db-Postgres.ps1
+++ b/app/lib/Db-Postgres.ps1
@@ -164,12 +164,28 @@ function Invoke-V6Ssh {
             # toast in the v10.1.13 incident).
             return "ERROR: ssh timed out after ${TimeoutSec}s"
         }
-        # Per Microsoft docs, an unbounded WaitForExit() after a bounded
-        # one ensures the async stream readers fully drain before we
-        # consume the tasks.
+        # The process exited within the deadline, but that is NOT enough to
+        # guarantee the async readers finish: if the remote command forked a
+        # grandchild that inherited ssh's stdout/stderr pipe write handle, the
+        # pipe never reaches EOF even though ssh.exe is gone, so ReadToEndAsync()
+        # stays pending. A bare .GetResult() would then block FOREVER — the
+        # "async stdout drain has no bounded wait" hang this function was
+        # documented to have. Bound the drain with a short grace window and
+        # abandon the readers if they don't complete, surfacing the same ERROR
+        # marker callers already string-match on the timeout path above.
         [void]$proc.WaitForExit()
-        [void]$errTask.GetAwaiter().GetResult()  # discarded — mirrors prior `2>$null`
-        $text = $outTask.GetAwaiter().GetResult()
+        $drainMs = 5000
+        $outDone = $false
+        try { $outDone = $outTask.Wait($drainMs) } catch { $outDone = $true }  # faulted reader = no more output
+        try { [void]$errTask.Wait($drainMs) } catch {}                          # discarded — mirrors prior `2>$null`
+        if (-not $outDone) {
+            if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                Write-DuneLog "Invoke-V6Ssh: stdout drain to $Ip did not finish within ${drainMs}ms after exit (pipe held open by a grandchild?); abandoning reader" 'WARN'
+            }
+            return "ERROR: ssh output drain timed out"
+        }
+        $text = $null
+        try { $text = $outTask.Result } catch { $text = $null }
         if ([string]::IsNullOrEmpty($text)) { return }
         # Emit one pipeline item per stdout line — matches the original
         # `& ssh ...` capture semantics so existing callers keep working.
@@ -243,9 +259,28 @@ function Invoke-DuneSshHidden {
                 Exit   = -1
             }
         }
+        # Bound the post-exit stream drain: a grandchild that inherited ssh's
+        # stdout/stderr pipe handle can keep the pipe open past ssh.exe's own
+        # exit, leaving ReadToEndAsync() pending and a bare .GetResult()
+        # blocking forever. Give it a short grace window, then abandon.
         [void]$proc.WaitForExit()
-        $stdoutText = $outTask.GetAwaiter().GetResult()
-        $stderrText = $errTask.GetAwaiter().GetResult()
+        $drainMs = 5000
+        $outDone = $false; $errDone = $false
+        try { $outDone = $outTask.Wait($drainMs) } catch { $outDone = $true }
+        try { $errDone = $errTask.Wait($drainMs) } catch { $errDone = $true }
+        if (-not ($outDone -and $errDone)) {
+            if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                Write-DuneLog "Invoke-DuneSshHidden: stream drain to $Ip did not finish within ${drainMs}ms after exit (pipe held open?); abandoning readers" 'WARN'
+            }
+            return @{
+                Stdout = @()
+                Stderr = "ssh output drain timed out after ${drainMs}ms"
+                Exit   = -1
+            }
+        }
+        $stdoutText = $null; $stderrText = $null
+        try { $stdoutText = $outTask.Result } catch { $stdoutText = $null }
+        try { $stderrText = $errTask.Result } catch { $stderrText = $null }
         return @{
             Stdout = if ([string]::IsNullOrEmpty($stdoutText)) { @() } else { @($stdoutText -split "`r?`n") }
             Stderr = $stderrText

--- a/app/server/lib/VmFileTransfer.ps1
+++ b/app/server/lib/VmFileTransfer.ps1
@@ -49,7 +49,7 @@ function Copy-DuneVmFileToLocal {
     # and Alpine's find never emits characters that need escaping (posix
     # dump-dir paths only). Wrapping in single quotes stops the local
     # shell + remote shell from re-interpreting whitespace or globs.
-    $psi.Arguments = "-o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i `"$KeyPath`" `"dune@$Ip`" sudo cat '$VmPath'"
+    $psi.Arguments = "-o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -o ServerAliveInterval=10 -o ServerAliveCountMax=3 -i `"$KeyPath`" `"dune@$Ip`" sudo cat '$VmPath'"
     $psi.RedirectStandardOutput = $true
     $psi.RedirectStandardError  = $true
     $psi.UseShellExecute        = $false
@@ -79,7 +79,10 @@ function Copy-DuneVmFileToLocal {
             return @{ ok = $false; error = "ssh cat timed out after ${TimeoutSec}s" }
         }
         [void]$proc.WaitForExit()
-        $stderr = $errTask.GetAwaiter().GetResult()
+        # Bound the stderr drain: a grandchild holding the pipe open past exit
+        # would otherwise make a bare .GetResult() block forever.
+        $stderr = $null
+        try { if ($errTask.Wait(5000)) { $stderr = $errTask.Result } } catch {}
         if ($proc.ExitCode -ne 0) {
             # Clean up the partial file — a 0-byte or half-written backup
             # would poison the local mirror folder / the local target.
@@ -121,7 +124,7 @@ function Copy-DuneLocalFileToVm {
     # `sudo tee` writes stdin to the target; `> /dev/null` suppresses tee's
     # stdout copy so the ssh stdout stays quiet. `sudo chmod 644` follows so
     # the file is world-readable (matches how `battlegroup backup` writes it).
-    $psi.Arguments = "-o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i `"$KeyPath`" `"dune@$Ip`" `"sudo tee '$VmPath' > /dev/null && sudo chmod 644 '$VmPath'`""
+    $psi.Arguments = "-o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -o ServerAliveInterval=10 -o ServerAliveCountMax=3 -i `"$KeyPath`" `"dune@$Ip`" `"sudo tee '$VmPath' > /dev/null && sudo chmod 644 '$VmPath'`""
     $psi.RedirectStandardInput  = $true
     $psi.RedirectStandardOutput = $true
     $psi.RedirectStandardError  = $true
@@ -154,7 +157,11 @@ function Copy-DuneLocalFileToVm {
             return @{ ok = $false; error = "ssh tee timed out after ${TimeoutSec}s" }
         }
         [void]$proc.WaitForExit()
-        $stderr = $errTask.GetAwaiter().GetResult()
+        # Drain stdout (redirected but otherwise unused here) + stderr with a
+        # bounded grace so a grandchild holding either pipe can't hang us post-exit.
+        try { [void]$outTask.Wait(5000) } catch {}
+        $stderr = $null
+        try { if ($errTask.Wait(5000)) { $stderr = $errTask.Result } } catch {}
         if ($proc.ExitCode -ne 0) {
             $tail = if ($stderr) { ": $($stderr.Trim())" } else { '' }
             return @{ ok = $false; error = "ssh tee failed rc=$($proc.ExitCode)$tail" }


### PR DESCRIPTION
## What

Bounds the **post-exit async stream drain** in the four ssh helper functions so a held pipe can't hang the backend:

- `Invoke-V6Ssh` and `Invoke-DuneSshHidden` (`app/lib/Db-Postgres.ps1`)
- `Copy-DuneVmFileToLocal` and `Copy-DuneLocalFileToVm` (`app/server/lib/VmFileTransfer.ps1`)

## The bug

All four drained their `ReadToEndAsync()` readers with an **unbounded `.GetResult()`** *after* the bounded `WaitForExit($TimeoutSec)`. If the remote command forked a grandchild that inherited ssh's stdout/stderr pipe handle, the pipe never reached EOF even though `ssh.exe` had exited — so the reader (and the whole call) blocked **forever**, past `TimeoutSec`. That's the documented *"async stdout drain has no bounded wait"* deferred item, and it can freeze the single-thread HTTP listener (one hung handler stalls every panel).

## The fix

- Each post-exit drain now uses `Task.Wait(5000)` and **abandons the readers** on expiry, returning the same `ERROR:` marker / return shape callers already handle.
- Added `ServerAliveInterval=10` / `ServerAliveCountMax=3` to both `VmFileTransfer` ssh invocations (they lacked the keepalive `Invoke-V6Ssh` already uses), so a silent mid-transfer stall tears the session down in ~30s even though the binary `CopyTo` byte-pump has no app-level bound.

## Verification

- **437 Pester tests green** — normal path unchanged (process exits → pipe closes → `Wait` returns instantly).
- **Reproduced the grandchild-holds-pipe case** (child exits immediately, grandchild holds the redirected stdout pipe): the new drain returns bounded at 5s where the old `.GetResult()` would block until the grandchild released the pipe (or indefinitely).

Encoding preserved (both files remain UTF-8 **with BOM**; parse-check clean).