### PR TITLE
Add sun exposure toggle and restore fuel burning to Experimental

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.0.0"
+      placeholder: "v13.0.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ here cover everything those tags shipped.
 ### Added
 
 - **Sun exposure toggle.** Game Config → Hydration gains **Sun Exposure Enabled**, which turns off the sun-exposure water drain when set to 0. Unlike the surrounding hydration settings it is a server-side console variable, so it applies on the server alone and needs no client-side apply. Reported working by a community tester.
+- **Fuel Burning Duration returns to Experimental.** This control was withdrawn in prerelease testing after showing no effect, and is restored for another round of field testing — it remains unconfirmed. A scan of the shipped server binary found no enable-gate for it, but did show that each burning fuel entry stores its own duration when it ignites, which suggests the multiplier applies at ignition rather than continuously. Fuel already burning in a generator would therefore be unaffected, so the control now tells testers to insert fresh fuel after restarting.
 
 ## [13.0.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.0.1] - 2026-07-30
+
+### Added
+
+- **Sun exposure toggle.** Game Config → Hydration gains **Sun Exposure Enabled**, which turns off the sun-exposure water drain when set to 0. Unlike the surrounding hydration settings it is a server-side console variable, so it applies on the server alone and needs no client-side apply. Reported working by a community tester.
+
 ## [13.0.0] - 2026-07-30
 
 ### Added
@@ -7295,7 +7301,8 @@ at the time. Also folds in the v3.0.1 / v3.1.2 patches.
   (`ssh`, `Gameplay Admin`, `setup-guide`, `report-issue`). _(originally
   3.1.2)_
 
