### PR TITLE
Gate Active Spice on live or pinned map partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- **Active Spice now only lists partitions that are live or pinned.** `dune.spicefield_types` keeps a row for every (map, size, instance) combination forever, so a battlegroup that has ever run a second instance of a map keeps those rows permanently. The card grouped only by map, so each size appeared twice with nothing to tell the rows apart — running a second Deep Desert also created duplicate-looking rows for Hagga Basin. Rows are now shown when their instance is currently running or is kept warm by a Map Spin-Up pin, and a map with more than one live instance labels them **Hagga Basin #1**, **#2** and so on. If the battlegroup can't be read, every row is shown rather than hiding real data. Map names also come from the same table the Game Servers list uses, so both read identically.
+
 ## [13.0.1] - 2026-07-30
 
 ### Added

--- a/app/server/lib/Maps.ps1
+++ b/app/server/lib/Maps.ps1
@@ -702,6 +702,104 @@ function Test-DuneGameServerPodName {
 # detached and the UI polls Server Health while it converges (~2-3 min).
 #
 # Shared by Game Config's "Apply INIs & restart" and the Landsraad control card.
+# -----------------------------------------------------------------------------
+# Active map partitions — which (map, dimension) pairs actually matter right now.
+#
+# dune.spicefield_types carries one row per (map, field-size, dimension), so a
+# battlegroup that has ever run two instances of a map keeps rows for both
+# dimensions forever. Displaying them ungated shows every size twice with
+# nothing to tell the rows apart, which reads as duplicate data.
+#
+# A pair is considered active when it is LIVE (present in the battlegroup CR's
+# status.servers) or PINNED (the director keeps it warm via MinServers). Live
+# alone is not enough: on-demand maps like Deep Desert are legitimately down most
+# of the time, and gating on live only would hide them right when an operator
+# wants to tune them. Pinned alone is not enough either: always-on maps such as
+# Survival_1 never appear in director.ini and so can never be pinned.
+#
+# ASSUMPTION: dimensionIndex is the instance index, so MinServers = N pins
+# dimensions 0..N-1. That matches a multi-sietch Hagga producing dimension 1,
+# but it is inferred from observed data rather than documented by Funcom.
+# -----------------------------------------------------------------------------
+
+# Spicefield rows key maps as HaggaBasin / DeepDesert; the battlegroup CR and
+# director.ini use Survival_1 / DeepDesert_1. Normalise onto the CR's ids so one
+# naming scheme drives Game Servers, Map Spin-Up and the spice readout.
+$script:DuneSpiceMapToServerMap = @{
+    'HaggaBasin' = 'Survival_1'
+    'DeepDesert' = 'DeepDesert_1'
+}
+
+function ConvertTo-DuneServerMapId {
+    param([string]$Name)
+    if ([string]::IsNullOrWhiteSpace($Name)) { return '' }
+    if ($script:DuneSpiceMapToServerMap.ContainsKey($Name)) {
+        return $script:DuneSpiceMapToServerMap[$Name]
+    }
+    return $Name
+}
+
+function Get-DuneActiveMapPartitions {
+    # Returns @{ ok; partitions = @( @{ mapId; dimensionIndex; live; pinned } ) }
+    # Best-effort: a failure to read either source degrades to "unknown", and the
+    # caller is expected to show everything rather than hide real data.
+    param([string]$Ip)
+
+    $live = @()
+    $bg = $null
+    try { $bg = (Get-V6Battlegroup -Ip $Ip).Bg } catch {}
+    if ($bg) {
+        $servers = @()
+        try { $servers = @($bg.status.servers) } catch {}
+        foreach ($s in $servers) {
+            if (-not $s) { continue }
+            $mapId = ''
+            if ($s.PSObject.Properties['partitionMap']) { $mapId = [string]$s.partitionMap }
+            if (-not $mapId) { continue }
+            $dim = 0
+            if ($s.PSObject.Properties['dimensionIndex']) { $dim = [int]$s.dimensionIndex }
+            $live += @{ mapId = $mapId; dimensionIndex = $dim }
+        }
+    }
+
+    $pins = @{}
+    try {
+        $spin = Get-DuneSpinUpMaps
+        if ($spin.ok) {
+            foreach ($m in @($spin.maps)) {
+                if ([int]$m.minServers -ge 1) { $pins["$($m.map)"] = [int]$m.minServers }
+            }
+        }
+    } catch {}
+
+    $out = New-Object 'System.Collections.Generic.List[object]'
+    foreach ($l in $live) {
+        $out.Add([ordered]@{
+            mapId          = $l.mapId
+            dimensionIndex = $l.dimensionIndex
+            live           = $true
+            pinned         = $pins.ContainsKey($l.mapId)
+        })
+    }
+    foreach ($mapId in $pins.Keys) {
+        for ($d = 0; $d -lt $pins[$mapId]; $d++) {
+            $already = $out | Where-Object { $_.mapId -eq $mapId -and [int]$_.dimensionIndex -eq $d }
+            if ($already) { continue }
+            $out.Add([ordered]@{
+                mapId          = $mapId
+                dimensionIndex = $d
+                live           = $false
+                pinned         = $true
+            })
+        }
+    }
+
+    return @{
+        ok         = ($null -ne $bg)
+        partitions = $out.ToArray()
+    }
+}
+
 function Invoke-DuneBattlegroupRestart {
     param([string]$Ip)
 

--- a/app/server/routes/GameConfig.ps1
+++ b/app/server/routes/GameConfig.ps1
@@ -506,10 +506,29 @@ Register-DuneRoute -Method GET -Path '/api/gameconfig/spicefields' -Handler {
     }
     try {
         $raw = Get-V6SpicefieldTypes -Ip $ctx.ip
+
+        # Which (map, dimension) pairs are live or pinned. Annotating rather than
+        # filtering here keeps the endpoint honest: the client decides what to
+        # show, and a failure to read the battlegroup degrades to "show all"
+        # instead of silently hiding real spicefield data.
+        $active = @{}
+        $gateOk = $false
+        try {
+            $ap = Get-DuneActiveMapPartitions -Ip $ctx.ip
+            $gateOk = [bool]$ap.ok
+            foreach ($p in @($ap.partitions)) {
+                $active["$($p.mapId)|$([int]$p.dimensionIndex)"] = $p
+            }
+        } catch {}
+
         $rows = @($raw | ForEach-Object {
+            $mapId = ConvertTo-DuneServerMapId -Name "$($_.map_name)"
+            $key   = "$mapId|$([int]$_.dimension_index)"
+            $hit   = $active[$key]
             @{
                 spicefieldTypeId = [int]$_.spicefield_type_id
                 mapName          = "$($_.map_name)"
+                mapId            = $mapId
                 fieldType        = "$($_.field_type)"
                 dimensionIndex   = [int]$_.dimension_index
                 maxActive        = [int]$_.max_globally_active
@@ -518,9 +537,12 @@ Register-DuneRoute -Method GET -Path '/api/gameconfig/spicefields' -Handler {
                 currentPrimed    = [int]$_.current_globally_primed
                 isSpawningActive = [bool]$_.is_spawning_active
                 spawnWeight      = [double]$_.global_spawn_weight
+                partitionLive    = [bool]($hit -and $hit.live)
+                partitionPinned  = [bool]($hit -and $hit.pinned)
+                partitionActive  = [bool]($null -ne $hit)
             }
         })
-        Write-DuneJson -Response $res -Body @{ available = $true; rows = $rows }
+        Write-DuneJson -Response $res -Body @{ available = $true; rows = $rows; partitionGate = $gateOk }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Spicefield types load failed: $($_.Exception.Message)"
     }

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -399,20 +399,30 @@ export type GameConfigBackupListResponse = {
 
 export type SpicefieldType = {
   spicefieldTypeId: number
-  mapName: string         // e.g. "HaggaBasin", "DeepDesert"
+  mapName: string         // raw DB name, e.g. "HaggaBasin", "DeepDesert"
+  mapId?: string          // normalised to the battlegroup's id, e.g. "Survival_1"
   fieldType: string       // e.g. "Small", "Medium", "Large"
-  dimensionIndex: number
+  dimensionIndex: number  // instance index — a map can have more than one
   maxActive: number
   maxPrimed: number
   currentActive: number   // read-only — maintained by the game
   currentPrimed: number   // read-only — maintained by the game
   isSpawningActive: boolean
   spawnWeight: number     // float
+  // Whether this (map, dimension) is currently running or kept warm by a pin.
+  // Rows survive in the DB long after an instance stops existing, so these
+  // drive what the dashboard shows.
+  partitionLive?: boolean
+  partitionPinned?: boolean
+  partitionActive?: boolean
 }
 
 export type SpicefieldsResponse = {
   available: boolean
   rows: SpicefieldType[]
+  // False when the battlegroup could not be read, in which case callers should
+  // show every row rather than hide real data on a transient failure.
+  partitionGate?: boolean
 }
 
 export type SpicefieldSaveResponse = {

--- a/webui/src/pages/dashboard/BgSpiceSummary.tsx
+++ b/webui/src/pages/dashboard/BgSpiceSummary.tsx
@@ -11,6 +11,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getSpicefields, setSpicefieldSpawning } from '../../api/gameconfig'
 import type { SpicefieldType } from '../../api/types'
+import { mapLabel } from '../../util/mapLabel'
 
 type Props = {
   enabled: boolean   // gate on BG ready
@@ -32,14 +33,10 @@ const SIZE_CLASS: Record<string, string> = {
 }
 
 // Map labels mirror the colors from the original bg-status terminal output.
+// Keyed on the normalised map id so it matches the Game Servers table.
 const MAP_LABEL_CLASS: Record<string, string> = {
-  HaggaBasin: 'text-success',
-  DeepDesert: 'text-accent-bright',
-}
-
-const MAP_DISPLAY: Record<string, string> = {
-  HaggaBasin: 'Hagga Basin',
-  DeepDesert: 'Deep Desert',
+  Survival_1: 'text-success',
+  DeepDesert_1: 'text-accent-bright',
 }
 
 // Color the Active count by fill ratio so the eye is drawn to busy fields.
@@ -63,6 +60,9 @@ function formatTime(d: Date) {
 
 export function BgSpiceSummary({ enabled }: Props) {
   const [rows, setRows] = useState<SpicefieldType[] | null>(null)
+  // False only when the backend could read the battlegroup; a failed read
+  // leaves this true so nothing is hidden on a transient error.
+  const [gateOk, setGateOk] = useState(false)
   const [err, setErr]   = useState<string | null>(null)
   const [updatedAt, setUpdatedAt] = useState<Date | null>(null)
   const [togglingId, setTogglingId] = useState<number | null>(null)
@@ -86,6 +86,7 @@ export function BgSpiceSummary({ enabled }: Props) {
     try {
       const data = await getSpicefields()
       setRows(data.rows)
+      setGateOk(data.partitionGate === true)
       setUpdatedAt(new Date())
       setErr(null)
     } catch (e) {
@@ -142,21 +143,57 @@ export function BgSpiceSummary({ enabled }: Props) {
     }
   }, [bumpCooldown, cooldownRemaining, togglingId])
 
-  const sorted = useMemo(() => {
+  // Only partitions that are live or pinned. dune.spicefield_types keeps a row
+  // per (map, size, dimension) forever, so a battlegroup that once ran two
+  // instances of a map still carries rows for the second one — which rendered as
+  // every size listed twice with nothing to distinguish them. When the backend
+  // could not read the battlegroup (partitionGate false) nothing is hidden, so a
+  // transient failure never silently drops real data.
+  const visible = useMemo(() => {
     if (!rows) return []
-    return [...rows].sort((a, b) => {
-      if (a.mapName !== b.mapName) return a.mapName.localeCompare(b.mapName)
+    if (!gateOk) return rows
+    return rows.filter(r => r.partitionActive !== false)
+  }, [rows, gateOk])
+
+  // Group key is map + dimension so two instances of the same map stay apart.
+  const groupKey = useCallback(
+    (r: SpicefieldType) => `${r.mapId ?? r.mapName}|${r.dimensionIndex ?? 0}`,
+    [],
+  )
+
+  const sorted = useMemo(() => {
+    return [...visible].sort((a, b) => {
+      const am = a.mapId ?? a.mapName
+      const bm = b.mapId ?? b.mapName
+      if (am !== bm) return am.localeCompare(bm)
+      const ad = a.dimensionIndex ?? 0
+      const bd = b.dimensionIndex ?? 0
+      if (ad !== bd) return ad - bd
       const ar = SIZE_RANK[a.fieldType] ?? 99
       const br = SIZE_RANK[b.fieldType] ?? 99
       return ar - br
     })
-  }, [rows])
+  }, [visible])
 
-  // Row span data so the Map column collapses repeats.
+  // Row span data so the Map column collapses repeats, per map+dimension.
   const mapSpan = useMemo(() => {
     const counts: Record<string, number> = {}
-    for (const r of sorted) counts[r.mapName] = (counts[r.mapName] ?? 0) + 1
+    for (const r of sorted) {
+      const k = groupKey(r)
+      counts[k] = (counts[k] ?? 0) + 1
+    }
     return counts
+  }, [sorted, groupKey])
+
+  // Only label instances when a map genuinely has more than one, so the common
+  // single-instance case stays uncluttered.
+  const multiInstanceMaps = useMemo(() => {
+    const dims: Record<string, Set<number>> = {}
+    for (const r of sorted) {
+      const m = r.mapId ?? r.mapName
+      ;(dims[m] ??= new Set()).add(r.dimensionIndex ?? 0)
+    }
+    return new Set(Object.keys(dims).filter(m => dims[m].size > 1))
   }, [sorted])
 
   if (!enabled) return null
@@ -198,9 +235,14 @@ export function BgSpiceSummary({ enabled }: Props) {
           <tbody>
             {sorted.map((r, idx) => {
               const prev      = idx > 0 ? sorted[idx - 1] : null
-              const newMap    = !prev || prev.mapName !== r.mapName
-              const labelCls  = MAP_LABEL_CLASS[r.mapName] ?? 'text-text'
-              const display   = MAP_DISPLAY[r.mapName] ?? r.mapName
+              const key       = groupKey(r)
+              const newMap    = !prev || groupKey(prev) !== key
+              const mapId     = r.mapId ?? r.mapName
+              const labelCls  = MAP_LABEL_CLASS[mapId] ?? 'text-text'
+              const dim       = r.dimensionIndex ?? 0
+              const display   = multiInstanceMaps.has(mapId)
+                ? `${mapLabel(mapId)} #${dim + 1}`
+                : mapLabel(mapId)
               const sizeCls   = SIZE_CLASS[r.fieldType] ?? 'text-text-muted'
               const activeCls = activeFillClass(r.currentActive, r.maxActive)
               const primCls   = primedClass(r.currentPrimed)
@@ -218,7 +260,7 @@ export function BgSpiceSummary({ enabled }: Props) {
                     className={newMap && idx > 0 ? 'border-t border-border/40' : ''}>
                   {newMap ? (
                     <td className={`align-top font-semibold ${labelCls} pr-3 py-0.5`}
-                        rowSpan={mapSpan[r.mapName]}>
+                        rowSpan={mapSpan[key]}>
                       {display}
                     </td>
                   ) : null}


### PR DESCRIPTION
## The problem

`dune.spicefield_types` holds one row per **(map, field size, dimension)** and keeps those rows forever. A battlegroup that has ever run a second instance of a map carries rows for it permanently.

The Active Spice card grouped only by map name, so every size rendered twice with nothing to tell the rows apart. Running a second Deep Desert also produced duplicate-looking rows for **Hagga Basin**, which is what surfaced this — confirmed against the live DB:

| map | size | dim | active |
|---|---|---|---|
| DeepDesert | L/M/S | 0 | 2 / 2 / 2 |
| DeepDesert | L/M/S | **1** | 0 / 1 / 1 |
| HaggaBasin | Small | 0 | 8 |
| HaggaBasin | Small | **1** | 5 |

## The gate

A row is shown when its `(map, dimension)` is **live** in the battlegroup CR **or** **pinned** via Map Spin-Up `MinServers`.

Neither signal works alone:
- **Live only** would hide on-demand maps like Deep Desert exactly when an operator wants to tune them before anyone goes there.
- **Pinned only** would hide always-on maps such as `Survival_1`, which never appear in `director.ini` and so can never be pinned. Verified: every `MinServers` on the live server is currently `0`, so a pinned-only gate would render an empty card.

If the battlegroup can't be read the gate is skipped and every row is shown, so a transient failure never silently drops real data.

## Naming

Map names now go through the same `mapLabel` table the Game Servers list uses, replacing a **third** private mapping that lived in the card (`HaggaBasin: 'Hagga Basin'`). The backend normalises the DB's `HaggaBasin` / `DeepDesert` onto the CR's `Survival_1` / `DeepDesert_1`, so one naming scheme drives Game Servers, Map Spin-Up and the spice readout.

When a map genuinely has more than one live instance, its rows label as **Hagga Basin #1**, **#2** — so multiple instances read as distinct rather than duplicated.

## Assumption (recorded in the lib)

`dimensionIndex` is treated as the instance index, so `MinServers = N` pins dimensions `0..N-1`. That matches a multi-sietch Hagga producing dimension 1, but it is inferred from observed data rather than documented by Funcom.

## Validation

- Verified against the live server: with only `Survival_1` dimension 0 running and every `MinServers` at 0, the gate keeps Hagga Basin dimension 0 and correctly drops both the stale dimension-1 rows and the idle Deep Desert rows
- 81 Pester tests pass across the touched suites
- Production web build clean; installer built with full version-parity, BOM and PS 5.1 preflights
- gitleaks clean

Targets the next release — no version bump in this PR.