### PR TITLE
Mirror Dune.DisableShieldOnShooting to the client, on field evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- **"Shield Drops While Shooting" is now offered for players to apply locally.** Field testing showed the game reads this one from each player's own `Engine.ini`, not from the server: two players in the same session on the same server behaved differently depending on which of them had it set. It now appears in the Player config list alongside Maximum Vehicles Per Player, so you can hand it to your players. Every other console variable is still applied by the server alone.
+
 ## [13.2.4] - 2026-08-03
 
 ### Changed

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -490,6 +490,13 @@ $script:DuneClientEvaluatedConsoleVariables = @(
     # client is reading its own file. (Display only - whether a server refuses
     # the extra vehicle is still untested.)
     'Vehicle.MaxVehiclesPerPlayer'
+
+    # Proven 2026-08-03 by two independent tests. (1) Toggled ONLY in the
+    # client's Engine.ini with the server left untouched: on and off each
+    # produced the matching in-game behaviour. (2) Two players in the SAME
+    # session on the SAME server saw different behaviour, decided by which of
+    # them had the key in their own file. The client reads its own value.
+    'Dune.DisableShieldOnShooting'
 )
 
 foreach ($field in $script:DuneGameConfigSchema) {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3418,9 +3418,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -3637,9 +3637,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -791,16 +791,30 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             @($script:DuneStartupConsoleVariableKeys) | Should -Contain $key
         }
 
-        # Promotion says a control works, not that the client reads it. Only the
-        # one with client-side field evidence is mirrored to a player config;
+        # Promotion says a control works, not that the client reads it. Only keys
+        # with client-side field evidence are mirrored to a player config;
         # everything else is applied server-side by the startup command alone.
+        # Driven off the evidence list itself so adding a newly proven key is a
+        # one-line change there, not a test edit.
         foreach ($key in $promoted) {
             $f = $script:DuneGameConfigSchema | Where-Object { $_.Key -eq $key }
-            if ($key -eq 'Vehicle.MaxVehiclesPerPlayer') {
+            if (@($script:DuneClientEvaluatedConsoleVariables) -contains $key) {
                 $f.ClientApply | Should -BeTrue
             } else {
                 $f.ClientApply | Should -Not -BeTrue
             }
+        }
+
+        # The evidence list is deliberately tiny. If it ever grows large someone
+        # has started adding keys that merely look client-read, which is the
+        # blanket-mirror bug v13.2.4 removed.
+        @($script:DuneClientEvaluatedConsoleVariables).Count | Should -BeLessOrEqual 5
+        foreach ($key in @($script:DuneClientEvaluatedConsoleVariables)) {
+            $f = $script:DuneGameConfigSchema | Where-Object { $_.Key -eq $key }
+            $f | Should -Not -BeNullOrEmpty
+            $f.ClientApply | Should -BeTrue
+            # A server-instance control could never be client-read.
+            $key | Should -Not -BeLike 'Bgd.*'
         }
 
         # Anything still on the Experimental pages is by definition unproven; a

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -2792,9 +2792,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4290,6 +4290,34 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4959,35 +4987,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite-node/node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
@@ -5061,34 +5060,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {
@@ -5189,35 +5160,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -49,6 +49,6 @@
   "overrides": {
     "dompurify": "3.4.12",
     "esbuild": "0.28.1",
-    "postcss": "8.5.18"
+    "postcss": "8.5.23"
   }
 }


### PR DESCRIPTION
## What

Adds `Dune.DisableShieldOnShooting` to the client-mirror list, so it's offered to players in Player config alongside `Vehicle.MaxVehiclesPerPlayer`.

## Why

v13.2.4 narrowed that list from a blanket 148 keys down to one, on the principle that **a key earns a place only by being field-proven to be read from the client's own file** — not by looking like it might be.

This one clears the bar twice:

1. **Client-only toggle.** Changed *only* in the client `Engine.ini`, server untouched. On and off each produced the matching in-game behaviour.
2. **Two players, one session.** Same server, same login session, different behaviour — decided by which of them had the key in their own file. No server-side explanation survives that.

The second test is the decisive one: a single server cannot produce two different results for two players simultaneously from its own config.

## Test change

The promotion test hardcoded `Vehicle.MaxVehiclesPerPlayer` as *the* mirrored key, so adding any new one broke it. It now derives from `$script:DuneClientEvaluatedConsoleVariables` itself, and adds guardrails against the list drifting back toward a blanket mirror:

- the list stays small (≤ 5 keys)
- every entry actually carries `ClientApply`
- no `Bgd.*` server-instance key can ever enter it

So a newly proven key is a one-line change to the evidence list, not a test edit.

## Effect on users

DST will now write this key into the admin's own `Engine.ini` when client config management is enabled, and include it in the block handed to players. That's intended, but it is a real change to what lands in people's files.

## Testing

Full suite **610 passed / 0 failed**.