### PR TITLE
Fix console-variable injection aborting on boolean values (v13.2.3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.2.2"
+      placeholder: "v13.2.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.2.3] - 2026-08-02
+
+### Fixed
+
+- **Console variables could stop applying entirely if any of them was set to true or false.** Settings that take a true/false value (the two sandworm collision and danger-zone controls) were run through a number check when the server startup command was rebuilt. That check failed on the word `false`, and the failure was hidden, so the rebuild produced no startup command at all and **every** console-variable setting silently stopped taking effect. Pressing Apply INIs & Restart reported success and changed nothing. Booleans now pass through correctly, and if the rebuild ever does fail the message says so instead of claiming success. Introduced in v13.2.2.
+
 ## [13.2.2] - 2026-08-02
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.2.2'
+$script:DuneToolVersion = '13.2.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.2.2',
+    [string]$Version = '13.2.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.2.2</Version>
+    <Version>13.2.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.2.2"
+#define MyAppVersion "13.2.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/lib/K8s.ps1
+++ b/app/lib/K8s.ps1
@@ -459,12 +459,21 @@ function Set-V6ConsoleVariableOverrides {
             $normalized[$name] = $null
             continue
         }
+        # Console variables are not all numeric. Boolean-typed ones (Type
+        # 'boolLower') legitimately carry true/false, and passing those through
+        # the numeric parser used to throw, which aborted the WHOLE rebuild and
+        # left the battlegroup with no startup commands at all - every console
+        # variable silently stopped applying. Pass booleans through verbatim.
+        if ($raw -match '^(?i:true|false)$') {
+            $normalized[$name] = $raw.ToLowerInvariant()
+            continue
+        }
         $number = 0.0
         $style = [System.Globalization.NumberStyles]::Float
         $culture = [System.Globalization.CultureInfo]::InvariantCulture
         if (-not [double]::TryParse($raw, $style, $culture, [ref]$number) -or
             [double]::IsNaN($number) -or [double]::IsInfinity($number)) {
-            throw "$name must be a finite number."
+            throw "$name must be a finite number or true/false."
         }
         $normalized[$name] = $number.ToString('0.################', $culture)
     }

--- a/app/server/lib/Maps.ps1
+++ b/app/server/lib/Maps.ps1
@@ -821,11 +821,18 @@ function Invoke-DuneBattlegroupRestart {
     }
 
     $result = Invoke-DuneCommandExternal -Name 'restart'
+    $message = 'Battlegroup restart launched - watch Server Health; it takes a couple of minutes to come back.'
+    if ($startupApply -is [hashtable] -and $startupApply.ContainsKey('ok') -and -not $startupApply['ok']) {
+        # Never report a clean apply when the startup commands were not rebuilt:
+        # the restart still happens, but the user's console variables will not be
+        # in force and silence here reads as "applied successfully".
+        $message = "Battlegroup restart launched, but the console-variable startup commands could NOT be rebuilt: $($startupApply['error']) Your console variables are not in force until this succeeds."
+    }
     return @{
         ok           = $true
         result       = $result
         startupApply = $startupApply
-        message      = 'Battlegroup restart launched - watch Server Health; it takes a couple of minutes to come back.'
+        message      = $message
     }
 }
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.2.2"
+$script:ToolVersion = "13.2.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -152,6 +152,52 @@ Describe 'Fuel burning startup override' -Tag 'GameConfig' {
         Should -Invoke _Invoke-V6BgJsonPatch -Times 0
     }
 
