### PR TITLE
Add Maggie Malone to Thanks for the Coffee credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- Maggie Malone (@magiemalone) added to the Thanks for the Coffee supporter credits.
+
 ## [12.20.4] - 2026-07-24
 
 ### Changed

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -513,6 +513,10 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <Icon name="Heart" size={14} className="text-ibad shrink-0" />
               <span className="flex-1">elwicki (@elwicki)</span>
             </div>
+            <div className="flex items-center gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted">
+              <Icon name="Heart" size={14} className="text-ibad shrink-0" />
+              <span className="flex-1">Maggie Malone (@magiemalone)</span>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Adds **Maggie Malone (@magiemalone)** to the Thanks for the Coffee supporter dropdown in the menu bar, plus a CHANGELOG [Unreleased] bullet. Ships with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)