### PR TITLE
Stage Experimental console variables until a battlegroup restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- Framework update.
+
 ## [13.0.5] - 2026-07-31
 
 ### Added

--- a/app/server/lib/Maps.ps1
+++ b/app/server/lib/Maps.ps1
@@ -809,11 +809,23 @@ function Invoke-DuneBattlegroupRestart {
         try { Clear-DuneBotStaleRunFlags } catch {}
     }
 
+    # Console variables are staged in UserEngine.ini and only reach the servers as
+    # startup commands. Rebuild those commands from whatever the INI says right
+    # now - however it was edited - so the restart applies the user's current
+    # values and no stale command can outrank the file. Best-effort: a failure
+    # here must not block the restart the user asked for.
+    $startupApply = $null
+    if ($Ip -and (Get-Command Sync-DuneStartupConsoleVariableOverrides -ErrorAction SilentlyContinue)) {
+        try { $startupApply = Sync-DuneStartupConsoleVariableOverrides -Ip $Ip }
+        catch { $startupApply = @{ ok = $false; error = $_.Exception.Message } }
+    }
+
     $result = Invoke-DuneCommandExternal -Name 'restart'
     return @{
-        ok      = $true
-        result  = $result
-        message = 'Battlegroup restart launched - watch Server Health; it takes a couple of minutes to come back.'
+        ok           = $true
+        result       = $result
+        startupApply = $startupApply
+        message      = 'Battlegroup restart launched - watch Server Health; it takes a couple of minutes to come back.'
     }
 }
 

--- a/app/server/routes/GameConfig.ps1
+++ b/app/server/routes/GameConfig.ps1
@@ -158,11 +158,12 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig' -Handler {
 
     try {
         Save-DuneGameConfig -Ip $ctx.ip -Updates $structured.ToArray()
-        $startupUpdate = $structured | Where-Object { $_.key -in $script:DuneStartupConsoleVariableKeys } | Select-Object -First 1
-        $startupApply = $null
-        if ($startupUpdate) {
-            $startupApply = Sync-DuneStartupConsoleVariableOverrides -Ip $ctx.ip
-        }
+        # Console variables are staged, never applied here. The values live in
+        # UserEngine.ini; the matching startup commands are rebuilt from that file
+        # at the start of every battlegroup restart. Patching pod specs on save
+        # would make the operator replace the Hagga pod and disconnect its players
+        # the moment someone hits Save.
+        $restartRequired = [bool]($structured | Where-Object { $_.key -in $script:DuneStartupConsoleVariableKeys } | Select-Object -First 1)
         $cfg = Get-DuneGameConfig -Ip $ctx.ip
         $clientApply = Get-DuneGameConfigClientApplyNotice -Updates $structured.ToArray()
 
@@ -196,7 +197,7 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig' -Handler {
             clientApply = $clientApply
         }
         if ($landsraadApply) { $body.landsraadGoalApply = $landsraadApply }
