### PR TITLE
Support a client config folder on another PC, and warn about the process check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Point DST at a client config folder on another PC.** If you play on a different machine than the one running DST, share that PC's Dune config folder and set it as your client config folder (for example `\\GAMINGPC\DuneConfig`) — DST manages `Game.ini` and `Engine.ini` over the network share. Game Config now says so, and warns when the folder is remote: DST can only tell whether Dune is running on the PC it is installed on, so the game must be closed on the other machine before applying, otherwise it rewrites `Engine.ini` on exit and the change is lost.
+
 ## [13.1.0] - 2026-08-01
 
 ### Added

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -586,13 +586,36 @@ function Get-DuneGameConfigClientApplyNotice {
 }
 
 # -----------------------------------------------------------------------------
-# LOCAL CLIENT CONFIG (admin's own machine; no SSH). DST runs locally, so it can
-# read/write the player's client Game.ini directly. Used by the optional
-# "apply to my client too" flow + the read-only client viewer.
+# CLIENT CONFIG (a player's own machine; no SSH). Normally this is the same PC
+# DST runs on, so it can read/write the client Game.ini directly. The folder is
+# user-settable, so it can also point at a network share when the player games
+# on a different PC than the one hosting the server - see
+# Test-DuneGameConfigClientDirRemote for what that costs.
 # -----------------------------------------------------------------------------
 $script:DuneGameConfigClientDirDefault     = '%LOCALAPPDATA%\DuneSandbox\Saved\Config\WindowsClient'
 $script:DuneGameConfigClientGameFileName   = 'Game.ini'
 $script:DuneGameConfigClientEngineFileName = 'Engine.ini'
+
+# Is the configured client-config folder on ANOTHER machine (a UNC path, or a
+# mapped network drive)? This matters because Test-DuneGameClientRunning can only
+# see processes on the machine DST runs on: when the folder is remote, the game
+# is running on a PC DST cannot inspect, so the "close Dune first" guard silently
+# passes and the game can overwrite Engine.ini on exit. Pure string/drive
+# inspection - never touches the network, so it cannot hang on an offline share.
+function Test-DuneGameConfigClientDirRemote {
+    param([string]$Dir = '')
+    $resolved = Resolve-DuneGameConfigClientDir -Dir $Dir
+    if ([string]::IsNullOrWhiteSpace($resolved)) { return $false }
+    if ($resolved -match '^\\\\[^\\]') { return $true }
+    try {
+        $root = [IO.Path]::GetPathRoot($resolved)
+        if (-not $root -or $root.Length -lt 2 -or $root[1] -ne ':') { return $false }
+        $drive = New-Object System.IO.DriveInfo($root)
+        return ($drive.DriveType -eq [IO.DriveType]::Network)
+    } catch {
+        return $false
+    }
+}
 
 # Engine.ini management is a disabled-by-default opt-in because the game
 # rewrites this file and client-side CVar overrides can materially change play.
@@ -671,6 +694,7 @@ function Get-DuneGameConfigClient {
         path            = $game.path
         exists          = $game.exists
         dirExists       = [bool](Test-Path -LiteralPath $dirResolved)
+        dirRemote       = (Test-DuneGameConfigClientDirRemote -Dir $dirRaw)
         default         = $script:DuneGameConfigClientDirDefault
         engineEnabled   = (Get-DuneGameConfigClientEngineEnabled)
         raw             = $game.raw

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -1095,6 +1095,35 @@ Describe 'GameConfig: Engine.ini opt-in setting' -Tag 'GameConfig' {
     }
 }
 
