### PR TITLE
Mirror only console variables the client is proven to read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- **Console variables are no longer offered for players to copy into their own `Engine.ini`.** Every console variable was being listed as something each player should mirror locally, "just in case". These settings reach the server through its startup command, not through any INI, so the copies were asking players to edit a file that changes nothing for all but one setting — Maximum Vehicles Per Player, which the game client genuinely reads for the cap it shows you. Only that one is still offered. Regular Game Config settings are unaffected and are still offered for client apply exactly as before. If client `Engine.ini` management is turned off, any console variables an earlier version wrote to the file are still cleaned up.
+
 ## [13.2.3] - 2026-08-02
 
 ### Fixed

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -462,13 +462,40 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecSandworm; Key='m_GiantWormMinimumPlayersOnSpiceField'; File='game'; Type='int'; Min=0; Unit='players'; Default='4'; Label='Giant Worm Min Players on Field'; Help='Minimum number of players on a spice field to trigger a giant sandworm spawn. Also needs client-side apply.'; ClientApply=$true; Category='Sandworm' }
 )
 
-# Gameplay console variables can be evaluated by either side. Mirror them into
-# the local client's Engine.ini when requested, but never copy server identity,
-# password, or URL/port settings to a player config.
+# Console variables are applied to the SERVER by the Hagga startup command, not
+# by any INI - field-proven 2026-08-02, in both directions: the injection alone
+# applied a value with both INIs blank, and both INIs set with the injection
+# stripped did nothing. So mirroring a console variable into a player's client
+# Engine.ini is never what makes it work on the server.
+#
+# A client copy only matters for the few console variables the CLIENT evaluates
+# independently for its own UI. That has to be established per control, because
+# mirroring one that the client does not read is not free:
+#
+#   1. It invites players to edit a file the game rewrites, for no effect.
+#   2. It contaminates field testing. Client apply mirrors the whole managed set
+#      onto the admin's own machine, so any result observed on his own server
+#      could be coming from either side - which is exactly how the Maximum
+#      Vehicles Per Player "Confirmed" status ended up resting on client-side
+#      evidence.
+#
+# So this list is EVIDENCE-ONLY: a key earns a place by being field-proven to be
+# read by the client, not by looking like it might be. Everything else stays
+# server-side, where the injection already applies it. Bgd.* could never qualify
+# regardless - those configure this server instance.
+$script:DuneClientEvaluatedConsoleVariables = @(
+    # Proven 2026-08-02: with this set ONLY in the client's Engine.ini, both a
+    # live retail Funcom server and a DST server displayed the client's value,
+    # overriding a server injection of 24. Retail cannot know that value, so the
+    # client is reading its own file. (Display only - whether a server refuses
+    # the extra vehicle is still untested.)
+    'Vehicle.MaxVehiclesPerPlayer'
+)
+
 foreach ($field in $script:DuneGameConfigSchema) {
     if ($field.File -eq 'engine' -and
         $field.Section -eq $script:DuneGcSecConsole -and
-        "$($field.Key)" -notlike 'Bgd.*') {
+        $script:DuneClientEvaluatedConsoleVariables -contains "$($field.Key)") {
         $field.ClientApply = $true
     }
 }
@@ -758,7 +785,14 @@ function Remove-DuneGameConfigClientEngineValues {
     $raw = [IO.File]::ReadAllText($path)
     $updates = New-Object 'System.Collections.Generic.List[object]'
     foreach ($f in $script:DuneGameConfigSchema) {
-        if ($f.File -ne 'engine' -or -not ($f.ContainsKey('ClientApply') -and $f.ClientApply)) { continue }
+        if ($f.File -ne 'engine') { continue }
+        # Removal sweeps everything DST could EVER have written here, not just
+        # what it mirrors today. Earlier versions flagged every non-Bgd console
+        # variable for client apply, so a user who had the opt-in on already has
+        # those keys in their file; narrowing the write set must not orphan them.
+        $wasManaged = ($f.ContainsKey('ClientApply') -and $f.ClientApply) -or
+                      ($f.Section -eq $script:DuneGcSecConsole -and "$($f.Key)" -notlike 'Bgd.*')
+        if (-not $wasManaged) { continue }
         if ($raw -match ('(?m)^\s*' + [regex]::Escape("$($f.Key)") + '\s*=')) {
             $updates.Add(@{ file = 'engine'; section = $f.Section; key = $f.Key; value = ''; remove = $true })
         }

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -735,9 +735,6 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             $fields[$key].File | Should -Be 'engine'
             $fields[$key].Category | Should -BeLike 'Experimental*'
             @($script:DuneStartupConsoleVariableKeys) | Should -Contain $key
-            if ($key -notlike 'Bgd.*') {
-                $fields[$key].ClientApply | Should -BeTrue
-            }
         }
         # Both lists are applied identically; the split is presentation only.
         # 128 still on the Experimental pages + the 9 promoted controls + the 12
@@ -792,8 +789,18 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             $f.Status | Should -Be 'Confirmed'
             $f.Startup | Should -BeTrue
             @($script:DuneStartupConsoleVariableKeys) | Should -Contain $key
-            # Console variables keep the blanket client-side mirror.
-            $f.ClientApply | Should -BeTrue
+        }
+
+        # Promotion says a control works, not that the client reads it. Only the
+        # one with client-side field evidence is mirrored to a player config;
+        # everything else is applied server-side by the startup command alone.
+        foreach ($key in $promoted) {
+            $f = $script:DuneGameConfigSchema | Where-Object { $_.Key -eq $key }
+            if ($key -eq 'Vehicle.MaxVehiclesPerPlayer') {
+                $f.ClientApply | Should -BeTrue
+            } else {
+                $f.ClientApply | Should -Not -BeTrue
+            }
         }
 
         # Anything still on the Experimental pages is by definition unproven; a
