### PR TITLE
test: cover sietches + database api wrappers and the version formatter

### DIFF
--- a/webui/tests/api/database.test.ts
+++ b/webui/tests/api/database.test.ts
@@ -1,0 +1,160 @@
+// Wrappers in src/api/database.ts forward to /api/db/* with specific payloads.
+// Several carry defaults (runSql readOnly/maxRows/timeout) or build query
+// strings (backup-history) that are easy to break in a refactor, and some feed
+// destructive backend actions (backup delete/prune), so lock the contracts.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as db from '../../src/api/database'
+
+interface FetchCall {
+  url: string
+  method?: string
+  body?: unknown
+}
+
+let calls: FetchCall[]
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  calls = []
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    let body: unknown = undefined
+    if (init?.body) {
+      try { body = JSON.parse(init.body as string) } catch { body = init.body }
+    }
+    calls.push({ url, method: init?.method, body })
+    return jsonResponse({ ok: true })
+  }))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function last(): FetchCall {
+  if (calls.length === 0) throw new Error('No fetch call recorded')
+  return calls[calls.length - 1]!
+}
+
+describe('read endpoints (GET, no body)', () => {
+  it('getDbInfo GETs /api/db/info', async () => {
+    await db.getDbInfo()
+    const c = last()
+    expect(c.url).toBe('/api/db/info')
+    expect(c.method).toBeUndefined()
+    expect(c.body).toBeUndefined()
+  })
+
+  it('getBackupSchedule / getBackupDumpPods / getBackupMirror hit the right URLs', async () => {
+    await db.getBackupSchedule()
+    expect(last().url).toBe('/api/db/backup-schedule')
+
+    await db.getBackupDumpPods()
+    expect(last().url).toBe('/api/db/backup-dump-pods')
+
+    await db.getBackupMirror()
+    expect(last().url).toBe('/api/db/backup-mirror')
+  })
+})
+
+describe('runSql defaults', () => {
+  it('applies readOnly=true, maxRows=1000, timeoutSec=30 when omitted', async () => {
+    await db.runSql({ sql: 'SELECT 1' })
+    const c = last()
+    expect(c.url).toBe('/api/db/query')
+    expect(c.method).toBe('POST')
+    expect(c.body).toEqual({ sql: 'SELECT 1', readOnly: true, maxRows: 1000, timeoutSec: 30 })
+  })
+
+  it('honours an explicit readOnly=false (write query) and custom caps', async () => {
+    await db.runSql({ sql: 'UPDATE x SET y=1', readOnly: false, maxRows: 50, timeoutSec: 5 })
+    expect(last().body).toEqual({ sql: 'UPDATE x SET y=1', readOnly: false, maxRows: 50, timeoutSec: 5 })
+  })
+})
+
+describe('backup-history query string', () => {
+  it('omits the query string entirely when no options are given', async () => {
+    await db.getBackupHistory()
+    expect(last().url).toBe('/api/db/backup-history')
+  })
+
+  it('encodes recent + logLines when provided', async () => {
+    await db.getBackupHistory({ recent: 10, logLines: 200 })
+    expect(last().url).toBe('/api/db/backup-history?recent=10&logLines=200')
+  })
+
+  it('includes recent=0 (a valid value, not treated as absent)', async () => {
+    await db.getBackupHistory({ recent: 0 })
+    expect(last().url).toBe('/api/db/backup-history?recent=0')
+  })
+})
+
+describe('schedule + transfer + destructive payloads', () => {
+  it('putBackupSchedule PUTs preset + retention knobs', async () => {
+    await db.putBackupSchedule({ preset: 'daily', keepLast: 10, keepLastPods: 5, keepDaysPods: 3 })
+    const c = last()
+    expect(c.url).toBe('/api/db/backup-schedule')
+    expect(c.method).toBe('PUT')
+    expect(c.body).toEqual({ preset: 'daily', keepLast: 10, keepLastPods: 5, keepDaysPods: 3 })
+  })
+
+  it('downloadBackup / uploadBackup forward the paths', async () => {
+    await db.downloadBackup({ vmPath: '/funcom/artifacts/a.backup', localPath: 'C:/dst/a.backup' })
+    expect(last().url).toBe('/api/db/backup-download')
+    expect(last().body).toEqual({ vmPath: '/funcom/artifacts/a.backup', localPath: 'C:/dst/a.backup' })
+
+    await db.uploadBackup({ localPath: 'C:/dst/a.backup' })
+    expect(last().url).toBe('/api/db/backup-upload')
+    expect(last().body).toEqual({ localPath: 'C:/dst/a.backup' })
+  })
+
+  it('deleteBackups forwards the exact paths array (destructive — no mutation)', async () => {
+    const paths = ['/funcom/artifacts/a.backup', '/funcom/artifacts/dst-scheduled-20260717-120000']
+    await db.deleteBackups({ paths })
+    expect(last().url).toBe('/api/db/backup-delete')
+    expect(last().method).toBe('POST')
+    expect(last().body).toEqual({ paths })
+  })
+
+  it('pruneBackupDumpPods sends keepLast + keepDays', async () => {
+    await db.pruneBackupDumpPods({ keepLast: 10, keepDays: 7 })
+    expect(last().url).toBe('/api/db/prune-backup-dump-pods')
+    expect(last().body).toEqual({ keepLast: 10, keepDays: 7 })
+  })
+})
+
+describe('local backup mirror', () => {
+  it('setBackupMirror forwards only the provided fields', async () => {
+    await db.setBackupMirror({ enabled: true, folder: 'C:/dst/mirror' })
+    expect(last().url).toBe('/api/db/backup-mirror')
+    expect(last().method).toBe('POST')
+    expect(last().body).toEqual({ enabled: true, folder: 'C:/dst/mirror' })
+
+    await db.setBackupMirror({ enabled: false })
+    expect(last().body).toEqual({ enabled: false })
+  })
+
+  it('openBackupMirrorFolder posts an empty object by default', async () => {
+    await db.openBackupMirrorFolder()
+    expect(last().url).toBe('/api/db/backup-mirror/open')
+    expect(last().body).toEqual({})
+
+    await db.openBackupMirrorFolder({ folder: 'C:/dst/mirror' })
+    expect(last().body).toEqual({ folder: 'C:/dst/mirror' })
+  })
+
+  it('syncBackupMirror posts to the sync endpoint with an empty body', async () => {
+    await db.syncBackupMirror()
+    expect(last().url).toBe('/api/db/backup-mirror/sync')
+    expect(last().method).toBe('POST')
+    expect(last().body).toEqual({})
+  })
+})

