### PR TITLE
Apply twelve saved-but-inert console variables at battlegroup startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Twelve server settings were being saved but never applied.** Console-variable settings that shipped before the startup-injection mechanism existed were written to the server's `UserEngine.ini` and nowhere else, so a battlegroup restart never picked them up — affecting Sun Exposure, the two mining multipliers and the PvP resource multiplier, both sandstorm toggles, all five sandworm controls, and Vehicle Durability Damage. They now travel with the server startup command like every other console variable, and a test enforces it so a future setting cannot be added without it.
+
 ## [13.2.1] - 2026-08-02
 
 ### Added

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -134,7 +134,7 @@ $script:DuneGameConfigSchema = @(
     # the server alone and needs no client-side apply. Reported working by a
     # community tester; the compiled default was not recovered, but sun exposure
     # is active in shipping gameplay.
-    @{ Section=$script:DuneGcSecConsole; Key='Hydration.SunExposureEnabled'; File='engine'; Type='bool01'; Default='1'; Label='Sun Exposure Enabled'; Help='Whether players take sun-exposure water drain. 0 disables sun exposure; field-reported working. Server-side only - no client apply needed.'; Category='Hydration' }
+    @{ Section=$script:DuneGcSecConsole; Key='Hydration.SunExposureEnabled'; File='engine'; Type='bool01'; Default='1'; Label='Sun Exposure Enabled'; Help='Whether players take sun-exposure water drain. 0 disables sun exposure; field-reported working. Server-side only - no client apply needed.'; Startup=$true; Category='Hydration' }
     @{ Section=$script:DuneGcSecHydration; Key='m_BiomeTierUpdateRateSeconds'; File='game'; Type='float'; Min=0; Unit='sec'; Default='2.5'; Label='Biome Tier Update Rate'; Help='How often (seconds) the biome hydration tier is re-evaluated. Also needs client-side apply.'; ClientApply=$true; Category='Hydration' }
 
     # --- Loot & Death (DuneSandboxGameModeBase) ---
@@ -144,9 +144,9 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecGameBase; Key='m_bShouldNpcDropLootOnDeath'; File='game'; Type='bool'; Default='True'; Label='NPCs Drop Loot on Death'; Help='Whether NPCs drop loot when killed. Also needs client-side apply.'; ClientApply=$true; Category='Loot & Death' }
 
     # --- Resources & Economy (engine ConsoleVariables) ---
