### PR TITLE
Use the shared battlegroup restart and fix the client-apply removal count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ here cover everything those tags shipped.
 
 - **Experimental Game Config no longer requires an acknowledgement.** The card kept its warning about these being server-only test settings, but the tick-box that gated editing has been removed — the controls are editable as soon as the card is expanded.
 - **Every server `Game.ini` setting can now be applied client-side.** Seventeen settings across Storm Cycle, Building, Guilds & Economy, PvP & Security, Taxation and Sandworm were written to the server's `Game.ini` — which the client also reads — but were not offered for client-side apply, while their neighbours in the same sections were. All game-file settings now carry the flag; console variables in `UserEngine.ini` remain server-only, as they should. Defaults are still never written to a player's `Game.ini`: a value equal to its default is stripped from the file, so only settings actually changed from default are handed out.
+- **Apply INIs now restarts the battlegroup.** The button previously rolled the game-server pods one at a time to keep other maps up. It reported success as soon as each container passed its readiness probe, while the game server was still loading the world — so it claimed the maps were back when they were not. Waiting for each map to genuinely report ready showed the real cost: roughly two minutes per map, sequentially. A battlegroup restart reloads every map in parallel and is simply faster, and the availability it was trading for never existed — restarting the Overmap disconnects players regardless of which map they are on. Both this button and the Landsraad card now run the same `restart` command as the Commands screen, so every path behaves identically and clears the stale bot run-flags a restart requires.
+
+### Fixed
+
+- **Client apply no longer reports keys it did not remove.** Every deprecated key was queued for removal on every save, whether or not the file contained it, and the result counted the queue. Saving a single setting could report "removed 18 keys" against a file that held none of them. The cleanup now reads the file first and only removes keys actually present, so the count reflects what changed.
 
 ## [13.0.0] - 2026-07-30
 

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -564,13 +564,6 @@ function Save-DuneGameConfigClient {
     }
     if ($clean.Count -eq 0) { throw 'No client-applicable keys in the supplied updates.' }
 
-    # Also scrub the deprecated no-op multiplier keys from the client file so a
-    # user's local Game.ini doesn't keep orphaned values DST no longer manages.
-    # (Same server-wins / keep-it-clean intent as the server managed block.)
-    foreach ($dk in $script:DuneGameConfigDeprecatedManagedKeys) {
-        $clean.Add(@{ section = $script:DuneGcSecGame; key = $dk; value = ''; remove = $true })
-    }
-
     $dirResolved = Resolve-DuneGameConfigClientDir -Dir $Dir
     if (-not (Test-Path -LiteralPath $dirResolved)) { throw "Client config folder not found: $dirResolved" }
     $path = Get-DuneGameConfigClientFilePath -Dir $Dir
@@ -580,6 +573,20 @@ function Save-DuneGameConfigClient {
     if (Test-Path -LiteralPath $path -PathType Leaf) {
         $existing = [IO.File]::ReadAllText($path)
         $created  = $false
+    }
+
+    # Also scrub the deprecated no-op multiplier keys from the client file so a
+    # user's local Game.ini doesn't keep orphaned values DST no longer manages.
+    # (Same server-wins / keep-it-clean intent as the server managed block.)
+    #
+    # Only queue the ones actually PRESENT in the file. Queueing all of them
+    # unconditionally made the result count every deprecated key as "removed",
+    # so saving a single setting reported "removed 18 keys" when the user's file
+    # contained none of them - alarming, and untrue.
+    foreach ($dk in $script:DuneGameConfigDeprecatedManagedKeys) {
+        if ($existing -match ('(?m)^\s*' + [regex]::Escape($dk) + '\s*=')) {
+            $clean.Add(@{ section = $script:DuneGcSecGame; key = $dk; value = ''; remove = $true })
+        }
     }
 
     $quoted = Get-DuneGameConfigQuotedKeys

--- a/app/server/lib/Landsraad.ps1
+++ b/app/server/lib/Landsraad.ps1
@@ -666,16 +666,11 @@ WHERE term_id = $($term.term_id)::bigint;
     }
 }
 
