### PR TITLE
Fix game UDP bridge routing and startup race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ here cover everything those tags shipped.
 ### Fixed
 - **Public IP / DDNS now handles mixed game-port bind states.** The UDP bridge
   reconciles each active port independently, so a LAN-bound map port no longer
-  suppresses DNAT for different ports bound only to the public IP. Cleanup is
-  limited to Dune game-port UDP rules for the VM.
+  suppresses DNAT for different ports bound only to the public IP. When separate
+  game processes bind the same port on both addresses, the public listener wins
+  so router-forwarded players reach the advertised map process. LAN-only ports
+  remain untouched. Cleanup is limited to Dune game-port UDP rules for the VM.
 
 ## [12.19.8] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ here cover everything those tags shipped.
   second and installs exact-port DNAT continuously instead of waiting for the
   old once-per-minute pass. Cluster lookups run independently with hard
   timeouts, so a stalled K3s API cannot stop listener polling. Cleanup is limited
-  to Dune game-port UDP rules for the VM. First-handoff behavior remains
-  unconfirmed pending Marcus's field test.
+  to Dune game-port UDP rules for the VM. Marcus's field test confirmed DNAT
+  appeared before DST showed the map green and the first external handoff
+  succeeded without P34.
 
 ## [12.19.8] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+- **Public IP / DDNS now handles mixed game-port bind states.** The UDP bridge
+  reconciles each active port independently, so a LAN-bound map port no longer
+  suppresses DNAT for different ports bound only to the public IP. Cleanup is
+  limited to Dune game-port UDP rules for the VM.
+
 ## [12.19.8] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,12 @@ here cover everything those tags shipped.
   suppresses DNAT for different ports bound only to the public IP. When separate
   game processes bind the same port on both addresses, the public listener wins
   so router-forwarded players reach the advertised map process. LAN-only ports
-  remain untouched. Cleanup is limited to Dune game-port UDP rules for the VM.
+  remain untouched. A supervised VM-side loop now targets detection within one
+  second and installs exact-port DNAT continuously instead of waiting for the
+  old once-per-minute pass. Cluster lookups run independently with hard
+  timeouts, so a stalled K3s API cannot stop listener polling. Cleanup is limited
+  to Dune game-port UDP rules for the VM. First-handoff behavior remains
+  unconfirmed pending Marcus's field test.
 
 ## [12.19.8] - 2026-07-20
 

--- a/app/resources/remote-scripts/dune-dnat-watch-install.sh
+++ b/app/resources/remote-scripts/dune-dnat-watch-install.sh
@@ -87,32 +87,78 @@ udp_listeners() {
     printf '%s\n' "$_out"
 }
 
-# Classify the game's UDP bind across ports 7777-7810:
-#   0 = public IP bound, LAN/wildcard NOT bound   -> bridge needed AND safe
-#   1 = LAN IP / 0.0.0.0 bound                     -> bridge would black-hole
-#   2 = indeterminate (no game listeners visible)  -> leave rules unchanged
-game_bind_state() {
-    _pub=0; _lanwild=0
-    for _e in $(udp_listeners); do
+# Classify one game UDP port:
+#   pub  = public IP bound, LAN/wildcard NOT bound -> bridge needed AND safe
+#   lan  = LAN IP / 0.0.0.0 bound                  -> bridge would black-hole
+#   none = no relevant listener visible            -> leave its rule unchanged
+#
+# Listener state is intentionally evaluated per port. Funcom can mix public-only
+# and LAN-bound map ports within the dynamic range.
+game_port_state() {
+    _want_port="$1"
+    _pub=0
+    _lanwild=0
+    for _e in $_udp_snapshot; do
         _port=${_e##*:}
         _addr=${_e%:*}
-        case "$_port" in ''|*[!0-9]*) continue ;; esac
-        { [ "$_port" -ge "$GAME_LO" ] && [ "$_port" -le "$GAME_HI" ]; } 2>/dev/null || continue
+        [ "$_port" = "$_want_port" ] || continue
         case "$_addr" in
             "$PUB")                  _pub=1 ;;
             "$VM_IP"|0.0.0.0|'*'|'') _lanwild=1 ;;
         esac
     done
-    [ "$_lanwild" = 1 ] && return 1
-    [ "$_pub" = 1 ] && return 0
-    return 2
+
+    if [ "$_lanwild" = 1 ]; then
+        echo lan
+    elif [ "$_pub" = 1 ]; then
+        echo pub
+    else
+        echo none
+    fi
 }
 
-# Delete every game-UDP DNAT rule currently in PREROUTING (any --to-destination).
-purge_game_bridge() {
-    iptables -t nat -S PREROUTING 2>/dev/null | grep -- "--dport ${GAME_PORTS}" | grep -- '-j DNAT' | sed 's/^-A/-D/' | while read -r _spec; do
-        iptables -t nat $_spec 2>/dev/null && log "removed game-UDP DNAT rule: $_spec"
-    done
+# Restrict cleanup to UDP DNAT rules whose destination is this Dune VM. Do not
+# touch unrelated DNAT rules that happen to use a game-range port.
+game_bridge_rules() {
+    iptables -t nat -S PREROUTING 2>/dev/null |
+        grep -F -- "-d ${VM_IP}/32" |
+        grep -F -- '-p udp' |
+        grep -F -- '-j DNAT'
+}
+
+purge_legacy_game_bridge() {
+    game_bridge_rules |
+        grep -E -- "--dport[[:space:]]+${GAME_PORTS}([[:space:]]|$)" |
+        sed 's/^-A/-D/' |
+        while read -r _spec; do
+            iptables -t nat $_spec 2>/dev/null &&
+                log "removed legacy broad game-UDP DNAT rule: $_spec"
+        done
+}
+
+purge_game_bridge_port() {
+    _port="$1"
+    game_bridge_rules |
+        grep -E -- "--dport[[:space:]]+${_port}([[:space:]]|$)" |
+        sed 's/^-A/-D/' |
+        while read -r _spec; do
+            iptables -t nat $_spec 2>/dev/null &&
+                log "removed game-UDP DNAT rule for port ${_port}: $_spec"
+        done
+}
+
+ensure_game_bridge_port() {
+    _port="$1"
+    if iptables -t nat -C PREROUTING -d "$VM_IP" -p udp --dport "$_port" -j DNAT --to-destination "$PUB" 2>/dev/null; then
+        return 0
+    fi
+
+    purge_game_bridge_port "$_port"
+    if iptables -t nat -I PREROUTING 1 -d "$VM_IP" -p udp --dport "$_port" -j DNAT --to-destination "$PUB" 2>/dev/null; then
+        log "installed game-UDP bridge: ${VM_IP}:${_port} -> ${PUB}:${_port} (game binds public IP only)"
+    else
+        log "failed to install game-UDP bridge for port ${_port}"
+    fi
 }
 
 NODE=$($KUBE get nodes --no-headers -o custom-columns=:metadata.name 2>/dev/null | head -1 | tr -d ' ')
@@ -147,24 +193,22 @@ fi
 
 # --- Game-UDP bridge: <VM_IP>:7777-7810/udp -> PUB (needs a valid VM LAN IP) ---
 if is_ipv4 "$VM_IP"; then
-    game_bind_state; _st=$?
-    if [ "$_st" = 0 ]; then
-        if iptables -t nat -C PREROUTING -d "$VM_IP" -p udp --dport "$GAME_PORTS" -j DNAT --to-destination "$PUB" 2>/dev/null; then
-            : # already correct
-        else
-            purge_game_bridge   # drop any stale rule (e.g. an old public IP) first
-            iptables -t nat -I PREROUTING 1 -d "$VM_IP" -p udp --dport "$GAME_PORTS" -j DNAT --to-destination "$PUB"
-            log "installed game-UDP bridge: ${VM_IP}:${GAME_PORTS} -> ${PUB} (game binds public IP only)"
+    _udp_snapshot=$(udp_listeners)
+    _legacy_reconciled=0
+    _p="$GAME_LO"
+    while [ "$_p" -le "$GAME_HI" ]; do
+        _state=$(game_port_state "$_p")
+        if [ "$_state" != none ] && [ "$_legacy_reconciled" = 0 ]; then
+            purge_legacy_game_bridge
+            _legacy_reconciled=1
         fi
-    elif [ "$_st" = 1 ]; then
-        # Game reachable on the LAN IP/wildcard already; a bridge would black-hole it.
-        if iptables -t nat -C PREROUTING -d "$VM_IP" -p udp --dport "$GAME_PORTS" -j DNAT --to-destination "$PUB" 2>/dev/null; then
-            purge_game_bridge
-            log "removed game-UDP bridge (game binds LAN/wildcard; bridge would black-hole)"
-        fi
-    else
-        : # indeterminate (pods not up?) -> leave whatever is there intact
-    fi
+        case "$_state" in
+            pub)  ensure_game_bridge_port "$_p" ;;
+            lan)  purge_game_bridge_port "$_p" ;;
+            none) : ;; # inactive/indeterminate -> preserve any exact-port rule
+        esac
+        _p=$((_p + 1))
+    done
 else
     log "node InternalIP not a valid IPv4 ('$VM_IP'); leaving game-UDP bridge intact"
 fi

--- a/app/resources/remote-scripts/dune-dnat-watch-install.sh
+++ b/app/resources/remote-scripts/dune-dnat-watch-install.sh
@@ -12,8 +12,9 @@
 #   drops the game bridge, and remote players hang forever on "Connecting" /
 #   time out with P34 (observed 2026-06-23: a ~19h stale RabbitMQ rule because a
 #   prior hardcoded-IP sync script only watched the OLD public IP). This watchdog
-#   reconciles both rules from the live cluster + socket state every minute, so a
-#   pod restart self-heals in <=60s.
+#   reconciles game listeners continuously and cluster-derived addresses in an
+#   independent bounded worker. Newly-bound public ports target exact-port DNAT
+#   within the listener cadence; field confirmation remains pending.
 #
 #   THE GAME-UDP BRIDGE IS BIND-DETECTED, NOT UNCONDITIONAL.
 #   A remote player's game traffic is forwarded by their home router to the VM's
@@ -28,51 +29,219 @@
 #   on the LOCAL IP"), traffic to the LAN IP ALREADY works, and rewriting it to
 #   the public IP would send it to a port nothing listens on -> black hole. That
 #   is exactly the regression removed in v12.16.9. So the watchdog installs the
-#   bridge ONLY when it positively detects public-only binding, actively REMOVES
-#   it when it detects LAN/wildcard binding, and leaves the rules untouched when
-#   binding is indeterminate (pods not up yet) -- never tearing down a working
-#   rule on a guess. Detection is IPv4-only (a dual-stack IPv6 `::` bind must not
-#   masquerade as a LAN bind and suppress a legitimately-needed bridge).
+#   bridge whenever it positively detects a public listener for that exact port
+#   (public wins over a separate LAN listener), actively REMOVES it for LAN-only
+#   binding, and leaves rules untouched when binding is indeterminate (pods not
+#   up yet) -- never tearing down a working rule on a guess. Detection is
+#   IPv4-only (a dual-stack IPv6 `::` bind must not masquerade as a LAN bind).
 #
 # DEFENDER-SAFE DESIGN
-#   All persistence logic (writing the watchdog + the cron entry) lives here in
-#   POSIX sh and runs on the Linux VM. DST only stages-and-runs this script over
+#   All persistence logic (watchdog, OpenRC service, health-check cron) lives
+#   here in POSIX sh and runs on the Linux VM. DST only stages-and-runs this over
 #   SSH -- the same mechanism as dune-clear-partitions.start -- so the packaged
 #   Windows app carries NO persistence-establishment code (that PowerShell
 #   pattern is what tripped the Defender ML false positive in v11.0.1).
 #
 # Staged to /tmp by DST and run once with sudo on every Start / Restart.
-# Idempotent and best-effort. Logged to /var/log/dune-dnat-watch.log.
+# Installation is transactional and fails closed. Logged to the VM watchdog log.
 
 set -u
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+if [ -n "${DUNE_DNAT_PATH_PREFIX:-}" ]; then PATH="$DUNE_DNAT_PATH_PREFIX:$PATH"; fi
+export PATH
 
