### PR TITLE
Give Item: rename Tier to Grade dropdown; require offline for Grade > 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ here cover everything those tags shipped.
 
 ### Changed
 
-- **Give Item "Tier" field renamed to "Grade" and is now a dropdown (Grade 1-6, default Grade 1).** Grades above the default are SQL-only writes that require the player to be offline — Give Item now refuses with a clear error when the target player is online and a higher Grade is selected (previously it wrote anyway with a "must relog" note). The "Give all grades" button applies the same offline requirement up front so the set is never partially delivered.
+- **Give Item "Tier" field renamed to "Grade" and is now a dropdown (Grade 0-5, default Grade 0).** Grades above 0 are SQL-only writes that require the player to be offline — Give Item now refuses with a clear error when the target player is online and a Grade above 0 is selected (previously it wrote anyway with a "must relog" note). The "Give all grades" button applies the same offline requirement up front so the set is never partially delivered.
 
 ## [12.20.3] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ here cover everything those tags shipped.
 
 ### Changed
 
-- **Give Item "Tier" field renamed to "Grade" and is now a dropdown (0-5, default 0).** Grades above 0 are SQL-only writes that require the player to be offline — Give Item now refuses with a clear error when the target player is online and a Grade above 0 is selected (previously it wrote anyway with a "must relog" note). The "Give whole tier set" button applies the same offline requirement up front so the set is never partially delivered.
+- **Give Item "Tier" field renamed to "Grade" and is now a dropdown (Grade 1-6, default Grade 1).** Grades above the default are SQL-only writes that require the player to be offline — Give Item now refuses with a clear error when the target player is online and a higher Grade is selected (previously it wrote anyway with a "must relog" note). The "Give all grades" button applies the same offline requirement up front so the set is never partially delivered.
 
 ## [12.20.3] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- **Give Item "Tier" field renamed to "Grade" and is now a dropdown (0-5, default 0).** Grades above 0 are SQL-only writes that require the player to be offline — Give Item now refuses with a clear error when the target player is online and a Grade above 0 is selected (previously it wrote anyway with a "must relog" note). The "Give whole tier set" button applies the same offline requirement up front so the set is never partially delivered.
+
 ## [12.20.3] - 2026-07-24
 
 ### Fixed

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -114,9 +114,9 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-solari' -Handl
 
 # POST /api/gameplay/players/give-item  { pawn_id, template, qty, quality, fls_id? }
 # v12.0.3 — Auto-routes between online (RMQ ServerCommand, instant) and offline
-# (SQL backpack insert, requires relog for online) based on player state.
+# (SQL backpack insert) based on player state.
 # - Online + quality<=0     → RMQ live (instant in-game)
-# - Online + quality>0      → SQL (preserves quality; player must relog)
+# - Online + quality>0      → ERROR — a Grade write is SQL-only and requires the player offline
 # - Offline                 → SQL (will appear on next login)
 # Response includes 'path' = 'rmq' | 'sql'. Use /give-item-live for explicit RMQ override.
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-item' -Handler {
@@ -149,14 +149,15 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-item' -Handler
                 if ($r.ok -and -not $r.path) { $r['path'] = 'rmq' }
                 return $r
             }