-    @{ Section=$script:DuneGcSecConsole; Key='Dune.GlobalMiningOutputMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Global Mining Multiplier'; Help='Scales hand-mining resource output.'; Category='Resources & Economy' }
-    @{ Section=$script:DuneGcSecConsole; Key='Dune.GlobalVehicleMiningOutputMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Vehicle Mining Multiplier'; Help='Scales vehicle-mining resource output.'; Category='Resources & Economy' }
-    @{ Section=$script:DuneGcSecConsole; Key='SecurityZones.PvpResourceMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='PvP Resource Multiplier'; Help='Resource yield multiplier inside PvP zones.'; Category='Resources & Economy' }
+    @{ Section=$script:DuneGcSecConsole; Key='Dune.GlobalMiningOutputMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Global Mining Multiplier'; Help='Scales hand-mining resource output.'; Startup=$true; Category='Resources & Economy' }
+    @{ Section=$script:DuneGcSecConsole; Key='Dune.GlobalVehicleMiningOutputMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='Vehicle Mining Multiplier'; Help='Scales vehicle-mining resource output.'; Startup=$true; Category='Resources & Economy' }
+    @{ Section=$script:DuneGcSecConsole; Key='SecurityZones.PvpResourceMultiplier'; File='engine'; Type='float'; Min=0; Default='1.0'; Label='PvP Resource Multiplier'; Help='Resource yield multiplier inside PvP zones.'; Startup=$true; Category='Resources & Economy' }
 
     # --- Crafting ---
     @{ Section=$script:DuneGcSecCrafting; Key='m_RepairCostWeight'; File='game'; Type='float'; Min=0; Default='1.0'; Label='Repair Cost Weight'; Help='Scales repair costs. Also needs client-side apply.'; ClientApply=$true; Category='Crafting' }
@@ -174,8 +174,8 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecStorm; Key='m_bCoriolisAutoSpawnEnabled'; File='game'; Type='bool'; Default='True'; Label='Coriolis Auto-Spawn'; Help='Whether Coriolis storms spawn automatically. Also needs client-side apply.'; ClientApply=$true; Category='Storm Cycle' }
     @{ Section=$script:DuneGcSecCoriolis; Key='m_bIsDbWipeEnabled'; File='game'; Type='bool'; Default='True'; Label='Database Wipe on Season End'; Help='Wipe the database when the season ends. Also needs client-side apply.'; ClientApply=$true; Category='Storm Cycle' }
     @{ Section=$script:DuneGcSecCoriolis; Key='m_bShouldRestartServerOnCycleEnd'; File='game'; Type='bool'; Default='True'; Label='Restart Server on Cycle End'; Help='Whether the dedicated server restarts itself when a Coriolis cycle (season) ends. Also needs client-side apply.'; ClientApply=$true; Category='Storm Cycle' }
-    @{ Section=$script:DuneGcSecConsole; Key='Sandstorm.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Sandstorm'; Help='Enable rolling sandstorms.'; Category='Storm Cycle' }
-    @{ Section=$script:DuneGcSecConsole; Key='Sandstorm.Treasure.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Sandstorm Treasure Spawns'; Help='Spawn treasure during sandstorms.'; Category='Storm Cycle' }
+    @{ Section=$script:DuneGcSecConsole; Key='Sandstorm.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Sandstorm'; Help='Enable rolling sandstorms.'; Startup=$true; Category='Storm Cycle' }
+    @{ Section=$script:DuneGcSecConsole; Key='Sandstorm.Treasure.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Sandstorm Treasure Spawns'; Help='Spawn treasure during sandstorms.'; Startup=$true; Category='Storm Cycle' }
     @{ Section=$script:DuneGcSecStorm; Key='m_bCoriolisDoesDamage'; File='game'; Type='bool'; Default='False'; Label='Coriolis Storm Does Damage'; Help='Whether being caught in a Coriolis storm damages players. Also needs client-side apply.'; ClientApply=$true; Category='Storm Cycle' }
     @{ Section=$script:DuneGcSecStorm; Key='m_bSandStormDebrisEnabled'; File='game'; Type='bool'; Default='True'; Label='Sandstorm Debris'; Help='Whether sandstorms spawn flying debris. Also needs client-side apply.'; ClientApply=$true; Category='Storm Cycle' }
     @{ Section=$script:DuneGcSecTimeOfDay; Key='m_bTimeOfDayEnabled'; File='game'; Type='bool'; Default='True'; Label='Time of Day Cycle'; Help='Whether the day/night cycle advances. Also needs client-side apply.'; ClientApply=$true; Category='Storm Cycle' }
@@ -212,11 +212,11 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecTaxation; Key='m_TaxationCycleLengthSeconds'; File='game'; Type='int'; Min=0; Unit='sec'; Default='1209600'; Label='Taxation Cycle'; Help='Seconds between taxation collection cycles. Also needs client-side apply.'; ClientApply=$true; Category='Taxation' }
 
     # --- Sandworm (engine cvars + game settings) ---