-# Clean battlegroup restart, detached so the HTTP request returns promptly; the
-# UI polls Server Health while it converges (~2-3 min). Mirrors the Sietches
-# config flow, which uses the same appliance command.
+# Clean battlegroup restart so the game re-reads the Landsraad term. Delegates to
+# the shared helper in lib/Maps.ps1, which runs the same 'restart' command as the
+# Commands screen, so Game Config's "Apply INIs & restart" and this card behave
+# identically.
 function Invoke-DuneLandsraadBgRestart {
-    param([Parameter(Mandatory)][string]$Ip)
-    $cmd = 'nohup /home/dune/.dune/bin/battlegroup restart >/tmp/dst-landsraad-restart.log 2>&1 & echo started'
-    $out = ((Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec 30) -join ' ').Trim()
-    return @{
-        ok      = $true
-        started = $out
-        message = 'Clean battlegroup restart underway - watch Server Health; it takes a couple of minutes to come back.'
-    }
+    param([string]$Ip)
+    return Invoke-DuneBattlegroupRestart -Ip $Ip
 }

--- a/app/server/lib/Maps.ps1
+++ b/app/server/lib/Maps.ps1
@@ -695,12 +695,45 @@ function Test-DuneGameServerPodName {
     return [bool]("$Name" -match $script:DuneGameServerPodNameRegex)
 }
 
