### PR TITLE
Fix fuel duration multiplier startup application

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.0.3"
+      placeholder: "v13.0.4"
     validations:
       required: true
 
@@ -93,7 +93,7 @@ body:
         - Web portal — Commands
         - Web portal — PowerShell (embedded xterm.js terminal)
         - Web portal — Game Config — VM INI (UserGame.ini / UserEngine.ini / Apply INIs to pods / Spicefield Types / Crafting / Land Claim Timer)
-        - Web portal — Game Config — Experimental server CVars (rewards / fuel / vehicles / sandworms / buildings / combat / safe zones)
+        - Web portal — Game Config — Experimental server CVars (rewards / fuel duration + startup override / vehicles / sandworms / buildings / combat / safe zones)
         - Web portal — Game Config — Server name (rename / battlegroup title shown in the in-game server browser)
         - Web portal — Game Config — Deep Desert PvP (live partitions / Apply & restart)
         - Web portal — Game Config — client-side INI (preview / Open in Notepad / client-apply reminder)
@@ -182,14 +182,14 @@ body:
 
         - Which exact setting(s) you changed, and to what value.
         - What DST shows for that value after a reload vs what you see in-game.
-        - Whether you **restarted the server zone** after saving (server INI
-          changes only take effect after a zone restart).
+        - Whether you **restarted the battlegroup** after saving (server INI
+          and startup-command changes only take effect after restart).
 
         Leave blank if your bug isn't about Game Config.
       placeholder: |
         Changed: Base > Max Building Extensions 5 -> 8; Player Inventory Volume 185 -> 195
         DST shows 195 after reload; in-game still behaves like 185.
-        Zone restarted after save? yes
+        Battlegroup restarted after save? yes
       render: shell
     validations:
       required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.0.4] - 2026-07-31
+
+### Fixed
+
+- **Fuel Burning Duration now applies through both config and server startup.** Field testing found that `dw.FuelBurningMultiplier` worked when supplied through both `UserEngine.ini` and `-ExecCmds`, while DST's prior INI-only control had no effect. DST now merges the value into each Hagga server's startup argument, preserving per-sietch names and other pod overrides. Resetting to `1` removes the startup override. Restarting the battlegroup applies the new duration to existing generator fuel too.
+
 ## [13.0.3] - 2026-07-31
 
 ### Changed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.0.3'
+$script:DuneToolVersion = '13.0.4'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.0.3',
+    [string]$Version = '13.0.4',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.0.3</Version>
+    <Version>13.0.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.0.3"
+#define MyAppVersion "13.0.4"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/lib/K8s.ps1
+++ b/app/lib/K8s.ps1
@@ -116,6 +116,94 @@ function _Invoke-V6BgJsonPatch {
     return @{ Success = [bool]$ok; Error = $errText; Raw = $clean; Rc = $rc }
 }
 