-WATCH=/usr/local/bin/dune-dnat-watch.sh
-LOG=/var/log/dune-dnat-watch.log
+WATCH="${DUNE_DNAT_INSTALL_WATCH:-/usr/local/bin/dune-dnat-watch.sh}"
+SERVICE="${DUNE_DNAT_INSTALL_SERVICE:-/etc/init.d/dune-dnat-watch}"
+LOG="${DUNE_DNAT_INSTALL_LOG:-/var/log/dune-dnat-watch.log}"
+K3S_REQUIRED="${DUNE_DNAT_K3S:-/usr/local/bin/k3s}"
+TXN="$$"
+WATCH_STAGE="${WATCH}.new.${TXN}"
+SERVICE_STAGE="${SERVICE}.new.${TXN}"
+WATCH_BACKUP="${WATCH}.previous.${TXN}"
+SERVICE_BACKUP="${SERVICE}.previous.${TXN}"
+CRON_BACKUP="/tmp/dune-dnat-watch.cron.${TXN}"
+CRON_FILTERED="/tmp/dune-dnat-watch.cron-filtered.${TXN}"
+STATE_DIR="${DUNE_DNAT_STATE_DIR:-/run/dune-dnat-watch}"
+OWNER_FILE="$STATE_DIR/owner"
+LISTENER_HEARTBEAT="$STATE_DIR/listener.heartbeat"
+MUTATION_LOCK="$STATE_DIR/mutation.lock"
+OWNER_SNAPSHOT="/tmp/dune-dnat-watch.owner.${TXN}"
+HEARTBEAT_SNAPSHOT="/tmp/dune-dnat-watch.heartbeat.${TXN}"
+CUTOVER_MARKER="/tmp/dune-dnat-watch.cutover.${TXN}"
+PRE_CUTOVER_OWNER=""
+MIGRATION_STARTED=0
+HAD_WATCH=0
+HAD_SERVICE=0
+HAD_CRONTAB=0
+HAD_RUNLEVEL=0
+PRIOR_SERVICE_RUNNING=0
 
 ts() { date "+%Y-%m-%d %H:%M:%S"; }
 log() { echo "[$(ts)] $*" >> "$LOG" 2>/dev/null; }
+cleanup_transaction_files() {
+    rm -f "$WATCH_STAGE" "$SERVICE_STAGE" "$WATCH_BACKUP" "$SERVICE_BACKUP" \
+        "$CRON_BACKUP" "$CRON_FILTERED" "$OWNER_SNAPSHOT" \
+        "$HEARTBEAT_SNAPSHOT" "$CUTOVER_MARKER"
+}
+
+watch_pids() {
+    pgrep -f '[/]usr/local/bin/dune-dnat-watch[.]sh([[:space:]]|$)' 2>/dev/null || true
+}
+
+stop_watch_processes() {
+    if [ -f "$SERVICE" ]; then rc-service dune-dnat-watch stop >/dev/null 2>&1 || true; fi
+    _stop_wait=0
+    while [ -n "$(watch_pids)" ] && [ "$_stop_wait" -lt 5 ]; do
+        _stop_pids=$(watch_pids)
+        [ -z "$_stop_pids" ] || kill $_stop_pids 2>/dev/null || true
+        sleep 1
+        _stop_wait=$((_stop_wait + 1))
+    done
+    _stop_pids=$(watch_pids)
+    if [ -n "$_stop_pids" ]; then
+        kill -9 $_stop_pids 2>/dev/null || true
+        sleep 1
+    fi
+    [ -z "$(watch_pids)" ]
+}
+
+clear_runtime_state() {
+    mkdir -p "$STATE_DIR" || return 1
+    (
+        flock -x 9 || exit 1
+        rm -f "$OWNER_FILE" "$LISTENER_HEARTBEAT"
+    ) 9>"$MUTATION_LOCK"
+}
+
+invalidate_runtime_state() {
+    mkdir -p "$STATE_DIR" || return 1
+    : > "$OWNER_SNAPSHOT" || return 1
+    : > "$HEARTBEAT_SNAPSHOT" || return 1
+    (
+        flock -x 9 || exit 1
+        if [ -r "$OWNER_FILE" ]; then cp -p "$OWNER_FILE" "$OWNER_SNAPSHOT" || exit 1; fi
+        if [ -r "$LISTENER_HEARTBEAT" ]; then cp -p "$LISTENER_HEARTBEAT" "$HEARTBEAT_SNAPSHOT" || exit 1; fi
+        rm -f "$OWNER_FILE" "$LISTENER_HEARTBEAT" || exit 1
+        touch "$CUTOVER_MARKER" || exit 1
+    ) 9>"$MUTATION_LOCK" || return 1
+    PRE_CUTOVER_OWNER=$(cat "$OWNER_SNAPSHOT" 2>/dev/null)
+    return 0
+}
+
+replacement_healthy() {
+    [ -r "$OWNER_FILE" ] && [ -r "$LISTENER_HEARTBEAT" ] || return 1
+    _replacement_owner=$(cat "$OWNER_FILE" 2>/dev/null) || return 1
+    _replacement_heartbeat_owner=$(cat "$LISTENER_HEARTBEAT" 2>/dev/null) || return 1
+    [ -n "$_replacement_owner" ] &&
+        [ "$_replacement_owner" != "$PRE_CUTOVER_OWNER" ] &&
+        [ "$_replacement_heartbeat_owner" = "$_replacement_owner" ] &&
+        [ "$LISTENER_HEARTBEAT" -nt "$CUTOVER_MARKER" ] &&
+        "$WATCH" --healthcheck >/dev/null 2>&1
+}
+
+restore_prior_state() {
+    log "DNAT watchdog migration failed; restoring previous files and lifecycle state"
+    stop_watch_processes || log "rollback warning: watchdog processes did not fully exit"
+    clear_runtime_state || log "rollback warning: failed to clear cutover runtime state"
+
+    if [ "$HAD_WATCH" -eq 1 ] && [ -f "$WATCH_BACKUP" ]; then
+        mv -f "$WATCH_BACKUP" "$WATCH" || log "rollback warning: failed to restore $WATCH"
+    else
+        rm -f "$WATCH"
+    fi
+    if [ "$HAD_SERVICE" -eq 1 ] && [ -f "$SERVICE_BACKUP" ]; then
+        mv -f "$SERVICE_BACKUP" "$SERVICE" || log "rollback warning: failed to restore $SERVICE"
+    else
+        rm -f "$SERVICE"
+    fi
+
+    if [ "$HAD_RUNLEVEL" -eq 1 ]; then
+        rc-update add dune-dnat-watch default >/dev/null 2>&1 ||
+            log "rollback warning: failed to restore OpenRC runlevel"
+    else
+        rc-update del dune-dnat-watch default >/dev/null 2>&1 || true
+    fi
+
+    if [ "$HAD_CRONTAB" -eq 1 ]; then
+        crontab "$CRON_BACKUP" >/dev/null 2>&1 ||
+            log "rollback warning: failed to restore prior crontab"
+    else
+        crontab -r >/dev/null 2>&1 || true
+    fi
+
+    if [ "$PRIOR_SERVICE_RUNNING" -eq 1 ] && [ "$HAD_SERVICE" -eq 1 ]; then
+        rc-service dune-dnat-watch start >/dev/null 2>&1 ||
+            log "rollback warning: failed to restart prior service"
+    fi
+}
+
+fail() {
+    _fail_message="$*"
+    log "$_fail_message"
+    if [ "$MIGRATION_STARTED" -eq 1 ]; then restore_prior_state; fi
+    cleanup_transaction_files
+    echo DUNE_DNAT_WATCH_FAILED
+    exit 1
+}
+
+on_interrupt() {
+    log "DNAT watchdog installer interrupted"
+    if [ "$MIGRATION_STARTED" -eq 1 ]; then restore_prior_state; fi
+    cleanup_transaction_files
+    exit 1
+}
+trap on_interrupt HUP INT TERM
+
+for _required in supervise-daemon rc-service rc-update crontab timeout stat flock pgrep; do
+    command -v "$_required" >/dev/null 2>&1 || fail "required command missing: $_required"
+done
+[ -x "$K3S_REQUIRED" ] || fail "required command missing: $K3S_REQUIRED"
 
 # ---------------------------------------------------------------------------
 # 1. Write the watchdog. Quoted heredoc -> nothing is expanded at write time;
 #    the watchdog resolves everything dynamically when it runs.
 # ---------------------------------------------------------------------------
-cat > "$WATCH" <<'WATCHEOF'
+if ! cat > "$WATCH_STAGE" <<'WATCHEOF'
 #!/bin/sh
 # Dune DNAT self-heal watchdog. Reconciles the RabbitMQ DNAT rule and the
-# bind-detected game-UDP bridge from the live k3s + socket state. Idempotent;
-# safe to run every minute. Installed + scheduled by dune-dnat-watch-install.sh.
-export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+# bind-detected game-UDP bridge from the live k3s + socket state. The supervised
+# listener loop targets one snapshot per second; k3s runs in a bounded worker.
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+if [ -n "${DUNE_DNAT_PATH_PREFIX:-}" ]; then PATH="$DUNE_DNAT_PATH_PREFIX:$PATH"; fi
+export PATH
 
-KUBE="/usr/local/bin/k3s kubectl"
-LOG=/var/log/dune-dnat-watch.log
+K3S="${DUNE_DNAT_K3S:-/usr/local/bin/k3s}"
+LOG="${DUNE_DNAT_LOG:-/var/log/dune-dnat-watch.log}"
 RABBIT_PORT=31982
 GAME_PORTS=7777:7810
 GAME_LO=7777
 GAME_HI=7810
+LOOP_SLEEP="${DUNE_DNAT_LOOP_SLEEP:-1}"
+CLUSTER_SLEEP="${DUNE_DNAT_CLUSTER_SLEEP:-5}"
+MAX_PASSES="${DUNE_DNAT_MAX_PASSES:-0}"
+STATE_DIR="${DUNE_DNAT_STATE_DIR:-/run/dune-dnat-watch}"
+CLUSTER_STATE="$STATE_DIR/cluster.state"
+OWNER_FILE="$STATE_DIR/owner"
+LISTENER_HEARTBEAT="$STATE_DIR/listener.heartbeat"
+WORKER_HEARTBEAT="$STATE_DIR/worker.heartbeat"
+MUTATION_LOCK="$STATE_DIR/mutation.lock"
+FAILURE_LOG_STAMP="$STATE_DIR/failure-log.stamp"
+WORKER_STALE_SEC=15
+LISTENER_STALE_SEC=5
 
 ts() { date "+%Y-%m-%d %H:%M:%S"; }
 log() { echo "[$(ts)] $*" >> "$LOG" 2>/dev/null; }
 is_ipv4() { echo "$1" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; }
+kube() { timeout 3 "$K3S" kubectl --request-timeout=2s "$@"; }
+file_age() {
+    _age_file="$1"
+    [ -r "$_age_file" ] || return 1
+    _age_now=$(date +%s)
+    _age_mtime=$(stat -c %Y "$_age_file" 2>/dev/null) || return 1
+    _age_value=$((_age_now - _age_mtime))
+    [ "$_age_value" -ge 0 ] || _age_value=0
+    printf '%s\n' "$_age_value"
+}
 
 # IPv4-only UDP listener addresses ("addr:port" per line). Funcom game pods run
 # hostNetwork so their binds are visible in the host net namespace. -4 / udp-only
@@ -161,86 +330,383 @@ ensure_game_bridge_port() {
     if iptables -t nat -I PREROUTING 1 -d "$VM_IP" -p udp --dport "$_port" -j DNAT --to-destination "$PUB" 2>/dev/null; then
         log "installed game-UDP bridge: ${VM_IP}:${_port} -> ${PUB}:${_port} (game binds public IP only)"
     else
-        log "failed to install game-UDP bridge for port ${_port}"
+        log_reconcile_failure "failed to install game-UDP bridge for port ${_port}"
     fi
 }
 
-NODE=$($KUBE get nodes --no-headers -o custom-columns=:metadata.name 2>/dev/null | head -1 | tr -d ' ')
-[ -z "$NODE" ] && exit 0
+PUB=""
+VM_IP=""
 
-# Public IP = authoritative node ExternalIP (tracks IP changes, never hardcoded).
-PUB=$($KUBE get node "$NODE" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}' 2>/dev/null)
-# VM LAN IP = node InternalIP (the -d match for router-forwarded remote traffic).
-VM_IP=$($KUBE get node "$NODE" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null)
-# Current mq-game pod IP from the service endpoints.
-POD=$($KUBE get endpoints --all-namespaces 2>/dev/null | grep mq-game | awk '{print $3}' | cut -d, -f1 | cut -d: -f1 | head -1)
-
-# PUB is the shared rewrite target for both rules -- without a valid one, never
-# touch anything. A missing/`<none>` value must never delete a good rule.
-if ! is_ipv4 "$PUB"; then log "node ExternalIP not a valid IPv4 ('$PUB'); leaving rules intact"; exit 0; fi
-
-# --- RabbitMQ login: public:31982/tcp -> POD:5672 (needs a valid pod IP) ---
-if is_ipv4 "$POD"; then
-    if iptables -t nat -C PREROUTING -d "${PUB}/32" -p tcp --dport "$RABBIT_PORT" -j DNAT --to-destination "${POD}:5672" 2>/dev/null; then
-        : # already correct
-    else
-        # Replacement IP validated above, so swapping the rule now is safe.
-        iptables -t nat -S PREROUTING | grep -- "--dport ${RABBIT_PORT}" | grep -- "-j DNAT" | sed "s/^-A/-D/" | while read -r spec; do
-            iptables -t nat $spec 2>/dev/null
-        done
-        iptables -t nat -I PREROUTING 1 -d "${PUB}/32" -p tcp --dport "$RABBIT_PORT" -j DNAT --to-destination "${POD}:5672"
-        log "reconciled rabbitmq DNAT: ${PUB}:${RABBIT_PORT} -> ${POD}:5672"
+log_reconcile_failure() {
+    _failure_now=$(date +%s)
+    _failure_last=0
+    if [ -r "$FAILURE_LOG_STAMP" ]; then _failure_last=$(cat "$FAILURE_LOG_STAMP" 2>/dev/null); fi
+    case "$_failure_last" in *[!0-9]*|'') _failure_last=0 ;; esac
+    if [ "$_failure_last" -eq 0 ] || [ $((_failure_now - _failure_last)) -ge 60 ]; then
+        log "$*"
+        printf '%s\n' "$_failure_now" > "$FAILURE_LOG_STAMP"
     fi
