### PR TITLE
Add supporter credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- Supporter added to list.
+
 ## [12.19.9] - 2026-07-21
 
 ### Fixed

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -505,6 +505,10 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <Icon name="Heart" size={14} className="text-ibad shrink-0" />
               <span className="flex-1">Chumdizzle (@chumdizzle)</span>
             </div>
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">Fargenbasteg (@fargenbasteg)</span>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Adds the newest in-app "Thanks for the Coffee" supporter credit to the menu bar, and rolls it into the changelog with generic wording (no supporter name in the changelog per standing privacy preference).

**Changes:**
- `webui/src/layout/MenuBar.tsx` — new supporter entry added after the last existing entry, matching existing markup/style.
- `CHANGELOG.md` — `Supporter added to list.` under `## [Unreleased]` / `### Changed`.

**Validation:** `cd webui; npm run build` — tsc + vite build succeeded, no errors.