+    It 'injects boolean console variables instead of aborting the whole rebuild' {
+        # Regression (v13.2.2): boolLower controls such as
+        # Sandworm.SandwormDangerZonesEnabled carry true/false, but the injector
+        # forced every value through [double]::TryParse and threw on the first
+        # boolean. Invoke-DuneBattlegroupRestart swallows that exception, so the
+        # rebuild silently produced NO startup commands at all and every console
+        # variable stopped applying on servers that had set a boolean one.
+        $script:patched = $null
+        Mock Get-V6Battlegroup {
+            @{ Bg = [pscustomobject]@{ spec = [pscustomobject]@{ serverGroup = [pscustomobject]@{
+                template = [pscustomobject]@{ spec = [pscustomobject]@{ sets = @(
+                    [pscustomobject]@{
+                        map = 'Survival_1'
+                        partitions = @(1)
+                    })
+                } } }
+            } } }
+        }
+        Mock _Invoke-V6BgJsonPatch { $script:patched = $Patches; @{ Success = $true; Raw = '' } }
+
+        $result = Set-V6ConsoleVariableOverrides -Ip '192.0.2.1' `
+            -Names @('Sandworm.SandwormDangerZonesEnabled', 'Vehicle.SandwormCollisionInteraction', 'dw.FuelBurningMultiplier') `
+            -Values @{
+                'Sandworm.SandwormDangerZonesEnabled' = 'false'
+                'Vehicle.SandwormCollisionInteraction' = 'true'
+                'dw.FuelBurningMultiplier'            = '7'
+            }
+
+        $result.Success | Should -BeTrue
+        $args = @($script:patched | ForEach-Object { $_.value } | ForEach-Object { $_.arguments })
+        $exec = @($args | Where-Object { $_ -like '-execcmds=*' })
+        $exec.Count | Should -Be 1
+        # The boolean keeps its literal true/false spelling, and the numeric
+        # neighbours still ride along in the same argument.
+        $exec[0] | Should -BeLike '*Sandworm.SandwormDangerZonesEnabled false*'
+        $exec[0] | Should -BeLike '*Vehicle.SandwormCollisionInteraction true*'
+        $exec[0] | Should -BeLike '*dw.FuelBurningMultiplier 7*'
+    }
+
+    It 'still rejects a value that is neither numeric nor boolean' {
+        { Set-V6ConsoleVariableOverrides -Ip '192.0.2.1' `
+            -Names @('dw.FuelBurningMultiplier') `
+            -Values @{ 'dw.FuelBurningMultiplier' = 'banana' } } |
+            Should -Throw '*finite number or true/false*'
+    }
+
     It 'merges fuel and a per-sietch name into one ExecCmds argument' {
         $arguments = @(_Set-V6ExecCommand `
             -Arguments @('-log', '-execcmds="Bgd.ServerDisplayName ''Hagga, Prime''"') `


### PR DESCRIPTION
Hotfix for a regression introduced in **v13.2.2**, field-reproduced on a live server tonight.

## What broke

`Set-V6ConsoleVariableOverrides` forced every value through `[double]::TryParse` and threw on the first non-numeric one:

```powershell
if (-not [double]::TryParse($raw, $style, $culture, [ref]$number) ...) {
    throw "$name must be a finite number."
}
```

Two of the twelve controls given `Startup=$true` in v13.2.2 are `boolLower` type and legitimately carry `true`/`false`:

- `Sandworm.SandwormDangerZonesEnabled`
- `Vehicle.SandwormCollisionInteraction`

Before v13.2.2 neither was ever passed to the injector, so the parser never saw a boolean.

## Why it was invisible

`Invoke-DuneBattlegroupRestart` wraps the rebuild in a `try/catch` that stores the error and carries on, then returns `ok = $true` with the normal "restart launched" message. So on any server with one of those set:

1. The rebuild threw on the first boolean and produced **no** startup commands.
2. The battlegroup restarted with an empty `-execcmds`, so **every** console variable stopped applying — not just the boolean ones.
3. **Apply INIs & Restart reported success and wrote nothing**, so the obvious remedy silently did nothing and the settings looked broken.

Reproduced end to end: the injection disappeared from the battlegroup CR and the live pod, and repeated Apply INIs runs could not restore it.

## Fix

- Boolean values pass through verbatim (normalised to lowercase) instead of hitting the numeric parser.
- Values that are neither numeric nor boolean still throw, with a clearer message.
- A failed rebuild is now surfaced in the restart message rather than reported as a clean apply.

## Tests

Two Pester regression tests in `tests/GameConfig.Tests.ps1`:

- booleans and numerics are injected together into a single `-execcmds` argument
- a genuinely invalid value still throws

`Invoke-Pester tests/GameConfig.Tests.ps1` — **91/91 passing**.

## Validation

- `Build-Installer.ps1` succeeded — `ProductVersion=13.2.3`, 48,366,540 bytes.
- Both edited `.ps1` files keep their UTF-8 BOM and parse clean.
- Five version stamps bumped, CHANGELOG rolled, bug-report template placeholder updated.

The installer will be rebuilt from the final merge commit before the asset is uploaded.