-else
-    log "mq-game endpoint not a valid IPv4 ('$POD'); leaving rabbitmq rule intact"
-fi
+}
 
-# --- Game-UDP bridge: <VM_IP>:7777-7810/udp -> PUB (needs a valid VM LAN IP) ---
-if is_ipv4 "$VM_IP"; then
-    _udp_snapshot=$(udp_listeners)
-    _legacy_reconciled=0
-    _p="$GAME_LO"
-    while [ "$_p" -le "$GAME_HI" ]; do
-        _state=$(game_port_state "$_p")
-        if [ "$_state" != none ] && [ "$_legacy_reconciled" = 0 ]; then
-            purge_legacy_game_bridge
-            _legacy_reconciled=1
+load_cluster_state() {
+    [ -r "$CLUSTER_STATE" ] || return 1
+    _cached_state=$(cat "$CLUSTER_STATE" 2>/dev/null) || return 1
+    set -- $_cached_state
+    [ "$#" -eq 2 ] || return 1
+    is_ipv4 "$1" && is_ipv4 "$2" || return 1
+    PUB="$1"
+    VM_IP="$2"
+}
+
+worker_owned() {
+    [ -r "$OWNER_FILE" ] && [ "$(cat "$OWNER_FILE" 2>/dev/null)" = "$1" ]
+}
+
+publish_owner() {
+    _publish_token="$1"
+    (
+        flock -x 9 || exit 1
+        _publish_tmp="${OWNER_FILE}.$$"
+        printf '%s\n' "$_publish_token" > "$_publish_tmp" &&
+            mv -f "$_publish_tmp" "$OWNER_FILE"
+    ) 9>"$MUTATION_LOCK"
+}
+
+write_cluster_state() {
+    _state_pub="$1"
+    _state_vm="$2"
+    _state_token="$3"
+    (
+        flock -x 9 || exit 1
+        worker_owned "$_state_token" || exit 0
+        _state_tmp="${CLUSTER_STATE}.$$"
+        if printf '%s\n%s\n' "$_state_pub" "$_state_vm" > "$_state_tmp" &&
+           mv -f "$_state_tmp" "$CLUSTER_STATE"; then
+            exit 0
         fi
-        case "$_state" in
-            pub)  ensure_game_bridge_port "$_p" ;;
-            lan)  purge_game_bridge_port "$_p" ;;
-            none) : ;; # inactive/indeterminate -> preserve any exact-port rule
-        esac
-        _p=$((_p + 1))
+        rm -f "$_state_tmp"
+        exit 1
+    ) 9>"$MUTATION_LOCK"
+}
+
+write_listener_heartbeat() {
+    (
+        flock -x 9 || exit 1
+        # Owner publication uses this same lock, so the check remains valid
+        # through the atomic rename.
+        worker_owned "$_owner_token" || exit 1
+        _listener_tmp="${LISTENER_HEARTBEAT}.$$"
+        if printf '%s\n' "$_owner_token" > "$_listener_tmp" &&
+           mv -f "$_listener_tmp" "$LISTENER_HEARTBEAT"; then
+            exit 0
+        fi
+        rm -f "$_listener_tmp"
+        exit 1
+    ) 9>"$MUTATION_LOCK"
+}
+
+clear_owner() {
+    _clear_token="$1"
+    (
+        flock -x 9 || exit 1
+        if worker_owned "$_clear_token"; then rm -f "$OWNER_FILE"; fi
+    ) 9>"$MUTATION_LOCK"
+}
+
+reconcile_rabbitmq() {
+    _rabbit_pub="$1"
+    _rabbit_pod="$2"
+    _rabbit_token="$3"
+    if ! is_ipv4 "$_rabbit_pub" || ! is_ipv4 "$_rabbit_pod"; then
+        return
+    fi
+
+    (
+        flock -x 9 || exit 1
+        # Ownership is checked after acquiring the kernel-released mutation lock.
+        worker_owned "$_rabbit_token" || exit 0
+        if iptables -t nat -C PREROUTING -d "${_rabbit_pub}/32" -p tcp --dport "$RABBIT_PORT" -j DNAT --to-destination "${_rabbit_pod}:5672" 2>/dev/null; then
+            exit 0
+        fi
+        iptables -t nat -S PREROUTING | grep -- "--dport ${RABBIT_PORT}" | grep -- "-j DNAT" | sed "s/^-A/-D/" | while read -r _spec; do
+            iptables -t nat $_spec 2>/dev/null
+        done
+        if iptables -t nat -I PREROUTING 1 -d "${_rabbit_pub}/32" -p tcp --dport "$RABBIT_PORT" -j DNAT --to-destination "${_rabbit_pod}:5672"; then
+            log "reconciled rabbitmq DNAT: ${_rabbit_pub}:${RABBIT_PORT} -> ${_rabbit_pod}:5672"
+        else
+            log_reconcile_failure "failed to install rabbitmq DNAT for endpoint ${_rabbit_pod}"
+        fi
+    ) 9>"$MUTATION_LOCK"
+}
+
+run_cluster_pass() {
+    _pass_token="$1"
+    _addresses=$(kube get nodes -o jsonpath='{range .items[0].status.addresses[*]}{.type}={.address}{"\n"}{end}' 2>/dev/null)
+    _worker_pub=$(printf '%s\n' "$_addresses" | awk -F= '$1=="ExternalIP"{print $2; exit}')
+    _worker_vm=$(printf '%s\n' "$_addresses" | awk -F= '$1=="InternalIP"{print $2; exit}')
+    if is_ipv4 "$_worker_pub" && is_ipv4 "$_worker_vm" && worker_owned "$_pass_token"; then
+        if write_cluster_state "$_worker_pub" "$_worker_vm" "$_pass_token"; then
+            _last_cluster_problem=""
+        else
+            _problem="failed to update atomic cluster cache; preserving prior cache and rules"
+            if [ "$_problem" != "$_last_cluster_problem" ]; then log "$_problem"; fi
+            _last_cluster_problem="$_problem"
+        fi
+    else
+        _problem="node addresses unavailable/invalid; preserving cached addresses and rules"
+        if [ "$_problem" != "$_last_cluster_problem" ]; then log "$_problem"; fi
+        _last_cluster_problem="$_problem"
+    fi
+
+    _worker_pod=$(kube get endpoints --all-namespaces 2>/dev/null | grep mq-game | awk '{print $3}' | cut -d, -f1 | cut -d: -f1 | head -1)
+    if is_ipv4 "$_worker_pub" && is_ipv4 "$_worker_pod"; then
+        reconcile_rabbitmq "$_worker_pub" "$_worker_pod" "$_pass_token"
+        _last_rabbit_problem=""
+    else
+        _problem="rabbitmq endpoint unavailable/invalid; leaving rule intact"
+        if [ "$_problem" != "$_last_rabbit_problem" ]; then log "$_problem"; fi
+        _last_rabbit_problem="$_problem"
+    fi
+}
+
+run_cluster_worker() {
+    _worker_token="$1"
+    _worker_parent="$2"
+    _last_cluster_problem=""
+    _last_rabbit_problem=""
+
+    while kill -0 "$_worker_parent" 2>/dev/null && worker_owned "$_worker_token"; do
+        run_cluster_pass "$_worker_token"
+        worker_owned "$_worker_token" || return
+        touch "$WORKER_HEARTBEAT"
+        sleep "$CLUSTER_SLEEP"
     done
-else
-    log "node InternalIP not a valid IPv4 ('$VM_IP'); leaving game-UDP bridge intact"
-fi
+}
 
-exit 0
+reconcile_game_udp() {
+    _game_token="$1"
+    # Invalid/indeterminate cached addresses must never remove a working bridge.
+    load_cluster_state || return
+
+    # Exactly one listener snapshot per pass. Public wins over LAN on each port.
+    _udp_snapshot=$(udp_listeners)
+    (
+        flock -x 9 || exit 1
+        # A superseded listener cannot mutate after replacement owns the service.
+        worker_owned "$_game_token" || exit 0
+        _legacy_reconciled=0
+        _p="$GAME_LO"
+        while [ "$_p" -le "$GAME_HI" ]; do
+            _state=$(game_port_state "$_p")
+            if [ "$_state" != none ] && [ "$_legacy_reconciled" = 0 ]; then
+                purge_legacy_game_bridge
+                _legacy_reconciled=1
+            fi
+            case "$_state" in
+                pub)  ensure_game_bridge_port "$_p" ;;
+                lan)  purge_game_bridge_port "$_p" ;;
+                none) : ;; # inactive/indeterminate -> preserve any exact-port rule
+            esac
+            _p=$((_p + 1))
+        done
+    ) 9>"$MUTATION_LOCK"
+}
+
+start_cluster_worker() {
+    touch "$WORKER_HEARTBEAT"
+    "$0" --cluster-loop "$_owner_token" "$$" &
+    _worker_pid=$!
+}
+
+stop_cluster_worker() {
+    if [ -n "${_worker_pid:-}" ]; then
+        if kill -0 "$_worker_pid" 2>/dev/null; then
+            kill "$_worker_pid" 2>/dev/null || true
+        fi
+        wait "$_worker_pid" 2>/dev/null || true
+    fi
+}
+
+cleanup_loop() {
+    stop_cluster_worker
+    clear_owner "$_owner_token"
+}
+
+ensure_cluster_worker() {
+    _worker_age=$(file_age "$WORKER_HEARTBEAT" 2>/dev/null) || _worker_age=$((WORKER_STALE_SEC + 1))
+    if ! kill -0 "$_worker_pid" 2>/dev/null || [ "$_worker_age" -gt "$WORKER_STALE_SEC" ]; then
+        stop_cluster_worker
+        start_cluster_worker
+    fi
+}
+
+run_loop() {
+    mkdir -p "$STATE_DIR" || exit 1
+    _owner_token="$$-$(date +%s)"
+    publish_owner "$_owner_token" || exit 1
+    _worker_pid=""
+    _passes=0
+    trap cleanup_loop EXIT
+    trap 'exit 0' HUP INT TERM
+    start_cluster_worker
+
+    while :; do
+        # A newer supervisor instance atomically replaces ownership. An orphaned
+        # old listener exits before it can overlap any reconciliation pass.
+        worker_owned "$_owner_token" || return 0
+        reconcile_game_udp "$_owner_token"
+        if ! write_listener_heartbeat; then
+            # Replacement can acquire ownership between the game pass and the
+            # heartbeat lock. That is a clean handoff, not a service failure.
+            worker_owned "$_owner_token" || return 0
+            log "failed to update listener heartbeat; exiting for supervisor restart"
+            cleanup_loop
+            return 1
+        fi
+        ensure_cluster_worker
+        _passes=$((_passes + 1))
+        if [ "$MAX_PASSES" -gt 0 ] && [ "$_passes" -ge "$MAX_PASSES" ]; then
+            return
+        fi
+        sleep "$LOOP_SLEEP"
+    done
+}
+
+run_once() {
+    healthcheck >/dev/null 2>&1 && return 0
+    mkdir -p "$STATE_DIR" || return 1
+    _owner_token="once-$$-$(date +%s)"
+    publish_owner "$_owner_token" || return 1
+    _last_cluster_problem=""
+    _last_rabbit_problem=""
+    run_cluster_pass "$_owner_token"
+    reconcile_game_udp "$_owner_token"
+    clear_owner "$_owner_token"
+}
+
+healthcheck() {
+    _listener_age=$(file_age "$LISTENER_HEARTBEAT" 2>/dev/null) || return 1
+    _listener_owner=$(cat "$LISTENER_HEARTBEAT" 2>/dev/null) || return 1
+    worker_owned "$_listener_owner" &&
+        [ "$_listener_age" -le "$LISTENER_STALE_SEC" ]
+}
+
+case "${1:-}" in
+    --loop) run_loop ;;
+    --cluster-loop) run_cluster_worker "$2" "$3" ;;
+    --healthcheck) healthcheck ;;
+    --once|'') run_once ;;
+    *) echo "usage: $0 [--loop|--once|--healthcheck]" >&2; exit 2 ;;
+esac
 WATCHEOF
-chmod 0755 "$WATCH" 2>/dev/null
+then
+    fail "failed to stage $WATCH"
+fi
+chmod 0755 "$WATCH_STAGE" 2>/dev/null || fail "failed to chmod staged watchdog"
+sh -n "$WATCH_STAGE" >/dev/null 2>&1 || fail "staged watchdog failed shell syntax validation"
 
 # ---------------------------------------------------------------------------
-# 2. Retire the legacy hardcoded-public-IP sync script if present. It only
-#    reconciled the OLD public IP's rule, which is exactly why the current-IP
-#    rule went stale and broke remote "Connecting".
+# 2. Install an OpenRC service. supervise-daemon owns exactly one foreground
+#    loop and respawns it after failure. No lock file exists, so a stale lock can
+#    never disable reconciliation permanently.
 # ---------------------------------------------------------------------------
