### PR TITLE
Document cross-battlegroup restores

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.19.5"
+      placeholder: "v12.19.6"
     validations:
       required: true
 
@@ -104,7 +104,7 @@ body:
         - Web portal — Gameplay Admin — Storage
         - Web portal — Gameplay Admin — Blueprints (incl. Blueprint Designer link)
         - Web portal — DD Map
-        - Web portal — Database (Backup / Restore / SQL Editor)
+        - Web portal — Database (Backup / Restore / Cross-VM or cross-BG migration / SQL Editor)
         - Web portal — Database (Backup Schedule / crontab)
         - Web portal — Sietches (Additional Survival_1 shards)
         - Web portal — Map SpinUp (incl. Restart Hagga / Restart Deep Desert)
@@ -131,7 +131,7 @@ body:
     id: menu_option
     attributes:
       label: Specific page / button / command
-      description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug?
+      description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug? For a database migration, name the failing step (Import backup, Restore Backup, first Reboot All, Apply public IP, or second Reboot All).
       placeholder: "e.g. Server Health 'Restart battlegroup' button, Server Health > Scheduled restarts > Save schedule, Server Health > Scheduled restarts > Send test message (Discord), Server Health > Scheduled restarts > Check for server update, Pods > select pod > events, Settings > Dune Server Tool updates > Test channel toggle, Settings > Dune Server Tool updates > pre-release dropdown, Settings > Public IP / DDNS > Save hostname, Settings > Public IP / DDNS > Resolve hostname, Settings > Public IP / DDNS > Apply public IP, Settings > Server Browser Ping > Apply (datacenter id fix), Settings > Public IP / DDNS > Connection check (P34) > Run check, Settings > Database connection > Test connection, Settings > Database port (empty Players/Bases/Storage), Settings > SSH key > Remove passphrase, Settings > SSH key > Generate new, Settings > Server authorization token > Apply new token & restart (403002 recovery), Sidebar > Web Portal > Open in browser ('page is unavailable'), Game Config > Server name > Rename & restart, Game Config > Spicefields > Save, Game Config > Landsraad > Save, Game Config > Crafting > Repair Cost Weight, Game Config > All Default Settings > Ctrl+C section header, Game Config > client INI 'Fix my client config', Gameplay Admin > Market Bot > toggle, Gameplay Admin > Market Bot > Reset to defaults, Gameplay Admin > Market Bot > Pricing rules > Market-follow pricing toggle, Gameplay Admin > Market Bot > Pricing rules > Market markup %, Gameplay Admin > Market Bot > Buy side > Over-market guard, Gameplay Admin > Players > Give Item (Allow overflow), Gameplay Admin > Players > Give Package > Import tcno.co list, Gameplay Admin > Players > Give Package (Allow overflow), Gameplay Admin > Players > Give Vehicle Kit > Sandbike (Allow overflow), Gameplay Admin > Players > inventory item > Repair, Gameplay Admin > Players > inventory item > Stack quantity, Gameplay Admin > Storage > container item > Stack quantity, Gameplay Admin > Bases > Release claim > confirm (backup ack), Gameplay Admin > Players > Cheat Scripts > Award Player XP, Gameplay Admin > Players > Specs > Set Level (per-track slider), Gameplay Admin > Players > Specs > Max / Reset (per track), Gameplay Admin > Players > Journey > Complete node, Gameplay Admin > Players > Progression > Progression Unlock > Apply Unlock (Atreides Ch3 Start), Gameplay Admin > Players > Progression > Complete Contract > search 'Skorda' > Complete Contract, Gameplay Admin > Players > Tags > search/add tag, Gameplay Admin > Players > Grant Cosmetic / Building Set > grant variant/swatch/skin or building set (Observer/murals/decor), Gameplay Admin > Players > Reset Faction > confirm wipe, Gameplay Admin > Players > Actions > Unlock Trainers > Swordmaster, Gameplay Admin > Players > Actions > Unlock Main Quest > A New Beginning, Gameplay Admin > Players > Progression > Apply Quick Preset > Complete: Find the Fremen (3rd ability slot + prescience), Gameplay Admin > Players > Landsraad > set House Ecaz, Gameplay Admin > Players > Actions > Punishment > Ban, Gameplay Admin > Players > Hide GM toggle, Settings > Mobile App > Generate QR Code, Settings > Mobile App > Repair Mobile Bridge, Gameplay Admin > Players (blank names / 0 pieces), Help > Keep serving while DST is closed, Database > Backup Schedule presets > Hourly, Database > backup file > Delete (single / select-all), Database > Completed backup & restore pods > Prune, Map SpinUp > Survival_2, Map SpinUp > Arrakeen loading counter, Map SpinUp > Restart Hagga, Help > Create GitHub Issue, CLI option 'e. reboot', or -Cmd startup"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.19.6] - 2026-07-19
