### PR TITLE
Release v13.2.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.2.1"
+      placeholder: "v13.2.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.2.2] - 2026-08-02
+
 ### Fixed
 
 - **Twelve server settings were being saved but never applied.** Console-variable settings that shipped before the startup-injection mechanism existed were written to the server's `UserEngine.ini` and nowhere else, so a battlegroup restart never picked them up — affecting Sun Exposure, the two mining multipliers and the PvP resource multiplier, both sandstorm toggles, all five sandworm controls, and Vehicle Durability Damage. They now travel with the server startup command like every other console variable, and a test enforces it so a future setting cannot be added without it.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.2.1'
+$script:DuneToolVersion = '13.2.2'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.2.1',
+    [string]$Version = '13.2.2',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.2.1</Version>
+    <Version>13.2.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.2.1"
+#define MyAppVersion "13.2.2"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.2.1"
+$script:ToolVersion = "13.2.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Release prep for **v13.2.2**.

- Five version stamps bumped to `13.2.2` (`app/DuneServer.ps1`, `app/build/Build-Exe.ps1`, `app/desktop/DuneShell/DuneShell.csproj`, `app/installer/DuneServer.iss`, `dune-server.ps1`).
- `CHANGELOG.md` `[Unreleased]` rolled into `[13.2.2] - 2026-08-02`.
- `.github/ISSUE_TEMPLATE/bug_report.yml` `tool_version` placeholder bumped.

## What it ships

The startup-injection fix from #631 — twelve console variables that were saved to the server's `UserEngine.ini` but never reached the battlegroup startup command now apply like every other console variable: Sun Exposure, the two mining multipliers, the PvP resource multiplier, both sandstorm toggles, all five sandworm controls, and Vehicle Durability Damage.

No new diagnostic surfaces, so the bundler needs no extension; the bug template's existing Game Config section already covers these.

## Validation

- `Build-Installer.ps1` succeeded — `app/installer/output/DuneServerSetup.exe`, 48,366,126 bytes, `ProductVersion=13.2.2`.
- Version-parity preflight passed (the build aborts on a mismatch).
- Encoding preflight passed — no BOM-less non-ASCII `.ps1` bundled.
- `Invoke-Pester tests/GameConfig.Tests.ps1` — 89/89 on the underlying change.

The installer will be rebuilt from the final merge commit before the asset is uploaded.