+if ! cat > "$SERVICE_STAGE" <<'SERVICEEOF'
+#!/sbin/openrc-run
+name="Dune DNAT listener reconciler"
+description="Continuously reconciles Dune RabbitMQ and game UDP DNAT"
+
+supervisor=supervise-daemon
+command="/usr/local/bin/dune-dnat-watch.sh"
+command_args="--loop"
+respawn_delay=2
+respawn_max=0
+healthcheck_delay=5
+healthcheck_timer=5
+
+depend() {
+    need localmount
+    after k3s
+}
+
+healthcheck() {
+    "$command" --healthcheck
+}
+SERVICEEOF
+then
+    fail "failed to stage $SERVICE"
+fi
+chmod 0755 "$SERVICE_STAGE" 2>/dev/null || fail "failed to chmod staged OpenRC service"
+sh -n "$SERVICE_STAGE" >/dev/null 2>&1 || fail "staged OpenRC service failed shell syntax validation"
+
+# Snapshot every prior lifecycle surface before changing live state.
+if [ -f "$WATCH" ]; then cp -p "$WATCH" "$WATCH_BACKUP" || fail "failed to snapshot prior watchdog"; HAD_WATCH=1; fi
+if [ -f "$SERVICE" ]; then cp -p "$SERVICE" "$SERVICE_BACKUP" || fail "failed to snapshot prior service"; HAD_SERVICE=1; fi
+if crontab -l > "$CRON_BACKUP" 2>/dev/null; then
+    HAD_CRONTAB=1
+else
+    : > "$CRON_BACKUP" || fail "failed to initialize crontab snapshot"
+fi
+if rc-update show default 2>/dev/null | grep -Eq '(^|[[:space:]])dune-dnat-watch([[:space:]]|$)'; then HAD_RUNLEVEL=1; fi
+if [ "$HAD_SERVICE" -eq 1 ] && rc-service dune-dnat-watch status >/dev/null 2>&1; then PRIOR_SERVICE_RUNNING=1; fi
+
+MIGRATION_STARTED=1
+
+# Quiesce cron first, then stop and verify every old watcher process exited.
+grep -v -e dune-mq-dnat-sync -e dune-rabbitmq-dnat-watch -e dune-dnat-watch "$CRON_BACKUP" > "$CRON_FILTERED" 2>/dev/null || true
+[ -f "$CRON_FILTERED" ] || fail "failed to prepare migration crontab"
+crontab "$CRON_FILTERED" >/dev/null 2>&1 || fail "failed to quiesce prior DNAT watchdog cron"
+stop_watch_processes || fail "prior DNAT watchdog processes did not fully exit"
+invalidate_runtime_state || fail "failed to invalidate prior DNAT watchdog runtime state"
+
+# Same-directory rename publishes each fully-validated staged file atomically.
+mv -f "$WATCH_STAGE" "$WATCH" || fail "failed to publish staged watchdog"
+mv -f "$SERVICE_STAGE" "$SERVICE" || fail "failed to publish staged OpenRC service"
+
+rc-update add dune-dnat-watch default >/dev/null 2>&1 || fail "failed to enable dune-dnat-watch in OpenRC"
+rc-update show default 2>/dev/null | grep -Eq '(^|[[:space:]])dune-dnat-watch([[:space:]]|$)' ||
+    fail "dune-dnat-watch missing from default OpenRC runlevel"
+
+# ---------------------------------------------------------------------------
+# 3. Restart onto the refreshed executable, then require a distinct owner and
+#    heartbeat written after the cutover marker. Age alone cannot prove that the
+#    replacement started because a SIGKILL fallback may leave fresh old files.
+# ---------------------------------------------------------------------------
+# Ensure second-resolution filesystems can order the replacement heartbeat
+# strictly after the cutover marker.
+sleep 1
+rc-service dune-dnat-watch restart >/dev/null 2>&1 ||
+    fail "failed to start supervised dune-dnat-watch service"
+rc-service dune-dnat-watch status >/dev/null 2>&1 ||
+    fail "dune-dnat-watch service did not remain running"
+_health_wait=0
+while ! replacement_healthy; do
+    _health_wait=$((_health_wait + 1))
+    [ "$_health_wait" -lt 6 ] || fail "replacement dune-dnat-watch did not publish a fresh owner and heartbeat"
+    sleep 1
+done
+
+# ---------------------------------------------------------------------------
+# 4. Cron is only a heartbeat health check. Install it after replacement health
+#    is proven so cron cannot race the controlled service cutover.
+# ---------------------------------------------------------------------------
+CRON_LINE="* * * * * $WATCH --healthcheck >/dev/null 2>&1 || $SERVICE restart >/dev/null 2>&1"
+if ! ( cat "$CRON_FILTERED"; echo "$CRON_LINE" ) | crontab -; then
+    fail "failed to install dune-dnat-watch cron health check"
+fi
+_cron_count=$(crontab -l 2>/dev/null | grep -Fxc "$CRON_LINE")
+[ "$_cron_count" -eq 1 ] || fail "canonical dune-dnat-watch cron health check missing or duplicated"
+_other_dnat_cron=$(crontab -l 2>/dev/null | grep -F dune-dnat-watch | grep -Fvx "$CRON_LINE")
+[ -z "$_other_dnat_cron" ] || fail "non-canonical dune-dnat-watch cron entry remains"
+
+MIGRATION_STARTED=0
+cleanup_transaction_files
+
+# Retire the old hardcoded-public-IP helper only after the replacement service
+# and lifecycle state are fully validated. A failed migration leaves it intact.
 if [ -f /usr/local/sbin/dune-mq-dnat-sync.sh ]; then
     mv -f /usr/local/sbin/dune-mq-dnat-sync.sh "/usr/local/sbin/dune-mq-dnat-sync.sh.disabled.$(date +%Y%m%d%H%M%S)" 2>/dev/null
     log "retired legacy /usr/local/sbin/dune-mq-dnat-sync.sh"
 fi
-
-# ---------------------------------------------------------------------------
-# 3. Reconcile the root crontab: drop any prior DNAT watchdog/sync lines
-#    (legacy or interim), then install the canonical every-minute entry.
-# ---------------------------------------------------------------------------
-( crontab -l 2>/dev/null | grep -v -e dune-mq-dnat-sync -e dune-rabbitmq-dnat-watch -e dune-dnat-watch ; echo "* * * * * $WATCH" ) | crontab -
-
-# ---------------------------------------------------------------------------
-# 4. Run once now so any current drift is fixed immediately, not in <=60s.
-# ---------------------------------------------------------------------------
-"$WATCH" 2>/dev/null
 
 log "dune-dnat-watch install/refresh done"
 echo DUNE_DNAT_WATCH_OK

--- a/app/resources/remote-scripts/dune-dnat-watch-install.sh
+++ b/app/resources/remote-scripts/dune-dnat-watch-install.sh
@@ -88,9 +88,9 @@ udp_listeners() {
 }
 
 # Classify one game UDP port:
-#   pub  = public IP bound, LAN/wildcard NOT bound -> bridge needed AND safe
-#   lan  = LAN IP / 0.0.0.0 bound                  -> bridge would black-hole
-#   none = no relevant listener visible            -> leave its rule unchanged
+#   pub  = public IP bound (including a dual bind) -> bridge needed
+#   lan  = LAN IP / 0.0.0.0 bound without public  -> bridge not needed
+#   none = no relevant listener visible           -> leave its rule unchanged
 #
 # Listener state is intentionally evaluated per port. Funcom can mix public-only
 # and LAN-bound map ports within the dynamic range.
@@ -108,10 +108,14 @@ game_port_state() {
         esac
     done
 
-    if [ "$_lanwild" = 1 ]; then
-        echo lan
-    elif [ "$_pub" = 1 ]; then
+    # A public listener wins when separate game processes also bind the LAN IP.
+    # Router-forwarded traffic otherwise reaches the wrong process and the map
+    # handshake stalls. A LAN bind suppresses DNAT only when no public listener
+    # exists for this exact port.
+    if [ "$_pub" = 1 ]; then
         echo pub
+    elif [ "$_lanwild" = 1 ]; then
+        echo lan
     else
         echo none
     fi

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -869,34 +869,69 @@ if [ -n "$POD_IP" ] && [ "$POD_IP" != "<none>" ]; then
       iptables -t nat -I PREROUTING 1 -d "$NEW_IP" -p tcp --dport "$RABBIT_PORT" -j DNAT --to-destination "${POD_IP}:5672"
 fi
 
-# Game-UDP bridge: <VM_IP>:7777-7810/udp -> NEW_IP, ONLY when the game binds the
-# public IP and NOT the LAN IP/wildcard (IPv4-only detection). Mirrors
-# dune-dnat-watch.sh; see that file for the full rationale.
+# Game-UDP bridge: <VM_IP>:7777-7810/udp -> NEW_IP, bind-detected per port.
+# Funcom can mix public-only and LAN-bound listeners within the dynamic range.
 udp_listeners() {
     _o=""
     if command -v ss >/dev/null 2>&1; then _o=$(ss -H -u -l -n -4 2>/dev/null | awk '{print $4}'); fi
     [ -n "$_o" ] || _o=$(netstat -uln 2>/dev/null | awk '$1=="udp"{print $4}')
     printf '%s\n' "$_o"
 }
-_pub=0; _lanwild=0
-for _e in $(udp_listeners); do
-    _port=${_e##*:}; _addr=${_e%:*}
-    case "$_port" in ''|*[!0-9]*) continue ;; esac
-    { [ "$_port" -ge "$GAME_LO" ] && [ "$_port" -le "$GAME_HI" ]; } 2>/dev/null || continue
-    case "$_addr" in
-        "$NEW_IP")               _pub=1 ;;
-        "$VM_IP"|0.0.0.0|'*'|'') _lanwild=1 ;;
-    esac
-done
-if [ "$_lanwild" = 1 ]; then
-    iptables -t nat -S PREROUTING 2>/dev/null | grep -- "--dport ${GAME_PORTS}" | grep -- '-j DNAT' | sed 's/^-A/-D/' | while read -r _s; do iptables -t nat $_s 2>/dev/null && log "removed game-UDP bridge (game binds LAN/wildcard): $_s"; done
-elif [ "$_pub" = 1 ]; then
-    if ! iptables -t nat -C PREROUTING -d "$VM_IP" -p udp --dport "$GAME_PORTS" -j DNAT --to-destination "$NEW_IP" 2>/dev/null; then
-        iptables -t nat -S PREROUTING 2>/dev/null | grep -- "--dport ${GAME_PORTS}" | grep -- '-j DNAT' | sed 's/^-A/-D/' | while read -r _s; do iptables -t nat $_s 2>/dev/null; done
-        iptables -t nat -I PREROUTING 1 -d "$VM_IP" -p udp --dport "$GAME_PORTS" -j DNAT --to-destination "$NEW_IP"
-        log "installed game-UDP bridge: ${VM_IP}:${GAME_PORTS} -> ${NEW_IP}"
+game_port_state() {
+    _want_port="$1"; _pub=0; _lanwild=0
+    for _e in $_udp_snapshot; do
+        _port=${_e##*:}; _addr=${_e%:*}
+        [ "$_port" = "$_want_port" ] || continue
+        case "$_addr" in
+            "$NEW_IP")               _pub=1 ;;
+            "$VM_IP"|0.0.0.0|'*'|'') _lanwild=1 ;;
+        esac
+    done
+    if [ "$_lanwild" = 1 ]; then echo lan; elif [ "$_pub" = 1 ]; then echo pub; else echo none; fi
+}
+game_bridge_rules() {
+    iptables -t nat -S PREROUTING 2>/dev/null |
+        grep -F -- "-d ${VM_IP}/32" |
+        grep -F -- '-p udp' |
+        grep -F -- '-j DNAT'
+}
+purge_legacy_game_bridge() {
+    game_bridge_rules | grep -E -- "--dport[[:space:]]+${GAME_PORTS}([[:space:]]|$)" | sed 's/^-A/-D/' | while read -r _s; do
+        iptables -t nat $_s 2>/dev/null && log "removed legacy broad game-UDP bridge: $_s"
+    done
+}
+purge_game_bridge_port() {
+    _port="$1"
+    game_bridge_rules | grep -E -- "--dport[[:space:]]+${_port}([[:space:]]|$)" | sed 's/^-A/-D/' | while read -r _s; do
+        iptables -t nat $_s 2>/dev/null && log "removed game-UDP bridge for port ${_port}: $_s"
+    done
+}
+ensure_game_bridge_port() {
+    _port="$1"
+    if iptables -t nat -C PREROUTING -d "$VM_IP" -p udp --dport "$_port" -j DNAT --to-destination "$NEW_IP" 2>/dev/null; then return 0; fi
+    purge_game_bridge_port "$_port"
+    if iptables -t nat -I PREROUTING 1 -d "$VM_IP" -p udp --dport "$_port" -j DNAT --to-destination "$NEW_IP" 2>/dev/null; then
+        log "installed game-UDP bridge: ${VM_IP}:${_port} -> ${NEW_IP}:${_port}"
+    else
+        log "failed to install game-UDP bridge for port ${_port}"
     fi
-fi
+}
+_udp_snapshot=$(udp_listeners)
+_legacy_reconciled=0
+_p="$GAME_LO"
+while [ "$_p" -le "$GAME_HI" ]; do
+    _state=$(game_port_state "$_p")
+    if [ "$_state" != none ] && [ "$_legacy_reconciled" = 0 ]; then
+        purge_legacy_game_bridge
+        _legacy_reconciled=1
+    fi
+    case "$_state" in
+        pub)  ensure_game_bridge_port "$_p" ;;
+        lan)  purge_game_bridge_port "$_p" ;;
+        none) : ;;
+    esac
+    _p=$((_p + 1))
+done
 DUNEBOOT
 } > /tmp/dune-iptables.start
 sudo install -m 0755 /tmp/dune-iptables.start /etc/local.d/dune-iptables.start
