### PR TITLE
Update README and marketing site for v13.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 
 **🌐 Website & feature tour: [coastal-ms.github.io/DST-DuneServerTool](https://coastal-ms.github.io/DST-DuneServerTool/)** — screenshots, install guide, and the full changelog.
 
-The current release is **v12.20.0**. The in-app version label and the
-website show plain semver tags (e.g. `v12.20.0`) — the previous
+The current release is **v13.0.5**. The in-app version label and the
+website show plain semver tags (e.g. `v13.0.5`) — the previous
 Roman-numeral stylization has been removed.
 
-> ## ✅ Confirmed compatible with Dune: Awakening **1.4.10.3**
-> DST **v12.19.x** is verified working against the **latest Funcom release** —
+> ## ✅ Confirmed compatible with Dune: Awakening **1.4.10.4**
+> DST **v13.0.x** is verified working against the **latest Funcom release** —
 > both the game **client** and the **self-hosted server** software — as of the
-> **1.4.10.3** patch. Compatibility was checked live against a running
+> **1.4.10.4** patch. Compatibility was checked live against a running
 > self-hosted server on that build, covering battlegroup management,
 > on-demand map spin-up, game-config and database editing, and backups.
 
@@ -28,6 +28,24 @@ the sidebar's **Web Portal** button hands the portal off to your default
 browser and keeps the server running in the background.
 
 ![Server Health](docs/img/server-health.png)
+
+### New in v13
+
+- **Experimental Game Config controls** expose testable gameplay CVars for
+  rewards, vehicles, sandworms, spice, buildings, combat, NPCs, journey
+  instances, and safe zones. They are isolated from proven settings, carry
+  explicit warnings, and show their exact keys.
+- **Optional local client `Engine.ini` management** mirrors settings that the
+  Dune client must also evaluate, including vehicle limits. It is disabled by
+  default, requires an explicit opt-in, never overrides public/live servers,
+  and removes only DST-managed values when switched off. Existing local
+  `Game.ini` support remains available independently.
+- **Fuel Burning Duration now applies at server startup** as well as through
+  `UserEngine.ini`, so changes take effect after the battlegroup restart.
+- **Every major page card can be collapsed** and remembers its state, letting
+  long Dashboard, Game Config, Database, and Settings pages stay focused.
+- **Active Spice distinguishes live map instances** and hides stale historical
+  rows unless battlegroup state cannot be read.
 
 ### New in v12.20
 
@@ -651,7 +669,12 @@ up on the server before every write**. A reminder prompts you to
 hit **Backup settings** first — and a **View backups** button lists the recent
 `.dstbak-*` restore points next to each file. Save flushes the files back to
 the VM and invalidates the Server Health port cache so any port change is
-reflected immediately.
+reflected immediately. Changed game-file settings can also be applied to the
+local Dune client. `Game.ini` support is always available; client `Engine.ini`
+management is a separate, disabled-by-default opt-in for settings the client
+must evaluate too. DST identifies which file each value belongs in, warns about
+multiplayer compatibility, blocks Engine.ini writes while the game is running,
+and removes only its own managed Engine.ini values when the opt-in is disabled.
 
 ### 🎮 Gameplay Admin
 

--- a/site/README.md
+++ b/site/README.md
@@ -90,9 +90,12 @@ site/
 
 ## Deployment
 
-A GitHub Actions workflow will be added once the site content is locked in. The general plan is: on push to `main` or release tag, build → upload `dist/` → publish to GitHub Pages. Until then, deploy manually if needed:
+`.github/workflows/deploy-site.yml` builds and publishes the site to GitHub
+Pages when a site file, `CHANGELOG.md`, or a screenshot changes on `main`.
+It can also be run manually from the Actions tab. The workflow installs locked
+dependencies, builds `site/dist/`, uploads the Pages artifact, and deploys it to
+<https://coastal-ms.github.io/DST-DuneServerTool/>.
 
 ```powershell
 npm run build
-# upload dist/ wherever
 ```

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -22,7 +22,7 @@ const sections = [
     id: "gameconfig",
     title: "Game Config",
     img: "game-config.png",
-    body: "Grouped editor for UserGame.ini and UserEngine.ini with every setting labelled and typed. It reads the live INIs on load, writes changes into DST-managed blocks, and now covers Landsraad / Coriolis seed controls, per-setting reset-to-default behavior, and the newer backup restore points. The same workflow also powers DST's Setup Wizard, which now has three paths: existing servers, fresh installs, or Hyper-V over LAN for a VM on a separate host.",
+    body: "Grouped editor for UserGame.ini and UserEngine.ini with every setting labelled and typed. It reads the live server INIs, writes changes into backed-up DST-managed blocks, and covers Landsraad / Coriolis seeds, per-setting defaults, restore points, and isolated Experimental gameplay controls. Changed game-file settings can also be applied to the local Dune client: Game.ini support is always available, while Engine.ini management is disabled by default and requires an explicit opt-in for client-evaluated settings such as vehicle limits. File-aware previews and warnings explain multiplayer compatibility, block Engine.ini writes while the game is running, and remove only DST-managed values when the opt-in is turned off.",
   },
   {
     id: "gameplay",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -9,7 +9,7 @@ const release = await getLatestRelease();
 const versionLabel = formatDisplayVersion(release.version);
 
 // Latest Funcom Dune: Awakening release this build is verified against.
-const funcomVersion = "1.4.10.3";
+const funcomVersion = "1.4.10.4";
 
 const features = [
   {
@@ -22,7 +22,7 @@ const features = [
   },
   {
     title: "Setup, config & database",
-    body: "A three-path Setup Wizard for fresh installs, existing servers, or a VM on a separate Hyper-V host over your LAN (with remote install support), grouped INI editors, and Postgres-backed backup + SQL workflows — all guarded by DST-managed writes and safe defaults.",
+    body: "A three-path Setup Wizard, grouped server INI editors, optional local client Game.ini and Engine.ini management, and Postgres-backed backup + SQL workflows — all guarded by DST-managed writes, explicit opt-ins, and safe defaults.",
   },
 ];
 ---
@@ -88,7 +88,7 @@ const features = [
         The current release ({versionLabel}) is verified against Funcom's
         latest update — both the game <strong class="text-dune-text">client</strong>
         and the <strong class="text-dune-text">self-hosted server</strong>
-        software — confirmed live on the 1.4.10.3 build (July 14, 2026).
+        software — confirmed live on the 1.4.10.4 build (July 31, 2026).
         No update to DST is required.
       </p>
     </div>
@@ -117,10 +117,10 @@ const features = [
       <div class="grid sm:grid-cols-2 gap-x-12 gap-y-3 text-dune-muted">
         <div>✓ Server health dashboard + map-spin-up diagnostics</div>
         <div>✓ Live spice-field controls + restart actions</div>
-        <div>✓ Game config (UserGame.ini / UserEngine.ini) with Landsraad + Coriolis seed controls</div>
+        <div>✓ Game config with Experimental gameplay controls and client INI support</div>
         <div>✓ Embedded PowerShell terminal</div>
         <div>✓ Monaco SQL editor over Postgres + backup scheduling</div>
-        <div>✓ Two-path Setup Wizard for existing servers or fresh installs, plus Hyper-V over LAN for a remote/headless host</div>
+        <div>✓ Three-path Setup Wizard including Hyper-V over LAN for a remote/headless host</div>
         <div>✓ Remote portal support for phone-friendly monitoring</div>
         <div>✓ Built-in auto-updater</div>
         <div>✓ Optional auto-start at Windows sign-in</div>

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -85,8 +85,8 @@ import DownloadButton from "../components/DownloadButton.astro";
           >Dune: Awakening Self-Hosted Server</strong
         > installed via Steam (provides the battlegroup-management folder and
         the Hyper-V VM image). Verified against the latest <strong
-          class="text-dune-text">1.4.10.3</strong
-        > build (July 14, 2026).
+          class="text-dune-text">1.4.10.4</strong
+        > build (July 31, 2026).
       </li>
       <li>
         <strong class="text-dune-text">SSH private key</strong> for your VM —


### PR DESCRIPTION
## Summary
- update README release status and v13 highlights
- document optional client Engine.ini management across README and site
- refresh Funcom compatibility and site deployment documentation

## Validation
- npm run check (site)
- npm run build (site)