### PR TITLE
Anonymize v12.19.9 field validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ here cover everything those tags shipped.
   second and installs exact-port DNAT continuously instead of waiting for the
   old once-per-minute pass. Cluster lookups run independently with hard
   timeouts, so a stalled K3s API cannot stop listener polling. Cleanup is limited
-  to Dune game-port UDP rules for the VM. Marcus's field test confirmed DNAT
-  appeared before DST showed the map green and the first external handoff
-  succeeded without P34.
+  to Dune game-port UDP rules for the VM. Field testing confirmed DNAT appeared
+  before DST showed the map green and the first external handoff succeeded
+  without P34.
 
 ## [12.19.8] - 2026-07-20
 


### PR DESCRIPTION
Removes tester attribution from the public v12.19.9 changelog while preserving the field-validation result.