### PR TITLE
Cut the returning-player reward controls: not enabled for self-host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Removed
+
+- **The three returning-player reward settings are gone.** A Funcom developer confirmed they are not enabled for self-hosted servers: the reward packs are granted by Funcom's own service rather than by your server, so there is nothing for a self-host to hand out no matter how the settings are configured. They have been removed rather than left looking functional, and DST clears them from your server config on the next save.
+
 ## [13.3.0] - 2026-08-03
 
 ### Added

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -95,11 +95,15 @@ $script:DuneGameConfigCategoryOrder = @(
     'Experimental','Experimental 2'
 )
 
-# Keys DST USED to expose but later removed after field testing. The managed-block
-# writer actively scrubs these from the DST-owned managed block on every save, so
-# they don't linger orphaned in existing users' files after the schema drops them.
-# Only touches the managed block — never the user's own (body) sections.
+# Keys DST USED to expose but later removed once they were shown not to work.
+# The managed-block writer actively scrubs these from the DST-owned managed block
+# on every save, so they don't linger orphaned in existing users' files after the
+# schema drops them. Only touches the managed block — never the user's own (body)
+# sections. Works for BOTH files: the scrub in ConvertTo-DuneIniManaged is
+# section-agnostic, so an engine [ConsoleVariables] key is cleaned the same way a
+# game-file key is.
 $script:DuneGameConfigDeprecatedManagedKeys = @(
+    # Removed after field testing showed no in-game effect.
     'm_GlobalHealthMultiplier'
     'm_GlobalDamageToNpcsMultiplier'
     'm_GlobalDamageToPlayersMultiplier'
@@ -108,6 +112,16 @@ $script:DuneGameConfigDeprecatedManagedKeys = @(
     'm_GlobalFameMultiplier'
     'm_GlobalHarvestAmountMultiplier'
     'm_GlobalHarvestHealthMultiplier'
+
+    # Returning-player reward packs. Removed 2026-08-04 on a FUNCOM DEV's
+    # confirmation that these are not enabled for self-hosted servers: the award
+    # packs are granted by Funcom's own backend, not locally, so a self-host has
+    # nothing to grant from. Corroborated here - the game database carries no
+    # award/reward/entitlement table for them at all. Do not re-expose these
+    # without new evidence that a self-host can source the packs locally.
+    'dw.ReturningPlayer.GiveAward.Enabled'
+    'dw.ReturningPlayer.DaysBeforeEligibleForReward'
+    'dw.ReturningPlayer.GiveAward.TierOverride'
 )
 
 $script:DuneGameConfigSchema = @(
@@ -394,9 +408,6 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecConsole; Key='Journey.EnableSimplifiedChallengeCompletion'; File='engine'; Type='bool01'; Label='Simplified Challenge Completion'; Help='Funcom: "Enable this to complete challenge when interacting with altar. Otherwise, complete on returning from challenge room after succefully completing it. (0) Disabled (default); (1) Enabled".'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='Progression.IgnorePrereqs'; File='engine'; Type='bool01'; Label='Ignore Training Module Prerequisites'; Help='Funcom: "If true, Training Modules can be equipped even if pre-reqs aren''t met".'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='Progression.ShowAllPerks'; File='engine'; Type='bool01'; Label='Show All Perks'; Help='Funcom: "If true, all Perks defined in data will be shown in the player''s Perks menu". May reveal perks that are defined in data but not finished.'; Category='Experimental 2' }
-    @{ Section=$script:DuneGcSecConsole; Key='dw.ReturningPlayer.GiveAward.Enabled'; File='engine'; Type='bool01'; Label='Returning Player Rewards'; Help='Funcom: "Whether to grant award packs for player when eligible".'; Category='Experimental 2' }
-    @{ Section=$script:DuneGcSecConsole; Key='dw.ReturningPlayer.DaysBeforeEligibleForReward'; File='engine'; Type='int'; Min=0; Unit='days'; Label='Days Away Before Reward'; Help='Funcom: "How many days a player must be logged out before being eligible for a returning player reward".'; Category='Experimental 2' }
-    @{ Section=$script:DuneGcSecConsole; Key='dw.ReturningPlayer.GiveAward.TierOverride'; File='engine'; Type='int'; Min=-1; Default='-1'; Label='Returning Player Reward Tier'; Help='Funcom: "Override the tier used when granting reward packs. If set to -1 (default) the character''s tier is used".'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='NPC.EnableFacingTargetCheck'; File='engine'; Type='bool01'; Label='NPCs Must Face Target To Fire'; Help='Funcom: "If set to 1, NPCs will check if facing their target before firing their weapon".'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='NPC.FacingTargetAngleStartThreshold'; File='engine'; Type='float'; Min=0; Label='NPC Facing Angle To Start Firing'; Help='Funcom: "Set yaw angle threshold to prevent NPCs from start shooting their weapon if they aren''t facing their target". Only applies while NPCs Must Face Target To Fire is on.'; Category='Experimental 2' }
     @{ Section=$script:DuneGcSecConsole; Key='NPC.FacingTargetAngleStopThreshold'; File='engine'; Type='float'; Min=0; Label='NPC Facing Angle To Stop Firing'; Help='Funcom: "Set yaw angle threshold to stop NPCs shooting their weapon if they aren''t facing their target". Only applies while NPCs Must Face Target To Fire is on.'; Category='Experimental 2' }

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -732,9 +732,6 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             'Journey.EnableSimplifiedChallengeCompletion'
             'Progression.IgnorePrereqs'
             'Progression.ShowAllPerks'
-            'dw.ReturningPlayer.GiveAward.Enabled'
-            'dw.ReturningPlayer.DaysBeforeEligibleForReward'
-            'dw.ReturningPlayer.GiveAward.TierOverride'
             'NPC.EnableFacingTargetCheck'
             'NPC.FacingTargetAngleStartThreshold'
             'NPC.FacingTargetAngleStopThreshold'
@@ -780,7 +777,7 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         $experimental2 = @($script:DuneGameConfigSchema | Where-Object Category -eq 'Experimental 2')
 
         $experimental.Count | Should -Be 57
-        $experimental2.Count | Should -Be 71
+        $experimental2.Count | Should -Be 68
         @($experimental.Key | Sort-Object) | Should -Be @($script:ExperimentalKeys | Sort-Object)
         @($experimental2.Key | Sort-Object) | Should -Be @($script:Experimental2Keys | Sort-Object)
         foreach ($key in @($script:ExperimentalKeys) + @($script:Experimental2Keys)) {
@@ -791,10 +788,10 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             @($script:DuneStartupConsoleVariableKeys) | Should -Contain $key
         }
         # Both lists are applied identically; the split is presentation only.
-        # 128 still on the Experimental pages + the 9 promoted controls + the 12
+        # 125 still on the Experimental pages + the 9 promoted controls + the 12
         # pre-existing console variables in real categories, all of which keep
         # startup injection via Startup=$true.
-        @($script:DuneStartupConsoleVariableKeys).Count | Should -Be 149
+        @($script:DuneStartupConsoleVariableKeys).Count | Should -Be 146
     }
 
     It 'groups every experimental control for the Experimental page' {
@@ -803,7 +800,7 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         # Uncategorized rather than being forced into a neighbouring group.
         $api = @(Get-DuneGameConfigSchemaApi)
         $fields = @($api | Where-Object { $_.category -like 'Experimental*' } | ForEach-Object { $_.fields })
-        $fields.Count | Should -Be 128
+        $fields.Count | Should -Be 125
         foreach ($f in $fields) {
             $f.group | Should -Not -BeNullOrEmpty
             $f.status | Should -BeIn @('Confirmed', 'Unconfirmed')
@@ -997,6 +994,53 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         foreach ($key in @($script:DuneGameConfigDeprecatedManagedKeys)) {
             @($script:DuneGameConfigSchema.Key) | Should -Not -Contain $key
         }
+    }
+
+    It 'scrubs the retired returning-player rewards out of an engine managed block' {
+        # A Funcom dev confirmed these are not enabled for self-hosted servers -
+        # the award packs come from Funcom's backend, so a self-host has nothing
+        # to grant from. They are gone from the schema, and existing users have
+        # them sitting in UserEngine.ini from earlier versions.
+        #
+        # This is the case the game-file-only pre-pass in Save-DuneGameConfig
+        # does NOT cover: these are engine [ConsoleVariables] keys, so the only
+        # thing that removes them is the section-agnostic scrub inside
+        # ConvertTo-DuneIniManaged. Assert that path directly, because listing an
+        # engine key in the deprecated array while only the game file was cleaned
+        # would look correct and silently do nothing.
+        $retired = @(
+            'dw.ReturningPlayer.GiveAward.Enabled'
+            'dw.ReturningPlayer.DaysBeforeEligibleForReward'
+            'dw.ReturningPlayer.GiveAward.TierOverride'
+        )
+        foreach ($key in $retired) {
+            @($script:DuneGameConfigSchema.Key) | Should -Not -Contain $key
+            @($script:DuneGameConfigDeprecatedManagedKeys) | Should -Contain $key
+            @($script:DuneStartupConsoleVariableKeys) | Should -Not -Contain $key
+        }
+
+        $raw = @"
+[/Script/DuneSandbox.SomeUserSection]
+dw.ReturningPlayer.GiveAward.Enabled=1
+
+; ===== Dune Server Tool (DST) managed section BEGIN =====
+[ConsoleVariables]
+dw.FuelBurningMultiplier=6
+dw.ReturningPlayer.GiveAward.Enabled=1
+dw.ReturningPlayer.DaysBeforeEligibleForReward=1
+dw.ReturningPlayer.GiveAward.TierOverride=2
+; ===== Dune Server Tool (DST) managed section END =====
+"@
+        $out = ConvertTo-DuneIniManaged -Raw $raw -Updates @() -QuotedKeys @{}
+
+        # Gone from the DST-owned block...
+        $out | Should -Not -Match 'DaysBeforeEligibleForReward'
+        $out | Should -Not -Match 'GiveAward\.TierOverride'
+        # ...and a setting that still works is untouched.
+        $out | Should -Match 'dw\.FuelBurningMultiplier=6'
+        # The user's own section is never touched, even for a dead key.
+        $out | Should -Match '(?m)^\[/Script/DuneSandbox\.SomeUserSection\]'
+        @([regex]::Matches($out, 'ReturningPlayer\.GiveAward\.Enabled')).Count | Should -Be 1
     }
 
     It 'keeps restored vehicle controls in the managed INI block on the next save' {


### PR DESCRIPTION
A Funcom developer confirmed these three are **not enabled for self-hosted servers** — the reward packs are granted by Funcom's own backend, not locally, so a self-host has nothing to hand out however they're configured:

```
dw.ReturningPlayer.GiveAward.Enabled
dw.ReturningPlayer.DaysBeforeEligibleForReward
dw.ReturningPlayer.GiveAward.TierOverride
```

Corroborated against the live game database, which carries **no** award / reward / entitlement table for them at all — only unrelated Landsraad reward tables. There's no local source to make them work from, so they're cut rather than left looking functional.

## What changes

- Removed from `$script:DuneGameConfigSchema` (Experimental 2 → 71 keys, startup injection → 146).
- Added to `$script:DuneGameConfigDeprecatedManagedKeys`, so they're scrubbed from existing users' `UserEngine.ini` rather than orphaned there, and drop out of the startup injection on the next restart.
- Marked `EXCLUDED` in the CVar triage catalogue with the reason, so they don't get re-proposed later.

## The trap worth flagging

The deprecated pre-pass in `Save-DuneGameConfig` is gated on `$file -eq 'game'` and hardcodes the game section — it does **nothing** for an engine `[ConsoleVariables]` key. All eight pre-existing deprecated keys are game-file `m_Global*`, so this is the first engine key to use that path.

What actually cleans these is the section-agnostic scrub inside `ConvertTo-DuneIniManaged`. Listing an engine key in the array while only the game file was cleaned would look correct and silently do nothing, so the new test drives the engine path directly and also asserts the user's own body sections are left untouched.

## Testing

Full suite **627 passed / 0 failed**.