-    @{ Section=$script:DuneGcSecConsole; Key='sandworm.dune.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Sandworm Enabled'; Help='Master toggle for the sandworm.'; Category='Sandworm' }
-    @{ Section=$script:DuneGcSecConsole; Key='Sandworm.SandwormDangerZonesEnabled'; File='engine'; Type='boolLower'; Default='true'; Label='Sandworm Danger Zones'; Help='Enable danger zones where the sandworm can attack.'; Category='Sandworm' }
-    @{ Section=$script:DuneGcSecConsole; Key='Vehicle.SandwormCollisionInteraction'; File='engine'; Type='boolLower'; Default='true'; Label='Sandworm Pushes Vehicles'; Help='Sandworm can push / damage vehicles.'; Category='Sandworm' }
-    @{ Section=$script:DuneGcSecConsole; Key='Vehicle.SandwormInvulnerabilitySecondsOnExit'; File='engine'; Type='float'; Min=0; Unit='sec'; Default='5.0'; Label='Invulnerability on Vehicle Exit'; Help='Seconds of sandworm invulnerability after exiting a vehicle.'; Category='Sandworm' }
-    @{ Section=$script:DuneGcSecConsole; Key='Vehicle.SandwormInvulnerabilitySecondsOnServerRestart'; File='engine'; Type='float'; Min=0; Unit='sec'; Default='60.0'; Label='Invulnerability on Server Restart'; Help='Seconds of sandworm invulnerability after a server restart.'; Category='Sandworm' }
+    @{ Section=$script:DuneGcSecConsole; Key='sandworm.dune.Enabled'; File='engine'; Type='bool01'; Default='1'; Label='Sandworm Enabled'; Help='Master toggle for the sandworm.'; Startup=$true; Category='Sandworm' }
+    @{ Section=$script:DuneGcSecConsole; Key='Sandworm.SandwormDangerZonesEnabled'; File='engine'; Type='boolLower'; Default='true'; Label='Sandworm Danger Zones'; Help='Enable danger zones where the sandworm can attack.'; Startup=$true; Category='Sandworm' }
+    @{ Section=$script:DuneGcSecConsole; Key='Vehicle.SandwormCollisionInteraction'; File='engine'; Type='boolLower'; Default='true'; Label='Sandworm Pushes Vehicles'; Help='Sandworm can push / damage vehicles.'; Startup=$true; Category='Sandworm' }
+    @{ Section=$script:DuneGcSecConsole; Key='Vehicle.SandwormInvulnerabilitySecondsOnExit'; File='engine'; Type='float'; Min=0; Unit='sec'; Default='5.0'; Label='Invulnerability on Vehicle Exit'; Help='Seconds of sandworm invulnerability after exiting a vehicle.'; Startup=$true; Category='Sandworm' }
+    @{ Section=$script:DuneGcSecConsole; Key='Vehicle.SandwormInvulnerabilitySecondsOnServerRestart'; File='engine'; Type='float'; Min=0; Unit='sec'; Default='60.0'; Label='Invulnerability on Server Restart'; Help='Seconds of sandworm invulnerability after a server restart.'; Startup=$true; Category='Sandworm' }
     @{ Section=$script:DuneGcSecSandworm; Key='WormDetectionDistance'; File='game'; Type='float'; Min=0; Default='5000.0'; Label='Worm Detection Distance'; Help='Distance at which worms detect players. Also needs client-side apply.'; ClientApply=$true; Category='Sandworm' }
     @{ Section=$script:DuneGcSecSandworm; Key='m_MinWormSpawnInternal'; File='game'; Type='float'; Min=0; Unit='sec'; Default='300.0'; Label='Min Worm Spawn Interval'; Help='Minimum seconds between worm spawns. Also needs client-side apply.'; ClientApply=$true; Category='Sandworm' }
     @{ Section=$script:DuneGcSecHazards; Key='m_SandwormQuicksandSpeedModifier'; File='game'; Type='float'; Min=0; Default='0.25'; Label='Quicksand Speed Modifier'; Help='Movement speed multiplier in quicksand. Also needs client-side apply.'; ClientApply=$true; Category='Sandworm' }
@@ -229,7 +229,7 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecContracts; Key='m_bIsEnabled'; File='game'; Type='bool'; Default='True'; Label='Contracts Enabled'; Help='Master toggle for the contracts subsystem. Also needs client-side apply.'; ClientApply=$true; Category='Encounters' }
 
     # --- Vehicles (engine cvars) ---
-    @{ Section=$script:DuneGcSecConsole; Key='dw.VehicleDurabilityDamageMultiplier'; File='engine'; Type='float'; Min=0; Max=10; Default='1.0'; Label='Vehicle Durability Damage'; Help='Durability damage multiplier for vehicles. 0 = off.'; Category='Vehicles' }
+    @{ Section=$script:DuneGcSecConsole; Key='dw.VehicleDurabilityDamageMultiplier'; File='engine'; Type='float'; Min=0; Max=10; Default='1.0'; Label='Vehicle Durability Damage'; Help='Durability damage multiplier for vehicles. 0 = off.'; Startup=$true; Category='Vehicles' }
 
     # --- Experimental binary-discovered engine cvars ---
     # These registered controls and their compiled help/defaults were decoded
@@ -486,6 +486,14 @@ foreach ($field in $script:DuneGameConfigSchema) {
 # promoted - INI-only does nothing for these. Never widen this to every
 # [ConsoleVariables] field: Bgd.ServerLoginPassword lives there and must never
 # be written into a process command line.
+#
+# The same gap existed for the console variables that shipped in real categories
+# BEFORE the Startup flag was introduced: they were written to UserEngine.ini and
+# nowhere else, so they never reached the startup command either. Those controls
+# now carry Startup=$true as well, and a test requires it of every engine-file
+# console variable outside Experimental except the Bgd.* pair - Bgd.ServerDisplayName
+# is injected per partition by the Sietch code, and Bgd.ServerLoginPassword must
+# never reach a command line.
 $script:DuneStartupConsoleVariableKeys = @(
     $script:DuneGameConfigSchema |
         Where-Object { $_.File -eq 'engine' -and ($_.Category -like 'Experimental*' -or $_.Startup -eq $true) } |

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -694,9 +694,10 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             }
         }
         # Both lists are applied identically; the split is presentation only.