+
+### Changed
+- **Database restore guidance now covers live-proven cross-VM and
+  cross-battlegroup migrations.** Full database backups can carry characters,
+  inventories, progression, bases, and world state to a different VM or
+  battlegroup; the previous same-server-only warning was incorrect. The Database
+  page now provides the exact migration sequence, including both intentional
+  full restarts used to clear stale pods and reconcile operators after any
+  public-IP change. Destructive-restore safeguards remain unchanged.
+
 ## [12.19.5] - 2026-07-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ browser and keeps the server running in the background.
 
 ### New in v12.19
 
+- **Cross-VM / cross-battlegroup database migration** (v12.19.6, Database).
+  Live testing confirmed that a full `.backup` can move characters, inventories,
+  progression, bases, and world state to a different VM or battlegroup. The
+  earlier same-server-only warning was too broad. Database now includes the
+  proven sequence: start the new server, stop its battlegroup, use **Backups →
+  Import backup**, run **Restore Backup**, run **Commands → Reboot All**, apply
+  any changed **Settings → Public IP / DDNS** value after it settles, then run
+  **Reboot All** again before logging in. The two restarts are intentional: one
+  clears stale pods after the database swap and one forces clean operator
+  reconciliation after the IP change. Keep the old VM and original backup until
+  every character, inventory, progression state, and base has been verified;
+  account-specific data problems can still prevent an individual character from
+  loading.
 - **Multi-Hagga sietches** (v12.19.4, Sietches). Configure how many Hagga Basin
   shards to run (up to 6), optionally name each one, and hit **Apply** — DST
   reconciles the battlegroup and restarts cleanly. **Server Health** labels each
@@ -220,12 +233,12 @@ browser and keeps the server running in the background.
 
 ### New in v12.13.x
 
-- **Restore warns about cross-server restores** (v12.13.17). Characters
-  are bound to Funcom accounts in the cloud, so restoring a backup onto
-  a *different* VM/battlegroup recovers the world and bases but may not
-  restore character logins (they can fail to load or get cleared on
-  boot). The Restore card and its confirmation prompt now say so —
-  restore is intended for the same server.
+- **Restore warning strengthened** (v12.13.17). The Restore card and typed
+  confirmation make clear that a restore replaces the entire battlegroup
+  database and permanently discards everything created after the selected
+  snapshot. Cross-VM / cross-battlegroup migration guidance was corrected in
+  v12.19.6 after a live migration proved that complete character data can carry
+  over.
 - **Server rename works again** (v12.13.16). Game Config → Server name
   no longer rejects a valid name with "A non-empty name is required" —
   the request-body reader now handles hashtable-parsed bodies, so the

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -148,7 +148,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.19.5'
+$script:DuneToolVersion = '12.19.6'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.19.5',
+    [string]$Version = '12.19.6',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.19.5</Version>
+    <Version>12.19.6</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.19.5"
+#define MyAppVersion "12.19.6"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.19.5"
+$script:ToolVersion = "12.19.6"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -122,7 +122,7 @@ export function Database() {
         'ALL players, bases, inventories, storage, blueprints, and the market will be rolled back to that snapshot. ' +
         'Everything created since the backup is permanently lost. This cannot be undone.\n\n' +
         'Take a fresh backup first if you have not. The battlegroup must be stopped.\n\n' +
-        'NOTE: restoring a backup onto a DIFFERENT server/battlegroup than it was taken on does NOT reliably restore characters — they are bound to your Funcom account in the cloud, so they may fail to load or get cleared on boot. Cross-server restores recover the world/bases, not character logins. Restore is intended for the SAME server.\n\n' +
+        'CROSS-VM / CROSS-BATTLEGROUP MIGRATION: a full backup can carry characters, inventories, progression, and bases to a different VM or battlegroup. Follow the migration guide on the Database page exactly, keep the old VM and original backup, and verify every character before decommissioning either one.\n\n' +
         'Type RESTORE to continue:',
       )
       if (typed == null) return
