### PR TITLE
release: v12.19.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.19.4"
+      placeholder: "v12.19.5"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.19.5] - 2026-07-18
+
 ### Changed
 - **Local Backup Mirror now organizes files into per-battlegroup subfolders.**
   Mirrored backups land in `<mirror folder>\<battlegroup>\<file>` (mirroring the
@@ -27,6 +29,12 @@ here cover everything those tags shipped.
   old `dst-scheduled-<timestamp>` name that stripped the battlegroup identity.
   Existing `dst-scheduled-*` files remain fully listed, prunable, downloadable,
   and deletable.
+
+### Fixed
+- **Backend no longer risks hanging on a stalled SSH command.** The SSH helpers
+  that talk to the VM (status checks, backup transfers) now bound the wait when
+  draining a finished command's output, so a remote process that leaves an
+  output pipe open can't freeze the backend's request handling.
 
 ## [12.19.4] - 2026-07-17
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.19.4'
+$script:DuneToolVersion = '12.19.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.19.4',
+    [string]$Version = '12.19.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.19.4</Version>
+    <Version>12.19.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.19.4"
+#define MyAppVersion "12.19.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.19.4"
+$script:ToolVersion = "12.19.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## v12.19.5

Version roll for the release. Bumps all 5 stamps (12.19.4 → 12.19.5) + bug_report.yml placeholder, rolls CHANGELOG `[Unreleased]` → `[12.19.5]`.

Bundles three already-merged fixes:
- **#550** — bound SSH post-exit stream drains so a held pipe can't hang the backend.
- **#552** — scheduled backups use Funcom's native `sh-<bg>-<ts>.backup` naming.
- **#553** — Local Backup Mirror organizes files into per-battlegroup subfolders.

Backup changes validated live end-to-end on PROD. Installer built (46.02 MB, version parity passed).