@@ -1014,14 +1021,29 @@ $script:DstManagedEnd
         }
     }
 
-    It 'includes experimental CVars in file-aware local client changes' {
+    It 'keeps experimental CVars out of local client changes' {
+        # Experimental controls are unproven console variables; nothing shows the
+        # client reads them, and the server applies them through the startup
+        # command. Offering them for client apply would tell a player to edit a
+        # file for no effect - and would mirror them onto the admin's own machine,
+        # confounding the very field test that is meant to prove them.
         Mock Get-DuneGameConfigClientEngineEnabled { $true }
         $notice = Get-DuneGameConfigClientApplyNotice -Updates @(
             @{ file='engine'; section=$script:DuneGcSecConsole; key='Dune.GiveDoubleDifficultyLoot'; value='1' },
             @{ file='engine'; section=$script:DuneGcSecConsole; key='Abilities.RespecCooldownTotalDurationSeconds'; value='0' }
         )
 
-        @($notice.items).Count | Should -Be 2
+        @($notice.items).Count | Should -Be 0
+    }
+
+    It 'offers the one client-read console variable for local client changes' {
+        Mock Get-DuneGameConfigClientEngineEnabled { $true }
+        $notice = Get-DuneGameConfigClientApplyNotice -Updates @(
+            @{ file='engine'; section=$script:DuneGcSecConsole; key='Vehicle.MaxVehiclesPerPlayer'; value='20' }
+        )
+
+        @($notice.items).Count | Should -Be 1
+        @($notice.items)[0].key | Should -Be 'Vehicle.MaxVehiclesPerPlayer'
         @($notice.items | ForEach-Object { $_.file } | Select-Object -Unique) | Should -Be @('engine')
         $notice.paths.engine | Should -Match 'Engine\.ini$'
     }
@@ -1163,11 +1185,22 @@ Describe 'GameConfig: client-apply flag covers local gameplay settings' -Tag 'Ga
         $missing -join ', ' | Should -Be ''
     }
 
