### PR TITLE
Release v13.0.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.0.1"
+      placeholder: "v13.0.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.0.2] - 2026-07-30
+
 ### Changed
 
 - **Active Spice now only lists partitions that are live or pinned.** `dune.spicefield_types` keeps a row for every (map, size, instance) combination forever, so a battlegroup that has ever run a second instance of a map keeps those rows permanently. The card grouped only by map, so each size appeared twice with nothing to tell the rows apart — running a second Deep Desert also created duplicate-looking rows for Hagga Basin. Rows are now shown when their instance is currently running or is kept warm by a Map Spin-Up pin, and a map with more than one live instance labels them **Hagga Basin #1**, **#2** and so on. If the battlegroup can't be read, every row is shown rather than hiding real data. Map names also come from the same table the Game Servers list uses, so both read identically.
@@ -7316,7 +7318,8 @@ at the time. Also folds in the v3.0.1 / v3.1.2 patches.
   (`ssh`, `Gameplay Admin`, `setup-guide`, `report-issue`). _(originally
   3.1.2)_
 
-[Unreleased]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.0.1...HEAD
+[Unreleased]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.0.2...HEAD
+[13.0.2]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.0.1...v13.0.2
 [13.0.1]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.0.0...v13.0.1
 [13.0.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v12.16.6...v13.0.0
 [6.1.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v6.0.1...v6.1.2

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.0.1'
+$script:DuneToolVersion = '13.0.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.0.1',
+    [string]$Version = '13.0.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.0.1</Version>
+    <Version>13.0.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.0.1"
+#define MyAppVersion "13.0.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.0.1"
+$script:ToolVersion = "13.0.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Release PR for **v13.0.2**.

Rolls the already-merged Active Spice partition gate into a dated CHANGELOG entry, bumps the five version stamps, and updates the `bug_report.yml` version placeholder.

## What ships

- **Active Spice now only lists partitions that are live or pinned.** `dune.spicefield_types` keeps a row for every (map, size, instance) forever, so a battlegroup that has ever run a second instance of a map keeps those rows permanently — the card grouped only by map, so each size appeared twice with nothing to tell the rows apart. Running a second Deep Desert also produced duplicate-looking rows for Hagga Basin, which is what surfaced it.
- Map names come from the same table the Game Servers list uses, and a map with more than one live instance labels its rows **Hagga Basin #1**, **#2**.
- If the battlegroup can't be read, every row is shown rather than hiding real data.

No functional changes in this PR beyond the version bump — the feature merged in the previous PR.

## Validation

- Five version stamps at `13.0.2`, BOM preserved on every rewritten file
- `bug_report.yml` parses clean
- gitleaks clean