-[Unreleased]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.0.0...HEAD
+[Unreleased]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.0.1...HEAD
+[13.0.1]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.0.0...v13.0.1
 [13.0.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v12.16.6...v13.0.0
 [6.1.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v6.0.1...v6.1.2
 [6.0.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v5.0.2...v6.0.1

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.0.0'
+$script:DuneToolVersion = '13.0.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.0.0',
+    [string]$Version = '13.0.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.0.0</Version>
+    <Version>13.0.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.0.0"
+#define MyAppVersion "13.0.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -108,7 +108,6 @@ $script:DuneGameConfigDeprecatedManagedKeys = @(
     'm_GlobalFameMultiplier'
     'm_GlobalHarvestAmountMultiplier'
     'm_GlobalHarvestHealthMultiplier'
-    'dw.FuelBurningMultiplier'
     'dw.VehicleHeatMultiplier'
     'dw.VehicleHeatInterpolationSpeed'
     'dw.VehiclePowerConsumptionMultiplier'
@@ -249,6 +248,16 @@ $script:DuneGameConfigSchema = @(
     # Hazard.DehydrationZonesEnabled is intentionally excluded because its
     # compiled Funcom help explicitly warns that enabling it crashes clients.
     @{ Section=$script:DuneGcSecConsole; Key='Dune.GiveDoubleDifficultyLoot'; File='engine'; Type='bool01'; Default='0'; Label='Double Difficulty Loot'; Help='Give double loot when encounter difficulty is above 0. Field-confirmed with dungeon loot; still experimental.'; Category='Experimental' }
+    # Removed in v12.21.3-experimental3 as ineffective, restored here for another
+    # round of field testing at the maintainer's request. A binary scan of the
+    # 1.4.10.4 server found no enable-gate CVar for this (unlike SafeZone.Scale,
+    # which is gated by SafeZone.EnableScale), but it did find BurningInitialTime
+    # and BurningFuelEntryStateData - each burning fuel entry stores its own
+    # duration as state at ignition. That suggests the multiplier applies when
+    # fuel STARTS burning rather than continuously, which would make an
+    # already-running generator show no change and could explain the earlier
+    # null result. Unverified.
+    @{ Section=$script:DuneGcSecConsole; Key='dw.FuelBurningMultiplier'; File='engine'; Type='float'; Default='1.0'; Label='Fuel Burning Duration'; Help='Scales how long all fuel burns. Larger values should make fuel last longer. An earlier round of field testing found no effect and this control was withdrawn; it is back under test. When testing, insert FRESH fuel after the restart - burn duration appears to be fixed when a fuel entry starts burning, so fuel already in a generator will not change.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='Abilities.RespecCooldownTotalDurationSeconds'; File='engine'; Type='int'; Min=0; Unit='sec'; Default='172800'; Label='Ability Respec Cooldown'; Help='Total ability-respec cooldown in seconds. Compiled default is 172800 (2 days); 0 may remove the cooldown but has not been field-verified.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='dw.LandsraadMissionRewardMultiplierFactionXP'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Landsraad Faction XP'; Help='Scales Faction XP from Landsraad missions. Field-confirmed at 10; mission preview may still show the base reward.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='dw.LandsraadMissionRewardMultiplierHouseCredit'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Landsraad House Credit'; Help='Scales House Credit from Landsraad missions. Field-confirmed at 10; mission preview may still show the base reward.'; Category='Experimental' }

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -140,6 +140,11 @@ $script:DuneGameConfigSchema = @(
 
     # --- Hydration ---
     @{ Section=$script:DuneGcSecHydration; Key='m_bHydrationEnabled'; File='game'; Type='bool'; Default='True'; Label='Hydration Enabled'; Help='Master toggle for the hydration / thirst system. Off = players never get thirsty. Also needs client-side apply.'; ClientApply=$true; Category='Hydration' }
+    # Server-side console variable rather than a game INI key, so it applies on
+    # the server alone and needs no client-side apply. Reported working by a
+    # community tester; the compiled default was not recovered, but sun exposure
+    # is active in shipping gameplay.
+    @{ Section=$script:DuneGcSecConsole; Key='Hydration.SunExposureEnabled'; File='engine'; Type='bool01'; Default='1'; Label='Sun Exposure Enabled'; Help='Whether players take sun-exposure water drain. 0 disables sun exposure; field-reported working. Server-side only - no client apply needed.'; Category='Hydration' }
     @{ Section=$script:DuneGcSecHydration; Key='m_BiomeTierUpdateRateSeconds'; File='game'; Type='float'; Min=0; Unit='sec'; Default='2.5'; Label='Biome Tier Update Rate'; Help='How often (seconds) the biome hydration tier is re-evaluated. Also needs client-side apply.'; ClientApply=$true; Category='Hydration' }
 
     # --- Loot & Death (DuneSandboxGameModeBase) ---

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.0.0"
+$script:ToolVersion = "13.0.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -312,6 +312,7 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
     BeforeAll {
         $script:ExperimentalKeys = @(
             'Dune.GiveDoubleDifficultyLoot'
+            'dw.FuelBurningMultiplier'
             'Abilities.RespecCooldownTotalDurationSeconds'
             'dw.LandsraadMissionRewardMultiplierFactionXP'
             'dw.LandsraadMissionRewardMultiplierHouseCredit'
@@ -346,12 +347,12 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         )
     }
 
-    It 'isolates all 32 testable binary-discovered controls in the Experimental category' {
+    It 'isolates all 33 testable binary-discovered controls in the Experimental category' {
         $fields = @{}
         foreach ($f in $script:DuneGameConfigSchema) { $fields[$f.Key] = $f }
         $experimental = @($script:DuneGameConfigSchema | Where-Object Category -eq 'Experimental')
 
-        $experimental.Count | Should -Be 32
+        $experimental.Count | Should -Be 33
         @($experimental.Key | Sort-Object) | Should -Be @($script:ExperimentalKeys | Sort-Object)
         foreach ($key in $script:ExperimentalKeys) {
             $fields.ContainsKey($key) | Should -BeTrue
@@ -367,12 +368,14 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
     }
 
     It 'excludes vehicle controls proven ineffective in prerelease testing' {
+        # dw.FuelBurningMultiplier was withdrawn alongside these but has been
+        # restored for another round of field testing, so it is deliberately
+        # absent from this list and from the deprecated-scrub list.
         $removed = @(
             'dw.VehicleHeatMultiplier'
             'dw.VehicleHeatInterpolationSpeed'
             'dw.VehiclePowerConsumptionMultiplier'
             'dw.VehicleCanOverHeat'
-            'dw.FuelBurningMultiplier'
             'Vehicle.MaxActiveVehicles'
             'Vehicle.MaxVehicles'
             'Vehicle.MaxVehiclesForSpawner'
@@ -381,6 +384,19 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         )
 
         foreach ($key in $removed) {
+            @($script:DuneGameConfigSchema.Key) | Should -Not -Contain $key
+        }
+    }
+
+    It 'keeps fuel burning available and out of the deprecated-scrub list' {
+        # A schema key that is also in the deprecated list would be written and
+        # then scrubbed on the same save, so the setting could never persist.
+        @($script:DuneGameConfigSchema.Key) | Should -Contain 'dw.FuelBurningMultiplier'
+        @($script:DuneGameConfigDeprecatedManagedKeys) | Should -Not -Contain 'dw.FuelBurningMultiplier'
+    }
+
+    It 'never lists a live schema key in the deprecated-scrub list' {
+        foreach ($key in @($script:DuneGameConfigDeprecatedManagedKeys)) {
             @($script:DuneGameConfigSchema.Key) | Should -Not -Contain $key
         }
     }
@@ -411,7 +427,6 @@ $script:DstManagedEnd
         ) -QuotedKeys @{}
 
         foreach ($key in @(
-            'dw.FuelBurningMultiplier',
             'dw.VehicleHeatMultiplier',
             'dw.VehicleHeatInterpolationSpeed',
             'dw.VehiclePowerConsumptionMultiplier',


### PR DESCRIPTION
Two Game Config additions for the 13.0.1 patch.

## Sun Exposure Enabled

Adds **Sun Exposure Enabled** to Game Config → Hydration, sitting directly between *Hydration Enabled* and *Biome Tier Update Rate*. Setting it to `0` turns off the sun-exposure water drain.

Unlike the two hydration settings either side of it, this is a **server-side console variable** (`Hydration.SunExposureEnabled` in `UserEngine.ini [ConsoleVariables]`) rather than a game INI key — so it applies on the server alone and needs **no client-side apply**. The help text says so, to save operators looking for a client step that doesn't exist.

Reported working by a community tester who confirmed `Hydration.SunExposureEnabled=0` disables sun exposure in-game. The compiled default couldn't be recovered from the server binary, so the schema default is `1` on the basis that sun exposure is demonstrably active in shipping gameplay — reasoning recorded in a comment rather than presented as a recovered value.

## Fuel Burning Duration restored to Experimental

`dw.FuelBurningMultiplier` was withdrawn in `v12.21.3-experimental3` after field testing showed no effect. It returns to the Experimental category for another round of testing at a community tester's request. **It remains unconfirmed** and is labelled as such.

### The bug this surfaced

The key was still in the deprecated-scrub list. Left there, the managed-block writer would have scrubbed it on every save — so the setting would have been written and immediately wiped, and would never have persisted. Removed, plus a new test that fails if **any** live schema key appears in that list.

### Why it may have looked ineffective

A scan of the shipped 1.4.10.4 server binary found **no enable-gate console variable** for fuel burning (unlike `SafeZone.Scale`, which is gated by `SafeZone.EnableScale`). Every enable-style CVar in the build is for sandstorms, sandworms, shelter, SafeZone scale or dehydration zones.

It did find `BurningInitialTime` and `BurningFuelEntryStateData`, indicating each burning fuel entry stores its own duration at ignition. That suggests the multiplier applies when fuel **starts** burning rather than continuously — an already-running generator would show no change regardless of the setting, which would produce exactly the null result observed.

That's inference from symbol names, not proof. The control's help text now tells testers to insert **fresh** fuel after restarting.

## Validation

- 58 GameConfig Pester tests pass (56 existing + 2 new guards)
- Production web build clean
- Installer built with full version-parity, BOM and PS 5.1 preflights
- Sun exposure installed and confirmed working in-game; fuel burning deliberately ships unconfirmed
- gitleaks clean

## Version

All five stamps at `13.0.1`; `bug_report.yml` placeholder bumped and CHANGELOG rolled.