### PR TITLE
Prepare v12.21.2 security release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v12.21.1"
+      placeholder: "v12.21.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [12.21.2] - 2026-07-27
+
+### Security
+
+- **Resolved every Trivy dependency finding in tracked source and bundled .NET runtime manifests.** Mobile, website, and web UI dependencies now use patched releases; affected React Router packages were replaced with a tested Wouter compatibility layer; self-contained desktop executables pin patched .NET runtimes; and a permanent pull-request, main-branch, and weekly Trivy gate now fails on any known vulnerability across production and development dependencies.
+
 ## [12.21.1] - 2026-07-26
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '12.21.1'
+$script:DuneToolVersion = '12.21.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '12.21.1',
+    [string]$Version = '12.21.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>12.21.1</Version>
+    <Version>12.21.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "12.21.1"
+#define MyAppVersion "12.21.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "12.21.1"
+$script:ToolVersion = "12.21.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Summary
- stamp v12.21.2 across all five version sources
- document complete Trivy remediation
- refresh bug-report version placeholder

## Validation
- full v12.21.2 installer build succeeded
- version-stamp, UTF-8 BOM, and PowerShell 5.1 parse preflights passed
- staged secret scan found no leaks