+# Split Unreal's comma-delimited ExecCmds payload without splitting commas that
+# appear inside quoted command values.
+function _Split-V6ExecCommands {
+    param([AllowEmptyString()][string]$Payload)
+
+    $commands = New-Object 'System.Collections.Generic.List[string]'
+    $current = New-Object System.Text.StringBuilder
+    $singleQuoted = $false
+    $doubleQuoted = $false
+    foreach ($ch in "$Payload".ToCharArray()) {
+        if ($ch -eq "'" -and -not $doubleQuoted) {
+            $singleQuoted = -not $singleQuoted
+            [void]$current.Append($ch)
+            continue
+        }
+        if ($ch -eq '"' -and -not $singleQuoted) {
+            $doubleQuoted = -not $doubleQuoted
+            [void]$current.Append($ch)
+            continue
+        }
+        if ($ch -eq ',' -and -not $singleQuoted -and -not $doubleQuoted) {
+            $command = $current.ToString().Trim()
+            if ($command) { $commands.Add($command) }
+            [void]$current.Clear()
+            continue
+        }
+        [void]$current.Append($ch)
+    }
+    $last = $current.ToString().Trim()
+    if ($last) { $commands.Add($last) }
+    return $commands.ToArray()
+}
+
+# Merge one command into the single ExecCmds argument Unreal reads. Repeating
+# -execcmds flags is ambiguous, so consolidate existing payloads while preserving
+# unrelated pod arguments and commands such as per-sietch display names.
+function _Set-V6ExecCommand {
+    param(
+        [object[]]$Arguments,
+        [Parameter(Mandatory)][string]$CommandName,
+        [AllowNull()][string]$Command
+    )
+
+    $plain = New-Object 'System.Collections.Generic.List[string]'
+    $commands = New-Object 'System.Collections.Generic.List[string]'
+    $namePattern = '^(?i)' + [regex]::Escape($CommandName) + '(?:\s|$)'
+    foreach ($raw in @($Arguments)) {
+        if ($null -eq $raw -or "$raw" -eq '') { continue }
+        $arg = "$raw"
+        $payload = $null
+        if ($arg -match '^(?i)-execcmds="(.*)"$') { $payload = $Matches[1] }
+        elseif ($arg -match '^(?i)-execcmds=(.*)$') { $payload = $Matches[1] }
+        else {
+            $plain.Add($arg)
+            continue
+        }
+        foreach ($existing in @(_Split-V6ExecCommands -Payload $payload)) {
+            if ($existing -notmatch $namePattern) { $commands.Add($existing) }
+        }
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Command)) { $commands.Add($Command.Trim()) }
+    if ($commands.Count -gt 0) {
+        $plain.Add('-execcmds="' + ($commands.ToArray() -join ',') + '"')
+    }
+    return $plain.ToArray()
+}
+
+function _Copy-V6PodSpec {
+    param([Parameter(Mandatory)]$PodSpec)
+    $copy = @{}
+    if ($PodSpec -is [hashtable]) {
+        foreach ($key in $PodSpec.Keys) { $copy[$key] = $PodSpec[$key] }
+    } else {
+        foreach ($prop in $PodSpec.PSObject.Properties) { $copy[$prop.Name] = $prop.Value }
+    }
+    return $copy
+}
+
+function _Test-V6PodSpecHasOverrides {
+    param([Parameter(Mandatory)][hashtable]$PodSpec)
+    foreach ($key in $PodSpec.Keys) {
+        if ($key -eq 'index') { continue }
+        if ($key -eq 'arguments' -and @($PodSpec[$key]).Count -eq 0) { continue }
+        return $true
+    }
+    return $false
+}
+
 # Sanitize a per-sietch display name for the -execcmds arg. The name is wrapped
 # in single quotes inside "-execcmds=\"Bgd.ServerDisplayName '<name>'\"", and
 # Funcom disallows ' and | in the value; strip control chars too. Empty -> $null.
@@ -141,7 +229,7 @@ function Get-V6SietchNames {
             foreach ($ps in @($s.podSpecs)) {
                 if (-not $ps.PSObject.Properties['arguments']) { continue }
                 foreach ($a in @($ps.arguments)) {
-                    if ("$a" -match "Bgd\.ServerDisplayName\s+'(.*)'") { $names[[int]$ps.index] = $Matches[1]; break }
+                    if ("$a" -match "Bgd\.ServerDisplayName\s+'([^']*)'") { $names[[int]$ps.index] = $Matches[1]; break }
                 }
             }
         }