--- a/webui/tests/api/sietches.test.ts
+++ b/webui/tests/api/sietches.test.ts
@@ -1,0 +1,77 @@
+// Wrappers in src/api/sietches.ts drive the v12.19.4 multi-Hagga sietch config
+// feature. These stub `fetch` and assert each wrapper builds the right URL +
+// body, so an accidental field rename (count/names/applyNames) or URL drift is
+// caught before it breaks the reconcile-the-battlegroup call.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as s from '../../src/api/sietches'
+
+interface FetchCall {
+  url: string
+  method?: string
+  body?: unknown
+}
+
+let calls: FetchCall[]
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  calls = []
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    let body: unknown = undefined
+    if (init?.body) {
+      try { body = JSON.parse(init.body as string) } catch { body = init.body }
+    }
+    calls.push({ url, method: init?.method, body })
+    return jsonResponse({ ok: true })
+  }))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function last(): FetchCall {
+  if (calls.length === 0) throw new Error('No fetch call recorded')
+  return calls[calls.length - 1]!
+}
+
+describe('sietches API', () => {
+  it('getSietches GETs /api/sietches with no body', async () => {
+    await s.getSietches()
+    const c = last()
+    expect(c.url).toBe('/api/sietches')
+    expect(c.method).toBeUndefined()
+    expect(c.body).toBeUndefined()
+  })
+
+  it('setSietchConfig POSTs count + names + applyNames', async () => {
+    await s.setSietchConfig(3, ['Alpha', 'Beta', 'Gamma'], true)
+    const c = last()
+    expect(c.url).toBe('/api/sietches/config')
+    expect(c.method).toBe('POST')
+    expect(c.body).toEqual({ count: 3, names: ['Alpha', 'Beta', 'Gamma'], applyNames: true })
+  })
+
+  it('setSietchConfig with applyNames=false still forwards the names array verbatim', async () => {
+    // When the rename checkbox is off the UI passes applyNames=false; the names
+    // array is still sent (backend ignores it) — the wrapper must not drop it.
+    await s.setSietchConfig(1, [], false)
+    expect(last().body).toEqual({ count: 1, names: [], applyNames: false })
+  })
+
+  it('setSietchConfig preserves an empty-string name in the middle of the array', async () => {
+    // A blank name for one shard must keep its slot index, so it maps to the
+    // right partition on the backend rather than shifting later names up.
+    await s.setSietchConfig(3, ['First', '', 'Third'], true)
+    expect(last().body).toEqual({ count: 3, names: ['First', '', 'Third'], applyNames: true })
+  })
+})