-            # Otherwise SQL (offline, OR online with custom quality)
-            $r = Invoke-DunePlayerGiveItem -Ip $ip -PawnId $pawn -Template $tmpl -Qty $qty -Quality $qual
-            if ($r.ok) {
-                $r['path'] = 'sql'
-                if ($isOnline) {
-                    $r['message'] = "$($r.message) Player is online — they must relog to see the item (quality $qual cannot be delivered live)."
-                }
+            # A Grade (quality) write only goes through SQL, and the game overwrites
+            # it from RAM while a live session exists — refuse instead of writing a
+            # value that silently won't stick.
+            if ($isOnline -and $qual -gt 0) {
+                return @{ ok = $false; error = 'Changing the Grade requires the player to be offline. Ask the player to log out, then retry.' }
             }
+            # Offline → SQL (appears on next login)
+            $r = Invoke-DunePlayerGiveItem -Ip $ip -PawnId $pawn -Template $tmpl -Qty $qty -Quality $qual
+            if ($r.ok) { $r['path'] = 'sql' }
             return $r
         }
     } catch {

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -694,7 +694,7 @@ const ACTIONS: ActionDef[] = [
 
   // ----- Items -----
   { id: 'give-item',      group: 'Items', label: 'Give Item', icon: 'PackagePlus', custom: 'give-item',
-    rowNote: 'Works online or offline — delivered instantly when online, on next login when offline',
+    rowNote: 'Works online or offline — delivered instantly when online, on next login when offline. Grade above 0 requires the player to be offline',
     run: () => Promise.resolve({ message: '' }) },
   { id: 'give-vehicle-kit', group: 'Items', label: 'Give Vehicle Kit', icon: 'Truck', custom: 'vehicle-kit',
     rowNote: 'Parts + fuel cell + welding torch Mk5 — works online or offline, needs inventory space',
@@ -963,6 +963,11 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
             <GiveItemForm busy={busy} submitLabel={def.label}
               onSubmit={(tpl, qty, qual, overflow) => runAction(def, () => giveItem(player.id, tpl, qty, qual, overflow))}
               onSubmitTierSet={(tpl, qty, overflow) => runAction(def, async () => {
+                // Grades above 0 are SQL-only writes the game overwrites from RAM while a
+                // live session exists — refuse up front so the set isn't partially delivered.
+                if (['online', 'loggingout'].includes((player.online_status || '').toLowerCase())) {
+                  throw new Error(`Changing the Grade requires the player to be offline — ask ${player.name} to log out, then retry.`)
+                }
                 for (let q = 0; q <= 5; q++) await giveItem(player.id, tpl, qty, q, overflow)
                 return { message: `Gave ${tpl} Mk1–Mk6 (x${qty} each) to ${player.name}.` }
               })} />
@@ -1408,10 +1413,14 @@ function GiveItemForm({ busy, submitLabel, onSubmit, onSubmitTierSet }: {
             className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
         </div>
         <div>
-          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Tier — Mk1-Mk6 (0-5)</label>
-          <input type="number" min={0} max={5} value={giveQual} disabled={busy}
+          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Grade</label>
+          <select value={giveQual} disabled={busy}
             onChange={e => setGiveQual(e.target.value)}
-            className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50" />
+            className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50">
+            {[0, 1, 2, 3, 4, 5].map(g => (
+              <option key={g} value={g}>{g === 0 ? '0 — Mk1 (default)' : `${g} — Mk${g + 1}`}</option>
+            ))}
+          </select>
         </div>
       </div>
       <OverflowToggle checked={overflow} disabled={busy} onChange={setOverflow} />

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -969,7 +969,7 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
                   throw new Error(`Changing the Grade requires the player to be offline — ask ${player.name} to log out, then retry.`)
                 }
                 for (let q = 0; q <= 5; q++) await giveItem(player.id, tpl, qty, q, overflow)
-                return { message: `Gave ${tpl} Grade 1–6 (x${qty} each) to ${player.name}.` }
+                return { message: `Gave ${tpl} Grade 0–5 (x${qty} each) to ${player.name}.` }
               })} />
           ) : def.custom === 'grant-reward' ? (
             <GrantRewardForm busy={busy} submitLabel={def.label}
@@ -1418,7 +1418,7 @@ function GiveItemForm({ busy, submitLabel, onSubmit, onSubmitTierSet }: {
             onChange={e => setGiveQual(e.target.value)}
             className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50">
             {[0, 1, 2, 3, 4, 5].map(g => (
-              <option key={g} value={g}>{g === 0 ? 'Grade 1 (default)' : `Grade ${g + 1}`}</option>
+              <option key={g} value={g}>{g === 0 ? 'Grade 0 (default)' : `Grade ${g}`}</option>
             ))}
           </select>
         </div>
@@ -1430,9 +1430,9 @@ function GiveItemForm({ busy, submitLabel, onSubmit, onSubmitTierSet }: {
       </button>
       {gradeable && (
         <button className="btn-secondary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
-          title="Gives one of this item at every grade, Grade 1 through Grade 6"
+          title="Gives one of this item at every grade, Grade 0 through Grade 5"
           onClick={() => onSubmitTierSet(giveTpl.trim(), Number(giveQty) || 1, overflow)}>
-          {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Layers" size={13} />} Give all grades (1-6)
+          {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Layers" size={13} />} Give all grades (0-5)
         </button>
       )}
     </div>

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -969,7 +969,7 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
                   throw new Error(`Changing the Grade requires the player to be offline — ask ${player.name} to log out, then retry.`)
                 }
                 for (let q = 0; q <= 5; q++) await giveItem(player.id, tpl, qty, q, overflow)
-                return { message: `Gave ${tpl} Mk1–Mk6 (x${qty} each) to ${player.name}.` }
+                return { message: `Gave ${tpl} Grade 1–6 (x${qty} each) to ${player.name}.` }
               })} />
           ) : def.custom === 'grant-reward' ? (
             <GrantRewardForm busy={busy} submitLabel={def.label}
@@ -1418,7 +1418,7 @@ function GiveItemForm({ busy, submitLabel, onSubmit, onSubmitTierSet }: {
             onChange={e => setGiveQual(e.target.value)}
             className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50">
             {[0, 1, 2, 3, 4, 5].map(g => (
-              <option key={g} value={g}>{g === 0 ? '0 — Mk1 (default)' : `${g} — Mk${g + 1}`}</option>
+              <option key={g} value={g}>{g === 0 ? 'Grade 1 (default)' : `Grade ${g + 1}`}</option>
             ))}
           </select>
         </div>
@@ -1430,9 +1430,9 @@ function GiveItemForm({ busy, submitLabel, onSubmit, onSubmitTierSet }: {
       </button>
       {gradeable && (
         <button className="btn-secondary w-full" disabled={busy || !isValidTemplateId(giveTpl)}
-          title="Gives one of this item at every grade, Mk1 through Mk6"
+          title="Gives one of this item at every grade, Grade 1 through Grade 6"
           onClick={() => onSubmitTierSet(giveTpl.trim(), Number(giveQty) || 1, overflow)}>
-          {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Layers" size={13} />} Give whole tier set (Mk1-Mk6)
+          {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Layers" size={13} />} Give all grades (1-6)
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Player admin -> Inventory -> **Give Item**: the "Tier — Mk1-Mk6 (0-5)" number input is renamed **"Grade"** and is now a dropdown (**Grade 0 (default)** through **Grade 5**). Grade is the item quality bump — separate from Mk, which is the item's main level and comes from the template selected in the item picker.
- **Any Grade above 0 now requires the player to be offline.** The give-item route returns an explicit error ("Changing the Grade requires the player to be offline. Ask the player to log out, then retry.") instead of the previous behavior of writing via SQL with a "must relog" note. Grade 0 online keeps the instant RMQ live path; offline gives keep the SQL path.
- **Give all grades (0-5)** (formerly "Give whole tier set") applies the same offline check up front so an online player can never receive a partial set.

## Testing

- Vitest 93/93, targeted Pester (GiveItemTemplateGuard, GiveItemStats, PlayersWrites) 61/61.
- Installer built at `app/installer/output/DuneServerSetup.exe` for live testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)