### PR TITLE
Release v12.21.0: VM info card, memory-pressure fix, encoding + heading fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.20.4"
+      placeholder: "v12.21.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.21.0] - 2026-07-26
+
 ### Added
 
 - **A read-only "VM info" card on the Database page.** Collapsed by default and purely informational: root-disk usage, swap, the battlegroup's database phase and any unfinished database operations, retained Funcom build images, the game UDP rule count, node conditions, and every map's current memory limit alongside a reference value. No thresholds, no colour-coding, no recommendations — DST cannot know the intent behind a number and does not pretend to. The numbers are there when you want them and silent when you don't.
@@ -25,6 +27,7 @@ here cover everything those tags shipped.
 
 ### Fixed
 
+- **The "Restore Backup" heading was unreadable.** It was coloured from the same accent as its icon, which left dark amber text on the dark card — legible on the green "Take Backup" card and effectively invisible on the destructive one. Both maintenance headings now use the same readable colour; Restore keeps its amber icon and primary button, so the destructive action still reads as destructive.
 - **The "possible VM memory pressure" warning no longer fires on healthy servers.** It was triggered by container restart counts alone, and Funcom's operators restart in lockstep by design (exit 255), so it was close to permanently on — including during a real outage with **94% of RAM free**, where it advised raising RAM that could not have helped. Elevated restarts now only count when corroborated by an actual memory signal (low available memory, an OOM kill, or the node's own MemoryPressure condition), ordinary operator churn is identified as such, and the "raise the VM's RAM" advice is suppressed when memory is plentiful.
 - Maggie Malone (@magiemalone) added to the Thanks for the Coffee supporter credits.
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.20.4'
+$script:DuneToolVersion = '12.21.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.20.4',
+    [string]$Version = '12.21.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.20.4</Version>
+    <Version>12.21.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.20.4"
+#define MyAppVersion "12.21.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/VmMemoryPressure.ps1
+++ b/app/server/lib/VmMemoryPressure.ps1
@@ -67,7 +67,7 @@ $script:DuneSwapModeMemoryValues = @('1Gi', '200Mi', '10Gi')
 # Funcom world-template per-map memory defaults (2026-05 snapshot), ported from
 # scripts/dune-swap-doctor.sh.
 #
-# ⚠ THIS TABLE GOES STALE. Funcom changes these between patches - verified
+# NOTE: THIS TABLE GOES STALE. Funcom changes these between patches - verified
 # 2026-07-26 against a healthy live server whose small story/DLC maps sit BELOW
 # this snapshot (Story_ProcesVerbal 2Gi vs 6Gi here, LostHarvest_ForgottenLab
 # 2Gi vs 5Gi) while Hagga/Deep Desert were deliberately raised ABOVE it. So it

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -1,4 +1,4 @@
-# /api/diagnostics — build a redacted ZIP of logs the user can attach to a
+﻿# /api/diagnostics — build a redacted ZIP of logs the user can attach to a
 # GitHub bug report. Triggered from the React "Help → Create GitHub Issue +
 # Save Logs" menu item and from the CLI `report-issue` command.
 #

--- a/app/server/routes/Maps.ps1
+++ b/app/server/routes/Maps.ps1
@@ -1,4 +1,4 @@
-# Routes for on-demand map control (currently DeepDesert).
+﻿# Routes for on-demand map control (currently DeepDesert).
 
 # Static route — clears drifted partitions so on-demand maps launch again.
 # Registered separately from /api/maps/{key} (it's a POST so there's no

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.20.4"
+$script:ToolVersion = "12.21.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/Database.tsx
+++ b/webui/src/pages/Database.tsx
@@ -532,7 +532,10 @@ function MaintCard(p: MaintCardProps) {
     <div className="card p-5 flex flex-col">
       <div className="flex items-center gap-3 mb-3">
         <Icon name={p.icon} size={22} className={accent} />
-        <h2 className={'text-base font-semibold tracking-tight ' + accent}>{p.title}</h2>
+        {/* Heading is always text-success so both maintenance cards read the
+            same and stay legible on the dark card; the destructive signal for
+            Restore lives on its icon and its primary button, not the title. */}
+        <h2 className="text-base font-semibold tracking-tight text-success">{p.title}</h2>
       </div>
       <p className="text-sm text-text-muted mb-3 flex-1">{p.description}</p>
       <p className="text-xs text-text-dim mb-4">{p.hint}</p>


### PR DESCRIPTION
Release prep for **v12.21.0**. All five version stamps bumped, `CHANGELOG` `[Unreleased]` rolled to `[12.21.0] - 2026-07-26`, and the bug-report template's `tool_version` placeholder bumped.

## What ships

Carries the three commits already on `main` past `v12.20.4`:

- **#583** — DST reports VM facts instead of judging configurations: read-only VM info card on the Database page, the memory-pressure false-positive fix (#577), startup naming a blocking database operation instead of "map pod was never found" (#576), a diagnostics bundle that can finally diagnose database-layer outages (#578), and the Hyper-V credential UX fixes (#574/#575).
- Maggie Malone (@magiemalone) supporter credit, owed since 2026-07-25.
- Docs cleanup (#573).

## Two fixes found while preparing this release

**Restored the UTF-8 BOM on `Diagnostics.ps1` and `Maps.ps1`.** Rewriting those files during #583 stripped it, and both contain em-dashes — PS2EXE decodes a BOM-less file as Windows-1252, so those would have mojibaked at runtime. CI does not catch this: it runs Pester and lint, never the installer build, whose preflight is the only thing that checks encoding. That preflight is what caught it here, exactly as intended. Also removed a non-ASCII character I'd introduced into `VmMemoryPressure.ps1`, keeping that file ASCII-clean as it was before.

**Fixed the unreadable "Restore Backup" heading.** It took its colour from the same accent as its icon, which left dark amber text on the dark card — legible on the green "Take Backup" card and effectively invisible on the destructive one, which is why it survived until someone looked at it. Both maintenance headings now share one readable colour; Restore keeps its amber icon and primary button so the destructive action still reads as destructive.

## Verification

Verified against a **live server**, not just fixtures:

- Probe v2 executed end-to-end over SSH — 89 lines, every new section populated (node conditions, disk, database operations, per-map limits, retained images, UDP rules).
- That real output through the parser: **0 faults, 0 warnings, no pressure** on a healthy box. It also confirmed a design decision — the server had 4 game pods but only 2 UDP rules, so a count-based rule would have false-positived; faulting only on *zero* is correct.
- `/api/diagnostics/vm-health` handler exercised live and its JSON field-matched against the `VmHealth` TypeScript interface (exact parity).
- All icon names resolved against `lucide-react`.
- Installer built and `ProductVersion` verified as **12.21.0** before tagging — the standing guard from the stale-asset incident.
- Pester **524/524**, Vitest **95/95**, webui build, lint, installer preflights.

## Not verified

The VM info card has not been visually confirmed in a running install yet — its data contract and icons are proven, but not the rendering.