### PR TITLE
Release v13.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.0.6"
+      placeholder: "v13.1.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.1.0] - 2026-08-01
+
 ### Added
 
 - **95 more Experimental server settings, in two lists.** Game Config gains an **Experimental 2** section alongside the existing one, together holding 137 console variables read out of the server binary — up from 42. New options include a deathstill conversion time, base backup tool limits and switches, a Landsraad control-point capture target, sandworm enrage/target-switching thresholds, threat-warning distances and breach-safety checks, encounter placement and cooldown controls, hazard zones and quicksand behaviour, NPC aiming and door-access rules, returning-player rewards, contract visibility, vehicle disassembly and collision rules, a server-wide PvP damage switch, and a player hard-cap override. Both lists start rolled up, and the second is simply the overflow of the same set — it is applied exactly the same way.
@@ -21,11 +23,13 @@ here cover everything those tags shipped.
 ### Fixed
 
 - **NPC Attack Limit Override can now actually take effect.** It depends on a separate switch that was never exposed, so on its own it had nothing to act on. That switch is now available next to it.
+- **Restarting no longer rewrites the battlegroup for servers that use none of these settings.** A restart rebuilds the server startup values from the config file; if the battlegroup carried any other override, such as per-sietch server names, it was rewritten even when nothing had changed.
 
 ### Notes
 
 - Every new description quotes Funcom's own wording, and anything Funcom does not give a default for is left unset rather than guessed. These are unconfirmed: they are what the server exposes, not a promise about what each one does.
 - Console variables that duplicate a setting Game Config already offers are deliberately not listed, so no behaviour ends up with two switches that can disagree.
+- Settings you do not touch change nothing: they are never written to the server config, never offered for client mirroring, and no longer cause any battlegroup write on restart.
 
 ## [13.0.6] - 2026-08-01
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.0.6'
+$script:DuneToolVersion = '13.1.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.0.6',
+    [string]$Version = '13.1.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.0.6</Version>
+    <Version>13.1.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.0.6"
+#define MyAppVersion "13.1.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.0.6"
+$script:ToolVersion = "13.1.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Release prep for **v13.1.0** — a minor bump, since #622 adds features rather than fixing behaviour.

- Five version stamps bumped 13.0.6 → 13.1.0 (`app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/installer/DuneServer.iss`, `dune-server.ps1`); the installer parity pre-flight reports "All 5 stamps match: 13.1.0".
- `CHANGELOG.md` `[Unreleased]` rolled into `[13.1.0] - 2026-08-01`, including the restart no-op fix and an explicit note that untouched settings change nothing.
- `.github/ISSUE_TEMPLATE/bug_report.yml`: `tool_version` placeholder bumped to v13.1.0. The Experimental surface option and the Game Config diagnostic section were already updated for both lists in #622.

Ships what merged in #622: the Experimental catalogue grows from 42 to 137 controls across **Experimental** and the new **Experimental 2**, both rolled up by default; `NPC.EnableNpcAttackLimits` makes the existing attack-limit override usable; the fuel and shelter pairs are completed; and a battlegroup restart no longer rewrites pod specs for servers that set no console variables.

Installer built from this branch: `app/installer/output/DuneServerSetup.exe`, 48,362,409 bytes, ProductVersion 13.1.0. A fresh installer will be rebuilt from the final merge commit before anything is published.

**Not published.** Publishing waits for explicit approval, so this PR stops at release prep.