-        if ($startupApply) { $body.startupConsoleApply = $startupApply }
+        if ($restartRequired) { $body.restartRequired = $true }
         Write-DuneJson -Response $res -Body $body
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Game config save failed: $($_.Exception.Message)"
@@ -224,7 +225,8 @@ Register-DuneRoute -Method POST -Path '/api/gameconfig/reload-pods' -Handler {
     }
     if (-not (Test-DunePlayerGuard -Req $req -Res $res -Ip $ctx.ip)) { return }
     try {
-        Sync-DuneStartupConsoleVariableOverrides -Ip $ctx.ip | Out-Null
+        # Invoke-DuneBattlegroupRestart rebuilds the startup console variables from
+        # the current INI before restarting, so no separate sync is needed here.
         $r = Invoke-DuneBattlegroupRestart -Ip $ctx.ip
         if (-not $r.ok) {
             Write-DuneError -Response $res -Status 502 -Message $r.message

--- a/tests/Maps.Tests.ps1
+++ b/tests/Maps.Tests.ps1
@@ -71,6 +71,64 @@ Describe 'Rolling INI reload waits for the map, not just the pod' {
     }
 }
 
+Describe 'Battlegroup restart stages console variables' {
+
+    # Console variables only reach the servers as startup commands, and those are
+    # rebuilt here rather than on save so that saving never replaces a running pod
+    # and no stale command can outrank a hand-edited INI.
+
+    It 'syncs the startup console variables before launching the restart' {
+        $order = New-Object 'System.Collections.Generic.List[string]'
+        Set-Item -Path 'function:global:Sync-DuneStartupConsoleVariableOverrides' -Value {
+            param([string]$Ip)
+            $order.Add("sync:$Ip")
+            @{ Success = $true }
+        }.GetNewClosure()
+        Set-Item -Path 'function:global:Invoke-DuneCommandExternal' -Value {
+            param([string]$Name)
+            $order.Add("cmd:$Name")
+            @{ ok = $true }
+        }.GetNewClosure()
+        try {
+            $r = Invoke-DuneBattlegroupRestart -Ip '192.0.2.1'
+            $r.ok | Should -BeTrue
+            @($order) | Should -Be @('sync:192.0.2.1', 'cmd:restart')
+        } finally {
+            Remove-Item 'function:global:Sync-DuneStartupConsoleVariableOverrides' -ErrorAction SilentlyContinue
+            Remove-Item 'function:global:Invoke-DuneCommandExternal' -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'still restarts when the console-variable sync fails' {
+        Set-Item -Path 'function:global:Sync-DuneStartupConsoleVariableOverrides' -Value {
+            param([string]$Ip)
+            throw 'battlegroup unreachable'
+        }
+        $script:ranRestart = $false
+        Set-Item -Path 'function:global:Invoke-DuneCommandExternal' -Value {
+            param([string]$Name)
+            $script:ranRestart = $true
+            @{ ok = $true }
+        }
+        try {
+            $r = Invoke-DuneBattlegroupRestart -Ip '192.0.2.1'
+            $r.ok | Should -BeTrue
+            $r.startupApply.ok | Should -BeFalse
+            $script:ranRestart | Should -BeTrue
+        } finally {
+            Remove-Item 'function:global:Sync-DuneStartupConsoleVariableOverrides' -ErrorAction SilentlyContinue
+            Remove-Item 'function:global:Invoke-DuneCommandExternal' -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'does not apply console variables on a Game Config save' {
+        $routeText = Get-Content (Join-Path $PSScriptRoot '..\app\server\routes\GameConfig.ps1') -Raw
+        $saveSection = $routeText.Substring(0, $routeText.IndexOf('/api/gameconfig/reload-pods'))
+        $saveSection | Should -Not -Match 'Sync-DuneStartupConsoleVariableOverrides'
+        $saveSection | Should -Match 'restartRequired'
+    }
+}
+
 Describe 'Director-driven map status' {
     BeforeAll {
         $script:bg = [pscustomobject]@{ status=[pscustomobject]@{ servers=@(

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -252,8 +252,8 @@ export function Sidebar({ collapsed }: Props) {
           title="Support development — Buy Me a Coffee"
           className={
             collapsed
-              ? 'w-full flex items-center justify-center h-8 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors'
-              : 'w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors uppercase tracking-widest font-semibold'
+              ? 'hidden w-full items-center justify-center h-8 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors'
+              : 'hidden w-full items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors uppercase tracking-widest font-semibold'
           }
         >
           <Icon name="Coffee" size={collapsed ? 14 : 11} />

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -841,12 +841,12 @@ export function GameConfig() {
         ? 'Client Engine.ini management is currently ON.'
         : 'Client Engine.ini management is currently OFF.'
       const ok = window.confirm(
-        `Save ${count} Experimental startup setting${count === 1 ? '' : 's'}?\n\n`
+        `Save ${count} Experimental setting${count === 1 ? '' : 's'}?\n\n`
+        + 'These are written to the server UserEngine.ini. Nothing on the server changes until you restart the battlegroup — use “Apply INIs & restart”. Saving on its own does not disconnect anyone.\n\n'
         + 'Confirmed behavior: some Experimental settings require matching client-side Engine.ini values before they take full effect. '
         + 'Every player may need compatible local values: normally the same value as the server, or an equal/higher value for client-enforced limits. '
         + 'These client edits do not affect public/live servers; those servers remain authoritative.\n\n'
-        + `${engineStatus} Turn it on under “Your client config” at the top of this page to let DST manage those values.\n\n`
-        + 'Saving also changes Hagga server startup commands and replaces the Hagga pod immediately. Players there will disconnect, and PostLandscape physics initialization can keep Hagga unavailable longer than a normal battlegroup restart.',
+        + `${engineStatus} Turn it on under “Your client config” at the top of this page to let DST manage those values.`,
       )
       if (!ok) return
     }
@@ -865,7 +865,7 @@ export function GameConfig() {
       const n = out.applied ?? dirtyKeys.length
       let msg = `Saved ${n} change${n === 1 ? '' : 's'} into the DST-managed block. Tip: use “Backup settings” to snapshot before big changes — DST no longer auto-backs-up on every save.`
       if (experimentalStartupDirtyKeys.length > 0) {
-        msg += ' Hagga startup commands were updated; its pod is being replaced and may remain unavailable during PostLandscape physics initialization.'
+        msg += ' Saved to the server INI only — restart the battlegroup with “Apply INIs & restart” to put these into effect.'
       }
       // If m_TaskGoalAmount was in this save, DST also rewrote the current
       // Landsraad term's goal_amount for every House row — surface the result.
@@ -1841,7 +1841,7 @@ function CategoryCard({
                 <Icon name="FlaskConical" size={14} /> Test settings
               </div>
               <p>
-                These CVars are written to the battlegroup&apos;s <span className="font-mono text-text">UserEngine.ini</span> under <span className="font-mono text-text">[ConsoleVariables]</span>. Custom values are also added to Hagga&apos;s startup commands, so saving an Experimental change immediately replaces the Hagga pod and disconnects players there. PostLandscape physics initialization can keep Hagga unavailable longer than a normal battlegroup restart. After saving, DST offers to mirror the same values into this PC&apos;s client <span className="font-mono text-text">Engine.ini</span>; close the game before applying them.
+                These CVars are written to the battlegroup&apos;s <span className="font-mono text-text">UserEngine.ini</span> under <span className="font-mono text-text">[ConsoleVariables]</span>. Saving changes nothing on a running server: the values are applied to the game servers when the battlegroup restarts, so use <strong className="text-text">Apply INIs &amp; restart</strong> to put them into effect. After saving, DST offers to mirror the same values into this PC&apos;s client <span className="font-mono text-text">Engine.ini</span>; close the game before applying them.
               </p>
               <p className="mt-1.5">
                 This catalogue contains 42 testable controls decoded from server build 1.4.10.4. Fuel Burning Duration, Double Difficulty Loot, and the three Landsraad reward multipliers have community field confirmation. Restored vehicle controls now receive the same dual INI and startup-command application for testing. Other controls may have no effect or unintended gameplay consequences. The dehydration-zone control is omitted because Funcom warns that enabling it crashes clients. Back up first and change one setting at a time.


### PR DESCRIPTION
## Problem

Saving an Experimental setting in Game Config patched the battlegroup CR's pod specs straight away. The operator reacts to that by replacing the Hagga pod, so **anyone playing on Hagga was disconnected the moment someone pressed Save** — before they had asked for any restart.

The startup commands are also the higher-precedence source: they outrank `UserEngine.ini`. Because they were only refreshed by the Game Config save path, a value edited through the raw INI browser (or by hand on the VM) could be silently overridden by a stale command, with the UI showing one value and the server running another.

## Change

- **Save writes `UserEngine.ini` only.** No CR patch, no pod replacement, no disconnects. The response carries `restartRequired` and the UI tells the user to restart.
- **`Invoke-DuneBattlegroupRestart` rebuilds the startup console variables from the current INI before restarting.** Apply INIs and the Landsraad restart therefore apply whatever the file says right now, however it was edited. Nothing is hardcoded — every command is derived from the user's own value, and a value at its default emits no command.
- A sync failure is reported on the response but never blocks the restart the user asked for.
- Minor framework update.

The startup-command mechanism itself is unchanged and still required: field testing re-confirmed that `dw.FuelBurningMultiplier` has no effect from `UserEngine.ini` alone.

## Verification

Live server, after installing this build and pressing **Apply INIs & restart**: the Hagga pod spec was rebuilt from the INI with all 17 non-default Experimental values, including `dw.FuelBurningMultiplier 8`, and fuel duration was confirmed working in game. Battlegroup returned Running / Ready 2/2.

Automated: 586 Pester (3 new in `tests/Maps.Tests.ps1` covering sync-before-restart ordering, restart-survives-sync-failure, and no sync on the save path), 107 Vitest, web UI production build, PowerShell 5.1 parse + BOM gates, full installer build.