@@ -913,12 +948,9 @@ if [ -n "$MQ_IP" ] && [ "$MQ_IP" != "<none>" ]; then
 else
   echo "mq-game endpoint not ready (got '${MQ_IP:-<empty>}'); rabbitmq DNAT deferred to dune-dnat-watch cron"
 fi
-# Game-UDP bridge (bind-detected; mirrors /etc/local.d/dune-iptables.start &
-# dune-dnat-watch.sh). Install <VM_IP>:7777-7810/udp -> NEW_IP ONLY when the game
-# binds the PUBLIC IP and NOT the LAN IP/wildcard, so a same-LAN / self join is
-# never black-holed (the v12.16.9 regression). On a re-apply/repair the game is
-# already bound to the current public IP, so this fixes an affected box at once;
-# otherwise the cron watchdog installs it within 60s once the game rebinds.
+# Game-UDP bridge (bind-detected per port; mirrors the boot script and watchdog).
+# Monitor the full dynamic range, but do not let one LAN-bound port suppress a
+# different public-only port.
 GBLO=7777; GBHI=7810; GBPORTS=7777:7810
 gb_listeners() {
   _o=""
@@ -926,30 +958,60 @@ gb_listeners() {
   [ -n "$_o" ] || _o=$(netstat -uln 2>/dev/null | awk '$1=="udp"{print $4}')
   printf '%s\n' "$_o"
 }
-gb_pub=0; gb_lanwild=0
-for gb_e in $(gb_listeners); do
-  gb_port=${gb_e##*:}; gb_addr=${gb_e%:*}
-  case "$gb_port" in ''|*[!0-9]*) continue;; esac
-  { [ "$gb_port" -ge "$GBLO" ] && [ "$gb_port" -le "$GBHI" ]; } 2>/dev/null || continue
-  case "$gb_addr" in
-    "$NEW_IP")               gb_pub=1;;
-    "$VM_IP"|0.0.0.0|'*'|'') gb_lanwild=1;;
-  esac
-done
-if [ "$gb_lanwild" = 1 ]; then
-  echo "game-UDP bridge: game binds LAN/wildcard -> ensuring absent (bridge would black-hole)"
-  sudo iptables -t nat -S PREROUTING 2>/dev/null | grep -- "--dport ${GBPORTS}" | grep -- '-j DNAT' | sed 's/^-A/-D/' | while read -r gb_s; do sudo iptables -t nat $gb_s 2>/dev/null || true; done
-elif [ "$gb_pub" = 1 ]; then
-  if sudo iptables -t nat -C PREROUTING -d "$VM_IP" -p udp --dport "$GBPORTS" -j DNAT --to-destination "$NEW_IP" 2>/dev/null; then
-    echo "game-UDP bridge: already correct (${VM_IP}:${GBPORTS} -> ${NEW_IP})"
-  else
-    sudo iptables -t nat -S PREROUTING 2>/dev/null | grep -- "--dport ${GBPORTS}" | grep -- '-j DNAT' | sed 's/^-A/-D/' | while read -r gb_s; do sudo iptables -t nat $gb_s 2>/dev/null || true; done
-    sudo iptables -t nat -I PREROUTING 1 -d "$VM_IP" -p udp --dport "$GBPORTS" -j DNAT --to-destination "$NEW_IP" || echo "game-UDP bridge: insert failed (non-fatal)"
-    echo "game-UDP bridge: installed ${VM_IP}:${GBPORTS} -> ${NEW_IP} (game binds public IP only)"
+gb_port_state() {
+  gb_want_port="$1"; gb_pub=0; gb_lanwild=0
+  for gb_e in $gb_udp_snapshot; do
+    gb_port=${gb_e##*:}; gb_addr=${gb_e%:*}
+    [ "$gb_port" = "$gb_want_port" ] || continue
+    case "$gb_addr" in
+      "$NEW_IP")               gb_pub=1;;
+      "$VM_IP"|0.0.0.0|'*'|'') gb_lanwild=1;;
+    esac
+  done
+  if [ "$gb_lanwild" = 1 ]; then echo lan; elif [ "$gb_pub" = 1 ]; then echo pub; else echo none; fi
+}
+gb_bridge_rules() {
+  sudo iptables -t nat -S PREROUTING 2>/dev/null |
+    grep -F -- "-d ${VM_IP}/32" |
+    grep -F -- '-p udp' |
+    grep -F -- '-j DNAT'
+}
+gb_purge_legacy_bridge() {
+  gb_bridge_rules | grep -E -- "--dport[[:space:]]+${GBPORTS}([[:space:]]|$)" | sed 's/^-A/-D/' | while read -r gb_s; do sudo iptables -t nat $gb_s 2>/dev/null || true; done
+}
+gb_purge_port() {
+  gb_port="$1"
+  gb_bridge_rules | grep -E -- "--dport[[:space:]]+${gb_port}([[:space:]]|$)" | sed 's/^-A/-D/' | while read -r gb_s; do sudo iptables -t nat $gb_s 2>/dev/null || true; done
+}
+gb_ensure_port() {
+  gb_port="$1"
+  if sudo iptables -t nat -C PREROUTING -d "$VM_IP" -p udp --dport "$gb_port" -j DNAT --to-destination "$NEW_IP" 2>/dev/null; then
+    echo "game-UDP bridge: already correct (${VM_IP}:${gb_port} -> ${NEW_IP}:${gb_port})"
+    return 0
   fi
-else
-  echo "game-UDP bridge: bind indeterminate (pods not up?); leaving rules unchanged"
-fi
+  gb_purge_port "$gb_port"
+  if sudo iptables -t nat -I PREROUTING 1 -d "$VM_IP" -p udp --dport "$gb_port" -j DNAT --to-destination "$NEW_IP" 2>/dev/null; then
+    echo "game-UDP bridge: installed ${VM_IP}:${gb_port} -> ${NEW_IP}:${gb_port} (game binds public IP only)"
+  else
+    echo "game-UDP bridge: insert failed for port ${gb_port} (non-fatal)"
+  fi
+}
+gb_udp_snapshot=$(gb_listeners)
+gb_legacy_reconciled=0
+gb_p="$GBLO"
+while [ "$gb_p" -le "$GBHI" ]; do
+  gb_state=$(gb_port_state "$gb_p")
+  if [ "$gb_state" != none ] && [ "$gb_legacy_reconciled" = 0 ]; then
+    gb_purge_legacy_bridge
+    gb_legacy_reconciled=1
+  fi
+  case "$gb_state" in
+    pub)  gb_ensure_port "$gb_p";;
+    lan)  gb_purge_port "$gb_p";;
+    none) :;;
+  esac
+  gb_p=$((gb_p + 1))
+done
 echo "NETWORK_DONE"
 '@
             $steps.Add((New-DunePublicIpStepResult 'vm-network' 'Update VM network, settings.conf, K3s, NAT' 'running' 'Applying network + persistent-config changes over SSH.')) | Out-Null

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -887,7 +887,7 @@ game_port_state() {
             "$VM_IP"|0.0.0.0|'*'|'') _lanwild=1 ;;
         esac
     done
