### PR TITLE
Promote nine field-confirmed controls out of Experimental; keep Apply INIs reachable

### DIFF
--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -238,15 +238,15 @@ $script:DuneGameConfigSchema = @(
     # compiled defaults stay unset rather than presenting an invented default.
     # Hazard.DehydrationZonesEnabled is intentionally excluded because its
     # compiled Funcom help explicitly warns that enabling it crashes clients.
-    @{ Section=$script:DuneGcSecConsole; Key='Dune.GiveDoubleDifficultyLoot'; File='engine'; Type='bool01'; Default='0'; Label='Double Difficulty Loot'; Help='Give double loot when encounter difficulty is above 0. Field-confirmed with dungeon loot; still experimental.'; Status='Confirmed'; Category='Experimental' }
+    @{ Section=$script:DuneGcSecConsole; Key='Dune.GiveDoubleDifficultyLoot'; File='engine'; Type='bool01'; Default='0'; Label='Double Difficulty Loot'; Help='Give double loot when encounter difficulty is above 0. Field-confirmed with dungeon loot.'; Status='Confirmed'; Startup=$true; Category='Loot & Death' }
     # Field testing established that INI-only application did not take effect,
     # while applying the same value through the Survival pod's ExecCmds did.
     # Existing generator fuel reflected the new duration after restart.
-    @{ Section=$script:DuneGcSecConsole; Key='dw.FuelBurningMultiplier'; File='engine'; Type='float'; Default='1.0'; Label='Fuel Burning Duration'; Help='Scales how long all fuel burns. DST applies the value in UserEngine.ini and the Hagga server startup command because INI-only application did not take effect in field testing. Restart the battlegroup to apply it; existing generator fuel updates after restart.'; Status='Confirmed'; Category='Experimental' }
+    @{ Section=$script:DuneGcSecConsole; Key='dw.FuelBurningMultiplier'; File='engine'; Type='float'; Default='1.0'; Label='Fuel Burning Duration'; Help='Scales how long all fuel burns. DST applies the value in UserEngine.ini and the Hagga server startup command because INI-only application did not take effect in field testing. Restart the battlegroup to apply it; existing generator fuel updates after restart.'; Status='Confirmed'; Startup=$true; Category='Building' }
     @{ Section=$script:DuneGcSecConsole; Key='Abilities.RespecCooldownTotalDurationSeconds'; File='engine'; Type='int'; Min=0; Unit='sec'; Default='172800'; Label='Ability Respec Cooldown'; Help='Total ability-respec cooldown in seconds. Compiled default is 172800 (2 days); 0 may remove the cooldown but has not been field-verified.'; Category='Experimental' }
-    @{ Section=$script:DuneGcSecConsole; Key='dw.LandsraadMissionRewardMultiplierFactionXP'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Landsraad Faction XP'; Help='Scales Faction XP from Landsraad missions. Field-confirmed at 10; mission preview may still show the base reward.'; Status='Confirmed'; Category='Experimental' }
-    @{ Section=$script:DuneGcSecConsole; Key='dw.LandsraadMissionRewardMultiplierHouseCredit'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Landsraad House Credit'; Help='Scales House Credit from Landsraad missions. Field-confirmed at 10; mission preview may still show the base reward.'; Status='Confirmed'; Category='Experimental' }
-    @{ Section=$script:DuneGcSecConsole; Key='dw.LandsraadMissionRewardMultiplierSpecializationXP'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Landsraad Specialization XP'; Help='Scales Specialization XP from Landsraad missions. Field-confirmed at 10; mission preview may still show the base reward.'; Status='Confirmed'; Category='Experimental' }
+    @{ Section=$script:DuneGcSecConsole; Key='dw.LandsraadMissionRewardMultiplierFactionXP'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Landsraad Faction XP'; Help='Scales Faction XP from Landsraad missions. Field-confirmed at 10; mission preview may still show the base reward.'; Status='Confirmed'; Startup=$true; Category='Landsraad' }
+    @{ Section=$script:DuneGcSecConsole; Key='dw.LandsraadMissionRewardMultiplierHouseCredit'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Landsraad House Credit'; Help='Scales House Credit from Landsraad missions. Field-confirmed at 10; mission preview may still show the base reward.'; Status='Confirmed'; Startup=$true; Category='Landsraad' }
+    @{ Section=$script:DuneGcSecConsole; Key='dw.LandsraadMissionRewardMultiplierSpecializationXP'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Landsraad Specialization XP'; Help='Scales Specialization XP from Landsraad missions. Field-confirmed at 10; mission preview may still show the base reward.'; Status='Confirmed'; Startup=$true; Category='Landsraad' }
     @{ Section=$script:DuneGcSecConsole; Key='dw.VehicleHeatMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Vehicle Heat Multiplier'; Help='Scales vehicle heat generation. 0 = no heat, 1 = normal, 2 = double. Applied through INI and Hagga startup command for local testing.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='dw.VehicleHeatInterpolationSpeed'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Vehicle Heat Interpolation Speed'; Help='Speeds up or slows down vehicle heat interpolation. Applied through INI and Hagga startup command for local testing.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='dw.VehiclePowerConsumptionMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Vehicle Power Consumption'; Help='Scales vehicle power use. 0 = no consumption, 1 = normal, 2 = double. Applied through INI and Hagga startup command for local testing.'; Category='Experimental' }
@@ -260,7 +260,7 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecConsole; Key='Vehicle.MaxActiveVehicles'; File='engine'; Type='int'; Min=-1; Default='-1'; Label='Maximum Active Vehicles'; Help='Rejects attempts to enter vehicle seats after this active-vehicle limit. -1 = unlimited. Applied through INI and Hagga startup command for local testing.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='Vehicle.MaxVehicles'; File='engine'; Type='int'; Min=-1; Default='-1'; Label='Maximum Vehicles'; Help='Rejects vehicle assembly or recovery after this total-vehicle limit. -1 = unlimited. Applied through INI and Hagga startup command for local testing.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='Vehicle.MaxVehiclesForSpawner'; File='engine'; Type='int'; Min=0; Default='400'; Label='Maximum Spawned Vehicles'; Help='Stops vehicle spawners after this many vehicles exist. Applied through INI and Hagga startup command for local testing.'; Category='Experimental' }
-    @{ Section=$script:DuneGcSecConsole; Key='Vehicle.MaxVehiclesPerPlayer'; File='engine'; Type='int'; Min=0; Default='10'; Label='Maximum Vehicles Per Player'; Help='Limits vehicles each player may spawn or claim. 0 = unlimited. Applied through INI and Hagga startup command for local testing.'; Status='Confirmed'; Category='Experimental' }
+    @{ Section=$script:DuneGcSecConsole; Key='Vehicle.MaxVehiclesPerPlayer'; File='engine'; Type='int'; Min=0; Default='10'; Label='Maximum Vehicles Per Player'; Help='Limits vehicles each player may spawn or claim. 0 = unlimited. DST applies it in UserEngine.ini and the Hagga server startup command. Field-confirmed: the limit is client-enforced, so every player also needs an equal or higher value in their own client Engine.ini before the raised cap shows in game.'; Status='Confirmed'; Startup=$true; Category='Vehicles' }
     @{ Section=$script:DuneGcSecConsole; Key='Vehicle.MaxVehiclesWarning'; File='engine'; Type='int'; Min=0; Label='Vehicle Count Warning Threshold'; Help='Vehicle count at which the amount notification becomes a warning. Applied through INI and Hagga startup command for local testing.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='Vehicle.CharacterHitDamageModifier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Vehicle Impact Character Damage'; Help='Scales damage dealt to characters by vehicle impacts. 0 should disable impact damage.'; Category='Experimental' }
     @{ Section=$script:DuneGcSecConsole; Key='Vehicle.DamagePlayerOnVehicleCollision'; File='engine'; Type='bool01'; Label='Vehicle Collision Damages Players'; Help='Whether vehicle collisions damage players. Compiled default was not recovered.'; Category='Experimental' }
@@ -300,7 +300,7 @@ $script:DuneGameConfigSchema = @(
 
     # Fills gaps in controls DST already exposes.
     @{ Section=$script:DuneGcSecConsole; Key='NPC.EnableNpcAttackLimits'; File='engine'; Type='bool01'; Label='Enable NPC Attack Limits'; Help='Funcom: "If set to 1, NPCs will utilize the attack limit curve when determining if they can attack a target". NPC Attack Limit Override above has no effect unless this is on. Compiled default was not recovered.'; Category='Experimental' }
-    @{ Section=$script:DuneGcSecConsole; Key='dw.FuelsBurningDuration'; File='engine'; Type='float'; Min=0; Unit='sec'; Label='Fuel Burn Time (seconds)'; Help='Funcom: "Time in seconds that every fuel consumed by the fuel powered generator will take to burn". An absolute time, unlike Fuel Burning Duration which is a multiplier. Setting both is untested. Compiled default was not recovered.'; Category='Experimental' }
+    @{ Section=$script:DuneGcSecConsole; Key='dw.FuelsBurningDuration'; File='engine'; Type='float'; Min=0; Unit='sec'; Label='Fuel Burn Time (seconds)'; Help='Funcom: "Time in seconds that every fuel consumed by the fuel powered generator will take to burn". An absolute time, unlike Fuel Burning Duration which is a multiplier. Field-confirmed. Setting both at once is still untested — use one or the other. Compiled default was not recovered.'; Status='Confirmed'; Startup=$true; Category='Building' }
     @{ Section=$script:DuneGcSecConsole; Key='dw.PlaceableShelterThresholdOverride'; File='engine'; Type='float'; Min=-1; Max=1; Default='-1'; Label='Placeable Shelter Threshold Override'; Help='Funcom: "The threshold value override for the placeable shelter, from 0 to 1. Negative value means it is disabled". Counterpart to Building Shelter Threshold Override.'; Category='Experimental' }
 
     # Survival and server ruleset.
@@ -357,12 +357,12 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecConsole; Key='Dac.EnableNearDeathDamageMitigation'; File='engine'; Type='bool01'; Label='Near-Death Damage Mitigation'; Help='Funcom: "If true, enable damage mitigation based on remaining health". Softens incoming damage as health drops.'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='Dac.EnableKnockbackDurationDamageScaling'; File='engine'; Type='bool01'; Label='Stagger Damage Scaling'; Help='Funcom: "If true, damage can be increased based on how long the target has been in stagger state".'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='Dac.ShieldBreakWhileAirborne'; File='engine'; Type='bool01'; Label='Shield Break While Airborne'; Help='Funcom: "Apply shield break stagger type when character is airborne".'; Category='Experimental 2' }
-    @{ Section=$script:DuneGcSecConsole; Key='Dune.DisableShieldOnShooting'; File='engine'; Type='bool01'; Label='Shield Drops While Shooting'; Help='Funcom: "Toggles if the shield should go down w". Funcom''s help text is truncated in the binary.'; Category='Experimental 2' }
+    @{ Section=$script:DuneGcSecConsole; Key='Dune.DisableShieldOnShooting'; File='engine'; Type='bool01'; Label='Shield Drops While Shooting'; Help='Funcom: "Toggles if the shield should go down w". Funcom''s help text is truncated in the binary. Field-confirmed: turning this off keeps a player''s shield up while they fire.'; Status='Confirmed'; Startup=$true; Category='PvP & Security' }
     @{ Section=$script:DuneGcSecConsole; Key='Abilities.HoltzmanShield.UsePowerWhenDisabled'; File='engine'; Type='bool01'; Default='0'; Label='Shield Uses Power When Disabled'; Help='Funcom: "0 (Default): off, 1 : on - When on shield will use power even if it''s disabled by ADS".'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='Abilities.AllowRepsecOutsideLandclaim'; File='engine'; Type='bool01'; Label='Respec Outside Land Claim'; Help='Funcom: "Allow players to repsec outside landclaim or socialhub". Funcom''s spelling is preserved in the key name.'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='Dune.LootNpcDroppedOnCorpseEnabled'; File='engine'; Type='bool01'; Label='NPC Loot On Corpses'; Help='Funcom: "Allows the client to enable or disable NPC loot dropped on NPC corpses". Controls where NPC loot lands, not whether NPCs drop loot - that is NPCs Drop Loot on Death under Loot & Death.'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='Dune.LootNpcDroppedOnContainerEnabled'; File='engine'; Type='bool01'; Label='NPC Loot In Containers'; Help='Funcom: "Allows the client to enable or disable NPC loot dropped on loot containers". Companion to NPC Loot On Corpses; both describe placement, not whether loot drops.'; Category='Experimental 2' }
-    @{ Section=$script:DuneGcSecConsole; Key='Loot.ShouldAlwaysRegeneratePerPlayerLoot'; File='engine'; Type='bool01'; Label='Regenerate Per-Player Loot'; Help='Funcom: "Should per player loot be regenerated each time player interact with loot container". Enabling this can make a single container farmable indefinitely.'; Category='Experimental 2' }
+    @{ Section=$script:DuneGcSecConsole; Key='Loot.ShouldAlwaysRegeneratePerPlayerLoot'; File='engine'; Type='bool01'; Label='Regenerate Per-Player Loot'; Help='Funcom: "Should per player loot be regenerated each time player interact with loot container". Field-confirmed. Enabling this can make a single container farmable indefinitely.'; Status='Confirmed'; Startup=$true; Category='Loot & Death' }
     @{ Section=$script:DuneGcSecConsole; Key='Inventory.GiveDefaultInventory.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Give Default Inventory On Respawn'; Help='Funcom: "If false player wont be given default inventory on respawn. (default=true)".'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='dw.Inventory.Item.Event.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Event Items Enabled'; Help='Funcom: "Are items which are only available from events enabled: 1 = enabled (default); 0 = disabled".'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='dw.Inventory.Item.Quest.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Quest Items Enabled'; Help='Funcom: "Are quest items which can be only looted and delivered enabled; 1: enabled (default); 0: disabled;".'; Category='Experimental 2' }
@@ -479,9 +479,16 @@ foreach ($field in $script:DuneGameConfigSchema) {
 # and had no effect. The commands are rebuilt from the INI at battlegroup restart
 # (see Invoke-DuneBattlegroupRestart), not on save. Both Experimental categories
 # qualify - they differ only in how the UI groups them.
+#
+# Startup=$true carries that same injection with a control once it is PROMOTED
+# out of Experimental into a real category. Without it, promotion would silently
+# drop the control from the startup command and break the very setting being
+# promoted - INI-only does nothing for these. Never widen this to every
+# [ConsoleVariables] field: Bgd.ServerLoginPassword lives there and must never
+# be written into a process command line.
 $script:DuneStartupConsoleVariableKeys = @(
     $script:DuneGameConfigSchema |
-        Where-Object { $_.File -eq 'engine' -and $_.Category -like 'Experimental*' } |
+        Where-Object { $_.File -eq 'engine' -and ($_.Category -like 'Experimental*' -or $_.Startup -eq $true) } |
         ForEach-Object { $_.Key }
 )
 
@@ -2480,6 +2487,11 @@ function Get-DuneGameConfigSchemaApi {
         if ($f.ContainsKey('Options')) {
             $field.options = @($f.Options | ForEach-Object { @{ value = $_.V; label = $_.L } })
         }
+        # Console variables live in UserEngine.ini [ConsoleVariables] and only take
+        # effect once the battlegroup restarts and rebuilds its startup command -
+        # unlike game INI keys, which apply on save. Flag them so the UI can say so
+        # on the field instead of leaving the user to find out by nothing happening.
+        if ($f.Section -eq $script:DuneGcSecConsole) { $field.consoleVar = $true }
         # Experimental controls are shown on their own page, grouped by what they
         # affect. Everything else keeps its Game Config category as the grouping.
         if ($cat -like 'Experimental*') {

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -320,8 +320,35 @@ function Get-DunePublicIpStatus {
 }
 
 # ----------------------------------------------------------------------------
-# P34 connectivity diagnostic.
+# Login distribution across game pods, parsed from the per-pod probe output.
+# Split out as a pure function so the collapsed-port-range decision is testable
+# without SSH, a cluster, or a DB.
 #
+# A collapsed forward looks like this: every external port in 7777-7810 is sent
+# to ONE internal port, so all clients arrive on whichever map owns that port.
+# The director granted them a different map/port, finds no matching completion
+# record, and refuses the login with Funcom's own `[Failure] FlowType:"Login"`
+# (surfaced to players as 2G2). Both conditions are required — logins funnelled
+# into a single pod AND Funcom actually rejecting them — so a quiet server, or a
+# server where everyone happens to be on one map legitimately, never fires it.
+# ----------------------------------------------------------------------------
+function Get-DuneP34LoginDistribution {
+    param([string]$ProbeOutput)
+    $pods = New-Object System.Collections.Generic.List[string]
+    $failures = 0
+    foreach ($m in [regex]::Matches([string]$ProbeOutput, 'POD=(\S+)\s+LOGIN=(\d+)\s+FAIL=(\d+)')) {
+        if ([int]$m.Groups[2].Value -gt 0) { $pods.Add($m.Groups[1].Value) | Out-Null }
+        $failures += [int]$m.Groups[3].Value
+    }
+    return [ordered]@{
+        pods      = @($pods)
+        failures  = $failures
+        collapsed = ($failures -gt 0 -and $pods.Count -eq 1)
+    }
+}
+
+# ----------------------------------------------------------------------------
+# P34 connectivity diagnostic.
 # "P34 / Connection Request Timed Out" AFTER the server is visible in the
 # in-game browser (FLS auth fine, no 403002) is, on self-hosted servers, almost
 # always a STALE PUBLIC IP: the game servers advertise an old external IPv4 to
@@ -351,6 +378,14 @@ function Get-DuneP34Diagnostic {
         staleK3sIp     = $false
         vmPublicIpUsable = $false
         serversReady   = $true
+        # Collapsed port-forward range: the router maps the external 7777-7810
+        # range onto ONE internal port, so every client lands on whichever map
+        # owns that port. The director issued a grant for a different map/port,
+        # finds no matching completion record, and refuses the login with 2G2.
+        # Detected from Funcom's own login-stage failure, never from a threshold.
+        loginPods      = @()
+        loginFailures  = 0
+        portsCollapsed = $false
         verdict        = 'unknown'
         summary        = $null
         error          = $null
@@ -553,8 +588,41 @@ fi
         default        { '' }
     }
 
+    # Collapsed port-forward range. When every external port in 7777-7810 is
+    # forwarded to ONE internal port, all clients arrive on whichever map owns
+    # that port. The director granted them a different map/port, so it finds no
+    # completion record and refuses the login with Funcom's own
+    # `[Failure] FlowType:"Login"` / `sb2G2$` error. We read that failure rather
+    # than inferring anything: ports being open is not the same as ports being
+    # forwarded to the right place, so the reachability checks above pass while
+    # nobody can actually join. Requires more than one game pod - on a
+    # single-map server every login landing on one pod is correct, not a fault.
+    if (@($maps).Count -gt 1) {
+        $logProbe = @'
+NS=$(sudo kubectl get battlegroup -A --no-headers -o custom-columns=:metadata.namespace 2>/dev/null | head -1)
+[ -z "$NS" ] && exit 0
+for p in $(sudo kubectl get pods -n "$NS" --no-headers -o custom-columns=:metadata.name 2>/dev/null | grep -- "-sg-"); do
+  L=$(sudo kubectl logs -n "$NS" "$p" --tail=3000 2>/dev/null | grep -c "flowtype=Login")
+  F=$(sudo kubectl logs -n "$NS" "$p" --tail=3000 2>/dev/null | grep -c '\[Failure\] FlowType:"Login"')
+  echo "POD=$p LOGIN=$L FAIL=$F"
+done
+'@ -replace "`r", ''
+        try {
+            $logRaw = (Invoke-V6Ssh -Ip $ctx.ip -Cmd $logProbe -TimeoutSec 45) -join "`n"
+            $collapse = Get-DuneP34LoginDistribution -ProbeOutput $logRaw
+            $result.loginPods = @($collapse.pods)
+            $result.loginFailures = [int]$collapse.failures
+            $result.portsCollapsed = [bool]$collapse.collapsed
+        } catch {}
+    }
+
     # Verdict, most-actionable first.
-    if ($result.datacenterPrivate) {
+    if ($result.portsCollapsed) {
+        $onePod = @($result.loginPods)[0]
+        $result.verdict = 'ports-collapsed'
+        $result.summary = "Players are reaching this server, but every connection is arriving on a single port. Your maps each listen on their own port ($((@($maps | ForEach-Object { $_.port } | Sort-Object -Unique) -join ', '))), and the server hands each player the port for the map they are joining — but all $($result.loginFailures) login attempt(s) landed on one map server ($onePod), so the server refused them. That refusal is the ""2G2"" error players see. This is a port-forwarding rule that sends the whole external UDP 7777-7810 range to one internal port: set the internal/local port range to 7777-7810 as well (or leave it blank) so each port maps straight through, then try joining again."
+    }
+    elseif ($result.datacenterPrivate) {
         # The persistent root: the director is pinned to advertise a private/LAN
         # address to every client. Ranked first because it's actionable even when
         # the servers look "down" from outside, and it's the explanation behind a

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -538,12 +538,7 @@ Describe 'DuneGameConfigSchema: only proven m_Global*Multiplier keys remain' -Ta
 Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
     BeforeAll {
         $script:ExperimentalKeys = @(
-            'Dune.GiveDoubleDifficultyLoot'
-            'dw.FuelBurningMultiplier'
             'Abilities.RespecCooldownTotalDurationSeconds'
-            'dw.LandsraadMissionRewardMultiplierFactionXP'
-            'dw.LandsraadMissionRewardMultiplierHouseCredit'
-            'dw.LandsraadMissionRewardMultiplierSpecializationXP'
             'dw.VehicleHeatMultiplier'
             'dw.VehicleHeatInterpolationSpeed'
             'dw.VehiclePowerConsumptionMultiplier'
@@ -557,7 +552,6 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             'Vehicle.MaxActiveVehicles'
             'Vehicle.MaxVehicles'
             'Vehicle.MaxVehiclesForSpawner'
-            'Vehicle.MaxVehiclesPerPlayer'
             'Vehicle.MaxVehiclesWarning'
             'Vehicle.CharacterHitDamageModifier'
             'Vehicle.DamagePlayerOnVehicleCollision'
@@ -582,7 +576,6 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             'SafeZone.Scale'
             # Second decode pass (build 2051294-0-shipping), UTF-16 aware.
             'NPC.EnableNpcAttackLimits'
-            'dw.FuelsBurningDuration'
             'dw.PlaceableShelterThresholdOverride'
             'Deathstill.ConversionTimeOverride'
             'Dac.DisablePvpDamage'
@@ -611,12 +604,10 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             'Dac.EnableNearDeathDamageMitigation'
             'Dac.EnableKnockbackDurationDamageScaling'
             'Dac.ShieldBreakWhileAirborne'
-            'Dune.DisableShieldOnShooting'
             'Abilities.HoltzmanShield.UsePowerWhenDisabled'
             'Abilities.AllowRepsecOutsideLandclaim'
             'Dune.LootNpcDroppedOnCorpseEnabled'
             'Dune.LootNpcDroppedOnContainerEnabled'
-            'Loot.ShouldAlwaysRegeneratePerPlayerLoot'
             'Inventory.GiveDefaultInventory.Enabled'
             'dw.Inventory.Item.Event.Enabled'
             'dw.Inventory.Item.Quest.Enabled'
@@ -688,8 +679,8 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         $experimental = @($script:DuneGameConfigSchema | Where-Object Category -eq 'Experimental')
         $experimental2 = @($script:DuneGameConfigSchema | Where-Object Category -eq 'Experimental 2')
 
-        $experimental.Count | Should -Be 64
-        $experimental2.Count | Should -Be 73
+        $experimental.Count | Should -Be 57
+        $experimental2.Count | Should -Be 71
         @($experimental.Key | Sort-Object) | Should -Be @($script:ExperimentalKeys | Sort-Object)
         @($experimental2.Key | Sort-Object) | Should -Be @($script:Experimental2Keys | Sort-Object)
         foreach ($key in @($script:ExperimentalKeys) + @($script:Experimental2Keys)) {
@@ -703,6 +694,8 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             }
         }
         # Both lists are applied identically; the split is presentation only.
+        # 128 still on the Experimental pages + the 9 promoted controls, which keep
+        # startup injection via Startup=$true.
         @($script:DuneStartupConsoleVariableKeys).Count | Should -Be 137
     }
 
@@ -712,7 +705,7 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         # Uncategorized rather than being forced into a neighbouring group.
         $api = @(Get-DuneGameConfigSchemaApi)
         $fields = @($api | Where-Object { $_.category -like 'Experimental*' } | ForEach-Object { $_.fields })
-        $fields.Count | Should -Be 137
+        $fields.Count | Should -Be 128
         foreach ($f in $fields) {
             $f.group | Should -Not -BeNullOrEmpty
             $f.status | Should -BeIn @('Confirmed', 'Unconfirmed')
@@ -727,18 +720,40 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         (Get-DuneExperimentalGroup -Key 'Totally.MadeUpKey') | Should -Be 'Uncategorized'
     }
 
-    It 'marks only field-confirmed controls as Confirmed' {
-        $api = @(Get-DuneGameConfigSchemaApi)
-        $fields = @($api | Where-Object { $_.category -like 'Experimental*' } | ForEach-Object { $_.fields })
-        $confirmed = @($fields | Where-Object { $_.status -eq 'Confirmed' } | ForEach-Object { $_.key })
-        @($confirmed | Sort-Object) | Should -Be @(
+    It 'promotes field-confirmed controls out of Experimental without losing startup injection' {
+        # Promotion is a metadata flip: a proven control leaves the Experimental
+        # pages for a real category. Startup=$true must travel with it, because
+        # these are console variables and INI-only application does nothing - the
+        # value only lands when the battlegroup restart rebuilds the startup
+        # command. Category alone used to drive that list, so promoting silently
+        # broke the very setting being promoted.
+        $promoted = @(
+            'Dune.DisableShieldOnShooting'
             'Dune.GiveDoubleDifficultyLoot'
             'dw.FuelBurningMultiplier'
+            'dw.FuelsBurningDuration'
             'dw.LandsraadMissionRewardMultiplierFactionXP'
             'dw.LandsraadMissionRewardMultiplierHouseCredit'
             'dw.LandsraadMissionRewardMultiplierSpecializationXP'
+            'Loot.ShouldAlwaysRegeneratePerPlayerLoot'
             'Vehicle.MaxVehiclesPerPlayer'
-        | Sort-Object)
+        )
+        foreach ($key in $promoted) {
+            $f = $script:DuneGameConfigSchema | Where-Object { $_.Key -eq $key }
+            $f | Should -Not -BeNullOrEmpty
+            $f.Category | Should -Not -BeLike 'Experimental*'
+            $f.Status | Should -Be 'Confirmed'
+            $f.Startup | Should -BeTrue
+            @($script:DuneStartupConsoleVariableKeys) | Should -Contain $key
+            # Console variables keep the blanket client-side mirror.
+            $f.ClientApply | Should -BeTrue
+        }
+
+        # Anything still on the Experimental pages is by definition unproven; a
+        # confirmed result is what triggers promotion.
+        $api = @(Get-DuneGameConfigSchemaApi)
+        $fields = @($api | Where-Object { $_.category -like 'Experimental*' } | ForEach-Object { $_.fields })
+        @($fields | Where-Object { $_.status -eq 'Confirmed' }) | Should -BeNullOrEmpty
     }
 
     It 'never lists the same control in both Experimental categories' {

--- a/tests/PublicIp.Tests.ps1
+++ b/tests/PublicIp.Tests.ps1
@@ -669,3 +669,63 @@ exit 0
         }
     }
 }
+
+Describe 'P34: collapsed port-forward range (2G2 on login)' {
+    # Signature taken verbatim from a real field case (2026-08-02): every
+    # external port forwarded to one internal port, so all logins landed on the
+    # Overmap pod while the director had granted Hagga on 7778.
+    It 'flags a collapse when every login lands on one pod and Funcom rejects them' {
+        $probe = @"
+POD=sh-abc-sg-overmap-pod-2 LOGIN=2 FAIL=2
+POD=sh-abc-sg-survival-1-pod-1 LOGIN=0 FAIL=0
+"@
+        $r = Get-DuneP34LoginDistribution -ProbeOutput $probe
+        $r.collapsed | Should -BeTrue
+        $r.failures  | Should -Be 2
+        @($r.pods).Count | Should -Be 1
+        @($r.pods)[0] | Should -Be 'sh-abc-sg-overmap-pod-2'
+    }
+
+    It 'does not flag a healthy server whose logins spread across maps' {
+        $probe = @"
+POD=sh-abc-sg-overmap-pod-2 LOGIN=5 FAIL=0
+POD=sh-abc-sg-survival-1-pod-1 LOGIN=3 FAIL=0
+"@
+        (Get-DuneP34LoginDistribution -ProbeOutput $probe).collapsed | Should -BeFalse
+    }
+
+    It 'does not flag when everyone is simply on one map and nothing is failing' {
+        # Legitimate: one map is busy, the other is empty. No refusals, no fault.
+        $probe = @"
+POD=sh-abc-sg-overmap-pod-2 LOGIN=7 FAIL=0
+POD=sh-abc-sg-survival-1-pod-1 LOGIN=0 FAIL=0
+"@
+        (Get-DuneP34LoginDistribution -ProbeOutput $probe).collapsed | Should -BeFalse
+    }
+
+    It 'does not flag when failures exist but logins are still reaching several maps' {
+        # Login failures alone are not a collapsed range - they could be the
+        # already-known zone-transfer cause of 2G2.
+        $probe = @"
+POD=sh-abc-sg-overmap-pod-2 LOGIN=4 FAIL=1
+POD=sh-abc-sg-survival-1-pod-1 LOGIN=2 FAIL=1
+"@
+        (Get-DuneP34LoginDistribution -ProbeOutput $probe).collapsed | Should -BeFalse
+    }
+
+    It 'stays silent on an idle server with no logins at all' {
+        $probe = @"
+POD=sh-abc-sg-overmap-pod-2 LOGIN=0 FAIL=0
+POD=sh-abc-sg-survival-1-pod-1 LOGIN=0 FAIL=0
+"@
+        $r = Get-DuneP34LoginDistribution -ProbeOutput $probe
+        $r.collapsed | Should -BeFalse
+        @($r.pods).Count | Should -Be 0
+    }
+
+    It 'returns a safe empty result when the probe produced nothing' {
+        $r = Get-DuneP34LoginDistribution -ProbeOutput ''
+        $r.collapsed | Should -BeFalse
+        $r.failures  | Should -Be 0
+    }
+}

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -132,6 +132,10 @@ export type GameConfigField = {
   max?: number
   quoted?: boolean
   clientApply?: boolean
+  // True for [ConsoleVariables] entries, which only take effect after a
+  // battlegroup restart rebuilds the startup command — unlike game INI keys
+  // that apply on save.
+  consoleVar?: boolean
   // When set, this field is a scalar member of a nested struct (e.g. the
   // LandsraadSettings Data=(...) box) rather than a flat INI key. Members that
   // share a (file, section, structKey) are written into one struct line.

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -62,6 +62,24 @@ function clientBundleFor(info: GameConfigClientInfo, file: 'game' | 'engine') {
   return file === 'engine' ? info.engine : (info.game ?? info)
 }
 
+// Scroll back to the top of the page. The app scrolls inside AppShell's <main>
+// element rather than the window, so walk up from the clicked button to the
+// nearest scrollable ancestor and fall back to <main> / the window.
+function scrollPageToTop(from: HTMLElement) {
+  let el: HTMLElement | null = from.parentElement
+  while (el) {
+    const overflowY = getComputedStyle(el).overflowY
+    if ((overflowY === 'auto' || overflowY === 'scroll') && el.scrollHeight > el.clientHeight) {
+      el.scrollTo({ top: 0, behavior: 'smooth' })
+      return
+    }
+    el = el.parentElement
+  }
+  const main = document.querySelector('main')
+  if (main) main.scrollTo({ top: 0, behavior: 'smooth' })
+  else window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
 const SANDWORM_ENABLED_KEY = 'sandworm.dune.Enabled'
 const CLIENT_INI_PATHS = {
   game: '%LOCALAPPDATA%\\DuneSandbox\\Saved\\Config\\WindowsClient\\Game.ini',
@@ -952,7 +970,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
       const ok = window.confirm(
         `Save ${count} Experimental setting${count === 1 ? '' : 's'}?\n\n`
         + (experimentalPage
-            ? 'These are written to the server UserEngine.ini. Nothing on the server changes until you restart the battlegroup — use “Apply INIs & restart” at the top. Saving on its own does not disconnect anyone.\n\n'
+            ? 'These are written to the server UserEngine.ini. Nothing on the server changes until you restart the battlegroup — use “Apply INIs & restart” in the bar at the bottom of this page. Saving on its own does not disconnect anyone.\n\n'
             : 'These are written to the server UserEngine.ini. Nothing on the server changes until you restart the battlegroup — use “Apply INIs & restart”. Saving on its own does not disconnect anyone.\n\n')
         + 'Confirmed behavior: some Experimental settings require matching client-side Engine.ini values before they take full effect. '
         + 'Every player may need compatible local values: normally the same value as the server, or an equal/higher value for client-enforced limits. '
@@ -977,7 +995,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
       let msg = `Saved ${n} change${n === 1 ? '' : 's'} into the DST-managed block. Tip: use “Backup settings” to snapshot before big changes — DST no longer auto-backs-up on every save.`
       if (experimentalStartupDirtyKeys.length > 0) {
         msg += experimentalPage
-          ? ' Saved to the server INI only — use “Apply INIs & restart” at the top to put these into effect.'
+          ? ' Saved to the server INI only — use “Apply INIs & restart” in the bar at the bottom of this page to put these into effect.'
           : ' Saved to the server INI only — restart the battlegroup with “Apply INIs & restart” to put these into effect.'
       }
       // If m_TaskGoalAmount was in this save, DST also rewrote the current
@@ -1131,7 +1149,8 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
                 <span className="text-text font-medium">Back up first and change one setting at a time.</span>
               </p>
               <p className="text-xs text-warning/90 leading-relaxed mt-1.5">
-                Saving here changes nothing on a running server — use “Apply INIs &amp; restart” at the top, or the same
+                Saving here changes nothing on a running server — use “Apply INIs &amp; restart” in the bar at the
+                bottom of this page, or the same
                 command on the Commands page. Many of these also need a matching value on each player&apos;s PC; use
                 “Player config” below to get the exact lines to hand out.
               </p>
@@ -1217,7 +1236,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
           <div>
             These are written to the server&apos;s <span className="font-mono text-text">UserEngine.ini</span> when you save.
             Nothing changes on a running server until the battlegroup restarts — use{' '}
-            <strong className="text-text">Apply INIs &amp; restart</strong> at the top of this page, or the same command
+            <strong className="text-text">Apply INIs &amp; restart</strong> in the bar at the bottom of this page, or the same command
             on the Commands page.
           </div>
         </div>
@@ -1726,6 +1745,26 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
               )}
             </div>
             <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={e => scrollPageToTop(e.currentTarget)}
+                className="btn-secondary"
+                title="Scroll back to the top of the page"
+              >
+                <Icon name="ArrowUp" size={14} /> Top
+              </button>
+              <button
+                type="button"
+                onClick={() => void onReloadPods()}
+                disabled={!vmRunning || reloadingPods || saving || dirtyKeys.length > 0 || loadState !== 'ready'}
+                className="btn-secondary"
+                title={dirtyKeys.length > 0
+                  ? 'Save or discard pending changes first'
+                  : 'Rebuild the server startup values from the INIs and restart the battlegroup so every map reloads with the current settings'}
+              >
+                <Icon name={reloadingPods ? 'Loader2' : 'RefreshCw'} size={14} className={reloadingPods ? 'animate-spin' : ''} />
+                {reloadingPods ? 'Restarting battlegroup…' : 'Apply INIs & restart'}
+              </button>
               <span className="text-xs text-text-muted">
                 {dirtyKeys.length === 0 ? 'No changes' : `${dirtyKeys.length} change${dirtyKeys.length === 1 ? '' : 's'}`}
               </span>
@@ -2100,6 +2139,16 @@ function FieldRow({ field, value, onChange, disabled, isDirty, isSet, isCustom, 
           {managed && (
             <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-accent/15 text-accent-bright" title="DST owns this section in the managed block">
               DST
+            </span>
+          )}
+          {field.consoleVar && (
+            <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-surface-2 text-text-muted" title="Console variable — saving alone changes nothing on a running server. It takes effect when the battlegroup restarts and rebuilds its startup command: use “Apply INIs & restart” in the bar at the bottom of this page. DST also offers to mirror console variables into this PC’s client Engine.ini; some are client-enforced and need every player to carry a matching value.">
+              CVar
+            </span>
+          )}
+          {field.clientApply && !field.consoleVar && (
+            <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-surface-2 text-text-muted" title="Client-enforced — each player also needs a matching (or equal/higher) value in their own client INI before this takes full effect. Use “Player config” to get the exact lines to hand out.">
+              Client
             </span>
           )}
           {isCustom ? (

--- a/webui/src/pages/settings/PublicIpCard.tsx
+++ b/webui/src/pages/settings/PublicIpCard.tsx
@@ -85,7 +85,10 @@ type P34Diagnostic = {
   staleFarmIp?: boolean
   staleK3sIp?: boolean
   serversReady?: boolean
-  verdict?: 'healthy' | 'stale-ip' | 'servers-down' | 'servers-not-ready' | 'igw-private' | 'datacenter-private' | 'unknown'
+  loginPods?: string[]
+  loginFailures?: number
+  portsCollapsed?: boolean
+  verdict?: 'healthy' | 'stale-ip' | 'servers-down' | 'servers-not-ready' | 'igw-private' | 'datacenter-private' | 'ports-collapsed' | 'unknown'
   summary?: string
   error?: string
 }
@@ -420,12 +423,12 @@ export function PublicIpCard() {
             <div className={
               p34.verdict === 'healthy'
                 ? 'rounded-lg border border-success/40 bg-success/10 p-3 text-sm text-success flex items-start gap-2'
-                : (p34.verdict === 'stale-ip' || p34.verdict === 'datacenter-private')
+                : (p34.verdict === 'stale-ip' || p34.verdict === 'datacenter-private' || p34.verdict === 'ports-collapsed')
                   ? 'rounded-lg border border-danger/40 bg-danger/10 p-3 text-sm text-danger flex items-start gap-2'
                   : 'rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm text-warning flex items-start gap-2'
             }>
               <Icon
-                name={p34.verdict === 'healthy' ? 'CheckCircle2' : (p34.verdict === 'stale-ip' || p34.verdict === 'datacenter-private') ? 'AlertTriangle' : 'AlertCircle'}
+                name={p34.verdict === 'healthy' ? 'CheckCircle2' : (p34.verdict === 'stale-ip' || p34.verdict === 'datacenter-private' || p34.verdict === 'ports-collapsed') ? 'AlertTriangle' : 'AlertCircle'}
                 size={15}
                 className="mt-0.5 shrink-0"
               />


### PR DESCRIPTION
Promotes nine field-confirmed controls out of Experimental into their proper categories (PvP & Security, Loot & Death, Building, Landsraad, Vehicles).

Adds **Apply INIs & restart** and **Top** to the sticky footer bar on Game Config and Experimental, so a saved change can be applied without scrolling back up. Console-variable fields get a CVar badge noting they need a restart.

Carries startup-command injection with an explicit `Startup=$true` flag. It was previously derived from the Experimental category, so promoting a control would have silently dropped it from the injection and broken it.

Adds a `ports-collapsed` verdict to the P34 connection check for a router that forwards the whole UDP 7777-7810 range to one internal port, which players see as a 2G2 error on login. Field-confirmed.

605 Pester, 113 Vitest, web build and installer preflight pass. No version bump.