### PR TITLE
Fix LAN SSH key fallback: directory guard + base64 pubkey auth

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.20.2"
+      placeholder: "v12.20.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.20.3] - 2026-07-24
+
+### Fixed
+
+- **SSH key fallback (LAN mode) now handles directory-as-key-path and uses base64 for pubkey authorization.** The v12.20.2 fallback had two issues: if the configured SSH key path pointed to the `DuneAwakeningServer` directory instead of the `sshKey` file inside it, `Remove-Item` prompted for confirmation to delete children; and the pubkey was passed via shell single-quotes which can break on key content characters. The path now auto-appends `sshKey` when it resolves to a directory, and the authorization uses base64 encoding (matching the proven `Initialize-DuneLanGuest` bootstrap path) to avoid shell-quoting issues.
+
 ## [12.20.2] - 2026-07-24
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.20.2'
+$script:DuneToolVersion = '12.20.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.20.2',
+    [string]$Version = '12.20.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.20.2</Version>
+    <Version>12.20.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.20.2"
+#define MyAppVersion "12.20.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.20.2"
+$script:ToolVersion = "12.20.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a
@@ -2229,9 +2229,16 @@ while ($true) {
             # HyperVLanInstall.ps1 Initialize-DuneLanGuest.
             $keyPath = $sshKey
             if (-not $keyPath) { $keyPath = Join-Path $env:LOCALAPPDATA 'DuneAwakeningServer\sshKey' }
+            # Guard: if $keyPath is a directory (e.g. config stored the parent
+            # folder instead of the file), append the expected filename.
+            if ((Test-Path -LiteralPath $keyPath) -and (Get-Item -LiteralPath $keyPath).PSIsContainer) {
+                $keyPath = Join-Path $keyPath 'sshKey'
+            }
             $keyDir = Split-Path -Parent $keyPath
             if ($keyDir -and -not (Test-Path $keyDir)) { New-Item -ItemType Directory -Force -Path $keyDir | Out-Null }
-            if (Test-Path -LiteralPath $keyPath)       { Remove-Item -LiteralPath $keyPath -Force }
+            if ((Test-Path -LiteralPath $keyPath) -and -not (Get-Item -LiteralPath $keyPath).PSIsContainer) {
+                Remove-Item -LiteralPath $keyPath -Force
+            }
             if (Test-Path -LiteralPath "$keyPath.pub") { Remove-Item -LiteralPath "$keyPath.pub" -Force }
             Write-Host "  Generating new SSH key at $keyPath ..." -ForegroundColor Yellow
             & ssh-keygen -t ed25519 -f $keyPath -N '""' -q -C "dst@$($env:COMPUTERNAME)" 2>&1 | Out-Null
@@ -2240,11 +2247,15 @@ while ($true) {
                 Write-Host ""; continue
             }
             Write-Host "  Key generated." -ForegroundColor Green
+            # Base64-encode the public key to avoid shell-quoting issues with
+            # the key content (spaces, +, = chars) — same approach as
+            # Initialize-DuneLanGuest.
             $pub = (Get-Content -Raw -LiteralPath "$keyPath.pub").Trim()
+            $b64Pub = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("$pub`n"))
             Write-Host ""
             Write-Host "  Authorizing on $sshUser@$ip ..." -ForegroundColor Yellow
             Write-Host "  Enter the '$sshUser' password when prompted:" -ForegroundColor Cyan
-            & ssh -o StrictHostKeyChecking=no "$sshUser@$ip" "mkdir -p `$HOME/.ssh && chmod 700 `$HOME/.ssh && echo '$pub' >> `$HOME/.ssh/authorized_keys && chmod 600 `$HOME/.ssh/authorized_keys"
+            & ssh -o StrictHostKeyChecking=no "$sshUser@$ip" "mkdir -p `$HOME/.ssh && chmod 700 `$HOME/.ssh && echo $b64Pub | base64 -d >> `$HOME/.ssh/authorized_keys && chmod 600 `$HOME/.ssh/authorized_keys"
         }
 
         # --- Guard: confirm the freshly-rotated key actually authenticates -----


### PR DESCRIPTION
## What

v12.20.2's SSH key fallback (LAN mode, no local `vm-utilities.ps1`) had two bugs found via Pat's diagnostic logs:

1. **Directory-as-key-path:** if `SshKey` in config pointed to `...\DuneAwakeningServer` (the directory) instead of `...\DuneAwakeningServer\sshKey` (the file), `Remove-Item` prompted to delete directory children. Pat's log showed `"The item at ... has children and the Recurse parameter was not specified"`.

2. **Shell-quoting:** the pubkey was injected into the SSH command via shell single-quotes (`echo '$pub'`), which can break on key content characters (`+`, `=`, spaces). Pat's log showed the authorization step completed but the key was NOT actually authorized.

## Fix

- Auto-appends `sshKey` when the resolved path is a directory
- Only `Remove-Item` on files, never directories
- Uses base64 encoding for pubkey transfer — matching the proven `Initialize-DuneLanGuest` bootstrap path

## Also

- Version bump to **v12.20.3**, CHANGELOG, bug template placeholder