@@ -331,7 +331,7 @@ export function Database() {
           title="Restore Backup"
           icon="Upload"
           tone="ibad"
-          description="Full destructive restore — REPLACES the entire BG database with a previously taken backup. All players, bases, inventories, storage, blueprints, and the market roll back to that snapshot; everything since is permanently lost. Funcom's `battlegroup import` handles the whole lifecycle: it stops the BG on its own, swaps the snapshot into the DB, and the game containers recover automatically. No need to pre-stop; runs from any state. This cannot be undone. Restoring onto a different server/BG than it came from won't reliably restore characters (they're cloud-bound to Funcom accounts) — world/bases come back, character logins may not."
+          description="Full destructive restore — REPLACES the entire BG database with a previously taken backup. All players, bases, inventories, storage, blueprints, and the market roll back to that snapshot; everything since is permanently lost. Funcom's `battlegroup import` handles the restore lifecycle for ordinary rollbacks. Full backups can also migrate characters, inventories, progression, and bases to a different VM or battlegroup when the migration guide below is followed. This cannot be undone."
           hint={
             !vmRunning ? 'VM must be running to restore a backup.'
             : 'Choose the backup file in the console window. Funcom will print a "should be stopped" advisory; type `yes` to proceed — the import stops the BG on its own, swaps the DB, and the game recovers automatically.'
@@ -341,6 +341,33 @@ export function Database() {
           busy={launching === 'import'}
           onClick={() => void runMaint('import')}
         />
+      </div>
+
+      <div className="card p-5 mb-6 border border-accent/40">
+        <div className="flex items-start gap-3 mb-4">
+          <Icon name="ServerCog" size={22} className="text-accent mt-0.5 shrink-0" />
+          <div>
+            <h2 className="text-sm font-semibold text-text">Cross-VM / Cross-Battlegroup Migration</h2>
+            <p className="text-xs text-text-dim mt-1">
+              Live-verified procedure for moving a complete database backup to a different VM or battlegroup. Characters can carry over with their inventory, progression, and bases; account-specific data problems can still prevent an individual character from loading.
+            </p>
+          </div>
+        </div>
+
+        <ol className="list-decimal pl-5 space-y-2 text-xs text-text-muted">
+          <li>Copy the old <code className="font-mono text-text">.backup</code> file from the old VM to your PC. Keep the old VM and original backup intact.</li>
+          <li>Set up and start the new server VM and battlegroup.</li>
+          <li>Stop the target battlegroup.</li>
+          <li>On this page, open <strong className="text-text">Backups</strong>, click <strong className="text-text">Import backup</strong>, and select the old <code className="font-mono text-text">.backup</code> file to upload it to the new VM.</li>
+          <li>Click <strong className="text-text">Restore Backup</strong>, select the uploaded file in the console window, and complete the restore.</li>
+          <li>Run <strong className="text-text">Commands → Reboot All</strong>.</li>
+          <li>If the old VM used different addressing, open <strong className="text-text">Settings → Public IP / DDNS</strong>, apply the correct public IP settings, and wait for the address to settle.</li>
+          <li>Run <strong className="text-text">Commands → Reboot All</strong> again, then log in and verify characters, inventories, progression, and bases.</li>
+        </ol>
+
+        <div className="mt-4 rounded border border-warning/30 bg-warning/5 px-3 py-2 text-xs text-text-muted">
+          <strong className="text-warning">Do not skip the two full restarts.</strong> The first clears stale pods after the database replacement. The second forces a clean operator reconciliation after the IP change settles. Do not delete the old VM or backup until every character has been verified.
+        </div>
       </div>
 
       {/* Configurable backup schedule (writes the VM's root crontab) */}


### PR DESCRIPTION
## Summary
- replace incorrect same-server-only restore warning
- add live-proven cross-VM/cross-battlegroup migration procedure
- preserve destructive-restore safeguards and document both required reboot cycles
- bump all release metadata to v12.19.6

## Validation
- web UI production build
- PowerShell 5.1 parse preflight
- full installer build
- staged gitleaks scan