-        # 128 still on the Experimental pages + the 9 promoted controls, which keep
+        # 128 still on the Experimental pages + the 9 promoted controls + the 12
+        # pre-existing console variables in real categories, all of which keep
         # startup injection via Startup=$true.
-        @($script:DuneStartupConsoleVariableKeys).Count | Should -Be 137
+        @($script:DuneStartupConsoleVariableKeys).Count | Should -Be 149
     }
 
     It 'groups every experimental control for the Experimental page' {
@@ -754,6 +755,31 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         $api = @(Get-DuneGameConfigSchemaApi)
         $fields = @($api | Where-Object { $_.category -like 'Experimental*' } | ForEach-Object { $_.fields })
         @($fields | Where-Object { $_.status -eq 'Confirmed' }) | Should -BeNullOrEmpty
+    }
+
+    It 'injects every non-Experimental console variable into the startup command' {
+        # Console variables that shipped in real categories before the Startup flag
+        # existed were written to UserEngine.ini and nowhere else, so they never
+        # reached the Hagga startup command - and INI-only application is
+        # field-proven inert for console variables. Every engine-file console
+        # variable outside Experimental must therefore carry Startup=$true. The
+        # Bgd.* pair is the deliberate exception: ServerDisplayName is injected per
+        # partition by the Sietch code and ServerLoginPassword must never reach a
+        # process command line.
+        $consoleFields = @(
+            $script:DuneGameConfigSchema |
+                Where-Object { $_.Section -eq $script:DuneGcSecConsole -and $_.Category -notlike 'Experimental*' }
+        )
+        $consoleFields.Count | Should -BeGreaterThan 0
+        foreach ($f in $consoleFields) {
+            if ($f.Key -like 'Bgd.*') {
+                $f.Startup | Should -Not -BeTrue
+                @($script:DuneStartupConsoleVariableKeys) | Should -Not -Contain $f.Key
+                continue
+            }
+            $f.Startup | Should -BeTrue
+            @($script:DuneStartupConsoleVariableKeys) | Should -Contain $f.Key
+        }
     }
 
     It 'never lists the same control in both Experimental categories' {


### PR DESCRIPTION
## Problem

Console variables that shipped in real Game Config categories **before** the `Startup` flag existed were written to the server's `UserEngine.ini` and nowhere else, so they never reached the Hagga startup command. INI-only application is field-proven inert for console variables (established with `dw.FuelBurningMultiplier`), which means these settings could be saved in the UI and have no effect.

Twelve controls were affected, and none of them carried an Experimental caveat — they present as ordinary shipped settings:

| Category | Key |
|---|---|
| Hydration | `Hydration.SunExposureEnabled` |
| Resources & Economy | `Dune.GlobalMiningOutputMultiplier`, `Dune.GlobalVehicleMiningOutputMultiplier`, `SecurityZones.PvpResourceMultiplier` |
| Storm Cycle | `Sandstorm.Enabled`, `Sandstorm.Treasure.Enabled` |
| Sandworm | `sandworm.dune.Enabled`, `Sandworm.SandwormDangerZonesEnabled`, `Vehicle.SandwormCollisionInteraction`, `Vehicle.SandwormInvulnerabilitySecondsOnExit`, `Vehicle.SandwormInvulnerabilitySecondsOnServerRestart` |
| Vehicles | `dw.VehicleDurabilityDamageMultiplier` |

This is the same class of defect caught pre-merge in v13.2.1, where promoting a control out of Experimental silently dropped it from the startup injection — except these predate the flag entirely rather than losing it on promotion.

## Change

- All twelve now carry `Startup=$true`, so they join `$script:DuneStartupConsoleVariableKeys`.
- New Pester test requires `Startup=$true` on **every** engine-file console variable outside Experimental, so a future setting cannot be added without it.
- The `Bgd.*` pair stays out by design and the test asserts their exclusion: `Bgd.ServerDisplayName` is injected per partition by the Sietch code, and `Bgd.ServerLoginPassword` must never reach a process command line.
- Comment above the key list documents the pre-flag gap alongside the existing promotion rule.

## Safety

No behaviour change for a setting the admin has not touched. `Sync-DuneStartupConsoleVariableOverrides` reads each key's effective value from the server's own `UserEngine.ini` and skips anything at its default, so the injection carries the user's configured value or nothing at all. It never reads a client file.

## Validation

- `Invoke-Pester tests/GameConfig.Tests.ps1` — 89/89 passing, including the new test and the startup-key count moving 137 → 149.
- `GameConfig.ps1` parses clean and retains its UTF-8 BOM (42 non-ASCII bytes).