-    It 'flags gameplay console variables but excludes server identity and ports' {
+    It 'mirrors only console variables the client is proven to read' {
+        # Console variables reach the server through the startup command, not any
+        # INI, so a client copy is only meaningful for the ones the client
+        # evaluates itself. Flagging the rest is not harmless: it tells players to
+        # edit a file for no effect, and it mirrors the whole managed set onto the
+        # admin's own machine, which confounds every result he field-tests.
         $gameplayEngine = @($script:DuneGameConfigSchema |
-            Where-Object { $_.File -eq 'engine' -and $_.Section -eq $script:DuneGcSecConsole -and $_.Key -notlike 'Bgd.*' })
-        @($gameplayEngine | Where-Object { -not $_.ClientApply }).Count | Should -Be 0
+            Where-Object { $_.File -eq 'engine' -and $_.Section -eq $script:DuneGcSecConsole })
 
+        $flagged = @($gameplayEngine | Where-Object { $_.ClientApply } | ForEach-Object { $_.Key })
+        @($flagged | Sort-Object) | Should -Be @($script:DuneClientEvaluatedConsoleVariables | Sort-Object)
+
+        # The one control with client-side field evidence.
+        $flagged | Should -Contain 'Vehicle.MaxVehiclesPerPlayer'
+
+        # Server-instance and connection settings could never qualify.
         foreach ($key in @('Bgd.ServerDisplayName','Bgd.ServerLoginPassword','Port','IGWPort')) {
             $field = @($script:DuneGameConfigSchema | Where-Object Key -eq $key)[0]
             $field.ContainsKey('ClientApply') | Should -BeFalse
@@ -1341,6 +1374,31 @@ Dune.GiveDoubleDifficultyLoot=1
         $result.changed | Should -BeTrue
         $raw | Should -Not -Match 'Vehicle\.MaxVehiclesPerPlayer'
         $raw | Should -Not -Match 'Dune\.GiveDoubleDifficultyLoot'
+        $raw | Should -Match 'r\.ScreenPercentage=100'
+    }
+
+    It 'still removes console variables written by earlier versions on opt-out' {
+        # Before the mirror was narrowed to client-read controls, DST flagged every
+        # non-Bgd console variable for client apply, so an existing user can have
+        # any of them sitting in their Engine.ini. Opting out must clear those too,
+        # or narrowing the write set silently strands them in the player's file.
+        $dir = Join-Path (Get-PSDrive TestDrive).Root 'legacy-cvars'
+        [void](New-Item -ItemType Directory -Path $dir)
+        [IO.File]::WriteAllText((Join-Path $dir 'Engine.ini'), @"
+[Renderer]
+r.ScreenPercentage=100
+
+[$script:DuneGcSecConsole]
+dw.FuelBurningMultiplier=7
+Abilities.RespecCooldownTotalDurationSeconds=0
+"@)
+
+        $result = Remove-DuneGameConfigClientEngineValues -Dir $dir
+        $raw = [IO.File]::ReadAllText((Join-Path $dir 'Engine.ini'))
+
+        $result.removed | Should -Be 2
+        $raw | Should -Not -Match 'dw\.FuelBurningMultiplier'
+        $raw | Should -Not -Match 'Abilities\.RespecCooldownTotalDurationSeconds'
         $raw | Should -Match 'r\.ScreenPercentage=100'
     }
 


### PR DESCRIPTION
## What

Console variables were all flagged for client-side apply except the `Bgd.*` pair, so changing any of them told players to copy the value into their own `Engine.ini`. Console variables reach the server through the battlegroup startup command, not through any INI — proven in both directions on 2026-08-02 — so those copies did nothing for all but one setting.

Only `Vehicle.MaxVehiclesPerPlayer` has field evidence that the client reads its own value: set solely in a client `Engine.ini`, it produced the displayed cap on a **live retail Funcom server**, which cannot know that value. That one keeps the mirror. The other 147 no longer offer it.

## Why it matters beyond tidiness

Client apply mirrored the whole managed console-variable set onto the admin's own machine, so any effect observed on his own server could have been coming from either side. That confound is how the Maximum Vehicles Per Player "Confirmed" status ended up resting on client-side evidence, and it was contaminating the Experimental testing programme.

## Not changed

- **Game.ini settings** — all 78 still mirror to clients exactly as before. They genuinely are read by both sides.
- **Startup injection** — still 149 keys. Nothing changes about how settings actually apply to the server.
- **The `Engine.ini` management opt-in** — still off by default, still gates all writes.

## Migration safety

Opt-out cleanup deliberately stays **broad**. It still sweeps every non-`Bgd` console variable out of the client file, so keys written by earlier versions are not orphaned now that the write set has narrowed. Covered by a new regression test.

## Validation

- Pester **610/610**
- Vitest **113/113**
- `webui` production build clean
- UTF-8 BOM on `GameConfig.ps1` verified preserved; test file stays pure ASCII
- Verified against the loaded schema: engine console vars with `clientApply` **148 → 1**, game-file `clientApply` unchanged at 78, startup keys unchanged at 149

## On the "Player config" dialog

An earlier draft of this description flagged `buildAllClientBlocks` (`webui/src/pages/GameConfig.tsx:146`) as missing an `engineEnabled` gate, since the paths at `:461` / `:476` have one. On review that is **not** a defect, and no gate was added:

- `:461` / `:476` are the **client-mismatch detector**, which drives a write to the admin's own machine. Gating on the opt-in is correct there.
- **Player config is a read-only hand-out list** ("Give your players this") describing what *other players* set on their own PCs. The opt-in governs whether DST writes to the admin's files, which is a separate concern. Gating it would hide the one genuinely client-read setting precisely when an admin has opted out of local management.

There is also no write hole behind the ungated display: `Save-DuneGameConfigClient` skips engine fields when the opt-in is off and throws `No client-applicable keys` if nothing remains, so engine writes are refused regardless of what the UI lists.

The user-visible confusion that prompted this work came from the 148 flagged CVars, not from that gate; with this change the dialog can surface at most one Engine.ini line.