-    if [ "$_lanwild" = 1 ]; then echo lan; elif [ "$_pub" = 1 ]; then echo pub; else echo none; fi
+    if [ "$_pub" = 1 ]; then echo pub; elif [ "$_lanwild" = 1 ]; then echo lan; else echo none; fi
 }
 game_bridge_rules() {
     iptables -t nat -S PREROUTING 2>/dev/null |
@@ -968,7 +968,7 @@ gb_port_state() {
       "$VM_IP"|0.0.0.0|'*'|'') gb_lanwild=1;;
     esac
   done
-  if [ "$gb_lanwild" = 1 ]; then echo lan; elif [ "$gb_pub" = 1 ]; then echo pub; else echo none; fi
+  if [ "$gb_pub" = 1 ]; then echo pub; elif [ "$gb_lanwild" = 1 ]; then echo lan; else echo none; fi
 }
 gb_bridge_rules() {
   sudo iptables -t nat -S PREROUTING 2>/dev/null |

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -939,14 +939,14 @@ rm -f /tmp/dune-iptables.start
 sh -n /etc/local.d/dune-iptables.start
 # mq-game endpoint may be the literal string "<none>" when the BG is Stopped /
 # the pod hasn't come up yet -- skip the immediate install in that case, the
-# per-minute dune-dnat-watch cron installs it once the pod is Ready. Feeding
+# supervised dune-dnat-watch service installs it once the pod is Ready. Feeding
 # "<none>" to iptables errors "Bad IP address" and fails the whole Apply step.
 MQ_IP=$(sudo kubectl get endpoints --all-namespaces -o wide 2>/dev/null | grep mq-game | awk '{print $3}' | cut -d, -f1 | cut -d: -f1 | head -1)
 if [ -n "$MQ_IP" ] && [ "$MQ_IP" != "<none>" ]; then
   sudo iptables -t nat -C PREROUTING -d "$NEW_IP" -p tcp --dport 31982 -j DNAT --to-destination "${MQ_IP}:5672" 2>/dev/null || \
     sudo iptables -t nat -I PREROUTING 1 -d "$NEW_IP" -p tcp --dport 31982 -j DNAT --to-destination "${MQ_IP}:5672"
 else
-  echo "mq-game endpoint not ready (got '${MQ_IP:-<empty>}'); rabbitmq DNAT deferred to dune-dnat-watch cron"
+  echo "mq-game endpoint not ready (got '${MQ_IP:-<empty>}'); rabbitmq DNAT deferred to dune-dnat-watch service"
 fi
 # Game-UDP bridge (bind-detected per port; mirrors the boot script and watchdog).
 # Monitor the full dynamic range, but do not let one LAN-bound port suppress a

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1,4 +1,4 @@
-#Requires -RunAsAdministrator
+﻿#Requires -RunAsAdministrator
 
 [CmdletBinding()]
 param(
@@ -1104,19 +1104,20 @@ function Invoke-DuneDnatWatchdogInstall {
     # Best-effort: stage the bundled DNAT self-heal watchdog installer to /tmp on
     # the VM (base64 over an ssh exec channel — no scp/sftp dependency), run it
     # once with sudo, remove it. The installer writes /usr/local/bin/dune-dnat-watch.sh
-    # plus a 1-minute root cron entry so the RabbitMQ (public:31982 -> mq-game pod)
-    # DNAT rule AND the game-UDP bridge (VM-LAN-IP:7777-7810 -> public IP) self-heal
-    # after a pod-only battlegroup restart -- which the boot script
+    # plus an OpenRC-supervised loop. It targets one-second game-listener checks
+    # while cluster-derived addresses refresh in an independent bounded worker.
+    # The RabbitMQ (public:31982 -> mq-game pod) DNAT rule and game-UDP bridge
+    # (VM-LAN-IP:7777-7810 -> public IP) self-heal after a pod-only battlegroup
+    # restart -- which the boot script
     # /etc/local.d/dune-iptables.start misses because it only re-derives at boot.
     # Without this, a pod restart leaves the RabbitMQ rule pointing at a dead pod IP
     # (players hang on "Connecting") or drops the game bridge (remote players P34)
     # until the next reboot (observed 2026-06-23). The game bridge is BIND-DETECTED:
-    # the watchdog installs it only when the game binds the public IP and NOT the
-    # LAN IP/wildcard, and removes it otherwise, so it never black-holes a same-LAN
-    # / self join the way the unconditional rule removed in v12.16.9 did.
+    # the watchdog installs it for each port with a public listener, even if a
+    # separate process also binds LAN, while LAN-only ports remain untouched.
     #
-    # ALL persistence (the watchdog file + cron line) lives in the staged POSIX-sh
-    # script, never in this app — so the packaged installer carries no
+    # ALL persistence (watchdog, OpenRC service, and health-check cron) lives in
+    # the staged POSIX-sh script, never in this app -- so the packaged installer carries no
     # persistence-establishment pattern (that PowerShell pattern is what tripped
     # the Defender ML false positive Trojan:Script/Wacatac.H!ml in v11.0.1).
     #
@@ -1150,7 +1151,7 @@ function Invoke-DuneDnatWatchdogInstall {
                     -i "$sshKey" "$sshUser@$Ip" `
                     "sudo -n sh $remoteTmp; rc=`$?; rm -f $remoteTmp; exit `$rc" 2>&1
     if (($runOut -join "`n") -match 'DUNE_DNAT_WATCH_OK') {
-        Write-Host "  [$Phase] DNAT self-heal watchdog installed/refreshed — RabbitMQ login + game-UDP bridge auto-recover after pod restarts." -ForegroundColor DarkGray
+        Write-Host "  [$Phase] DNAT self-heal watchdog installed/refreshed — supervised rapid game-listener + RabbitMQ reconciliation active." -ForegroundColor DarkGray
     } else {
         Write-Host "  [$Phase] DNAT watchdog install reported a problem (non-fatal): $runOut" -ForegroundColor DarkYellow
     }
@@ -1720,6 +1721,10 @@ while ($true) {
         Write-Host "  Settling 10s before starting battlegroup..." -ForegroundColor DarkGray
         Start-Sleep -Seconds 10
 
+        # Refresh monitoring before issuing battlegroup start; reconciliation is
+        # continuous and does not depend on a later readiness/green transition.
+        Invoke-DuneDnatWatchdogInstall -Ip $ip -Phase 'pre-startup'
+
         # ---- Step 3: battlegroup start ----
         Write-Host ""
         $estBg = Format-PhaseEstimate 'battlegroup-start'
@@ -1770,7 +1775,6 @@ while ($true) {
         # itself failed (no point waiting on operator that never reconciled).
         if ($bgStartExit -eq 0) {
             Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'post-startup' -Fast
-            Invoke-DuneDnatWatchdogInstall -Ip $ip -Phase 'post-startup'
             Invoke-DuneBackupDumpPodPrune -Ip $ip -Phase 'post-startup'
         } else {
             Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
@@ -2021,6 +2025,10 @@ while ($true) {
         Write-Host "  Settling 10s before starting battlegroup..." -ForegroundColor DarkGray
         Start-Sleep -Seconds 10
 
+        # The VM reboot restarted OpenRC already; refresh the service definition
+        # before battlegroup start so first-listener DNAT is readiness-independent.
+        Invoke-DuneDnatWatchdogInstall -Ip $ip -Phase 'pre-reboot-start'
+
         # ---- Step 3: start battlegroup ----
         Write-Host ""
         $estBg = Format-PhaseEstimate 'battlegroup-start'
@@ -2048,7 +2056,6 @@ while ($true) {
         # still be reconciling on-demand ServerSets.
         if ($bgStartExit -eq 0) {
             Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 45 -Phase 'post-reboot'
-            Invoke-DuneDnatWatchdogInstall -Ip $ip -Phase 'post-reboot'
             Invoke-DuneBackupDumpPodPrune -Ip $ip -Phase 'post-reboot'
         } else {
             Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
@@ -2477,6 +2484,11 @@ fi
         ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" $preflight
     }
 
+    if ($cmdName -eq 'start' -or $cmdName -eq 'restart') {
+        # Refresh monitoring before issuing start/restart, not after readiness.
+        Invoke-DuneDnatWatchdogInstall -Ip $ip -Phase "pre-$cmdName"
+    }
+
     ssh -t -o StrictHostKeyChecking=no -o LogLevel=QUIET -i "$sshKey" "$sshUser@$ip" "$bgBinPath $cmdName"
     $bgFallbackExit = $LASTEXITCODE
 
@@ -2493,9 +2505,6 @@ fi
         # The persistent VM watchdog / manual Fix Partitions command covers
         # slower post-reconcile drift without making every start feel hung.
         Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase "post-$cmdName" -Fast
-        # Install/refresh the DNAT self-heal watchdog so the RabbitMQ + game-port
-        # rules recover automatically after a pod-only restart (no host reboot).
-        Invoke-DuneDnatWatchdogInstall -Ip $ip -Phase "post-$cmdName"
     }
 
     # After start/restart, resolve director port

--- a/tests/PublicIp.Tests.ps1
+++ b/tests/PublicIp.Tests.ps1
@@ -163,6 +163,7 @@ Describe 'Mixed-bind game UDP bridge' {
         $script:dnatWatchPath = Join-Path $PSScriptRoot '..\app\resources\remote-scripts\dune-dnat-watch-install.sh'
         $script:dnatWatchSource = Get-Content -LiteralPath $script:dnatWatchPath -Raw
         $script:publicIpSource = Get-Content -LiteralPath (Join-Path $PSScriptRoot '..\app\server\lib\PublicIp.ps1') -Raw
+        $script:launcherSource = Get-Content -LiteralPath (Join-Path $PSScriptRoot '..\dune-server.ps1') -Raw
 
         $script:posixShell = Get-Command sh -ErrorAction SilentlyContinue
         if (-not $script:posixShell) {
@@ -240,5 +241,425 @@ game_port_state 7781
         $script:publicIpSource | Should -Match 'gb_udp_snapshot=\$\(gb_listeners\)'
         $script:publicIpSource | Should -Not -Match '(?m)iptables .* -I PREROUTING .*--dport "\$GAME_PORTS"'
         $script:publicIpSource | Should -Not -Match '(?m)iptables .* -I PREROUTING .*--dport "\$GBPORTS"'
+    }
+
+    It 'polls one listener snapshot per pass at one-second cadence' {
+        $script:dnatWatchSource | Should -Match '(?m)^LOOP_SLEEP="\$\{DUNE_DNAT_LOOP_SLEEP:-1\}"$'
+        $script:dnatWatchSource | Should -Match '(?ms)^run_loop\(\) \{.*?reconcile_game_udp.*?sleep "\$LOOP_SLEEP".*?^\}'
+        $script:dnatWatchSource | Should -Match '(?ms)^reconcile_game_udp\(\) \{.*?_udp_snapshot=\$\(udp_listeners\).*?^\}'
+        ([regex]::Matches(
+            ([regex]::Match($script:dnatWatchSource, '(?ms)^reconcile_game_udp\(\) \{.*?^\}').Value),
+            '_udp_snapshot=\$\(udp_listeners\)'
+        )).Count | Should -Be 1
+    }
+
+    It 'bounds kubectl and isolates cluster refresh from the listener loop' {
+        $script:dnatWatchSource | Should -Match 'kube\(\) \{ timeout 3 "\$K3S" kubectl --request-timeout=2s'
+        $script:dnatWatchSource | Should -Match '(?ms)^run_cluster_pass\(\) \{.*?kube get nodes.*?kube get endpoints.*?^\}'
+        $script:dnatWatchSource | Should -Match '(?ms)^run_cluster_worker\(\) \{.*?run_cluster_pass.*?^\}'
+        $script:dnatWatchSource | Should -Match '(?ms)^run_loop\(\) \{.*?start_cluster_worker.*?while :; do.*?reconcile_game_udp.*?ensure_cluster_worker'
+        ([regex]::Match($script:dnatWatchSource, '(?ms)^run_loop\(\) \{.*?^\}').Value) |
+            Should -Not -Match '\bkube\b'
+    }
+
+    It 'installs supervised lifecycle and heartbeat health recovery' {
+        $script:dnatWatchSource | Should -Match '(?m)^supervisor=supervise-daemon$'
+        $script:dnatWatchSource | Should -Match '(?m)^command_args="--loop"$'
+        $script:dnatWatchSource | Should -Match '(?m)^respawn_delay=2$'
+        $script:dnatWatchSource | Should -Match '(?m)^respawn_max=0$'
+        $script:dnatWatchSource | Should -Match '(?m)^healthcheck_timer=5$'
+        $script:dnatWatchSource | Should -Match '(?ms)^healthcheck\(\) \{.*?--healthcheck.*?^\}'
+        $script:dnatWatchSource | Should -Match 'rc-update add dune-dnat-watch default'
+        $script:dnatWatchSource | Should -Match 'rc-service dune-dnat-watch restart'
+        $script:dnatWatchSource | Should -Match 'rc-service dune-dnat-watch status'
+    }
+
+    It 'uses cron only to recover the supervisor and never to overlap reconciliation' {
+        $script:dnatWatchSource | Should -Match 'CRON_LINE="\* \* \* \* \* \$WATCH --healthcheck .* \|\| \$SERVICE restart'
+        $script:dnatWatchSource | Should -Not -Match '(?m)^\(.*echo "\* \* \* \* \* \$WATCH"'
+    }
+
+    It 'uses kernel-released mutation serialization instead of a stale lock gate' {
+        $script:dnatWatchSource | Should -Match '(?m)^MUTATION_LOCK='
+        $script:dnatWatchSource | Should -Match 'flock -x 9'
+        $script:dnatWatchSource | Should -Match '(?ms)^worker_owned\(\) \{.*?OWNER_FILE.*?^\}'
+        $script:dnatWatchSource | Should -Match 'Ownership is checked after acquiring the kernel-released mutation lock'
+        $script:dnatWatchSource | Should -Match 'old listener exits before it can overlap'
+        $script:dnatWatchSource | Should -Match '(?m)^\s*trap cleanup_loop EXIT$'
+        $script:dnatWatchSource | Should -Match '(?ms)^write_cluster_state\(\) \{.*?flock -x 9.*?worker_owned.*?mv -f.*?CLUSTER_STATE.*?^\}'
+        $script:dnatWatchSource | Should -Match '(?ms)^write_listener_heartbeat\(\) \{.*?flock -x 9.*?worker_owned.*?mv -f.*?LISTENER_HEARTBEAT.*?^\}'
+        $script:dnatWatchSource | Should -Match '(?ms)^clear_owner\(\) \{.*?flock -x 9.*?worker_owned.*?rm -f "\$OWNER_FILE".*?^\}'
+    }
+
+    It 'fails installation unless generated files, runlevel, cron, and heartbeat are canonical' {
+        $script:dnatWatchSource | Should -Match 'chmod 0755 "\$WATCH_STAGE".*\|\| fail'
+        $script:dnatWatchSource | Should -Match 'sh -n "\$WATCH_STAGE".*\|\| fail'
+        $script:dnatWatchSource | Should -Match 'rc-update show default'
+        $script:dnatWatchSource | Should -Match 'grep -Fxc "\$CRON_LINE"'
+        $script:dnatWatchSource | Should -Match 'non-canonical dune-dnat-watch cron entry remains'
+        $script:dnatWatchSource | Should -Match 'replacement dune-dnat-watch did not publish a fresh owner and heartbeat'
+        $script:dnatWatchSource | Should -Match '(?ms)^replacement_healthy\(\) \{.*?PRE_CUTOVER_OWNER.*?LISTENER_HEARTBEAT.*?-nt "\$CUTOVER_MARKER".*?^\}'
+    }
+
+    It 'stages atomically, supports legacy no-arg cron, and rolls migration back' {
+        $script:dnatWatchSource | Should -Match 'WATCH_STAGE="\$\{WATCH\}\.new\.\$\{TXN\}"'
+        $script:dnatWatchSource | Should -Match 'mv -f "\$WATCH_STAGE" "\$WATCH"'
+        $script:dnatWatchSource | Should -Match "(?m)^\s*--once\|''\) run_once ;;\s*$"
+        $script:dnatWatchSource | Should -Match '(?ms)^restore_prior_state\(\) \{.*?WATCH_BACKUP.*?SERVICE_BACKUP.*?CRON_BACKUP.*?PRIOR_SERVICE_RUNNING.*?^\}'
+        $script:dnatWatchSource | Should -Match 'stop_watch_processes \|\| fail "prior DNAT watchdog processes did not fully exit"'
+        $script:dnatWatchSource | Should -Match '(?ms)^MIGRATION_STARTED=0.*?retired legacy /usr/local/sbin/dune-mq-dnat-sync.sh'
+    }
+
+    It 'rejects a fresh stale pre-cutover heartbeat and accepts only a different new token' {
+        if (-not $script:posixShell) {
+            Set-ItResult -Skipped -Because 'A POSIX shell is not installed.'
+            return
+        }
+
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dst-dnat-rollback-{0}" -f [guid]::NewGuid())
+        $bin = Join-Path $tempRoot 'bin'
+        $live = Join-Path $tempRoot 'live'
+        $state = Join-Path $tempRoot 'state'
+        New-Item -ItemType Directory -Path $bin,$live,$state -Force | Out-Null
+        $escapedRoot = $tempRoot.Replace("'", "'\''")
+        $posixRoot = (& $script:posixShell.FullName -lc "cygpath -u '$escapedRoot'").Trim()
+
+        $installerPath = Join-Path $tempRoot 'install.sh'
+        $watchPath = Join-Path $live 'watch.sh'
+        $servicePath = Join-Path $live 'service'
+        $cronPath = Join-Path $tempRoot 'crontab'
+        $oldWatch = "#!/bin/sh`necho OLD_WATCH`n"
+        $oldService = "#!/bin/sh`necho OLD_SERVICE`n"
+        $oldCron = "7 * * * * $posixRoot/live/watch.sh`n13 * * * * echo unrelated`n"
+        $process = $null
+        $successProcess = $null
+
+        try {
+            [System.IO.File]::WriteAllText($installerPath, $script:dnatWatchSource, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText($watchPath, $oldWatch, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText($servicePath, $oldService, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText($cronPath, $oldCron, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $tempRoot 'service-state'), "running`n", [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $tempRoot 'runlevel-state'), "default`n", [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $tempRoot 'crontab-writes'), "0`n", [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $state 'owner'), "old-owner`n", [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $state 'listener.heartbeat'), "old-owner`n", [System.Text.UTF8Encoding]::new($false))
+
+            [System.IO.File]::WriteAllText((Join-Path $bin 'crontab'), @'
+#!/bin/sh
+case "${1:-}" in
+  -l) [ -f "$FAKE_CRON_FILE" ] && cat "$FAKE_CRON_FILE" && exit 0; exit 1 ;;
+  -r) rm -f "$FAKE_CRON_FILE"; exit 0 ;;
+esac
+_n=$(cat "$FAKE_CRON_WRITES")
+_n=$((_n + 1))
+printf '%s\n' "$_n" > "$FAKE_CRON_WRITES"
+if [ "$1" = - ]; then
+  cat > "$FAKE_CRON_FILE"
+else
+  cp "$1" "$FAKE_CRON_FILE"
+fi
+'@, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $bin 'rc-service'), @'
+#!/bin/sh
+case "$2" in
+  status) grep -qx running "$FAKE_SERVICE_STATE" ;;
+  stop) echo stopped > "$FAKE_SERVICE_STATE" ;;
+  start) echo running > "$FAKE_SERVICE_STATE" ;;
+  restart)
+    echo running > "$FAKE_SERVICE_STATE"
+    if [ "${FAKE_CREATE_HEARTBEAT:-no}" = yes ]; then
+      printf '%s\n' new-owner > "$FAKE_STATE_DIR/owner"
+      printf '%s\n' new-owner > "$FAKE_STATE_DIR/listener.heartbeat"
+    fi
+    ;;
+  *) exit 1 ;;
+esac
+'@, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $bin 'rc-update'), @'
+#!/bin/sh
+case "$1" in
+  show) grep -qx default "$FAKE_RUNLEVEL_STATE" && echo "dune-dnat-watch | default" ;;
+  add) echo default > "$FAKE_RUNLEVEL_STATE" ;;
+  del) echo absent > "$FAKE_RUNLEVEL_STATE" ;;
+  *) exit 1 ;;
+esac
+'@, [System.Text.UTF8Encoding]::new($false))
+            foreach ($name in 'supervise-daemon','timeout','flock') {
+                [System.IO.File]::WriteAllText((Join-Path $bin $name), "#!/bin/sh`nexit 0`n", [System.Text.UTF8Encoding]::new($false))
+            }
+            [System.IO.File]::WriteAllText((Join-Path $bin 'stat'), "#!/bin/sh`ndate +%s`n", [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $bin 'pgrep'), "#!/bin/sh`nexit 1`n", [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $bin 'k3s'), "#!/bin/sh`nexit 0`n", [System.Text.UTF8Encoding]::new($false))
+
+            & $script:posixShell.FullName -lc "chmod +x '$posixRoot/install.sh' '$posixRoot/live/watch.sh' '$posixRoot/live/service' '$posixRoot/bin/'*"
+            $LASTEXITCODE | Should -Be 0
+
+            $psi = [System.Diagnostics.ProcessStartInfo]::new()
+            $psi.FileName = $script:posixShell.FullName
+            $psi.ArgumentList.Add("$posixRoot/install.sh")
+            $psi.UseShellExecute = $false
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError = $true
+            $psi.Environment['DUNE_DNAT_PATH_PREFIX'] = "$posixRoot/bin"
+            $psi.Environment['DUNE_DNAT_INSTALL_WATCH'] = "$posixRoot/live/watch.sh"
+            $psi.Environment['DUNE_DNAT_INSTALL_SERVICE'] = "$posixRoot/live/service"
+            $psi.Environment['DUNE_DNAT_INSTALL_LOG'] = "$posixRoot/install.log"
+            $psi.Environment['DUNE_DNAT_K3S'] = "$posixRoot/bin/k3s"
+            $psi.Environment['DUNE_DNAT_STATE_DIR'] = "$posixRoot/state"
+            $psi.Environment['FAKE_CRON_FILE'] = "$posixRoot/crontab"
+            $psi.Environment['FAKE_CRON_WRITES'] = "$posixRoot/crontab-writes"
+            $psi.Environment['FAKE_SERVICE_STATE'] = "$posixRoot/service-state"
+            $psi.Environment['FAKE_RUNLEVEL_STATE'] = "$posixRoot/runlevel-state"
+            $psi.Environment['FAKE_STATE_DIR'] = "$posixRoot/state"
+            $psi.Environment['FAKE_CREATE_HEARTBEAT'] = 'no'
+
+            $process = [System.Diagnostics.Process]::new()
+            $process.StartInfo = $psi
+            $process.Start() | Should -BeTrue
+            $process.WaitForExit(15000) | Should -BeTrue
+            $process.ExitCode | Should -Be 1
+            $failureOutput = $process.StandardOutput.ReadToEnd()
+            $failureOutput | Should -Match 'DUNE_DNAT_WATCH_FAILED'
+            $failureOutput | Should -Not -Match 'DUNE_DNAT_WATCH_OK'
+
+            (Get-Content -LiteralPath $watchPath -Raw) | Should -Be $oldWatch
+            (Get-Content -LiteralPath $servicePath -Raw) | Should -Be $oldService
+            (Get-Content -LiteralPath $cronPath -Raw) | Should -Be $oldCron
+            (Get-Content -LiteralPath (Join-Path $tempRoot 'service-state') -Raw).Trim() | Should -Be 'running'
+            (Get-Content -LiteralPath (Join-Path $tempRoot 'runlevel-state') -Raw).Trim() | Should -Be 'default'
+            Test-Path -LiteralPath (Join-Path $state 'owner') | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path $state 'listener.heartbeat') | Should -BeFalse
+            @(Get-ChildItem -LiteralPath $live -Filter '*.new.*').Count | Should -Be 0
+            @(Get-ChildItem -LiteralPath $live -Filter '*.previous.*').Count | Should -Be 0
+
+            [System.IO.File]::WriteAllText((Join-Path $state 'owner'), "old-owner`n", [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $state 'listener.heartbeat'), "old-owner`n", [System.Text.UTF8Encoding]::new($false))
+            $psi.Environment['FAKE_CREATE_HEARTBEAT'] = 'yes'
+            $successProcess = [System.Diagnostics.Process]::new()
+            $successProcess.StartInfo = $psi
+            $successProcess.Start() | Should -BeTrue
+            $successProcess.WaitForExit(15000) | Should -BeTrue
+            $successOutput = $successProcess.StandardOutput.ReadToEnd()
+            $successError = $successProcess.StandardError.ReadToEnd()
+            $successProcess.ExitCode | Should -Be 0 -Because "stdout: $successOutput stderr: $successError"
+            $successOutput | Should -Match 'DUNE_DNAT_WATCH_OK'
+            (Get-Content -LiteralPath (Join-Path $state 'owner') -Raw).Trim() | Should -Be 'new-owner'
+            (Get-Content -LiteralPath (Join-Path $state 'listener.heartbeat') -Raw).Trim() | Should -Be 'new-owner'
+        } finally {
+            if ($successProcess -and -not $successProcess.HasExited) { $successProcess.Kill($true) }
+            if ($process -and -not $process.HasExited) { $process.Kill($true) }
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'rate-limits persistent iptables insertion failures' {
+        $script:dnatWatchSource | Should -Match '(?ms)^log_reconcile_failure\(\) \{.*?-ge 60.*?^\}'
+        $script:dnatWatchSource | Should -Match 'log_reconcile_failure "failed to install game-UDP bridge'
+        $script:dnatWatchSource | Should -Match 'log_reconcile_failure "failed to install rabbitmq DNAT'
+    }
+
+    It 'refreshes supervision before every battlegroup start or restart path' {
+        $script:launcherSource | Should -Match "Invoke-DuneDnatWatchdogInstall -Ip \`$ip -Phase 'pre-startup'"
+        $script:launcherSource | Should -Match "Invoke-DuneDnatWatchdogInstall -Ip \`$ip -Phase 'pre-reboot-start'"
+        $script:launcherSource | Should -Match 'Invoke-DuneDnatWatchdogInstall -Ip \$ip -Phase "pre-\$cmdName"'
+        $script:launcherSource | Should -Not -Match 'Invoke-DuneDnatWatchdogInstall -Ip \$ip -Phase "post-\$cmdName"'
+    }
+
+    It 'keeps legacy no-argument cron functional with one safe reconciliation pass' {
+        if (-not $script:posixShell) {
+            Set-ItResult -Skipped -Because 'A POSIX shell is not installed.'
+            return
+        }
+
+        $watchMatch = [regex]::Match(
+            $script:dnatWatchSource,
+            '(?ms)^if ! cat > "\$WATCH_STAGE" <<''WATCHEOF''\r?\n(.*?)\r?\nWATCHEOF$'
+        )
+        $watchMatch.Success | Should -BeTrue
+
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dst-dnat-once-{0}" -f [guid]::NewGuid())
+        $bin = Join-Path $tempRoot 'bin'
+        $state = Join-Path $tempRoot 'state'
+        New-Item -ItemType Directory -Path $bin,$state -Force | Out-Null
+        $escapedRoot = $tempRoot.Replace("'", "'\''")
+        $posixRoot = (& $script:posixShell.FullName -lc "cygpath -u '$escapedRoot'").Trim()
+        $watchPath = Join-Path $tempRoot 'watch.sh'
+        $iptablesLog = Join-Path $tempRoot 'iptables.log'
+        $process = $null
+
+        try {
+            [System.IO.File]::WriteAllText($watchPath, $watchMatch.Groups[1].Value, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $state 'cluster.state'), "203.0.113.10`n192.168.1.20`n", [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $bin 'ss'), @'
+#!/bin/sh
+echo "UNCONN 0 0 203.0.113.10:7782 0.0.0.0:*"
+'@, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $bin 'iptables'), @'
+#!/bin/sh
+case " $* " in
+  *" -C "*) exit 1 ;;
+  *" -I "*) echo "$*" >> "$HARNESS_IPTABLES_LOG"; exit 0 ;;
+  *) exit 0 ;;
+esac
+'@, [System.Text.UTF8Encoding]::new($false))
+            foreach ($name in 'flock','k3s') {
+                [System.IO.File]::WriteAllText((Join-Path $bin $name), "#!/bin/sh`nexit 0`n", [System.Text.UTF8Encoding]::new($false))
+            }
+
+            & $script:posixShell.FullName -lc "chmod +x '$posixRoot/watch.sh' '$posixRoot/bin/'*"
+            $LASTEXITCODE | Should -Be 0
+
+            $psi = [System.Diagnostics.ProcessStartInfo]::new()
+            $psi.FileName = $script:posixShell.FullName
+            $psi.ArgumentList.Add("$posixRoot/watch.sh")
+            $psi.UseShellExecute = $false
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError = $true
+            $psi.Environment['DUNE_DNAT_PATH_PREFIX'] = "$posixRoot/bin"
+            $psi.Environment['DUNE_DNAT_K3S'] = "$posixRoot/bin/k3s"
+            $psi.Environment['DUNE_DNAT_STATE_DIR'] = "$posixRoot/state"
+            $psi.Environment['DUNE_DNAT_LOG'] = "$posixRoot/watch.log"
+            $psi.Environment['HARNESS_IPTABLES_LOG'] = "$posixRoot/iptables.log"
+
+            $process = [System.Diagnostics.Process]::new()
+            $process.StartInfo = $psi
+            $process.Start() | Should -BeTrue
+            $process.WaitForExit(10000) | Should -BeTrue
+            $process.ExitCode | Should -Be 0
+
+            Get-Content -LiteralPath $iptablesLog -Raw | Should -Match '-I PREROUTING 1 -d 192\.168\.1\.20 -p udp --dport 7782 -j DNAT --to-destination 203\.0\.113\.10'
+            Test-Path -LiteralPath (Join-Path $state 'owner') | Should -BeFalse
+        } finally {
+            if ($process -and -not $process.HasExited) { $process.Kill($true) }
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'keeps listener passes running while the bounded cluster worker stalls' {
+        if (-not $script:posixShell) {
+            Set-ItResult -Skipped -Because 'A POSIX shell is not installed.'
+            return
+        }
+
+        $watchMatch = [regex]::Match(
+            $script:dnatWatchSource,
+            '(?ms)^if ! cat > "\$WATCH_STAGE" <<''WATCHEOF''\r?\n(.*?)\r?\nWATCHEOF$'
+        )
+        $watchMatch.Success | Should -BeTrue
+
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dst-dnat-loop-{0}" -f [guid]::NewGuid())
+        $bin = Join-Path $tempRoot 'bin'
+        $state = Join-Path $tempRoot 'state'
+        New-Item -ItemType Directory -Path $bin,$state -Force | Out-Null
+
+        $escapedRoot = $tempRoot.Replace("'", "'\''")
+        $posixRoot = (& $script:posixShell.FullName -lc "cygpath -u '$escapedRoot'").Trim()
+        $watchPath = Join-Path $tempRoot 'watch.sh'
+        $ssCount = Join-Path $tempRoot 'ss-count'
+        $iptablesLog = Join-Path $tempRoot 'iptables.log'
+        $ruleState = Join-Path $tempRoot 'rule-state'
+        $k3sStarted = Join-Path $tempRoot 'k3s-started'
+        $process = $null
+        $replacement = $null
+
+        try {
+            [System.IO.File]::WriteAllText($watchPath, $watchMatch.Groups[1].Value, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $state 'cluster.state'), "203.0.113.10`n192.168.1.20`n", [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $bin 'ss'), @'
+#!/bin/sh
+_n=0
+[ ! -r "$HARNESS_SS_COUNT" ] || _n=$(cat "$HARNESS_SS_COUNT")
+_n=$((_n + 1))
+printf '%s\n' "$_n" > "$HARNESS_SS_COUNT"
+echo "UNCONN 0 0 203.0.113.10:7782 0.0.0.0:*"
+'@, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $bin 'iptables'), @'
+#!/bin/sh
+echo "$HARNESS_ID $*" >> "$HARNESS_IPTABLES_LOG"
+case " $* " in
+  *" -C "*) [ -f "$HARNESS_RULE_STATE" ] && exit 0 || exit 1 ;;
+  *" -I "*) : > "$HARNESS_RULE_STATE"; exit 0 ;;
+  *) exit 0 ;;
+esac
+'@, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $bin 'k3s'), @'
+#!/bin/sh
+: > "$HARNESS_K3S_STARTED"
+sleep 2
+exit 1
+'@, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText((Join-Path $bin 'flock'), @'
+#!/bin/sh
+exit 0
+'@, [System.Text.UTF8Encoding]::new($false))
+
+            & $script:posixShell.FullName -lc "chmod +x '$posixRoot/watch.sh' '$posixRoot/bin/ss' '$posixRoot/bin/iptables' '$posixRoot/bin/k3s' '$posixRoot/bin/flock'"
+            $LASTEXITCODE | Should -Be 0
+
+            function Start-DnatHarness([string] $Id, [int] $MaxPasses) {
+                $psi = [System.Diagnostics.ProcessStartInfo]::new()
+                $psi.FileName = $script:posixShell.FullName
+                $psi.ArgumentList.Add("$posixRoot/watch.sh")
+                $psi.ArgumentList.Add('--loop')
+                $psi.UseShellExecute = $false
+                $psi.RedirectStandardOutput = $true
+                $psi.RedirectStandardError = $true
+                $psi.Environment['DUNE_DNAT_PATH_PREFIX'] = "$posixRoot/bin"
+                $psi.Environment['DUNE_DNAT_K3S'] = "$posixRoot/bin/k3s"
+                $psi.Environment['DUNE_DNAT_STATE_DIR'] = "$posixRoot/state"
+                $psi.Environment['DUNE_DNAT_LOG'] = "$posixRoot/watch.log"
+                $psi.Environment['DUNE_DNAT_LOOP_SLEEP'] = '0.1'
+                $psi.Environment['DUNE_DNAT_CLUSTER_SLEEP'] = '5'
+                $psi.Environment['DUNE_DNAT_MAX_PASSES'] = "$MaxPasses"
+                $psi.Environment['HARNESS_ID'] = $Id
+                $psi.Environment['HARNESS_SS_COUNT'] = "$posixRoot/ss-count"
+                $psi.Environment['HARNESS_IPTABLES_LOG'] = "$posixRoot/iptables.log"
+                $psi.Environment['HARNESS_RULE_STATE'] = "$posixRoot/rule-state"
+                $psi.Environment['HARNESS_K3S_STARTED'] = "$posixRoot/k3s-started"
+                $p = [System.Diagnostics.Process]::new()
+                $p.StartInfo = $psi
+                if (-not $p.Start()) { throw "Failed to start $Id harness" }
+                return $p
+            }
+
+            $process = Start-DnatHarness -Id old -MaxPasses 20
+            for ($i = 0; $i -lt 100 -and -not (Test-Path -LiteralPath $ruleState); $i++) {
+                Start-Sleep -Milliseconds 25
+            }
+            Test-Path -LiteralPath $ruleState | Should -BeTrue
+            $oldOwner = Get-Content -LiteralPath (Join-Path $state 'owner') -Raw
+            $oldInsertBefore = @((Get-Content -LiteralPath $iptablesLog) | Where-Object {
+                $_ -match '^old .* -I PREROUTING .*--dport 7782 '
+            }).Count
+
+            $replacement = Start-DnatHarness -Id new -MaxPasses 3
+            for ($i = 0; $i -lt 100; $i++) {
+                $newOwner = Get-Content -LiteralPath (Join-Path $state 'owner') -Raw -ErrorAction SilentlyContinue
+                if ($newOwner -and $newOwner -ne $oldOwner) { break }
+                Start-Sleep -Milliseconds 25
+            }
+            $newOwner | Should -Not -Be $oldOwner
+            Remove-Item -LiteralPath $ruleState -Force
+
+            $replacement.WaitForExit(10000) | Should -BeTrue
+            $replacement.ExitCode | Should -Be 0
+            $process.WaitForExit(10000) | Should -BeTrue
+            $process.ExitCode | Should -Be 0
+
+            [int](Get-Content -LiteralPath $ssCount -Raw) | Should -BeGreaterThan 3
+            Test-Path -LiteralPath $k3sStarted | Should -BeTrue
+            $iptables = Get-Content -LiteralPath $iptablesLog
+            @($iptables | Where-Object {
+                $_ -match '^new .* -I PREROUTING 1 -d 192\.168\.1\.20 -p udp --dport 7782 -j DNAT --to-destination 203\.0\.113\.10'
+            }).Count | Should -Be 1
+            @($iptables | Where-Object {
+                $_ -match '^old .* -I PREROUTING .*--dport 7782 '
+            }).Count | Should -Be $oldInsertBefore
+        } finally {
+            if ($replacement -and -not $replacement.HasExited) { $replacement.Kill($true) }
+            if ($process -and -not $process.HasExited) { $process.Kill($true) }
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
     }
 }

