### PR TITLE
Release v13.2.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.2.3"
+      placeholder: "v13.2.4"
     validations:
       required: true
 
@@ -97,7 +97,7 @@ body:
         - Web portal — Commands — Apply INIs & Restart
         - Web portal — Game Config — Server name (rename / battlegroup title shown in the in-game server browser)
         - Web portal — Game Config — Deep Desert PvP (live partitions / Apply & restart)
-        - Web portal — Game Config — client-side INI (Game.ini / Engine.ini opt-in / preview / Open in Notepad / client-apply reminder)
+        - Web portal — Game Config — client-side INI (Game.ini / Engine.ini opt-in / preview / Open in Notepad / client-apply reminder / Player config hand-out list)
         - Web portal — Gameplay Admin — Overview
         - Web portal — Gameplay Admin — Market / Market Bot
         - Web portal — Gameplay Admin — Players

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.2.4] - 2026-08-03
+
 ### Changed
 
 - **Console variables are no longer offered for players to copy into their own `Engine.ini`.** Every console variable was being listed as something each player should mirror locally, "just in case". These settings reach the server through its startup command, not through any INI, so the copies were asking players to edit a file that changes nothing for all but one setting — Maximum Vehicles Per Player, which the game client genuinely reads for the cap it shows you. Only that one is still offered. Regular Game Config settings are unaffected and are still offered for client apply exactly as before. If client `Engine.ini` management is turned off, any console variables an earlier version wrote to the file are still cleaned up.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.2.3'
+$script:DuneToolVersion = '13.2.4'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.2.3',
+    [string]$Version = '13.2.4',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.2.3</Version>
+    <Version>13.2.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.2.3"
+#define MyAppVersion "13.2.4"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.2.3"
+$script:ToolVersion = "13.2.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
Release prep for **v13.2.4**.

- Rolls the `Unreleased` console-variable client-mirror change into a dated `[13.2.4]` entry
- Bumps all five version stamps to `13.2.4`
- Refreshes `bug_report.yml`: version placeholder, and names the Player config hand-out list on the client-side INI option

## What v13.2.4 ships

Console variables are no longer offered for players to copy into their own `Engine.ini`. They reach the server through the battlegroup startup command, not through any INI, so those copies did nothing for every setting except Maximum Vehicles Per Player — which the game client genuinely reads for the cap it displays. Only that one is still offered.

Regular Game Config settings are unaffected and still mirror to clients exactly as before. Opt-out cleanup still removes console variables written by earlier versions, so nothing is stranded in a player's file.

## Verification

- Installer built from this branch: **48,367,031 bytes**, SHA256 `2C771370599310EAE09DD33DBD2B1A0775DD75645CF956ECB1316911152D89BD`, `ProductVersion=13.2.4`
- Will be **rebuilt from `main` after this merges** and re-verified before upload, per the stale-asset guard
- Pester 610/610, Vitest 113/113, webui build clean on the merged feature commit
- BOM state verified unchanged on all five stamp files