@@ -170,7 +258,7 @@ function Get-V6DeepDesertInstancesFromBg {
             foreach ($ps in @($set.podSpecs)) {
                 if (-not $ps.PSObject.Properties['index'] -or -not $ps.PSObject.Properties['arguments']) { continue }
                 foreach ($arg in @($ps.arguments)) {
-                    if ("$arg" -match "Bgd\.ServerDisplayName\s+'(.*)'") {
+                    if ("$arg" -match "Bgd\.ServerDisplayName\s+'([^']*)'") {
                         $names[[int]$ps.index] = $Matches[1]
                         break
                     }
@@ -301,16 +389,30 @@ function Set-V6SietchConfig {
         $wpParts += @{ dimension = $d; disable = $false; id = $ids[$d]; maxX = 1; maxY = 1; minX = 0; minY = 0 }
     }
 
-    $podSpecs = $null
-    if ($null -ne $Names) {
-        $podSpecs = @()
-        for ($d = 0; $d -lt $Count; $d++) {
-            $raw = if ($d -lt $Names.Count) { $Names[$d] } else { '' }
-            $nm  = Format-V6SietchName $raw
-            if ($nm) { $podSpecs += @{ index = $ids[$d]; arguments = @("-execcmds=`"Bgd.ServerDisplayName '$nm'`"") } }
+    $existingPodSpecs = @{}
+    if ($set.PSObject.Properties['podSpecs'] -and $set.podSpecs) {
+        foreach ($podSpec in @($set.podSpecs)) {
+            if ($podSpec.PSObject.Properties['index']) {
+                $existingPodSpecs[[int]$podSpec.index] = $podSpec
+            }
         }
-        if ($podSpecs.Count -eq 0) { $podSpecs = $null }
     }
+    $podSpecs = @()
+    for ($d = 0; $d -lt $Count; $d++) {
+        $id = [int]$ids[$d]
+        $podSpec = if ($existingPodSpecs.ContainsKey($id)) {
+            _Copy-V6PodSpec -PodSpec $existingPodSpecs[$id]
+        } else {
+            @{ index = $id }
+        }
+        $raw = if ($null -ne $Names -and $d -lt $Names.Count) { $Names[$d] } else { '' }
+        $nm = Format-V6SietchName $raw
+        $nameCommand = if ($nm) { "Bgd.ServerDisplayName '$nm'" } else { $null }
+        $podSpec.arguments = @(_Set-V6ExecCommand -Arguments @($podSpec.arguments) `
+            -CommandName 'Bgd.ServerDisplayName' -Command $nameCommand)
+        if (_Test-V6PodSpecHasOverrides -PodSpec $podSpec) { $podSpecs += $podSpec }
+    }
+    if ($podSpecs.Count -eq 0) { $podSpecs = $null }
 
     $setPath = "/spec/serverGroup/template/spec/sets/$setIdx"
     $wpPath  = "/spec/database/template/spec/deployment/spec/worldPartitions/$wpIdx"
@@ -338,6 +440,88 @@ function Set-V6SietchConfig {
         $applied += @{ dimension = $d; partitionId = $ids[$d]; name = $nm }
     }
     return @{ Success = $true; Count = $Count; Sietches = $applied; Raw = $res.Raw }
+}
+
+# Keep dw.FuelBurningMultiplier in the Survival server command line as well as
+# UserEngine.ini. Field testing found the dual application effective where the
+# INI value alone was not. One podSpec is required per Hagga partition.
+function Set-V6FuelBurningMultiplier {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [AllowNull()][string]$Value
+    )
+
+    $command = $null
+    $normalized = $null
+    if (-not [string]::IsNullOrWhiteSpace($Value)) {
+        $number = 0.0
+        $style = [System.Globalization.NumberStyles]::Float
+        $culture = [System.Globalization.CultureInfo]::InvariantCulture
+        if (-not [double]::TryParse($Value.Trim(), $style, $culture, [ref]$number) -or
+            [double]::IsNaN($number) -or [double]::IsInfinity($number)) {
+            throw "Fuel burning multiplier must be a finite number."
+        }
+        $normalized = $number.ToString('0.################', $culture)
+        $command = "dw.FuelBurningMultiplier $normalized"
+    }
+
+    $info = Get-V6Battlegroup -Ip $Ip
+    $sets = $info.Bg.spec.serverGroup.template.spec.sets
+    $patches = @()
+    $foundSurvival = $false
+    for ($setIndex = 0; $setIndex -lt $sets.Count; $setIndex++) {
+        $set = $sets[$setIndex]
+        $isDedicated = $false
+        if ($set.PSObject.Properties['dedicatedScaling']) { $isDedicated = [bool]$set.dedicatedScaling }
+        if ($set.map -ne 'Survival_1' -or $isDedicated) { continue }
+        $foundSurvival = $true
+
+        $byIndex = @{}
+        foreach ($existing in @($set.podSpecs)) {
+            if ($null -eq $existing) { continue }
+            if ($existing.PSObject.Properties['index']) { $byIndex[[int]$existing.index] = $existing }
+        }
+        $partitionIds = @($set.partitions | ForEach-Object { [int]$_ })
+        $allIds = @(@($byIndex.Keys) + $partitionIds | Sort-Object -Unique)
+        $podSpecs = @()
+        foreach ($id in $allIds) {
+            $podSpec = if ($byIndex.ContainsKey([int]$id)) {
+                _Copy-V6PodSpec -PodSpec $byIndex[[int]$id]
+            } else {
+                @{ index = [int]$id }
+            }
+            $podSpec.arguments = @(_Set-V6ExecCommand -Arguments @($podSpec.arguments) `
+                -CommandName 'dw.FuelBurningMultiplier' -Command $command)
+            if (_Test-V6PodSpecHasOverrides -PodSpec $podSpec) { $podSpecs += $podSpec }
+        }
+
+        $path = "/spec/serverGroup/template/spec/sets/$setIndex/podSpecs"
+        $hasPodSpecs = ($set.PSObject.Properties['podSpecs'] -and $null -ne $set.podSpecs)
+        if ($podSpecs.Count -gt 0) {
+            $patches += @{
+                op = if ($hasPodSpecs) { 'replace' } else { 'add' }
+                path = $path
+                value = $podSpecs
+            }
+        } elseif ($hasPodSpecs) {
+            $patches += @{ op = 'remove'; path = $path }
+        }
+    }
+    if ($patches.Count -eq 0) {
+        if ($foundSurvival) {
+            return @{ Success = $true; NoChange = $true; Raw = ''; Value = $normalized }
+        }
+        return @{ Success = $false; Error = 'No non-dedicated Survival_1 server set found.'; Value = $normalized }
+    }
+
+    $result = _Invoke-V6BgJsonPatch -Ip $Ip -Info $info -Patches $patches
+    return @{
+        Success = [bool]$result.Success
+        Error   = $result.Error
+        Raw     = $result.Raw
+        Value   = $normalized
+    }
 }
 
 function Set-V6BattlegroupTitle {

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -248,16 +248,10 @@ $script:DuneGameConfigSchema = @(
     # Hazard.DehydrationZonesEnabled is intentionally excluded because its
     # compiled Funcom help explicitly warns that enabling it crashes clients.
     @{ Section=$script:DuneGcSecConsole; Key='Dune.GiveDoubleDifficultyLoot'; File='engine'; Type='bool01'; Default='0'; Label='Double Difficulty Loot'; Help='Give double loot when encounter difficulty is above 0. Field-confirmed with dungeon loot; still experimental.'; Category='Experimental' }
-    # Removed in v12.21.3-experimental3 as ineffective, restored here for another
-    # round of field testing at the maintainer's request. A binary scan of the
-    # 1.4.10.4 server found no enable-gate CVar for this (unlike SafeZone.Scale,
-    # which is gated by SafeZone.EnableScale), but it did find BurningInitialTime
-    # and BurningFuelEntryStateData - each burning fuel entry stores its own
-    # duration as state at ignition. That suggests the multiplier applies when
-    # fuel STARTS burning rather than continuously, which would make an
-    # already-running generator show no change and could explain the earlier
-    # null result. Unverified.
-    @{ Section=$script:DuneGcSecConsole; Key='dw.FuelBurningMultiplier'; File='engine'; Type='float'; Default='1.0'; Label='Fuel Burning Duration'; Help='Scales how long all fuel burns. Larger values should make fuel last longer. An earlier round of field testing found no effect and this control was withdrawn; it is back under test. When testing, insert FRESH fuel after the restart - burn duration appears to be fixed when a fuel entry starts burning, so fuel already in a generator will not change.'; Category='Experimental' }
+    # Field testing established that INI-only application did not take effect,
+    # while applying the same value through the Survival pod's ExecCmds did.
+    # Existing generator fuel reflected the new duration after restart.
+    @{ Section=$script:DuneGcSecConsole; Key='dw.FuelBurningMultiplier'; File='engine'; Type='float'; Default='1.0'; Label='Fuel Burning Duration'; Help='Scales how long all fuel burns. DST applies the value in UserEngine.ini and the Hagga server startup command because INI-only application did not take effect in field testing. Restart the battlegroup to apply it; existing generator fuel updates after restart.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='Abilities.RespecCooldownTotalDurationSeconds'; File='engine'; Type='int'; Min=0; Unit='sec'; Default='172800'; Label='Ability Respec Cooldown'; Help='Total ability-respec cooldown in seconds. Compiled default is 172800 (2 days); 0 may remove the cooldown but has not been field-verified.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='dw.LandsraadMissionRewardMultiplierFactionXP'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Landsraad Faction XP'; Help='Scales Faction XP from Landsraad missions. Field-confirmed at 10; mission preview may still show the base reward.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='dw.LandsraadMissionRewardMultiplierHouseCredit'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Landsraad House Credit'; Help='Scales House Credit from Landsraad missions. Field-confirmed at 10; mission preview may still show the base reward.'; Category='Experimental' }
@@ -1231,6 +1225,35 @@ function Get-DuneGameConfig {
             managedSections = (Get-DuneIniManagedSectionNames -Raw $engineRaw)
         }
     }
+}
+
+function Set-DuneFuelBurningStartupOverride {
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [AllowNull()][string]$Value
+    )
+    if (-not (Get-Command Set-V6FuelBurningMultiplier -ErrorAction SilentlyContinue)) {
+        throw 'Battlegroup helper unavailable (K8s.ps1 not loaded).'
+    }
+    $result = Set-V6FuelBurningMultiplier -Ip $Ip -Value $Value
+    if (-not $result.Success) {
+        $why = if ($result.Error) { $result.Error } else { $result.Raw }
+        throw "Fuel startup override failed: $why"
+    }
+    return $result
+}
+
+function Sync-DuneFuelBurningStartupOverride {
+    param([Parameter(Mandatory)][string]$Ip)
+    $config = Get-DuneGameConfig -Ip $Ip
+    $value = $null
+    if ($config.engine.effectiveByKey.ContainsKey('dw.FuelBurningMultiplier')) {
+        $candidate = "$($config.engine.effectiveByKey['dw.FuelBurningMultiplier'])".Trim()
+        if (-not (Test-DuneGameConfigValueIsDefault -Key 'dw.FuelBurningMultiplier' -Value $candidate)) {
+            $value = $candidate
+        }
+    }
+    return Set-DuneFuelBurningStartupOverride -Ip $Ip -Value $value
 }
 
 # Player-facing server name (the battlegroup title shown in the in-game server

--- a/app/server/lib/Status.ps1
+++ b/app/server/lib/Status.ps1
@@ -391,7 +391,7 @@ function Get-DuneSietchNamesFromBgJson {
             foreach ($ps in @($s.podSpecs)) {
                 if (-not $ps.PSObject.Properties['arguments']) { continue }
                 foreach ($a in @($ps.arguments)) {
-                    if ("$a" -match "Bgd\.ServerDisplayName\s+'(.*)'") { $pairs += @{ id = [int]$ps.index; name = $Matches[1] }; break }
+                    if ("$a" -match "Bgd\.ServerDisplayName\s+'([^']*)'") { $pairs += @{ id = [int]$ps.index; name = $Matches[1] }; break }
                 }
             }
             break

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -434,6 +434,9 @@ echo ""
 echo "=== per-map memory limits (battlegroup spec) ==="
 sudo kubectl get battlegroup -n "$NS" -o jsonpath='{range .items[0].spec.serverGroup.template.spec.sets[*]}{.map}{"  "}{.resources.limits.memory}{"\n"}{end}' 2>&1
 echo ""
+echo "=== per-map startup arguments (battlegroup podSpecs) ==="
+sudo kubectl get battlegroup -n "$NS" -o jsonpath='{range .items[0].spec.serverGroup.template.spec.sets[*]}{.map}{"\n"}{range .podSpecs[*]}{"  index="}{.index}{" args="}{.arguments}{"\n"}{end}{end}' 2>&1
+echo ""
 echo "=== node conditions ==="
 sudo kubectl get node -o jsonpath='{range .items[0].status.conditions[*]}{.type}{"="}{.status}{"  "}{.reason}{"\n"}{end}' 2>&1
 echo ""

--- a/app/server/routes/GameConfig.ps1
+++ b/app/server/routes/GameConfig.ps1
@@ -158,6 +158,12 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig' -Handler {
 
     try {
         Save-DuneGameConfig -Ip $ctx.ip -Updates $structured.ToArray()
+        $fuelUpdate = $structured | Where-Object { $_.key -eq 'dw.FuelBurningMultiplier' } | Select-Object -Last 1
+        $fuelApply = $null
+        if ($fuelUpdate) {
+            $fuelValue = if ($fuelUpdate.remove) { $null } else { "$($fuelUpdate.value)" }
+            $fuelApply = Set-DuneFuelBurningStartupOverride -Ip $ctx.ip -Value $fuelValue
+        }
         $cfg = Get-DuneGameConfig -Ip $ctx.ip
         $clientApply = Get-DuneGameConfigClientApplyNotice -Updates $structured.ToArray()
 
@@ -191,6 +197,7 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig' -Handler {
             clientApply = $clientApply
         }
         if ($landsraadApply) { $body.landsraadGoalApply = $landsraadApply }
+        if ($fuelApply) { $body.fuelStartupApply = $fuelApply }
         Write-DuneJson -Response $res -Body $body
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Game config save failed: $($_.Exception.Message)"
@@ -218,6 +225,7 @@ Register-DuneRoute -Method POST -Path '/api/gameconfig/reload-pods' -Handler {
     }
     if (-not (Test-DunePlayerGuard -Req $req -Res $res -Ip $ctx.ip)) { return }
     try {
+        Sync-DuneFuelBurningStartupOverride -Ip $ctx.ip | Out-Null
         $r = Invoke-DuneBattlegroupRestart -Ip $ctx.ip
         if (-not $r.ok) {
             Write-DuneError -Response $res -Status 502 -Message $r.message

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.0.3"
+$script:ToolVersion = "13.0.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -115,6 +115,141 @@ m_bShouldForceEnablePvpOnAllPartitions=True
     }
 }
 
+Describe 'Fuel burning startup override' -Tag 'GameConfig' {
+    It 'merges fuel and a per-sietch name into one ExecCmds argument' {
+        $arguments = @(_Set-V6ExecCommand `
+            -Arguments @('-log', '-execcmds="Bgd.ServerDisplayName ''Hagga, Prime''"') `
+            -CommandName 'dw.FuelBurningMultiplier' `
+            -Command 'dw.FuelBurningMultiplier 10')
+
+        $arguments | Should -Contain '-log'
+        @($arguments | Where-Object { $_ -like '-execcmds=*' }).Count | Should -Be 1
+        $arguments | Should -Contain '-execcmds="Bgd.ServerDisplayName ''Hagga, Prime'',dw.FuelBurningMultiplier 10"'
+    }
+
+    It 'removes only the fuel command when reset to default' {
+        $arguments = @(_Set-V6ExecCommand `
+            -Arguments @('-execcmds="Bgd.ServerDisplayName ''Hagga'',dw.FuelBurningMultiplier 10"') `
+            -CommandName 'dw.FuelBurningMultiplier' `
+            -Command $null)
+
+        $arguments | Should -Be @('-execcmds="Bgd.ServerDisplayName ''Hagga''"')
+    }
+
+    It 'treats default with no existing pod overrides as a successful no-op' {
+        Mock Get-V6Battlegroup {
+            @{
+                Ns = 'dune-ns'
+                Name = 'dune-bg'
+                Bg = [pscustomobject]@{ spec = [pscustomobject]@{
+                    serverGroup = [pscustomobject]@{ template = [pscustomobject]@{ spec = [pscustomobject]@{
+                        sets = @([pscustomobject]@{
+                            map = 'Survival_1'
+                            dedicatedScaling = $false
+                            partitions = @(1)
+                        })
+                    } } }
+                } }
+            }
+        }
+        Mock _Invoke-V6BgJsonPatch { throw 'Patch must not run for a no-op reset.' }
+
+        $result = Set-V6FuelBurningMultiplier -Ip '192.0.2.1' -Value $null
+
+        $result.Success | Should -BeTrue
+        $result.NoChange | Should -BeTrue
+        Should -Invoke _Invoke-V6BgJsonPatch -Times 0
+    }
+
+    It 'patches every Hagga partition while preserving names and other pod overrides' {
+        Mock Get-V6Battlegroup {
+            @{
+                Ns = 'dune-ns'
+                Name = 'dune-bg'
+                Bg = [pscustomobject]@{ spec = [pscustomobject]@{
+                    serverGroup = [pscustomobject]@{ template = [pscustomobject]@{ spec = [pscustomobject]@{
+                        sets = @(
+                            [pscustomobject]@{
+                                map = 'Survival_1'
+                                dedicatedScaling = $false
+                                partitions = @(1, 4)
+                                podSpecs = @(
+                                    [pscustomobject]@{
+                                        index = 1
+                                        arguments = @('-execcmds="Bgd.ServerDisplayName ''Hagga''"')
+                                        nodeSelector = @{ disk = 'fast' }
+                                    }
+                                )
+                            },
+                            [pscustomobject]@{ map = 'Overmap'; dedicatedScaling = $false; partitions = @(2) }
+                        )
+                    } } }
+                } }
+            }
+        }
+        $script:fuelPatches = $null
+        Mock _Invoke-V6BgJsonPatch {
+            param($Ip, $Info, $Patches)
+            $script:fuelPatches = $Patches
+            @{ Success = $true; Raw = 'patched'; Error = $null }
+        }
+
+        $result = Set-V6FuelBurningMultiplier -Ip '192.0.2.1' -Value '10.0'
+
+        $result.Success | Should -BeTrue
+        $result.Value | Should -Be '10'
+        @($script:fuelPatches).Count | Should -Be 1
+        $specs = @($script:fuelPatches[0].value)
+        @($specs.index | Sort-Object) | Should -Be @(1, 4)
+        $specs[0].nodeSelector.disk | Should -Be 'fast'
+        $specs[0].arguments | Should -Contain '-execcmds="Bgd.ServerDisplayName ''Hagga'',dw.FuelBurningMultiplier 10"'
+        $specs[1].arguments | Should -Contain '-execcmds="dw.FuelBurningMultiplier 10"'
+    }
+
+    It 'keeps the fuel command when sietch names are changed' {
+        Mock Get-V6Battlegroup {
+            @{
+                Ns = 'dune-ns'
+                Name = 'dune-bg'
+                Bg = [pscustomobject]@{ spec = [pscustomobject]@{
+                    serverGroup = [pscustomobject]@{ template = [pscustomobject]@{ spec = [pscustomobject]@{
+                        sets = @([pscustomobject]@{
+                            map = 'Survival_1'
+                            dedicatedScaling = $false
+                            replicas = 1
+                            partitions = @(1)
+                            podSpecs = @([pscustomobject]@{
+                                index = 1
+                                arguments = @('-execcmds="dw.FuelBurningMultiplier 10"')
+                            })
+                        })
+                    } } }
+                    database = [pscustomobject]@{ template = [pscustomobject]@{ spec = [pscustomobject]@{
+                        deployment = [pscustomobject]@{ spec = [pscustomobject]@{
+                            worldPartitions = @([pscustomobject]@{
+                                map = 'Survival_1'
+                                partitions = @([pscustomobject]@{ id=1; dimension=0; disable=$false; maxX=1; maxY=1; minX=0; minY=0 })
+                            })
+                        } }
+                    } } }
+                } }
+            }
+        }
+        $script:sietchPatches = $null
+        Mock _Invoke-V6BgJsonPatch {
+            param($Ip, $Info, $Patches)
+            $script:sietchPatches = $Patches
+            @{ Success = $true; Raw = 'patched'; Error = $null }
+        }
+
+        $result = Set-V6SietchConfig -Ip '192.0.2.1' -Count 1 -Names @('Hagga')
+
+        $result.Success | Should -BeTrue
+        $podPatch = $script:sietchPatches | Where-Object { $_.path -like '*/podSpecs' }
+        $podPatch.value[0].arguments | Should -Contain '-execcmds="dw.FuelBurningMultiplier 10,Bgd.ServerDisplayName ''Hagga''"'
+    }
+}
+
 Describe 'ConvertTo-DuneIniManaged: duplicate-section de-dup' -Tag 'GameConfig' {
 
     It 'collapses a pre-existing duplicate NON-target header to exactly one' {


### PR DESCRIPTION
## Summary
- apply `dw.FuelBurningMultiplier` through both `UserEngine.ini` and each Hagga server's `-ExecCmds`
- merge startup commands without clobbering per-sietch names or other pod overrides; reset cleanly at multiplier `1`
- add startup-argument diagnostics and prepare v13.0.4 release metadata

## Field verification
- live battlegroup remained Healthy with `dw.FuelBurningMultiplier 50` persisted on Hagga
- existing generator fuel updated after restart to 1,543 days; no fresh-fuel replacement required

## Validation
- 570 Pester tests passed
- live CRD server-side dry-run accepted combined display-name + fuel command without persistence
- v13.0.4 installer built with matching ProductVersion and encoding/PowerShell 5.1 preflights