+# Clean battlegroup restart. Delegates to the SAME command the Commands screen
+# runs ('restart') rather than issuing its own SSH, so every caller gets the
+# identical, already-proven path - including the stale bot run-flag clear that a
+# battlegroup restart requires. Returns immediately; the launched command runs
+# detached and the UI polls Server Health while it converges (~2-3 min).
+#
+# Shared by Game Config's "Apply INIs & restart" and the Landsraad control card.
+function Invoke-DuneBattlegroupRestart {
+    param([string]$Ip)
+
+    # Restarting the BG cycles game state, so an in-flight seed or list-tick from
+    # a prior run is moot; leaving the flag set would block fresh runs afterwards.
+    if (Get-Command Clear-DuneBotStaleRunFlags -ErrorAction SilentlyContinue) {
+        try { Clear-DuneBotStaleRunFlags } catch {}
+    }
+
+    $result = Invoke-DuneCommandExternal -Name 'restart'
+    return @{
+        ok      = $true
+        result  = $result
+        message = 'Battlegroup restart launched - watch Server Health; it takes a couple of minutes to come back.'
+    }
+}
+
 function Restart-DuneGameServerPodsRolling {
     param([Parameter(Mandatory)][string]$Ip)
 
     # One remote script performs an all-pods health preflight before deleting
     # anything, then restarts game pods sequentially. The next pod is not touched
-    # until the operator has recreated the prior pod and Kubernetes reports Ready.
+    # until the prior map is genuinely back.
+    #
+    # "Back" means the BATTLEGROUP CR reports that map ready, not just that the
+    # pod passed its Kubernetes readiness probe. The pod goes Running/Ready as
+    # soon as the container is up, but the game server then loads the world and
+    # only later moves Startup -> Running with ready=true in the CR. Gating on
+    # the pod condition alone reported success while both maps were still in
+    # Startup, and let the next pod be deleted while the previous map was still
+    # loading - which defeats the point of rolling one at a time and puts two
+    # concurrent world loads on the host at once.
     $bash = @'
     set -u
     KUBE="sudo kubectl"
@@ -718,8 +751,20 @@ function Restart-DuneGameServerPodsRolling {
       printf '%s\n' "$BAD"
       exit 0
     fi
+    # Map slug carried by the pod name, e.g. ...-sg-survival-1-pod-1 -> survival-1.
+    # The CR's partitionMap for that map is Survival_1, so compare lowercased
+    # with underscores folded to hyphens.
+    map_ready() {
+      _ns="$1"; _slug="$2"
+      $KUBE -n "$_ns" get battlegroups -o jsonpath='{range .items[*].status.servers[*]}{.partitionMap}{"|"}{.ready}{"\n"}{end}' 2>/dev/null |
+        awk -F'|' -v want="$_slug" '
+          { m = tolower($1); gsub(/_/, "-", m); if (m == want && $2 == "true") { found = 1 } }
+          END { exit found ? 0 : 1 }
+        '
+    }
     printf '%s\n' "$TARGETS" | while IFS='|' read -r ns pod phase deleting ready; do
       [ -n "$ns" ] && [ -n "$pod" ] || continue
+      SLUG=$(printf '%s' "$pod" | sed -n 's/.*-sg-\(.*\)-pod-[0-9][0-9]*$/\1/p')
       echo "===RESTARTING===$ns|$pod"
       if ! $KUBE -n "$ns" delete pod "$pod" --wait=true --timeout=90s 2>&1; then
         echo "===FAILED===$ns|$pod|delete"
@@ -738,6 +783,24 @@ function Restart-DuneGameServerPodsRolling {
       if [ "$REPLACEMENT_READY" != "true" ]; then
         echo "===FAILED===$ns|$pod|ready-timeout"
         exit 22
+      fi
+      # Container is up; now wait for the game server to finish loading the world
+      # and for the battlegroup to report this map ready. Loading a large map can
+      # take minutes, so this gets its own, longer deadline.
+      if [ -n "$SLUG" ]; then
+        MAP_DEADLINE=$((SECONDS + 900))
+        MAP_READY=false
+        while [ "$SECONDS" -lt "$MAP_DEADLINE" ]; do
+          if map_ready "$ns" "$SLUG"; then
+            MAP_READY=true
+            break
+          fi
+          sleep 5
+        done
+        if [ "$MAP_READY" != "true" ]; then
+          echo "===FAILED===$ns|$pod|map-ready-timeout"
+          exit 23
+        fi
       fi
       echo "===READY===$ns|$pod"
     done
@@ -775,7 +838,7 @@ function Restart-DuneGameServerPodsRolling {
     if ($raw -match '===FAILED===([^|]+)\|([^|]+)\|([^\r\n]+)') {
         return @{
             ok=$false; status=502; found=$count; restarted=$ready.Count; pods=$ready; raw=$raw
-            message="Rolling reload stopped at $($Matches[1])/$($Matches[2]) during $($Matches[3]). Already-restarted pods are Ready."
+            message="Rolling reload stopped at $($Matches[1])/$($Matches[2]) during $($Matches[3]). Already-restarted pods finished loading."
         }
     }
     if ($raw -notmatch '===COMPLETE===(\d+)' -or $ready.Count -ne $count) {
@@ -786,6 +849,6 @@ function Restart-DuneGameServerPodsRolling {
     }
     return @{
         ok=$true; found=$count; restarted=$ready.Count; pods=$ready; raw=$raw
-        message="Reloaded $($ready.Count) game-server pod(s) one at a time. Every replacement reached Ready."
+        message="Reloaded $($ready.Count) game-server pod(s) one at a time. Every map finished loading and reported ready."
     }
 }

--- a/app/server/routes/GameConfig.ps1
+++ b/app/server/routes/GameConfig.ps1
@@ -198,9 +198,16 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig' -Handler {
 }
 
 # -----------------------------------------------------------------------------
-# POST /api/gameconfig/reload-pods — apply startup-read INI changes without a
-# full battlegroup restart. Restarts only operator-owned game-server pods,
-# sequentially, waiting for each replacement to become Ready.
+# POST /api/gameconfig/reload-pods — apply startup-read INI changes by doing a
+# clean battlegroup restart.
+#
+# This used to roll the game-server pods one at a time to keep the other maps up.
+# That looked faster than it was: it returned as soon as each container passed
+# its Kubernetes readiness probe, while the game server was still loading the
+# world. Waiting for the maps to genuinely report ready made the honest cost
+# visible - roughly two minutes per map, sequentially - which is slower than a
+# battlegroup restart that reloads every map in parallel. The rolling path is
+# retained in lib/Maps.ps1 for callers that need per-map restarts.
 # -----------------------------------------------------------------------------
 Register-DuneRoute -Method POST -Path '/api/gameconfig/reload-pods' -Handler {
     param($req, $res, $routeParams, $body)
@@ -211,14 +218,17 @@ Register-DuneRoute -Method POST -Path '/api/gameconfig/reload-pods' -Handler {
     }
     if (-not (Test-DunePlayerGuard -Req $req -Res $res -Ip $ctx.ip)) { return }
     try {
-        $r = Restart-DuneGameServerPodsRolling -Ip $ctx.ip
+        $r = Invoke-DuneBattlegroupRestart -Ip $ctx.ip
         if (-not $r.ok) {
-            Write-DuneError -Response $res -Status ([int]$r.status) -Message $r.message
+            Write-DuneError -Response $res -Status 502 -Message $r.message
             return
         }
-        Write-DuneJson -Response $res -Body $r
+        Write-DuneJson -Response $res -Body @{
+            ok      = $true
+            message = 'Battlegroup restart underway - every map reloads together. Watch Server Health; it takes a couple of minutes to come back.'
+        }
     } catch {
-        Write-DuneError -Response $res -Status 502 -Message "Game-server pod reload failed: $($_.Exception.Message)"
+        Write-DuneError -Response $res -Status 502 -Message "Battlegroup restart failed: $($_.Exception.Message)"
     }
 }
 

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -657,6 +657,19 @@ Describe 'GameConfig: client-apply flag covers every game-file setting' -Tag 'Ga
         Test-DuneGameConfigValueIsDefault -Key 'm_WaterConsumptionRate' -Value '1.0' | Should -BeTrue
         Test-DuneGameConfigValueIsDefault -Key 'm_WaterConsumptionRate' -Value '2.0' | Should -BeFalse
     }
+
+    It 'only queues a deprecated key for removal when the file actually contains it' {
+        # Regression: every deprecated key used to be queued unconditionally, so
+        # saving one setting reported "removed 18 keys" against a file that held
+        # none of them. The scrub must be driven by the file's real contents.
+        $src = (Get-Command Save-DuneGameConfigClient).ScriptBlock.ToString()
+        $deprecatedLoop = [regex]::Match(
+            $src,
+            '(?s)foreach \(\$dk in \$script:DuneGameConfigDeprecatedManagedKeys\).*?\n\s*\}'
+        ).Value
+        $deprecatedLoop | Should -Not -BeNullOrEmpty
+        $deprecatedLoop | Should -Match '\$existing -match'
+    }
 }
 
 Describe 'GameConfig: reset-to-default removes the key from the INI' -Tag 'GameConfig' {

--- a/tests/Maps.Tests.ps1
+++ b/tests/Maps.Tests.ps1
@@ -28,6 +28,49 @@ Describe 'Rolling INI game-pod reload safety' {
     }
 }
 
+Describe 'Rolling INI reload waits for the map, not just the pod' {
+
+    # The pod goes Running/Ready as soon as the container starts, but the game
+    # server then loads the world and only later reports ready in the battlegroup
+    # CR. Gating on the pod condition alone claimed success while both maps were
+    # still in Startup, and let the next pod be deleted mid-load. These lock the
+    # remote script's shape so that regression can't return silently.
+
+    BeforeAll {
+        $script:rollingScript = (Get-Command Restart-DuneGameServerPodsRolling).ScriptBlock.ToString()
+    }
+
+    It 'queries the battlegroup CR readiness, not only the pod condition' {
+        $script:rollingScript | Should -Match 'get battlegroups'
+        $script:rollingScript | Should -Match 'partitionMap'
+    }
+
+    It 'derives the map slug from the pod name' {
+        # ...-sg-survival-1-pod-1 -> survival-1
+        $script:rollingScript | Should -Match '\-sg\-'
+        $script:rollingScript | Should -Match 'SLUG'
+    }
+
+    It 'folds underscores so Survival_1 matches the survival-1 pod slug' {
+        $script:rollingScript | Should -Match 'gsub\(/_/'
+    }
+
+    It 'fails the roll when a map never reports ready' {
+        $script:rollingScript | Should -Match 'map-ready-timeout'
+    }
+
+    It 'gives world loading a longer deadline than container startup' {
+        $script:rollingScript | Should -Match 'MAP_DEADLINE'
+    }
+
+    It 'no longer claims readiness on the pod condition alone' {
+        # The success message must not promise more than was verified.
+        $libText = Get-Content (Join-Path $PSScriptRoot '..\app\server\lib\Maps.ps1') -Raw
+        $libText | Should -Not -Match 'Every replacement reached Ready'
+        $libText | Should -Match 'Every map finished loading and reported ready'
+    }
+}
+
 Describe 'Director-driven map status' {
     BeforeAll {
         $script:bg = [pscustomobject]@{ status=[pscustomobject]@{ servers=@(

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -857,7 +857,7 @@ export function GameConfig() {
                 : 'Restart only running game-server pods, one at a time, and wait for each replacement to become Ready'}
             >
               <Icon name={reloadingPods ? 'Loader2' : 'RefreshCw'} size={14} className={reloadingPods ? 'animate-spin' : ''} />
-              {reloadingPods ? 'Applying to pods…' : 'Apply INIs to pods'}
+              {reloadingPods ? 'Restarting battlegroup…' : 'Apply INIs & restart'}
             </button>
             <button
               type="button"
@@ -904,7 +904,7 @@ export function GameConfig() {
             you have a restore point — backups are saved on the server next to each file and can be restored via the File Browser.
           </p>
           <p className="text-xs text-warning/90 leading-relaxed mt-1.5">
-            Some settings are read only when a game pod starts. Use “Apply INIs to pods” after saving to reload game pods sequentially without restarting the database or full battlegroup.
+            Some settings are read only when a game pod starts. Use “Apply INIs &amp; restart” after saving to do a clean battlegroup restart so every map reloads with the new values.
           </p>
           <button
             type="button"
@@ -1673,7 +1673,7 @@ function CategoryCard({
                 These server CVars are written only to the battlegroup&apos;s <span className="font-mono text-text">UserEngine.ini</span> under <span className="font-mono text-text">[ConsoleVariables]</span>. They are not copied to this PC&apos;s local client <span className="font-mono text-text">Game.ini</span>.
               </p>
               <p className="mt-1.5">
-                This catalogue contains 33 testable controls decoded from server build 1.4.10.4. Double Difficulty Loot and the three Landsraad reward multipliers have community field confirmation; vehicle heat, power, overheat, and limit controls proven ineffective were removed. Other controls may have no effect or unintended gameplay consequences. The dehydration-zone control is omitted because Funcom warns that enabling it crashes clients. Back up first, change one setting at a time, then use Apply INIs to pods before testing.
+                This catalogue contains 33 testable controls decoded from server build 1.4.10.4. Double Difficulty Loot and the three Landsraad reward multipliers have community field confirmation; vehicle heat, power, overheat, and limit controls proven ineffective were removed. Other controls may have no effect or unintended gameplay consequences. The dehydration-zone control is omitted because Funcom warns that enabling it crashes clients. Back up first, change one setting at a time, then use Apply INIs &amp; restart before testing.
               </p>
             </div>
           )}


### PR DESCRIPTION
Two fixes surfaced by field testing.

## Apply INIs now restarts the battlegroup

The button rolled the game-server pods one at a time to keep other maps up. It reported success as soon as each container passed its **Kubernetes** readiness probe — but the game server then loads the world and only later reports ready in the battlegroup CR. So DST said *"every replacement reached Ready"* while both maps were still in `Startup`, and it deleted the next pod while the previous map was still loading.

Gating on the CR's per-map ready flag made the honest cost visible: **~2 minutes per map, sequentially**. A battlegroup restart reloads every map in parallel and finishes sooner.

And the availability it was trading that time for **never existed** — restarting the Overmap disconnects players regardless of which map they're standing on, confirmed in the field. So the old path cost double the time and kicked the player anyway.

Both **Apply INIs & restart** and the **Landsraad control card** now call the same `restart` command the Commands screen runs, instead of issuing their own SSH. That path also calls `Clear-DuneBotStaleRunFlags`, which a battlegroup restart requires so an in-flight seed or list-tick doesn't block fresh runs afterwards — the bespoke helper silently skipped it.

The rolling reload stays in `lib/Maps.ps1` for `/api/maps/restart-pods`, now correctly waiting on the CR's per-map ready flag with its own longer deadline, and failing the roll if a map never comes back.

## Client apply no longer reports keys it did not remove

Every deprecated key was queued for removal on every save, whether or not the file contained it, and the result counted the queue. Saving one setting reported **"removed 18 keys"** against a file that held none of them — verified against the maintainer's live `Game.ini`: 0 of 17 present.

The cleanup now reads the file first and only queues keys actually there, so the count reflects what changed.

## Validation

- 81 Pester tests pass across the touched suites; full suite green
- New tests lock: the reload waits on the CR rather than the pod condition, the pod-name→`partitionMap` slug fold (`Survival_1` ↔ `survival-1`), failure when a map never reports ready, and that the deprecated scrub is driven by file contents
- Slug matching validated against the live server: `overmap` → ready, `survival-1` → ready, `bogus-map` → not ready
- Production web build clean; installer built with full version-parity, BOM and PS 5.1 preflights
- gitleaks clean