### PR TITLE
Flag spicefield rows whose map instance is no longer running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Spice fields for maps that are no longer running are now marked, instead of sitting alongside live ones.** The game database keeps a row for every map instance that has ever existed, so a Deep Desert spun up for testing months ago still appears in the Spicefields card with no way to tell it apart from a running map. Those groups now sort to the bottom and carry a "not running" label. They are still shown rather than hidden, because a map being temporarily down is not the same as it being gone.
+
 ### Removed
 
 - **The three returning-player reward settings are gone.** A Funcom developer confirmed they are not enabled for self-hosted servers: the reward packs are granted by Funcom's own service rather than by your server, so there is nothing for a self-host to hand out no matter how the settings are configured. They have been removed rather than left looking functional, and DST clears them from your server config on the next save.

--- a/webui/src/pages/gameconfig/SpicefieldsCard.tsx
+++ b/webui/src/pages/gameconfig/SpicefieldsCard.tsx
@@ -109,11 +109,29 @@ export function SpicefieldsCard({ vmRunning }: Props) {
     return () => window.clearInterval(id)
   }, [vmRunning, load])
 
+  // Maps whose partition is running or pinned come first; retired instances sink
+  // to the bottom rather than being hidden. The DB keeps spicefield rows long
+  // after an instance stops existing (a Deep Desert used for testing months ago
+  // still has rows), so without this an operator sees dead maps mixed in with
+  // live ones and cannot tell which is which. Hiding them outright would be
+  // worse: partitionActive is undefined when the battlegroup could not be read,
+  // and silently dropping real data is not a trade worth making.
   const grouped = useMemo(() => {
     const out: Record<string, SpicefieldType[]> = {}
     for (const r of rows ?? []) (out[r.mapName] ??= []).push(r)
     return out
   }, [rows])
+
+  const groupOrder = useMemo(() => {
+    const isRetired = (list: SpicefieldType[]) =>
+      list.length > 0 && list.every(r => r.partitionActive === false)
+    return Object.entries(grouped).sort(([an, al], [bn, bl]) => {
+      const ar = isRetired(al) ? 1 : 0
+      const br = isRetired(bl) ? 1 : 0
+      if (ar !== br) return ar - br
+      return an.localeCompare(bn)
+    })
+  }, [grouped])
 
   function isDirty(r: SpicefieldType) {
     const d = drafts[r.spicefieldTypeId]
@@ -294,16 +312,26 @@ export function SpicefieldsCard({ vmRunning }: Props) {
 
       {vmRunning && rows && rows.length > 0 && (
         <div className="space-y-4">
-          {Object.entries(grouped).map(([mapName, list]) => {
+          {groupOrder.map(([mapName, list]) => {
             const totalActive = list.reduce((s, r) => s + r.currentActive, 0)
             const totalMaxActive = list.reduce((s, r) => s + r.maxActive, 0)
             const totalPrimed = list.reduce((s, r) => s + r.currentPrimed, 0)
             const totalMaxPrimed = list.reduce((s, r) => s + r.maxPrimed, 0)
+            // Every row for this map belongs to a partition that is neither
+            // running nor pinned - i.e. leftovers from an instance that no
+            // longer exists.
+            const retired = list.length > 0 && list.every(r => r.partitionActive === false)
             return (
-            <div key={mapName}>
+            <div key={mapName} className={retired ? 'opacity-60' : ''}>
               <div className="flex items-center justify-between mb-2">
-                <div className="text-[11px] font-mono uppercase tracking-wider text-text-dim">
+                <div className="text-[11px] font-mono uppercase tracking-wider text-text-dim flex items-center gap-2">
                   {mapName}
+                  {retired && (
+                    <span className="normal-case font-sans tracking-normal text-text-dim border border-border rounded px-1.5 py-0.5"
+                          title="This map instance is not running and is not pinned. These rows are left over in the database from an instance that no longer exists.">
+                      not running
+                    </span>
+                  )}
                 </div>
                 <div className="text-[11px] text-text-muted flex items-center gap-3">
                   <span title={`Total currently active across all ${mapName} field sizes`}>


### PR DESCRIPTION
The Spicefields endpoint has always annotated each row with `partitionLive` / `partitionPinned` / `partitionActive`, and its own comment says *"the client decides what to show"* - but the card never read them, so every row rendered identically.

That matters because the game database keeps a spicefield row for **every map instance that has ever existed**. A Deep Desert spun up for PvP testing months ago still has rows today, indistinguishable from a running map, and the operator has no way to tell which numbers are real. Until now the only remedy was deleting rows by hand in the database.

## What changes

Groups whose every row belongs to an inactive partition now sort to the bottom and carry a **"not running"** label, dimmed.

## What deliberately does not change

They are **not hidden**:

- `partitionActive` is `undefined` when the battlegroup could not be read, so hiding would drop real data on a transient failure.
- A map being temporarily down is not the same as an instance that no longer exists - the Deep Desert is on-demand and legitimately down most of the time.

Sorting and labelling states the fact and lets the operator decide. Hiding would be a guess.

## Scope

One file, plus a changelog entry. No backend change - the data was already there.

Found while building the in-game chat commands (#649), where the same stale rows caused spawn requests to be queued against a server that no longer exists.