### PR TITLE
Hide stable Test-channel mirrors from Active Tests

### DIFF
--- a/site/src/lib/testing.ts
+++ b/site/src/lib/testing.ts
@@ -25,7 +25,7 @@ export interface ActiveTestRelease {
 
 export function isStableMirror(release: GitHubTestRelease): boolean {
   const text = `${release.name ?? ""}\n${release.body ?? ""}`;
-  return /\b(?:test|stable)\s+mirror\b/i.test(text);
+  return /\b(?:test|stable)(?:[-\s]+channel)?[-\s]+mirror\b/i.test(text);
 }
 
 export function getActiveTestReleases(


### PR DESCRIPTION
## Summary
- recognize Test channel mirror and Test-channel mirror wording as stable mirrors
- keep the v13.0.5 stable mirror out of the Active Tests page

## Validation
- npm run check (site)
- npm run build (site)
- live GitHub release fixture: mirror detected, zero active real tests