--- a/tests/PublicIp.Tests.ps1
+++ b/tests/PublicIp.Tests.ps1
@@ -208,10 +208,16 @@ game_port_state 7781
             )
             $actual = @(& $script:posixShell.FullName $tempScript)
             $LASTEXITCODE | Should -Be 0
-            $actual | Should -Be @('pub', 'lan', 'lan', 'none')
+            $actual | Should -Be @('pub', 'pub', 'lan', 'none')
         } finally {
             Remove-Item -LiteralPath $tempScript -Force -ErrorAction SilentlyContinue
         }
+    }
+
+    It 'prefers the public listener when different processes dual-bind one port' {
+        $script:dnatWatchSource | Should -Match 'if \[ "\$_pub" = 1 \]; then'
+        $script:publicIpSource | Should -Match 'if \[ "\$_pub" = 1 \]; then echo pub; elif \[ "\$_lanwild" = 1 \]'
+        $script:publicIpSource | Should -Match 'if \[ "\$gb_pub" = 1 \]; then echo pub; elif \[ "\$gb_lanwild" = 1 \]'
     }
 
     It 'scopes watchdog cleanup to UDP DNAT rules for the Dune VM' {

--- a/tests/PublicIp.Tests.ps1
+++ b/tests/PublicIp.Tests.ps1
@@ -157,3 +157,82 @@ Describe 'Public IP apply state file' {
         $st.running | Should -BeTrue
     }
 }
