### PR TITLE
Release v13.0.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.0.5"
+      placeholder: "v13.0.6"
     validations:
       required: true
 
@@ -93,7 +93,7 @@ body:
         - Web portal — Commands
         - Web portal — PowerShell (embedded xterm.js terminal)
         - Web portal — Game Config — VM INI (UserGame.ini / UserEngine.ini / Apply INIs to pods / Spicefield Types / Crafting / Land Claim Timer)
-        - Web portal — Game Config — Experimental server CVars (rewards / fuel duration + startup override / vehicles / sandworms / buildings / combat / safe zones)
+        - Web portal — Game Config — Experimental server CVars (rewards / fuel duration / vehicles / sandworms / buildings / combat / safe zones — applied on battlegroup restart)
         - Web portal — Game Config — Server name (rename / battlegroup title shown in the in-game server browser)
         - Web portal — Game Config — Deep Desert PvP (live partitions / Apply & restart)
         - Web portal — Game Config — client-side INI (Game.ini / Engine.ini opt-in / preview / Open in Notepad / client-apply reminder)
@@ -182,8 +182,10 @@ body:
 
         - Which exact setting(s) you changed, and to what value.
         - What DST shows for that value after a reload vs what you see in-game.
-        - Whether you **restarted the battlegroup** after saving (server INI
-          and startup-command changes only take effect after restart).
+        - Whether you **restarted the battlegroup** after saving. Saving writes
+          the server INI only; Experimental console variables are applied to the
+          servers when the battlegroup restarts, so nothing changes in-game until
+          you use **Apply INIs & restart** or another battlegroup restart.
 
         Leave blank if your bug isn't about Game Config.
       placeholder: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.0.6] - 2026-08-01
+
 ### Changed
 
+- **Experimental settings no longer disconnect Hagga players when you press Save.** Saving now only writes the server `UserEngine.ini`; the matching server startup values are applied when the battlegroup restarts. Use **Apply INIs & restart** (or any battlegroup restart) to put a change into effect. Previously, saving an Experimental setting immediately replaced the Hagga server and dropped everyone playing on it, before any restart had been requested.
+- **A restart always applies what the config file currently says.** The startup values are rebuilt from `UserEngine.ini` at the start of every battlegroup restart, so a value edited in the INI browser is no longer silently overridden by an older one, and the tool and server can't disagree about what is in force.
 - Framework update.
 
 ## [13.0.5] - 2026-07-31

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.0.5'
+$script:DuneToolVersion = '13.0.6'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.0.5',
+    [string]$Version = '13.0.6',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.0.5</Version>
+    <Version>13.0.6</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.0.5"
+#define MyAppVersion "13.0.6"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.0.5"
+$script:ToolVersion = "13.0.6"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Release prep for **v13.0.6**.

- Five version stamps bumped 13.0.5 → 13.0.6 (`app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/installer/DuneServer.iss`, `dune-server.ps1`); the installer parity pre-flight passes.
- `CHANGELOG.md` `[Unreleased]` rolled into `[13.0.6] - 2026-08-01`.
- `.github/ISSUE_TEMPLATE/bug_report.yml`: `tool_version` placeholder bumped, the Experimental CVar surface option reworded to say the values apply on battlegroup restart, and the Game Config diagnostic section updated to ask whether the reporter restarted the battlegroup after saving.

Ships the change merged in #620: saving an Experimental setting writes the server INI only and no longer replaces the Hagga server out from under its players, while any battlegroup restart rebuilds the applied values from the current INI.

Installer built from this branch: `app/installer/output/DuneServerSetup.exe`, 48,355,380 bytes, ProductVersion 13.0.6. A fresh installer will be rebuilt from the final merge commit before the release is published.