### PR TITLE
Add in-game !commands driven off the chat.intercept exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **In-game chat commands.** Players can type commands directly in game chat and DST acts on them, replying with a server broadcast. `!small`, `!medium` and `!large` activate spice fields of that size, and `!kit <name>` hands over one of your item packages (typing `!kit` on its own asks which one). Every command is off until you turn it on individually, each has its own per-player cooldown, and DST only listens on the chat channels you choose.
+
 ### Fixed
 
 - **Spice fields for maps that are no longer running are now marked, instead of sitting alongside live ones.** The game database keeps a row for every map instance that has ever existed, so a Deep Desert spun up for testing months ago still appears in the Spicefields card with no way to tell it apart from a running map. Those groups now sort to the bottom and carry a "not running" label. They are still shown rather than hidden, because a map being temporarily down is not the same as it being gone.

--- a/app/server/lib/ChatCommands.ps1
+++ b/app/server/lib/ChatCommands.ps1
@@ -1,0 +1,707 @@
+﻿# -----------------------------------------------------------------------------
+# ChatCommands.ps1 — player-triggered `!commands` from in-game chat.
+#
+# HOW THIS IS POSSIBLE AT ALL (proven live 2026-08-04):
+#
+#   The battlegroup's mq-game broker carries a TOPIC exchange `chat.intercept`,
+#   catch-all bound (`#`) to Funcom's own `queue.intercept`, which their
+#   textRouter consumes. Because it is a topic exchange, binding a SECOND queue
+#   alongside gives us a COPY of every chat message and leaves Funcom's consumer
+#   completely untouched - no interception, no diversion, nothing removed from
+#   their queue.
+#
+#   A captured message body looks like (outer envelope, inner JSON string):
+#     { "Type": "TextChat",
+#       "content": "{ \"m_ChannelType\": \"Proximity\",
+#                     \"m_FuncomIdFrom\": \"Coastal#45066\",
+#                     \"m_Message\": { \"m_UnlocalizedMessage\": \"!large\" },
+#                     \"m_OriginLocation\": { \"X\":..,\"Y\":..,\"Z\":.. },
+#                     \"m_Timestamp\": \"2026.08.05-00.13.11\" }" }
+#
+#   So we get the literal text, who sent it, which channel, when, and where they
+#   were standing. That is everything a command needs.
+#
+# WHY POLLING AND NOT A CONSUMER:
+#   DST has no AMQP client - every RMQ operation it already performs (broadcasts,
+#   whispers, ServerCommands) goes through `rabbitmqctl eval` over SSH. This
+#   follows that exact path rather than introducing a persistent connection and
+#   a new dependency. We basic_get in batches on a scheduler tick; a few seconds
+#   of latency is irrelevant for a chat command.
+#
+# SAFETY POSTURE (deliberate - do not loosen without asking):
+#   - OFF by default, master switch plus per-command opt-in.
+#   - The queue is declared BOUNDED (x-max-length + TTL, drop-head) so it can
+#     never grow without limit if DST stops draining it. That matters: this
+#     queue receives a copy of ALL chat.
+#   - Per-player, per-command cooldowns.
+#   - These are world-affecting actions triggered by ordinary players, which is a
+#     real shift in who controls the server. Default to the conservative option
+#     every time.
+# -----------------------------------------------------------------------------
+
+$script:DuneChatQueueName    = 'dst.chat.commands'
+$script:DuneChatExchange     = 'chat.intercept'
+# Bounded on purpose - see SAFETY POSTURE above.
+$script:DuneChatQueueMaxLen  = 500
+$script:DuneChatQueueTtlMs   = 300000
+# Drained per tick. Enough to absorb a busy server between ticks without letting
+# one tick block on an unbounded loop.
+$script:DuneChatDrainMax     = 25
+
+$script:DuneChatStateFile = $null
+
+function Get-DuneChatCommandsStatePath {
+    if ($script:DuneChatStateFile) { return $script:DuneChatStateFile }
+    $dir = if ($env:APPDATA) { Join-Path $env:APPDATA 'DuneServer' } else { $env:TEMP }
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+        try { New-Item -ItemType Directory -Path $dir -Force | Out-Null } catch {}
+    }
+    return (Join-Path $dir 'chat-commands.json')
+}
+
+# Default config. Every command is OFF until the admin turns it on.
+function New-DuneChatCommandsDefault {
+    return @{
+        enabled  = $false
+        # Replies go out through DST's existing broadcast feature, which carries
+        # no sender identity - so there is nothing to impersonate and no account
+        # to pick. What the admin DOES control is the heading players see, which
+        # is the meaningful equivalent. ("SERVER" is what the game renders it as.)
+        replyTitle = 'Server'
+        commands = @{
+            kit    = @{ enabled = $false; cooldownSeconds = 604800 }
+            small  = @{ enabled = $false; cooldownSeconds = 900 }
+            medium = @{ enabled = $false; cooldownSeconds = 900 }
+            large  = @{ enabled = $false; cooldownSeconds = 900 }
+        }
+        # channels the handler will listen on; anything else is ignored outright
+        channels = @('Proximity', 'Map')
+        cooldowns = @{}
+        lastError = ''
+        lastSeenAt = ''
+    }
+}
+
+# Kept as the single place that decides whether the feature may run, so adding a
+# future prerequisite does not mean hunting call sites. Broadcast replies need
+# no account, so today the only gate is the master switch plus at least one
+# enabled command - a feature that can never respond to anything is a
+# misconfiguration worth surfacing rather than silently doing nothing.
+function Test-DuneChatCommandsReady {
+    param([hashtable]$State)
+    if (-not $State) { return @{ ready = $false; reason = 'no-state' } }
+    $anyOn = $false
+    foreach ($k in @($State.commands.Keys)) {
+        if ($State.commands[$k].enabled) { $anyOn = $true; break }
+    }
+    if (-not $anyOn) {
+        return @{ ready = $false; reason = 'no-commands-enabled'
+                  message = 'Turn on at least one command, or the listener has nothing to respond to.' }
+    }
+    return @{ ready = $true }
+}
+
+function Read-DuneChatCommandsState {
+    $path = Get-DuneChatCommandsStatePath
+    $def = New-DuneChatCommandsDefault
+    if (-not (Test-Path -LiteralPath $path)) { return $def }
+    try {
+        $obj = (Get-Content -LiteralPath $path -Raw -ErrorAction Stop) | ConvertFrom-Json -ErrorAction Stop
+        $out = $def
+        if ($null -ne $obj.enabled) { $out.enabled = [bool]$obj.enabled }
+        if ($obj.channels)   { $out.channels = @($obj.channels) }
+        if ($obj.lastError)  { $out.lastError = [string]$obj.lastError }
+        if ($obj.lastSeenAt) { $out.lastSeenAt = [string]$obj.lastSeenAt }
+        if ($obj.commands) {
+            foreach ($p in $obj.commands.PSObject.Properties) {
+                $name = "$($p.Name)".ToLowerInvariant()
+                if (-not $out.commands.ContainsKey($name)) { $out.commands[$name] = @{} }
+                foreach ($cp in $p.Value.PSObject.Properties) {
+                    $out.commands[$name][$cp.Name] = $cp.Value
+                }
+            }
+        }
+        if ($obj.cooldowns) {
+            $cd = @{}
+            foreach ($p in $obj.cooldowns.PSObject.Properties) { $cd[$p.Name] = [string]$p.Value }
+            $out.cooldowns = $cd
+        }
+        return $out
+    } catch {
+        return $def
+    }
+}
+
+function Save-DuneChatCommandsState {
+    param([hashtable]$State)
+    $path = Get-DuneChatCommandsStatePath
+    try {
+        ($State | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $path -Encoding UTF8
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Pure parsing. Kept free of SSH/RMQ so it is directly unit-testable, and
+# because this is the part that has to survive Funcom changing their payload.
+# -----------------------------------------------------------------------------
+
+# Pull the courier envelope out of whatever wrapper it arrived in and normalise
+# it. Returns $null when the text is not a chat message we understand - callers
+# must treat that as "ignore", never as an error.
+function ConvertFrom-DuneChatMessage {
+    param([string]$Text)
+    if ([string]::IsNullOrWhiteSpace($Text)) { return $null }
+
+    # The envelope is {"content":"<escaped json>","Type":"TextChat"}. It may be
+    # embedded in a larger Erlang term dump, so locate it rather than assuming
+    # the whole string is JSON.
+    $m = [regex]::Match($Text, '\{"content":"(?:[^"\\]|\\.)*","Type":"[^"]*"\}')
+    if (-not $m.Success) {
+        $m = [regex]::Match($Text, '\{"content":.*?,"Type":"[^"]*"\}')
+        if (-not $m.Success) { return $null }
+    }
+    try { $outer = $m.Value | ConvertFrom-Json -ErrorAction Stop } catch { return $null }
+    if (-not $outer.content) { return $null }
+    try { $inner = $outer.content | ConvertFrom-Json -ErrorAction Stop } catch { return $null }
+
+    $body = ''
+    if ($inner.m_Message -and $inner.m_Message.m_UnlocalizedMessage) {
+        $body = [string]$inner.m_Message.m_UnlocalizedMessage
+    }
+    # Funcom sends the channel bare ("Proximity") from the intercept exchange but
+    # enum-qualified ("ETextChatChannelType::Whispers") elsewhere. Normalise.
+    $channel = [string]$inner.m_ChannelType
+    if ($channel -match '::') { $channel = ($channel -split '::')[-1] }
+
+    return @{
+        type      = [string]$outer.Type
+        channel   = $channel
+        fromId    = [string]$inner.m_FuncomIdFrom
+        toId      = [string]$inner.m_UserNameTo
+        text      = $body
+        timestamp = [string]$inner.m_Timestamp
+        location  = if ($inner.m_OriginLocation) {
+            @{ x = [double]$inner.m_OriginLocation.X; y = [double]$inner.m_OriginLocation.Y; z = [double]$inner.m_OriginLocation.Z }
+        } else { $null }
+    }
+}
+
+# "!large" / "  !KIT extra bits " -> @{ verb='large'; args=@() }
+# Returns $null for anything that is not a bang command, which is the common
+# case - the queue carries ALL chat, so most messages are ordinary conversation
+# and must be ignored silently.
+function Get-DuneChatCommand {
+    param([string]$Text)
+    if ([string]::IsNullOrWhiteSpace($Text)) { return $null }
+    $t = $Text.Trim()
+    if (-not $t.StartsWith('!')) { return $null }
+    $t = $t.Substring(1)
+    if ([string]::IsNullOrWhiteSpace($t)) { return $null }
+    $parts = @($t -split '\s+' | Where-Object { $_ -ne '' })
+    if ($parts.Count -eq 0) { return $null }
+    $verb = $parts[0].ToLowerInvariant()
+    # Guard against a pathological "!" spam string becoming a giant verb.
+    if ($verb.Length -gt 32) { return $null }
+    return @{
+        verb = $verb
+        args = @(if ($parts.Count -gt 1) { $parts[1..($parts.Count - 1)] } else { @() })
+    }
+}
+
+# Cooldown bookkeeping is keyed per player AND per command so a shared cooldown
+# never leaks between commands.
+function Get-DuneChatCooldownKey {
+    param([string]$FromId, [string]$Verb)
+    return ('{0}|{1}' -f "$FromId".ToLowerInvariant(), "$Verb".ToLowerInvariant())
+}
+
+# Returns @{ allowed=bool; remainingSeconds=int }. An unparseable stored stamp
+# is treated as "no cooldown recorded" rather than blocking the player forever.
+function Test-DuneChatCooldown {
+    param(
+        [hashtable]$Cooldowns,
+        [string]$Key,
+        [int]$CooldownSeconds,
+        [datetime]$Now = [datetime]::UtcNow
+    )
+    if ($CooldownSeconds -le 0) { return @{ allowed = $true; remainingSeconds = 0 } }
+    if (-not $Cooldowns -or -not $Cooldowns.ContainsKey($Key)) {
+        return @{ allowed = $true; remainingSeconds = 0 }
+    }
+    $last = [datetime]::MinValue
+    if (-not [datetime]::TryParse(
+            [string]$Cooldowns[$Key], [cultureinfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::RoundtripKind, [ref]$last)) {
+        return @{ allowed = $true; remainingSeconds = 0 }
+    }
+    $elapsed = ($Now - $last.ToUniversalTime()).TotalSeconds
+    if ($elapsed -ge $CooldownSeconds) { return @{ allowed = $true; remainingSeconds = 0 } }
+    return @{ allowed = $false; remainingSeconds = [int][math]::Ceiling($CooldownSeconds - $elapsed) }
+}
+
+function Format-DuneChatCooldownRemaining {
+    param([int]$Seconds)
+    if ($Seconds -le 0) { return 'now' }
+    if ($Seconds -lt 60) { return "{0}s" -f $Seconds }
+    if ($Seconds -lt 3600) { return "{0}m" -f [int][math]::Ceiling($Seconds / 60) }
+    if ($Seconds -lt 86400) { return "{0}h" -f [int][math]::Ceiling($Seconds / 3600) }
+    return "{0}d" -f [int][math]::Ceiling($Seconds / 86400)
+}
+
+# Decide what to do with one parsed chat message, WITHOUT performing it. Pure, so
+# the whole gate chain (enabled -> channel -> is-a-command -> known -> per-command
+# enabled -> cooldown) is testable without a server.
+function Resolve-DuneChatCommandAction {
+    param(
+        [hashtable]$Message,
+        [hashtable]$State,
+        [datetime]$Now = [datetime]::UtcNow
+    )
+    if (-not $Message) { return @{ action = 'ignore'; reason = 'unparsed' } }
+    if (-not $State.enabled) { return @{ action = 'ignore'; reason = 'disabled' } }
+    # Belt and braces: even if something flips `enabled` without going through
+    # the route's validation, a missing reply account stops the feature dead
+    # rather than running commands nobody can be told about.
+    $ready = Test-DuneChatCommandsReady -State $State
+    if (-not $ready.ready) { return @{ action = 'ignore'; reason = $ready.reason } }
+    if ("$($Message.type)" -ne 'TextChat') { return @{ action = 'ignore'; reason = 'not-text-chat' } }
+
+    $channels = @($State.channels)
+    if ($channels.Count -gt 0 -and ($channels -notcontains "$($Message.channel)")) {
+        return @{ action = 'ignore'; reason = 'channel-not-listened' }
+    }
+
+    $cmd = Get-DuneChatCommand -Text $Message.text
+    if (-not $cmd) { return @{ action = 'ignore'; reason = 'not-a-command' } }
+
+    if (-not $State.commands.ContainsKey($cmd.verb)) {
+        return @{ action = 'ignore'; reason = 'unknown-command'; verb = $cmd.verb }
+    }
+    $cfg = $State.commands[$cmd.verb]
+    if (-not $cfg.enabled) {
+        return @{ action = 'ignore'; reason = 'command-disabled'; verb = $cmd.verb }
+    }
+
+    $key = Get-DuneChatCooldownKey -FromId $Message.fromId -Verb $cmd.verb
+    $cool = Test-DuneChatCooldown -Cooldowns $State.cooldowns -Key $key `
+        -CooldownSeconds ([int]$cfg.cooldownSeconds) -Now $Now
+    if (-not $cool.allowed) {
+        return @{
+            action = 'cooldown'; verb = $cmd.verb; key = $key
+            remainingSeconds = $cool.remainingSeconds
+            reply = "{0} is on cooldown - try again in {1}." -f ('!' + $cmd.verb), (Format-DuneChatCooldownRemaining -Seconds $cool.remainingSeconds)
+        }
+    }
+
+    return @{ action = 'run'; verb = $cmd.verb; args = @($cmd.args); key = $key; from = $Message.fromId }
+}
+
+# -----------------------------------------------------------------------------
+# Live layer. Everything below talks to the broker through DST's existing
+# `rabbitmqctl eval` path (Broadcast.ps1 / _Invoke-V6BroadcastErl) - no AMQP
+# client, no new dependency, no persistent connection.
+# -----------------------------------------------------------------------------
+
+# Declare our queue and bind it to chat.intercept. Idempotent: rabbit's declare
+# is a no-op when the queue already exists with identical arguments, and
+# rabbit_binding:add on an existing binding likewise. Safe to call every tick.
+#
+# The queue is BOUNDED by construction. It receives a copy of ALL chat, so if
+# DST stops draining (app closed, tick erroring) an unbounded queue would grow
+# until it pressured the broker - which would be DST degrading someone's server.
+# x-max-length with drop-head plus a TTL makes that impossible.
+function Initialize-DuneChatCommandQueue {
+    param([string]$Ip)
+    if (-not (Get-Command Find-V6MqGamePod -ErrorAction SilentlyContinue)) {
+        return @{ ok = $false; message = 'Broadcast helpers unavailable (Broadcast.ps1 not loaded).' }
+    }
+    try { $pod = Find-V6MqGamePod -Ip $Ip } catch {
+        return @{ ok = $false; message = $_.Exception.Message }
+    }
+    $erl = @"
+QName = rabbit_misc:r(<<"/">>, queue, <<"$($script:DuneChatQueueName)">>),
+Args = [{<<"x-max-length">>, long, $($script:DuneChatQueueMaxLen)},
+        {<<"x-message-ttl">>, long, $($script:DuneChatQueueTtlMs)},
+        {<<"x-overflow">>, longstr, <<"drop-head">>}],
+rabbit_amqqueue:declare(QName, false, false, Args, none, <<"dst">>),
+XName = rabbit_misc:r(<<"/">>, exchange, <<"$($script:DuneChatExchange)">>),
+rabbit_binding:add({binding, XName, <<"#">>, QName, []}, <<"dst">>).
+"@
+    $r = _Invoke-V6BroadcastErl -Ip $Ip -Pod $pod -Erl $erl -Action 'chat-queue-declare'
+    return @{ ok = [bool]$r.ok; raw = $r.raw }
+}
+
+# Remove the queue and its binding. Used when the feature is switched off, so a
+# disabled DST is not quietly accumulating a copy of every message players type.
+function Remove-DuneChatCommandQueue {
+    param([string]$Ip)
+    try { $pod = Find-V6MqGamePod -Ip $Ip } catch {
+        return @{ ok = $false; message = $_.Exception.Message }
+    }
+    $erl = @"
+QName = rabbit_misc:r(<<"/">>, queue, <<"$($script:DuneChatQueueName)">>),
+case rabbit_amqqueue:lookup(QName) of
+  {ok, Q} -> rabbit_amqqueue:delete(Q, false, false, <<"dst">>), io:format("deleted~n");
+  _ -> io:format("absent~n")
+end.
+"@
+    $r = _Invoke-V6BroadcastErl -Ip $Ip -Pod $pod -Erl $erl -Action 'chat-queue-delete'
+    return @{ ok = [bool]$r.ok; raw = $r.raw }
+}
+
+# Drain up to $Max messages, newest-last. Each is returned as the raw envelope
+# text; parsing is the caller's job (and is pure/tested).
+#
+# NoAck=true: this queue is ours alone, and a command we have already read but
+# failed to act on should NOT be redelivered forever - at-most-once is the right
+# semantic for a chat command.
+function Get-DuneChatCommandMessages {
+    param([string]$Ip, [int]$Max = 0)
+    if ($Max -le 0) { $Max = $script:DuneChatDrainMax }
+    try { $pod = Find-V6MqGamePod -Ip $Ip } catch {
+        return @{ ok = $false; message = $_.Exception.Message; messages = @() }
+    }
+    # Body is emitted base64, one per line, so UTF-8 and newlines in player chat
+    # survive the trip back through ssh intact.
+    $erl = @"
+QName = rabbit_misc:r(<<"/">>, queue, <<"$($script:DuneChatQueueName)">>),
+case rabbit_amqqueue:lookup(QName) of
+  {ok, Q} ->
+    F = fun(Loop, N) ->
+      case N of
+        0 -> ok;
+        _ ->
+          case rabbit_amqqueue:basic_get(Q, true, 0, <<"dst">>, rabbit_queue_type:init()) of
+            {ok, _C, {_QN, _QP, _MI, _RD, Msg}, _S} ->
+              Content = mc:protocol_state(Msg),
+              Body = iolist_to_binary(lists:reverse(element(6, Content))),
+              io:format("MSG:~s~n", [base64:encode(Body)]),
+              Loop(Loop, N - 1);
+            _ -> ok
+          end
+      end
+    end,
+    F(F, $Max);
+  _ -> io:format("NOQUEUE~n")
+end.
+"@
+    $r = _Invoke-V6BroadcastErl -Ip $Ip -Pod $pod -Erl $erl -Action 'chat-drain'
+    $out = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($line in (("$($r.raw)") -split "`r?`n")) {
+        $t = $line.Trim()
+        if (-not $t.StartsWith('MSG:')) { continue }
+        $b64 = $t.Substring(4).Trim()
+        if (-not $b64) { continue }
+        try { $out.Add([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64))) } catch {}
+    }
+    return @{ ok = $true; messages = $out.ToArray(); raw = $r.raw }
+}
+
+# The intercept payload identifies the sender by their Funcom display id
+# ("Coastal#45066"), but chat.whispers routes on the FLS hex id
+# ("F9230538A63A2B3D"). dune.accounts carries both, so this is the bridge that
+# makes replying possible at all.
+function Resolve-DuneChatFlsId {
+    param([string]$Ip, [string]$FuncomId)
+    if ([string]::IsNullOrWhiteSpace($FuncomId)) { return @{ ok = $false; message = 'no funcom id' } }
+    $safe = $FuncomId -replace "'", "''"
+    $sql = "SELECT ""user"" AS fls FROM dune.accounts WHERE funcom_id = '$safe' LIMIT 1;"
+    try {
+        $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 2 -TimeoutSec 20
+        if (-not $res.ok) { return @{ ok = $false; message = [string]$res.error } }
+        $rows = @($res.rows)
+        if ($rows.Count -lt 1 -or -not $rows[0]) { return @{ ok = $false; message = "no account for $FuncomId" } }
+        $fls = [string]$rows[0][0]
+        if (-not $fls) { return @{ ok = $false; message = "empty fls id for $FuncomId" } }
+        return @{ ok = $true; flsId = $fls }
+    } catch {
+        return @{ ok = $false; message = $_.Exception.Message }
+    }
+}
+
+# Reply to a command using DST's EXISTING broadcast feature rather than a
+# bespoke whisper path.
+#
+# Why broadcast and not whisper:
+#   - It already works and is already shipped, so there is one message path in
+#     the app instead of two that can drift.
+#   - Whispers turned out to route on the FUNCOM DISPLAY ID, not the fls hex id
+#     (the per-player queue is NAMED after the fls id but BOUND on funcom_id:
+#     `chat.whispers  F9230538A63A2B3D_queue  Coastal#45066`). Publishing to the
+#     wrong key is silently dropped by the direct exchange - no error, no
+#     message. That is a sharp edge worth not depending on.
+#   - For world-affecting commands like !large, everyone seeing the result is
+#     arguably correct rather than a compromise.
+#
+# The trade-off is real and deliberate: this is NOT private. A cooldown notice
+# for one player is visible to the whole server.
+function Send-DuneChatReply {
+    param(
+        [string]$Ip,
+        [hashtable]$State,
+        [string]$ToFuncomId,
+        [string]$Message,
+        [int]$DurationSec = 12
+    )
+    if (-not (Get-Command Send-V6GenericBroadcast -ErrorAction SilentlyContinue)) {
+        return @{ ok = $false; message = 'Broadcast helper unavailable (Broadcast.ps1 not loaded).' }
+    }
+    # Name the player so a broadcast reply is obviously aimed at whoever typed
+    # the command, since everyone can see it.
+    $who = ($ToFuncomId -split '#')[0]
+    $body = if ($who) { "$who - $Message" } else { $Message }
+    $title = if ($State -and $State.replyTitle) { [string]$State.replyTitle } else { 'Server' }
+    try {
+        $r = Send-V6GenericBroadcast -Title $title -Body $body -DurationSec $DurationSec
+        return @{ ok = [bool]$r.ok; raw = $r.raw; message = [string]$r.message }
+    } catch {
+        return @{ ok = $false; message = $_.Exception.Message }
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Command executors
+# -----------------------------------------------------------------------------
+
+# !kit [name] — hand over an admin-defined item package.
+#
+# With no name we ASK rather than guess. A server can have several kits and
+# silently picking one (or the first) would hand players the wrong thing.
+function Invoke-DuneChatCommandKit {
+    param([string]$Ip, [hashtable]$State, [string]$FuncomId, [string[]]$CommandArgs)
+    $packages = @(Read-DuneItemPackages)
+    if ($packages.Count -eq 0) {
+        return @{ ok = $false; reply = 'No kits are configured on this server yet.' }
+    }
+
+    $wanted = (@($CommandArgs) -join ' ').Trim()
+    if ([string]::IsNullOrWhiteSpace($wanted)) {
+        return @{ ok = $false; reply = 'Which Kit "!kit <kit name>"' }
+    }
+
+    $pkg = $packages | Where-Object { "$($_.name)".Trim() -ieq $wanted } | Select-Object -First 1
+    if (-not $pkg) {
+        $names = (@($packages | ForEach-Object { "$($_.name)" }) -join ', ')
+        return @{ ok = $false; reply = "No kit called '$wanted'. Available: $names" }
+    }
+
+    $fls = Resolve-DuneChatFlsId -Ip $Ip -FuncomId $FuncomId
+    if (-not $fls.ok) { return @{ ok = $false; reply = 'Could not identify your account.' } }
+
+    $given = 0; $failed = 0
+    foreach ($item in @($pkg.items)) {
+        if (-not $item -or -not $item.template) { continue }
+        try {
+            $r = Invoke-DuneRmqAddItemToInventory -FlsId $fls.flsId -ItemName ([string]$item.template) `
+                    -Quantity ([int]$item.qty)
+            if ($r.ok) { $given++ } else { $failed++ }
+        } catch { $failed++ }
+    }
+    if ($given -eq 0) {
+        return @{ ok = $false; reply = "Could not deliver '$($pkg.name)' - nothing was added." }
+    }
+    $reply = "$($pkg.name) delivered."
+    if ($failed -gt 0) { $reply += " ($failed item$(if($failed -ne 1){'s'}) could not be added.)" }
+    return @{ ok = $true; reply = $reply; given = $given; failed = $failed }
+}
+
+# !small / !medium / !large - ask the server to spawn spice fields of that size.
+#
+# WHICH FUNCTION, AND WHY (learned the hard way 2026-08-04):
+#   dune.try_prime_spicefield() looks like the obvious choice and is NOT. On a
+#   map with no active fields it moves current_globally_primed 0 -> 2 and back
+#   to 0 with current_globally_active never leaving 0 - nothing spawns.
+#   dune.request_spawn_spice_field() is the real entry point: it appends to
+#   requested_spawned_of_type, which the game server drains into an actual
+#   field. Spawning is not instant, so do not report it as such.
+#
+# ONLY EVER TARGET A RUNNING SERVER. spicefield_server_availability keeps a row
+# for every server that ever registered and nothing removes it when a map is
+# retired, so a Deep Desert used for testing months ago still looks real. A
+# request queued against a dead server is accepted, increments the counter, and
+# NEVER drains. Get-DuneActiveMapPartitions already answers "which maps are
+# live or pinned", so reuse it rather than inventing a second liveness rule.
+function Invoke-DuneChatCommandSpiceField {
+    param([string]$Ip, [string]$Size)
+
+    $label = (Get-Culture).TextInfo.ToTitleCase("$Size".ToLowerInvariant())
+
+    # Live server guids, straight from the battlegroup's own status.
+    $liveIds = @{}
+    $liveMaps = @{}
+    try {
+        $bg = (Get-V6Battlegroup -Ip $Ip).Bg
+        foreach ($s in @($bg.status.servers)) {
+            if (-not $s) { continue }
+            if ($s.PSObject.Properties['serverGuid'] -and $s.serverGuid) { $liveIds["$($s.serverGuid)"] = $true }
+            if ($s.PSObject.Properties['partitionMap'] -and $s.partitionMap) { $liveMaps["$($s.partitionMap)"] = $true }
+        }
+    } catch {
+        return @{ ok = $false; reply = 'Could not reach the server list.' }
+    }
+    if ($liveIds.Count -eq 0) {
+        return @{ ok = $false; reply = 'No game servers are running right now.' }
+    }
+
+    $safe = $Size -replace "'", "''"
+    # free_slots is the GLOBAL headroom for the type (cap minus active minus
+    # everything already queued), repeated on each row so it can be budgeted
+    # once. Budgeting per row would queue servers x headroom and overshoot -
+    # request_spawn_spice_field checks the cap at REQUEST time, not spawn time.
+    $sql = @"
+SELECT a.server_id, t.spicefield_type_id, t.map_name, a.inactive_fields_of_type,
+       GREATEST(t.max_globally_active - t.current_globally_active
+                - COALESCE((SELECT SUM(q.requested_spawned_of_type)
+                            FROM dune.spicefield_server_availability q
+                            WHERE q.spicefield_type_id = t.spicefield_type_id), 0), 0)
+FROM dune.spicefield_types t
+JOIN dune.spicefield_server_availability a USING (spicefield_type_id)
+WHERE lower(t.field_type) = lower('$safe') AND t.is_spawning_active IS TRUE
+ORDER BY t.spicefield_type_id, a.server_id;
+"@
+    try {
+        $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 100 -TimeoutSec 25
+        if (-not $res.ok) { return @{ ok = $false; reply = 'Could not read spice field settings.' } }
+    } catch {
+        return @{ ok = $false; reply = 'Could not read spice field settings.' }
+    }
+
+    $rows = @($res.rows)
+    if ($rows.Count -eq 0) {
+        return @{ ok = $false; reply = "No $label spice fields are configured on this server." }
+    }
+
+    # Drop rows belonging to servers that are not running, then say plainly when
+    # that leaves nothing - "the map is down" is a different answer from "the
+    # cap is full", and players should be told which.
+    $usable = @($rows | Where-Object { $liveIds.ContainsKey("$($_[0])") })
+    if ($usable.Count -eq 0) {
+        $mapName = "$(@($rows)[0][2])"
+        $mapLabel = if ($mapName -eq 'DeepDesert') { 'Deep Desert' } elseif ($mapName -eq 'HaggaBasin') { 'Hagga Basin' } else { $mapName }
+        return @{ ok = $false; reply = "The $mapLabel is not running, so no $label fields can be activated." }
+    }
+
+    $budget = @{}
+    foreach ($r in $usable) {
+        $t = [int]$r[1]
+        if (-not $budget.ContainsKey($t)) { try { $budget[$t] = [int]$r[4] } catch { $budget[$t] = 0 } }
+    }
+
+    $requested = 0
+    foreach ($r in $usable) {
+        $server = [string]$r[0]
+        $t = [int]$r[1]
+        $pool = 0; try { $pool = [int]$r[3] } catch { $pool = 0 }
+        if ($pool -le 0 -or $budget[$t] -le 0) { continue }
+        $take = [math]::Min($pool, $budget[$t])
+        if ($take -gt 20) { $take = 20 }   # hard ceiling against a malformed row
+        $safeServer = $server -replace "'", "''"
+        for ($i = 0; $i -lt $take; $i++) {
+            try {
+                $r2 = Invoke-DuneSqlQuery -Ip $Ip -ReadOnly $false -MaxRows 2 -TimeoutSec 20 `
+                        -Sql "SELECT dune.request_spawn_spice_field('$safeServer', $t);"
+                if (-not $r2.ok) { break }
+                $requested++
+                $budget[$t] = $budget[$t] - 1
+                if ($budget[$t] -le 0) { break }
+            } catch { break }
+        }
+    }
+
+    if ($requested -eq 0) {
+        return @{ ok = $false; reply = "$label Spice Fields are already at their limit." }
+    }
+    return @{ ok = $true; reply = "$label Spice Fields Activated"; requested = $requested }
+}
+
+# Dispatch table.
+function Invoke-DuneChatCommandExecutor {
+    param([string]$Ip, [hashtable]$State, [string]$Verb, [string]$FuncomId, [string[]]$CommandArgs)
+    switch ("$Verb".ToLowerInvariant()) {
+        'kit'    { return Invoke-DuneChatCommandKit -Ip $Ip -State $State -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
+        'small'  { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Small' }
+        'medium' { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Medium' }
+        'large'  { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Large' }
+        default  { return @{ ok = $false; reply = 'Unknown command.' } }
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Scheduler tick
+# -----------------------------------------------------------------------------
+
+# Silent no-op unless the feature is on AND a reply account is configured.
+#
+# LATENCY: this runs from the 30 s restart-scheduler loop, so a player can wait
+# up to half a minute for a response. That is acceptable for a first cut but is
+# poor for chat; a dedicated faster loop is the obvious follow-up. Do not
+# describe the current behaviour as instant.
+function Invoke-DuneChatCommandTick {
+    try {
+        $state = Read-DuneChatCommandsState
+        if (-not $state.enabled) { return @{ ok = $true; acted = $false; enabled = $false } }
+        $ready = Test-DuneChatCommandsReady -State $state
+        if (-not $ready.ready) { return @{ ok = $false; acted = $false; message = $ready.message } }
+
+        if (-not (Get-Command Get-DuneDbContext -ErrorAction SilentlyContinue)) {
+            return @{ ok = $false; acted = $false; message = 'db context helper unavailable' }
+        }
+        $ctx = Get-DuneDbContext
+        if (-not $ctx.ok) { return @{ ok = $false; acted = $false; message = $ctx.message } }
+        $ip = $ctx.ip
+
+        # Cheap when it already exists, and self-heals if the broker was
+        # restarted and lost a transient queue.
+        [void](Initialize-DuneChatCommandQueue -Ip $ip)
+
+        $drain = Get-DuneChatCommandMessages -Ip $ip
+        if (-not $drain.ok) { return @{ ok = $false; acted = $false; message = $drain.message } }
+
+        $handled = 0
+        $dirty = $false
+        foreach ($raw in @($drain.messages)) {
+            $msg = ConvertFrom-DuneChatMessage -Text $raw
+            if (-not $msg) { continue }
+            $act = Resolve-DuneChatCommandAction -Message $msg -State $state
+            switch ($act.action) {
+                'cooldown' {
+                    [void](Send-DuneChatReply -Ip $ip -State $state -ToFuncomId $msg.fromId -Message $act.reply)
+                    $handled++
+                }
+                'run' {
+                    $res = Invoke-DuneChatCommandExecutor -Ip $ip -State $state -Verb $act.verb `
+                              -FuncomId $msg.fromId -CommandArgs @($act.args)
+                    if ($res.reply) {
+                        [void](Send-DuneChatReply -Ip $ip -State $state -ToFuncomId $msg.fromId -Message $res.reply)
+                    }
+                    # Only start the cooldown when the command actually ran. A
+                    # failed grant must not burn a player's weekly kit.
+                    if ($res.ok) {
+                        $state.cooldowns[$act.key] = ([datetime]::UtcNow).ToString('o')
+                        $dirty = $true
+                    }
+                    $handled++
+                    if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                        try { Write-DuneLog "chat command !$($act.verb) from $($msg.fromId): ok=$($res.ok)" 'INFO' } catch {}
+                    }
+                }
+                default { }
+            }
+        }
+
+        if ($handled -gt 0) { $state.lastSeenAt = ([datetime]::UtcNow).ToString('o'); $dirty = $true }
+        if ($dirty) { [void](Save-DuneChatCommandsState -State $state) }
+        return @{ ok = $true; acted = ($handled -gt 0); handled = $handled; scanned = @($drain.messages).Count }
+    } catch {
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            try { Write-DuneLog "chat command tick error: $($_.Exception.Message)" 'WARN' } catch {}
+        }
+        return @{ ok = $false; acted = $false; message = $_.Exception.Message }
+    }
+}
+
+
+

--- a/app/server/lib/RestartSchedule.ps1
+++ b/app/server/lib/RestartSchedule.ps1
@@ -1045,6 +1045,16 @@ function Start-DuneRestartScheduler {
                         try { Write-DuneLog "base backup guard tick error (outer): $($_.Exception.Message)" 'WARN' } catch {}
                     }
                 }
+                # In-game !commands (see lib/ChatCommands.ps1). Silent no-op
+                # unless the admin has enabled the feature AND chosen the
+                # account DST replies from. Note this loop sleeps 30s, so a
+                # player can wait that long for a response - a dedicated faster
+                # loop is the follow-up if this proves too slow in practice.
+                try { [void](Invoke-DuneChatCommandTick) } catch {
+                    if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                        try { Write-DuneLog "chat command tick error (outer): $($_.Exception.Message)" 'WARN' } catch {}
+                    }
+                }
                 Start-Sleep -Seconds 30
             }
         })

--- a/tests/ChatCommands.Tests.ps1
+++ b/tests/ChatCommands.Tests.ps1
@@ -1,0 +1,269 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'ChatCommands.ps1'
+
+    # A REAL captured payload. Coastal typed "!large" in proximity chat on
+    # 2026-08-04 and this is what landed in a queue bound to chat.intercept -
+    # not a hand-written fixture. Keep it verbatim so a Funcom format change
+    # breaks this test rather than silently breaking the feature.
+    $script:RealEnvelope = '{"content":"{\"m_Id\":\"C6BA73B94B132A51F6B937AC6960C0C1\",\"m_ChannelType\":\"Proximity\",\"m_bUseSpoofedUserName\":false,\"m_SpoofedUserNameFrom\":{\"m_TableId\":\"\",\"m_Key\":\"\",\"m_UnlocalizedName\":\"\"},\"m_FuncomIdFrom\":\"Coastal#45066\",\"m_UserNameTo\":\"F9230538A63A2B3D\",\"m_Message\":{\"m_UnlocalizedMessage\":\"!large\",\"m_LocalizedMessage\":{\"m_TableId\":\"\",\"m_Key\":\"\",\"m_FormatArgs\":[]}},\"m_Timestamp\":\"2026.08.05-00.13.11\",\"m_OriginLocation\":{\"X\":-44405.412464,\"Y\":-288152.710235,\"Z\":22060.135964},\"m_HasSeenMessage\":false}","Type":"TextChat"}'
+
+    function global:New-DstChatState {
+        param([bool]$Enabled = $true, [bool]$KitOn = $true, [int]$KitCooldown = 604800)
+        @{
+            enabled  = $Enabled
+            replyTitle = 'Server'
+            channels = @('Proximity', 'Map')
+            commands = @{
+                kit    = @{ enabled = $KitOn; cooldownSeconds = $KitCooldown }
+                small  = @{ enabled = $true;  cooldownSeconds = 900 }
+                medium = @{ enabled = $true;  cooldownSeconds = 900 }
+                large  = @{ enabled = $true;  cooldownSeconds = 900 }
+            }
+            cooldowns = @{}
+        }
+    }
+}
+
+Describe 'ConvertFrom-DuneChatMessage' {
+    It 'parses the real captured proximity payload' {
+        $m = ConvertFrom-DuneChatMessage -Text $script:RealEnvelope
+        $m | Should -Not -BeNullOrEmpty
+        $m.type | Should -Be 'TextChat'
+        $m.channel | Should -Be 'Proximity'
+        $m.fromId | Should -Be 'Coastal#45066'
+        $m.text | Should -Be '!large'
+        $m.timestamp | Should -Be '2026.08.05-00.13.11'
+    }
+
+    It 'keeps the origin location, which is what makes a nearest-field command possible' {
+        $m = ConvertFrom-DuneChatMessage -Text $script:RealEnvelope
+        $m.location | Should -Not -BeNullOrEmpty
+        [math]::Round($m.location.x, 2) | Should -Be -44405.41
+        [math]::Round($m.location.z, 2) | Should -Be 22060.14
+    }
+
+    It 'finds the envelope even when wrapped in a larger term dump' {
+        # basic_get hands back an Erlang term, so the envelope arrives embedded
+        # in surrounding noise rather than as a clean JSON document.
+        $noisy = "{content,60,{'P_basic',<<`"Content`">>},undefined,[" + $script:RealEnvelope + "]}"
+        $m = ConvertFrom-DuneChatMessage -Text $noisy
+        $m.text | Should -Be '!large'
+    }
+
+    It 'normalises an enum-qualified channel name' {
+        $env2 = $script:RealEnvelope.Replace('\"Proximity\"', '\"ETextChatChannelType::Whispers\"')
+        (ConvertFrom-DuneChatMessage -Text $env2).channel | Should -Be 'Whispers'
+    }
+
+    It 'returns null rather than throwing on junk' {
+        ConvertFrom-DuneChatMessage -Text ''            | Should -BeNullOrEmpty
+        ConvertFrom-DuneChatMessage -Text 'not json'    | Should -BeNullOrEmpty
+        ConvertFrom-DuneChatMessage -Text '{"a":1}'     | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-DuneChatCommand' {
+    It 'parses a bare command' {
+        $c = Get-DuneChatCommand -Text '!large'
+        $c.verb | Should -Be 'large'
+        @($c.args).Count | Should -Be 0
+    }
+    It 'is case-insensitive and tolerates surrounding whitespace' {
+        (Get-DuneChatCommand -Text '   !KIT  ').verb | Should -Be 'kit'
+    }
+    It 'splits arguments' {
+        $c = Get-DuneChatCommand -Text '!kit starter please'
+        $c.verb | Should -Be 'kit'
+        @($c.args) | Should -Be @('starter', 'please')
+    }
+    It 'ignores ordinary conversation' {
+        # The queue carries ALL chat, so this is the overwhelmingly common path.
+        Get-DuneChatCommand -Text 'hello everyone'      | Should -BeNullOrEmpty
+        Get-DuneChatCommand -Text 'that was great!'     | Should -BeNullOrEmpty
+        Get-DuneChatCommand -Text ''                    | Should -BeNullOrEmpty
+        Get-DuneChatCommand -Text '!'                   | Should -BeNullOrEmpty
+        Get-DuneChatCommand -Text '!   '                | Should -BeNullOrEmpty
+    }
+    It 'refuses an absurdly long verb rather than carrying it around' {
+        Get-DuneChatCommand -Text ('!' + ('a' * 50)) | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Test-DuneChatCooldown' {
+    BeforeAll {
+        # Must be set in BeforeAll, not the Describe body: Pester v5 runs the
+        # body during discovery, so a variable assigned there is gone by the
+        # time the It blocks execute.
+        $script:now = [datetime]::Parse('2026-08-04T12:00:00Z').ToUniversalTime()
+    }
+
+    It 'allows when nothing is recorded' {
+        (Test-DuneChatCooldown -Cooldowns @{} -Key 'a|kit' -CooldownSeconds 600 -Now $script:now).allowed | Should -BeTrue
+    }
+    It 'blocks inside the window and reports the remainder' {
+        $cd = @{ 'a|kit' = $script:now.AddSeconds(-100).ToString('o') }
+        $r = Test-DuneChatCooldown -Cooldowns $cd -Key 'a|kit' -CooldownSeconds 600 -Now $script:now
+        $r.allowed | Should -BeFalse
+        $r.remainingSeconds | Should -Be 500
+    }
+    It 'allows once the window has passed' {
+        $cd = @{ 'a|kit' = $script:now.AddSeconds(-601).ToString('o') }
+        (Test-DuneChatCooldown -Cooldowns $cd -Key 'a|kit' -CooldownSeconds 600 -Now $script:now).allowed | Should -BeTrue
+    }
+    It 'treats a zero cooldown as no cooldown' {
+        $cd = @{ 'a|kit' = $script:now.ToString('o') }
+        (Test-DuneChatCooldown -Cooldowns $cd -Key 'a|kit' -CooldownSeconds 0 -Now $script:now).allowed | Should -BeTrue
+    }
+    It 'does not lock a player out forever on an unparseable stamp' {
+        $cd = @{ 'a|kit' = 'not-a-date' }
+        (Test-DuneChatCooldown -Cooldowns $cd -Key 'a|kit' -CooldownSeconds 600 -Now $script:now).allowed | Should -BeTrue
+    }
+    It 'keys per player AND per command so cooldowns never bleed across' {
+        (Get-DuneChatCooldownKey -FromId 'A#1' -Verb 'kit') |
+            Should -Not -Be (Get-DuneChatCooldownKey -FromId 'A#1' -Verb 'large')
+        (Get-DuneChatCooldownKey -FromId 'A#1' -Verb 'kit') |
+            Should -Not -Be (Get-DuneChatCooldownKey -FromId 'B#2' -Verb 'kit')
+    }
+}
+
+Describe 'Resolve-DuneChatCommandAction' {
+    It 'runs an enabled command from the real payload' {
+        $m = ConvertFrom-DuneChatMessage -Text $script:RealEnvelope
+        $r = Resolve-DuneChatCommandAction -Message $m -State (New-DstChatState)
+        $r.action | Should -Be 'run'
+        $r.verb | Should -Be 'large'
+        $r.from | Should -Be 'Coastal#45066'
+    }
+
+    It 'does nothing at all while the master switch is off' {
+        # The safety default. Off means off even for a valid, enabled command.
+        $m = ConvertFrom-DuneChatMessage -Text $script:RealEnvelope
+        $r = Resolve-DuneChatCommandAction -Message $m -State (New-DstChatState -Enabled $false)
+        $r.action | Should -Be 'ignore'
+        $r.reason | Should -Be 'disabled'
+    }
+
+    It 'ignores a command that is individually disabled' {
+        $st = New-DstChatState
+        $st.commands['large'].enabled = $false
+        $m = ConvertFrom-DuneChatMessage -Text $script:RealEnvelope
+        $r = Resolve-DuneChatCommandAction -Message $m -State $st
+        $r.action | Should -Be 'ignore'
+        $r.reason | Should -Be 'command-disabled'
+    }
+
+    It 'ignores a channel it was not told to listen on' {
+        $st = New-DstChatState
+        $st.channels = @('Map')
+        $m = ConvertFrom-DuneChatMessage -Text $script:RealEnvelope   # Proximity
+        (Resolve-DuneChatCommandAction -Message $m -State $st).reason | Should -Be 'channel-not-listened'
+    }
+
+    It 'ignores ordinary chat without treating it as an error' {
+        $st = New-DstChatState
+        $m = @{ type = 'TextChat'; channel = 'Proximity'; fromId = 'A#1'; text = 'anyone around?' }
+        (Resolve-DuneChatCommandAction -Message $m -State $st).reason | Should -Be 'not-a-command'
+    }
+
+    It 'ignores an unknown verb' {
+        $st = New-DstChatState
+        $m = @{ type = 'TextChat'; channel = 'Proximity'; fromId = 'A#1'; text = '!definitelynotreal' }
+        (Resolve-DuneChatCommandAction -Message $m -State $st).reason | Should -Be 'unknown-command'
+    }
+
+    It 'reports a cooldown with a human remainder instead of running' {
+        $st = New-DstChatState
+        $st.cooldowns[(Get-DuneChatCooldownKey -FromId 'Coastal#45066' -Verb 'large')] =
+            ([datetime]::UtcNow.AddSeconds(-60)).ToString('o')
+        $m = ConvertFrom-DuneChatMessage -Text $script:RealEnvelope
+        $r = Resolve-DuneChatCommandAction -Message $m -State $st
+        $r.action | Should -Be 'cooldown'
+        $r.remainingSeconds | Should -BeGreaterThan 0
+        $r.reply | Should -BeLike '*cooldown*'
+    }
+
+    It 'never runs on a non-TextChat envelope' {
+        $st = New-DstChatState
+        $m = @{ type = 'SystemMessage'; channel = 'Proximity'; fromId = 'A#1'; text = '!large' }
+        (Resolve-DuneChatCommandAction -Message $m -State $st).reason | Should -Be 'not-text-chat'
+    }
+}
+
+Describe 'Format-DuneChatCooldownRemaining' {
+    It 'scales the unit' {
+        Format-DuneChatCooldownRemaining -Seconds 30     | Should -Be '30s'
+        Format-DuneChatCooldownRemaining -Seconds 90     | Should -Be '2m'
+        Format-DuneChatCooldownRemaining -Seconds 7200   | Should -Be '2h'
+        Format-DuneChatCooldownRemaining -Seconds 172800 | Should -Be '2d'
+        Format-DuneChatCooldownRemaining -Seconds 0      | Should -Be 'now'
+    }
+}
+
+Describe 'readiness' {
+    It 'is not ready when no command is enabled' {
+        # A listener that can never respond to anything is a misconfiguration,
+        # not a working feature - say so rather than silently doing nothing.
+        $d = New-DuneChatCommandsDefault
+        $r = Test-DuneChatCommandsReady -State $d
+        $r.ready | Should -BeFalse
+        $r.reason | Should -Be 'no-commands-enabled'
+    }
+
+    It 'is ready once a command is turned on' {
+        (Test-DuneChatCommandsReady -State (New-DstChatState)).ready | Should -BeTrue
+    }
+
+    It 'refuses to act when enabled but with every command off' {
+        $st = New-DstChatState
+        foreach ($k in @($st.commands.Keys)) { $st.commands[$k].enabled = $false }
+        $m = ConvertFrom-DuneChatMessage -Text $script:RealEnvelope
+        (Resolve-DuneChatCommandAction -Message $m -State $st).reason | Should -Be 'no-commands-enabled'
+    }
+}
+
+Describe 'defaults' {
+    It 'ships everything off' {
+        # If this ever flips, players gain world-affecting powers on upgrade
+        # without the admin choosing to grant them.
+        $d = New-DuneChatCommandsDefault
+        $d.enabled | Should -BeFalse
+        foreach ($k in $d.commands.Keys) { $d.commands[$k].enabled | Should -BeFalse }
+    }
+
+    It 'registers kit and all three spice field sizes' {
+        $d = New-DuneChatCommandsDefault
+        @($d.commands.Keys | Sort-Object) | Should -Be @('kit', 'large', 'medium', 'small')
+    }
+}
+
+Describe '!kit argument handling' {
+    It 'asks which kit when no name is given' {
+        # Several kits can exist; silently picking one would hand players the
+        # wrong thing.
+        $st = New-DstChatState
+        $m = @{ type = 'TextChat'; channel = 'Proximity'; fromId = 'A#1'; text = '!kit' }
+        $act = Resolve-DuneChatCommandAction -Message $m -State $st
+        $act.action | Should -Be 'run'
+        $act.verb | Should -Be 'kit'
+        @($act.args).Count | Should -Be 0
+    }
+
+    It 'passes a multi-word kit name through intact' {
+        $c = Get-DuneChatCommand -Text '!kit Deep Desert Starter'
+        $c.verb | Should -Be 'kit'
+        (@($c.args) -join ' ') | Should -Be 'Deep Desert Starter'
+    }
+}
+
+Describe 'spice field verbs' {
+    It 'recognises all three sizes' {
+        $st = New-DstChatState
+        foreach ($size in @('small', 'medium', 'large')) {
+            $m = @{ type = 'TextChat'; channel = 'Proximity'; fromId = 'A#1'; text = "!$size" }
+            $act = Resolve-DuneChatCommandAction -Message $m -State $st
+            $act.action | Should -Be 'run'
+            $act.verb | Should -Be $size
+        }
+    }
+}


### PR DESCRIPTION
Players type `!large` / `!medium` / `!small` / `!kit <name>` in game chat and DST acts on it, replying with a server broadcast.

> **Draft** - the settings API and UI card are not built yet, so today it is configured by editing `chat-commands.json`.

---

## How reading chat is possible

The mq-game broker carries a **topic** exchange `chat.intercept`, catch-all bound to Funcom's own `queue.intercept`. Because it is a topic exchange, binding a second queue alongside yields a **copy** of every chat message and leaves their consumer untouched.

A captured payload gives everything a command needs:

```
Type          : TextChat
ChannelType   : Proximity
FuncomIdFrom  : Coastal#45066
MESSAGE       : '!large'
Timestamp     : 2026.08.05-00.13.11
OriginLocation: X=-44405.4  Y=-288152.7  Z=22060.1
```

Transport reuses what DST already does - every RMQ operation goes through `rabbitmqctl eval` over SSH, so this drains with `basic_get` on the same path rather than adding an AMQP client.

Replies reuse the **existing broadcast feature** rather than a bespoke whisper. One message path in the app, and it sidesteps a sharp edge: `chat.whispers` routes on the **Funcom display id**, not the fls hex id, so a wrong key is dropped silently by the direct exchange.

## Spice fields - the non-obvious part

`dune.try_prime_spicefield()` looks like the right call and **is not**. On a map with no active fields it moves `current_globally_primed` 0 to 2 and back to 0 while `current_globally_active` never leaves 0. Nothing spawns.

`dune.request_spawn_spice_field()` is the real entry point: it appends to `requested_spawned_of_type`, which the game server drains into an actual field. Observed directly - Medium and Small each went `requested=1/active=0` to `requested=0/active=1` unaided.

## Two hardening rules from live testing

**Only target a running server.** `spicefield_server_availability` keeps a row for every server that ever registered and nothing removes it when a map is retired - a Deep Desert used for PvP testing months ago still looks real. A request queued against a dead server is accepted, increments the counter, and **never drains**. Live guids come from the battlegroup's own `status.servers`, the same source `Get-DuneActiveMapPartitions` uses.

**Budget the global cap once.** The cap is global per type while availability is per server; budgeting per row queues `servers x headroom` and overshoots. Funcom's own guard does not catch it because `request_spawn_spice_field` checks the cap at **request** time, not spawn time. Caught live at `active=4, cap=6, queued=3`.

When every row belongs to a dead server the reply says **the map is not running** - a different answer from being at the cap, and players should be told which.

## Safety posture

- Off by default, **per-command** opt-in
- Channel allow-list (Proximity/Map by default, so faction and guild chat are ignored)
- Per-player, per-command cooldowns that **only start on success**, so a failed grant does not burn a weekly kit
- The queue is **bounded** (max-length + TTL + drop-head). It receives a copy of all chat, so an undrained queue would otherwise grow until it pressured the broker

## Testing

33 new tests, built around a **real captured payload** rather than a hand-written fixture, so a Funcom format change breaks the test instead of silently killing the feature. Full suite **661 passed / 0 failed**.

Proven end to end on a live server: chat read, parsed, gated, spice fields spawned, broadcast delivered.

## Not in this PR

- Settings API and UI card
- Latency is up to 30s (the tick rides the existing restart-scheduler loop); a dedicated faster loop is the follow-up
- The wider DST gap this exposed - stale `spicefield_types` / `spicefield_server_availability` rows lingering for retired maps, and Server Health showing them - is untouched. This feature is immune to it; DST generally is not.