+Describe 'GameConfig: client config folder on another PC' -Tag 'GameConfig' {
+
+    # A player whose gaming PC is not the machine running DST can share that PC's
+    # config folder and point DST at the share. That works, but the "close Dune
+    # first" guard only sees processes on the DST host, so the UI has to say so.
+
+    It 'flags a UNC folder as remote' {
+        Test-DuneGameConfigClientDirRemote -Dir '\\GAMINGPC\DuneConfig' | Should -BeTrue
+        Test-DuneGameConfigClientDirRemote -Dir '\\GAMINGPC\Users\Someone\AppData\Local\DuneSandbox' | Should -BeTrue
+    }
+
+    It 'does not flag a local folder' {
+        Test-DuneGameConfigClientDirRemote -Dir (Get-PSDrive TestDrive).Root | Should -BeFalse
+        Test-DuneGameConfigClientDirRemote -Dir 'C:\Users\Someone\AppData\Local\DuneSandbox' | Should -BeFalse
+    }
+
+    It 'does not flag an unresolvable or empty folder' {
+        Test-DuneGameConfigClientDirRemote -Dir '' | Should -BeFalse
+        Test-DuneGameConfigClientDirRemote -Dir 'not-a-rooted-path' | Should -BeFalse
+    }
+
+    It 'surfaces the flag on the client payload so the UI can warn' {
+        Mock Get-DuneGameConfigClientEngineEnabled { $false }
+        $client = Get-DuneGameConfigClient -Dir (Get-PSDrive TestDrive).Root
+        $client.ContainsKey('dirRemote') | Should -BeTrue
+        $client.dirRemote | Should -BeFalse
+    }
+}
+
 Describe 'GameConfig: local client Game.ini and Engine.ini' -Tag 'GameConfig' {
 
     BeforeEach {

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -298,6 +298,8 @@ export type GameConfigClientInfo = GameConfigClientFileInfo & {
   dir: string
   dirResolved: string
   dirExists: boolean
+  /** Folder lives on another machine (UNC path or mapped network drive). */
+  dirRemote: boolean
   default: string
   engineEnabled: boolean
   game: GameConfigClientFileInfo

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -1120,7 +1120,9 @@ export function GameConfig() {
         <p className="text-xs text-text-muted mb-3">
           DST can mirror game settings into <span className="font-mono">Game.ini</span>. Managing{' '}
           <span className="font-mono">Engine.ini</span> is a separate opt-in because client console-variable overrides
-          can materially change gameplay.
+          can materially change gameplay. If you play on a different PC than the one running DST, share that PC&apos;s
+          config folder and point this at the share (for example{' '}
+          <span className="font-mono">\\GAMINGPC\DuneConfig</span>) — DST will manage the files over the network.
         </p>
         <label className="mb-3 flex items-start gap-3 rounded-lg border border-warning/30 bg-warning/5 p-3 cursor-pointer select-none">
           <input
@@ -1163,6 +1165,16 @@ export function GameConfig() {
             <Icon name="Save" size={14} /> Save
           </button>
         </div>
+        {clientInfo?.dirRemote && (
+          <div className="mt-2 rounded-lg border border-warning/35 bg-warning/10 p-2.5 text-[11px] text-text-muted">
+            <div className="mb-1 flex items-center gap-1.5 font-semibold text-warning">
+              <Icon name="Network" size={13} /> This folder is on another PC
+            </div>
+            <p>
+              That works — DST reads and writes the files over the network share. But it can only see whether Dune: Awakening is running on <em>this</em> PC, so it cannot warn you when the game is open on the machine that owns these files. <strong className="text-text">Close Dune on that PC before applying</strong>, otherwise the game rewrites <span className="font-mono text-text">Engine.ini</span> when it exits and your change is silently discarded. &ldquo;Open in Notepad&rdquo; also opens on this PC, not the other one.
+            </p>
+          </div>
+        )}
         {clientInfo && (
           <div className="text-[11px] text-text-dim mt-2 font-mono break-all space-y-0.5">
             {(['game', 'engine'] as const).map(file => {


### PR DESCRIPTION
## The question

If someone plays on one PC and runs DST on the server PC on the same LAN, can they share their client config folder and point DST at it?

**Yes, and it already worked** — the client config folder is a stored setting (`ClientConfigPath`), expanded and used directly for reads and writes, and the only validation is that the folder resolves and exists. A UNC path satisfies that. Nothing in the UI said so, though, and one caveat was completely invisible.

## The caveat

DST's "close Dune before writing `Engine.ini`" guard is `Get-Process` **on the machine DST runs on**. When the folder is on another PC, the game is running somewhere DST cannot inspect, so the guard silently passes — and Dune rewrites `Engine.ini` when it exits, discarding the change with no error anywhere.

DST cannot detect that across the network, so it now says so rather than letting a check that doesn't apply look like protection.

## Change

- `Test-DuneGameConfigClientDirRemote` — true for a UNC path or a network-mapped drive. Pure string and `DriveInfo` inspection, so it never touches the network and cannot hang on an offline share.
- Surfaced as `dirRemote` on the client config payload.
- Game Config shows a warning when the folder is remote: writes work over the share, but close Dune on that PC first, and "Open in Notepad" opens on the DST machine rather than the other one.
- The folder description now mentions the share option with an example path.

Consistent with reporting facts rather than judging setups: the warning fires on a state the system itself knows — the configured path is on another machine, so a local process check cannot apply — not on a threshold anyone invented. It stays silent for the normal same-PC case.

## Notes for whoever sets this up

The backend runs as the signed-in user (per-logon scheduled task; the keep-serving variant stores that user's password at RunLevel Highest, deliberately not LocalSystem so it can still see Hyper-V), so SMB access uses that account and the share must grant it write access.

## Verification

596 Pester (4 new: UNC detected, local not flagged, empty/unrooted safe, and the flag present on the payload), 107 Vitest, web UI production build, PowerShell 5.1 parse and BOM gates, full installer build. Not field-tested against a real share — the behaviour is established by reading the code, and the warning is written to match.