+
+Describe 'Mixed-bind game UDP bridge' {
+    BeforeAll {
+        $script:dnatWatchPath = Join-Path $PSScriptRoot '..\app\resources\remote-scripts\dune-dnat-watch-install.sh'
+        $script:dnatWatchSource = Get-Content -LiteralPath $script:dnatWatchPath -Raw
+        $script:publicIpSource = Get-Content -LiteralPath (Join-Path $PSScriptRoot '..\app\server\lib\PublicIp.ps1') -Raw
+
+        $script:posixShell = Get-Command sh -ErrorAction SilentlyContinue
+        if (-not $script:posixShell) {
+            $gitShell = Join-Path $env:ProgramFiles 'Git\bin\sh.exe'
+            if (Test-Path -LiteralPath $gitShell) {
+                $script:posixShell = Get-Item -LiteralPath $gitShell
+            }
+        }
+    }
+
+    It 'classifies each active port independently from one listener snapshot' {
+        if (-not $script:posixShell) {
+            Set-ItResult -Skipped -Because 'A POSIX shell is not installed.'
+            return
+        }
+
+        $functionMatch = [regex]::Match(
+            $script:dnatWatchSource,
+            '(?ms)^game_port_state\(\) \{\r?\n.*?^\}'
+        )
+        $functionMatch.Success | Should -BeTrue
+
+        $harness = @'
+PUB=203.0.113.10
+VM_IP=192.168.1.20
+_udp_snapshot='203.0.113.10:7777
+203.0.113.10:7779
+0.0.0.0:7779
+192.168.1.20:7780'
+'@ + "`n" + $functionMatch.Value + "`n" + @'
+game_port_state 7777
+game_port_state 7779
+game_port_state 7780
+game_port_state 7781
+'@
+
+        $tempScript = Join-Path ([System.IO.Path]::GetTempPath()) ("dst-dnat-state-{0}.sh" -f [guid]::NewGuid())
+        try {
+            [System.IO.File]::WriteAllText(
+                $tempScript,
+                $harness,
+                [System.Text.UTF8Encoding]::new($false)
+            )
+            $actual = @(& $script:posixShell.FullName $tempScript)
+            $LASTEXITCODE | Should -Be 0
+            $actual | Should -Be @('pub', 'lan', 'lan', 'none')
+        } finally {
+            Remove-Item -LiteralPath $tempScript -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'scopes watchdog cleanup to UDP DNAT rules for the Dune VM' {
+        $script:dnatWatchSource | Should -Match 'game_bridge_rules\(\)'
+        $script:dnatWatchSource | Should -Match 'grep -F -- "-d \$\{VM_IP\}/32"'
+        $script:dnatWatchSource | Should -Match "grep -F -- '-p udp'"
+        $script:dnatWatchSource | Should -Not -Match '(?m)iptables .* -I PREROUTING .*--dport "\$GAME_PORTS"'
+    }
+
+    It 'preserves the legacy bridge while listener state is fully indeterminate' {
+        $script:dnatWatchSource | Should -Match '\[ "\$_state" != none \] && \[ "\$_legacy_reconciled" = 0 \]'
+        $script:publicIpSource | Should -Match '\[ "\$_state" != none \] && \[ "\$_legacy_reconciled" = 0 \]'
+        $script:publicIpSource | Should -Match '\[ "\$gb_state" != none \] && \[ "\$gb_legacy_reconciled" = 0 \]'
+    }
+
+    It 'uses per-port reconciliation in both embedded Public IP apply paths' {
+        $script:publicIpSource | Should -Match 'game_port_state\(\)'
+        $script:publicIpSource | Should -Match 'gb_port_state\(\)'
+        $script:publicIpSource | Should -Match '_udp_snapshot=\$\(udp_listeners\)'
+        $script:publicIpSource | Should -Match 'gb_udp_snapshot=\$\(gb_listeners\)'
+        $script:publicIpSource | Should -Not -Match '(?m)iptables .* -I PREROUTING .*--dport "\$GAME_PORTS"'
+        $script:publicIpSource | Should -Not -Match '(?m)iptables .* -I PREROUTING .*--dport "\$GBPORTS"'
+    }
+}


### PR DESCRIPTION
## Summary
- reconcile game UDP DNAT independently for each exact port in `7777-7810`
- make a public listener win whenever `PUBLIC_IP:port` exists, even if a different process owns `VM_LAN_IP:port`
- target one listener snapshot per second before map readiness instead of waiting for a minute cron pass
- isolate and bound Kubernetes/RabbitMQ discovery so API stalls cannot block listener polling
- install the OpenRC supervisor before battlegroup start/restart
- make watchdog upgrades transactional with rollback, ownership serialization, and fresh replacement-health proof

## Field confirmation
The test release confirmed both failures are resolved:

- a fresh map exposed public port `7782`; matching DNAT appeared immediately when `ss` showed it and before DST showed the map green
- public-listener ports received DNAT while LAN-only ports remained untouched
- first external handoff succeeded without P34
- listener ports are not paired per process: an existing process still owned `VM_LAN_IP:7782`, while the new map bound `PUBLIC_IP:7782` and `VM_LAN_IP:7785`

That proves a same-number LAN listener cannot suppress DNAT for a public listener because the sockets may belong to different game processes.

## Validation
- 34 targeted `PublicIp.Tests.ps1` tests passed
- executable harness proves listener passes continue while Kubernetes stalls
- installer, generated watchdog, and OpenRC service pass shell syntax checks
- PowerShell parse, UTF-8 BOM, and diff checks pass
- full installer build passes all five version stamps, PS 5.1 preflight, web UI, backend, shell, and Inno Setup
- gitleaks found no leaks in the rebased commit range

## Test release
- `v12.19.7-udp-test-3`
- tested commit before rebase: `0d7f375f6e4b5616683b5f7c1b501a671b4b64bd`
- field result: confirmed