### PR TITLE
Drop vehicle heat from the 13.3.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ here cover everything those tags shipped.
 
 ### Fixed
 
-- **Console variables now apply in the Deep Desert.** Settings such as fuel burn rate, mining multipliers, sandworm behaviour and vehicle heat were only ever sent to Hagga Basin's server, so the Deep Desert ran at the game's stock defaults. It went unnoticed because DST used to copy every console variable into your own client config and that copy covered the gap; once that was narrowed to proven settings in 13.2.4, the Deep Desert quietly reverted to defaults. Both maps now receive them.
+- **Console variables now apply in the Deep Desert.** Settings such as fuel burn rate, mining multipliers and sandworm behaviour were only ever sent to Hagga Basin's server, so the Deep Desert ran at the game's stock defaults. It went unnoticed because DST used to copy every console variable into your own client config and that copy covered the gap; once that was narrowed to proven settings in 13.2.4, the Deep Desert quietly reverted to defaults. Both maps now receive them.
 
 ## [13.2.4] - 2026-08-03
 


### PR DESCRIPTION
Vehicle heat and overheat are field-confirmed to do nothing, so listing them among the settings that now reach the Deep Desert implies they work.

The injection fix itself is unaffected — the example was simply wrong. Fuel burn, mining multipliers and sandworm behaviour stay.

The published release notes and the Discord posts carry the same wording and are being corrected alongside this.