--- a/webui/tests/format.test.ts
+++ b/webui/tests/format.test.ts
@@ -1,0 +1,36 @@
+// fmtToolVersion is the single UI helper for the tool's own version. It must
+// always emit PLAIN semver with a "v" prefix (never the retired Roman-numeral
+// stylization) — a standing product rule. These tests guard that contract.
+
+import { describe, expect, it } from 'vitest'
+import { fmtToolVersion } from '../src/format'
+
+describe('fmtToolVersion', () => {
+  it('prefixes a bare numeric version with v', () => {
+    expect(fmtToolVersion('12.19.4')).toBe('v12.19.4')
+    expect(fmtToolVersion('10.1.2')).toBe('v10.1.2')
+  })
+
+  it('does not double-prefix an already-v-prefixed version (case-insensitive)', () => {
+    expect(fmtToolVersion('v12.19.4')).toBe('v12.19.4')
+    expect(fmtToolVersion('V12.19.4')).toBe('v12.19.4')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(fmtToolVersion('  12.19.4  ')).toBe('v12.19.4')
+  })
+
+  it('returns an empty string for null / undefined / empty input', () => {
+    expect(fmtToolVersion(null)).toBe('')
+    expect(fmtToolVersion(undefined)).toBe('')
+    expect(fmtToolVersion('')).toBe('')
+    expect(fmtToolVersion('   ')).toBe('')
+    expect(fmtToolVersion('v')).toBe('')
+  })
+
+  it('emits plain semver, never Roman numerals', () => {
+    const out = fmtToolVersion('12.19.4')
+    expect(out).toBe('v12.19.4')
+    expect(out).toMatch(/^v\d+\.\d+\.\d+$/)
+  })
+})


### PR DESCRIPTION
## What

Adds **23 webui tests** across three previously-untested surfaces, following the existing `fetch`-stub URL+body harness:

- **`tests/api/sietches.test.ts`** (4) — the v12.19.4 multi-Hagga config wrappers: `getSietches` (GET) and `setSietchConfig` payload (`count`/`names`/`applyNames`), incl. preserving a blank name's slot index.
- **`tests/api/database.test.ts`** (14) — `/api/db/*` wrappers: `runSql` defaults (readOnly/maxRows/timeout), `backup-history` query encoding (incl. `recent=0` not treated as absent), schedule PUT, download/upload/**delete**/**prune** payloads, and the local backup mirror set/open/sync.
- **`tests/format.test.ts`** (5) — `fmtToolVersion`: guards the standing *plain-semver, never Roman numerals* product rule (double-prefix, whitespace, null/empty edge cases).

## Why

The webui had only three test files. These modules — including the **destructive** backup delete/prune contracts and the new sietch feature — had zero coverage. `fmtToolVersion` enforces a documented product rule with no guard test.

## Verification

Full webui suite green: **74 passed (was 51)**. No product code touched.