### PR TITLE
Add welcome back packages, chat command settings UI, and !item / !vehicle / !water

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.3.0"
+      placeholder: "v13.4.0"
     validations:
       required: true
 
@@ -100,6 +100,8 @@ body:
         - Web portal — Game Config — BaseBackUp (allowed maps / cooldown / extensions / keep stored bases through the Deep Desert reset)
         - Web portal — Game Config — client-side INI (Game.ini / Engine.ini opt-in / preview / Open in Notepad / client-apply reminder / Player config hand-out list)
         - Web portal — Gameplay Admin — Overview
+        - Web portal — Gameplay Admin — Overview — In-game commands (!kit / !item / !vehicle / !water / !small / !medium / !large — listening, per-command toggles + cooldowns, !item quantity cap, chat channels, reply heading)
+        - Web portal — Gameplay Admin — Overview — Welcome back (returning-player package / days away / announce)
         - Web portal — Gameplay Admin — Market / Market Bot
         - Web portal — Gameplay Admin — Players
         - Web portal — Gameplay Admin — Players — Give Item / Give Package / Give Vehicle Kit / Grant Cosmetic / Variant (incl. "Allow overflow")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ here cover everything those tags shipped.
 
 ### Added
 
-- **In-game chat commands.** Players can type commands directly in game chat and DST acts on them, replying with a server broadcast. `!small`, `!medium` and `!large` activate spice fields of that size, and `!kit <name>` hands over one of your item packages (typing `!kit` on its own asks which one). Every command is off until you turn it on individually, each has its own per-player cooldown, and DST only listens on the chat channels you choose.
+- **In-game chat commands.** Players can type commands directly in game chat and DST acts on them, replying with a server broadcast. `!kit <name>` hands over one of your item packages, `!item <name> [amount]` hands over any single item from the catalog, `!vehicle <name>` hands over a vehicle part kit with fuel and a repair tool, `!water` refills the player's stillsuit and jons, and `!small`, `!medium` and `!large` activate spice fields of that size. `!kit`, `!item`, `!vehicle` and `!water` only ever affect whoever typed them — none of them can be aimed at another player. Every command is off until you turn it on individually, each has its own per-player cooldown, `!item` additionally has a cap on how much can be asked for at once, and DST only listens on the chat channels you choose.
+
+- **Welcome back packages.** DST can give a returning player one of your item packages when they come back after time away, replacing the three returning-player settings that were removed because they do nothing on a self-hosted server. You choose the package and how many days away counts. The gap is measured between a player's previous login and the one that just happened, so each player is given the package once per absence and turning the feature on cannot hand packages to your whole existing player base at once.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,17 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.4.0] - 2026-08-04
+
 ### Added
 
 - **In-game chat commands.** Players can type commands directly in game chat and DST acts on them, replying with a server broadcast. `!kit <name>` hands over one of your item packages, `!item <name> [amount]` hands over any single item from the catalog, `!vehicle <name>` hands over a vehicle part kit with fuel and a repair tool, `!water` refills the player's stillsuit and jons, and `!small`, `!medium` and `!large` activate spice fields of that size. `!kit`, `!item`, `!vehicle` and `!water` only ever affect whoever typed them — none of them can be aimed at another player. Every command is off until you turn it on individually, each has its own per-player cooldown, `!item` additionally has a cap on how much can be asked for at once, and DST only listens on the chat channels you choose.
 
-- **Welcome back packages.** DST can give a returning player one of your item packages when they come back after time away, replacing the three returning-player settings that were removed because they do nothing on a self-hosted server. You choose the package and how many days away counts. The gap is measured between a player's previous login and the one that just happened, so each player is given the package once per absence and turning the feature on cannot hand packages to your whole existing player base at once.
+- **Welcome back packages.** DST can give a returning player one of your item packages when they come back after time away, replacing the three returning-player settings that were removed because they do nothing on a self-hosted server. You choose the package and how many days away counts. The gap is measured between a player's previous login and the one that just happened, so each player is given the package once per absence and turning the feature on cannot hand packages to your whole existing player base at once. Setting the days to 0 means every return counts.
+
+- **Spice field limits are editable from the chat command settings.** When `!small`, `!medium` or `!large` is switched on, each running map shows how many fields of that size are active out of its limit, and the limit can be changed there. "!large did nothing" is almost always "the map is already at its cap", so it warns when a map is at its limit — and says so plainly when no running map has fields of that size at all, which is the case for Large on Hagga Basin.
+
+- **You choose how often DST checks for chat commands.** Replies arrive about as fast as the interval you pick, and the picker shows what each one costs: roughly half a processor core at 3 seconds down to a twentieth at 30. The cost is paid per check rather than per message, and only while the feature is switched on.
 
 ### Fixed
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.3.0'
+$script:DuneToolVersion = '13.4.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.3.0',
+    [string]$Version = '13.4.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.3.0</Version>
+    <Version>13.4.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.3.0"
+#define MyAppVersion "13.4.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/ChatCommands.ps1
+++ b/app/server/lib/ChatCommands.ps1
@@ -69,10 +69,13 @@ function New-DuneChatCommandsDefault {
         # is the meaningful equivalent. ("SERVER" is what the game renders it as.)
         replyTitle = 'Server'
         commands = @{
-            kit    = @{ enabled = $false; cooldownSeconds = 604800 }
-            small  = @{ enabled = $false; cooldownSeconds = 900 }
-            medium = @{ enabled = $false; cooldownSeconds = 900 }
-            large  = @{ enabled = $false; cooldownSeconds = 900 }
+            kit     = @{ enabled = $false; cooldownSeconds = 604800 }
+            item    = @{ enabled = $false; cooldownSeconds = 3600; maxQty = 1000 }
+            water   = @{ enabled = $false; cooldownSeconds = 300 }
+            vehicle = @{ enabled = $false; cooldownSeconds = 604800 }
+            small   = @{ enabled = $false; cooldownSeconds = 900 }
+            medium  = @{ enabled = $false; cooldownSeconds = 900 }
+            large   = @{ enabled = $false; cooldownSeconds = 900 }
         }
         # channels the handler will listen on; anything else is ignored outright
         channels = @('Proximity', 'Map')
@@ -618,14 +621,181 @@ ORDER BY t.spicefield_type_id, a.server_id;
 }
 
 # Dispatch table.
+# !water - refill the sender's water containers (stillsuits, jons, canteens).
+#
+# Reuses the exact RMQ command behind the Player Admin "Fill Water" button
+# (UpdateAllWaterFillables) rather than the SQL refill, because the sender is by
+# definition online: an online player holds their inventory in memory, so a
+# direct SQL write is ignored and overwritten on their next save. Same reasoning
+# as the give-item path in PlayersWrites.ps1.
+function Invoke-DuneChatCommandWater {
+    param([string]$Ip, [string]$FuncomId)
+    $fls = Resolve-DuneChatFlsId -Ip $Ip -FuncomId $FuncomId
+    if (-not $fls.ok) { return @{ ok = $false; reply = 'Could not identify your account.' } }
+    try {
+        $r = Invoke-DuneRmqUpdateAllWaterFillables -FlsId $fls.flsId -WaterAmount 1000000
+        if (-not $r.ok) {
+            return @{ ok = $false; reply = 'Could not refill your water.' }
+        }
+        return @{ ok = $true; reply = 'Water refilled.' }
+    } catch {
+        return @{ ok = $false; reply = 'Could not refill your water.' }
+    }
+}
+
+# !vehicle - deliver a vehicle part kit to the sender.
+#
+# Mirrors the Players page "Give Vehicle Kit" action exactly: it hands over the
+# vehicle's parts plus fuel and a repair tool, into the player's inventory, to be
+# assembled at a Vehicle Assembly. It does NOT spawn a drivable vehicle, and the
+# reply says so - a player told "vehicle delivered" would go looking for one.
+#
+# Vehicles with no part kit (Tank, Container Vehicle) are filtered out for the
+# same reason the UI filters them: there is nothing to give.
+function Invoke-DuneChatCommandVehicle {
+    param([string]$Ip, [string]$FuncomId, [string[]]$CommandArgs)
+    $catalog = Get-DuneVehicleKitCatalog
+    $vehicles = @(@($catalog.vehicles) | Where-Object { @($_.kit).Count -gt 0 })
+    if ($vehicles.Count -eq 0) {
+        return @{ ok = $false; reply = 'No vehicle kits are available on this server.' }
+    }
+
+    $wanted = (@($CommandArgs) -join ' ').Trim()
+    if ([string]::IsNullOrWhiteSpace($wanted)) {
+        $names = (@($vehicles | ForEach-Object { "$($_.label)" }) -join ', ')
+        return @{ ok = $false; reply = "Which vehicle? Available: $names" }
+    }
+
+    # Match on the friendly label first, then the id, so both "!vehicle Ornithopter (Light)"
+    # and "!vehicle OrnithopterLight" work.
+    $veh = $vehicles | Where-Object { "$($_.label)".Trim() -ieq $wanted } | Select-Object -First 1
+    if (-not $veh) {
+        $veh = $vehicles | Where-Object { "$($_.id)".Trim() -ieq $wanted } | Select-Object -First 1
+    }
+    if (-not $veh) {
+        $names = (@($vehicles | ForEach-Object { "$($_.label)" }) -join ', ')
+        return @{ ok = $false; reply = "No vehicle called '$wanted'. Available: $names" }
+    }
+
+    $fls = Resolve-DuneChatFlsId -Ip $Ip -FuncomId $FuncomId
+    if (-not $fls.ok) { return @{ ok = $false; reply = 'Could not identify your account.' } }
+
+    $parts = @()
+    $parts += @($veh.kit)
+    $parts += @($veh.unique)
+    if ($catalog.fuelTemplate)  { $parts += $catalog.fuelTemplate }
+    if ($catalog.torchTemplate) { $parts += $catalog.torchTemplate }
+
+    $given = 0; $failed = 0
+    foreach ($tpl in $parts) {
+        if ([string]::IsNullOrWhiteSpace($tpl)) { continue }
+        $qty = 1
+        if ($veh.qty -and $veh.qty.Contains("$tpl")) { $qty = [int]$veh.qty["$tpl"] }
+        if ($qty -lt 1) { $qty = 1 }
+        try {
+            $r = Invoke-DuneRmqAddItemToInventory -FlsId $fls.flsId -ItemName ([string]$tpl) -Quantity $qty
+            if ($r.ok) { $given++ } else { $failed++ }
+        } catch { $failed++ }
+    }
+    if ($given -eq 0) {
+        return @{ ok = $false; reply = "Could not deliver the $($veh.label) kit - nothing was added." }
+    }
+    $reply = "$($veh.label) kit delivered - assemble it at a Vehicle Assembly."
+    if ($failed -gt 0) { $reply += " ($failed part$(if($failed -ne 1){'s'}) could not be added.)" }
+    return @{ ok = $true; reply = $reply; given = $given; failed = $failed }
+}
+
+# !item <name> [qty] - give the sender an item from the catalog.
+#
+# The broadest of the commands by a distance: every other one is bounded by
+# something the admin defined up front (a package, a vehicle kit, their own
+# water), whereas this one can produce anything in the game. It is off by
+# default like the rest, and additionally capped by maxQty so enabling it cannot
+# be turned into "!item <anything> 999999999". Treat raising that cap as the
+# same decision as handing out admin.
+#
+# Name resolution deliberately refuses to guess: an ambiguous term lists the
+# candidates back rather than picking one, because silently delivering the wrong
+# item is worse than asking again.
+function Invoke-DuneChatCommandItem {
+    param([string]$Ip, [hashtable]$State, [string]$FuncomId, [string[]]$CommandArgs)
+    $argv = @(@($CommandArgs) | Where-Object { "$_".Trim() })
+    if ($argv.Count -eq 0) {
+        return @{ ok = $false; reply = 'Which item? "!item <name> [amount]"' }
+    }
+
+    # A trailing all-digits token is the amount; everything before it is the name,
+    # so multi-word items ("Plastanium Ingot 10") work.
+    $qty = 1
+    if ($argv.Count -gt 1 -and "$($argv[-1])" -match '^\d+$') {
+        $qty = [int]$argv[-1]
+        $argv = @($argv[0..($argv.Count - 2)])
+    }
+    $wanted = (@($argv) -join ' ').Trim()
+    if ([string]::IsNullOrWhiteSpace($wanted)) {
+        return @{ ok = $false; reply = 'Which item? "!item <name> [amount]"' }
+    }
+
+    $cfg = $State.commands['item']
+    $max = 1000
+    if ($cfg -and $cfg.maxQty) { $max = [int]$cfg.maxQty }
+    if ($max -lt 1) { $max = 1 }
+    if ($qty -lt 1) { $qty = 1 }
+    $capped = $false
+    if ($qty -gt $max) { $qty = $max; $capped = $true }
+
+    $items = @((Get-DuneItemCatalog).items)
+    if ($items.Count -eq 0) {
+        return @{ ok = $false; reply = 'The item catalog is not available on this server.' }
+    }
+
+    # Exact template id, then exact name, then a unique substring.
+    $hit = $items | Where-Object { "$($_.templateId)" -ieq $wanted } | Select-Object -First 1
+    if (-not $hit) {
+        $hit = $items | Where-Object { "$($_.name)" -ieq $wanted } | Select-Object -First 1
+    }
+    if (-not $hit) {
+        $partial = @($items | Where-Object { "$($_.name)" -imatch [regex]::Escape($wanted) })
+        if ($partial.Count -eq 1) {
+            $hit = $partial[0]
+        } elseif ($partial.Count -gt 1) {
+            $names = (@($partial | Select-Object -First 6 | ForEach-Object { "$($_.name)" }) -join ', ')
+            $more = if ($partial.Count -gt 6) { " (+$($partial.Count - 6) more)" } else { '' }
+            return @{ ok = $false; reply = "'$wanted' matches several items: $names$more" }
+        }
+    }
+    if (-not $hit) {
+        return @{ ok = $false; reply = "No item called '$wanted'." }
+    }
+
+    $fls = Resolve-DuneChatFlsId -Ip $Ip -FuncomId $FuncomId
+    if (-not $fls.ok) { return @{ ok = $false; reply = 'Could not identify your account.' } }
+
+    try {
+        $r = Invoke-DuneRmqAddItemToInventory -FlsId $fls.flsId -ItemName ([string]$hit.templateId) -Quantity $qty
+        if (-not $r.ok) {
+            return @{ ok = $false; reply = "Could not deliver $($hit.name)." }
+        }
+    } catch {
+        return @{ ok = $false; reply = "Could not deliver $($hit.name)." }
+    }
+
+    $reply = "$($hit.name) x$qty delivered."
+    if ($capped) { $reply += " (capped at $max)" }
+    return @{ ok = $true; reply = $reply; template = [string]$hit.templateId; qty = $qty }
+}
+
 function Invoke-DuneChatCommandExecutor {
     param([string]$Ip, [hashtable]$State, [string]$Verb, [string]$FuncomId, [string[]]$CommandArgs)
     switch ("$Verb".ToLowerInvariant()) {
-        'kit'    { return Invoke-DuneChatCommandKit -Ip $Ip -State $State -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
-        'small'  { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Small' }
-        'medium' { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Medium' }
-        'large'  { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Large' }
-        default  { return @{ ok = $false; reply = 'Unknown command.' } }
+        'kit'     { return Invoke-DuneChatCommandKit -Ip $Ip -State $State -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
+        'item'    { return Invoke-DuneChatCommandItem -Ip $Ip -State $State -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
+        'water'   { return Invoke-DuneChatCommandWater -Ip $Ip -FuncomId $FuncomId }
+        'vehicle' { return Invoke-DuneChatCommandVehicle -Ip $Ip -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
+        'small'   { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Small' }
+        'medium'  { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Medium' }
+        'large'   { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Large' }
+        default   { return @{ ok = $false; reply = 'Unknown command.' } }
     }
 }
 

--- a/app/server/lib/ChatCommands.ps1
+++ b/app/server/lib/ChatCommands.ps1
@@ -79,6 +79,13 @@ function New-DuneChatCommandsDefault {
         }
         # channels the handler will listen on; anything else is ignored outright
         channels = @('Proximity', 'Map')
+        # How often DST drains the queue, in seconds. This is a genuine trade the
+        # admin should own rather than one baked in: the cost is paid per CALL,
+        # not per message, because `rabbitmqctl eval` starts a hidden Erlang node
+        # each time (~1.5 core-seconds, measured 2026-08-04 on an 8-core VM). So
+        # roughly 3s ~ 0.50 of a core sustained, 10s ~ 0.15, 30s ~ 0.05 - against
+        # a reply that lands in about that many seconds. Defaults to responsive.
+        pollSeconds = 3
         cooldowns = @{}
         lastError = ''
         lastSeenAt = ''
@@ -115,6 +122,10 @@ function Read-DuneChatCommandsState {
         if ($obj.channels)   { $out.channels = @($obj.channels) }
         if ($obj.lastError)  { $out.lastError = [string]$obj.lastError }
         if ($obj.lastSeenAt) { $out.lastSeenAt = [string]$obj.lastSeenAt }
+        if ($null -ne $obj.pollSeconds) {
+            $p = 0
+            if ([int]::TryParse("$($obj.pollSeconds)", [ref]$p)) { $out.pollSeconds = $p }
+        }
         if ($obj.commands) {
             foreach ($p in $obj.commands.PSObject.Properties) {
                 $name = "$($p.Name)".ToLowerInvariant()
@@ -135,8 +146,33 @@ function Read-DuneChatCommandsState {
     }
 }
 
-function Save-DuneChatCommandsState {
+# Allowed poll intervals, and the measured cost of each. Kept as a list rather
+# than a free number so the UI and the scheduler agree on what is offerable, and
+# so nobody sets 1s without seeing what it costs.
+#
+# Cost is per CALL, not per message: `rabbitmqctl eval` starts a hidden Erlang
+# node every time (~1.5 core-seconds, measured 2026-08-04 on an 8-core VM). So
+# the sustained cost is roughly 1.5 / interval cores, for as long as the feature
+# is enabled, whether or not anyone is chatting.
+$script:DuneChatPollChoices = @(3, 5, 10, 15, 30)
+$script:DuneChatPollDefault = 3
+
+# What the scheduler actually sleeps between drains. Clamped here rather than
+# trusted from the state file, because this value directly sets a permanent load
+# on someone's game server.
+function Get-DuneChatCommandPollSeconds {
     param([hashtable]$State)
+    $n = $script:DuneChatPollDefault
+    try {
+        if (-not $State) { $State = Read-DuneChatCommandsState }
+        if ($State -and $State.pollSeconds) { $n = [int]$State.pollSeconds }
+    } catch { $n = $script:DuneChatPollDefault }
+    if ($n -lt 1)  { $n = 1 }
+    if ($n -gt 60) { $n = 60 }
+    return $n
+}
+
+function Save-DuneChatCommandsState {    param([hashtable]$State)
     $path = Get-DuneChatCommandsStatePath
     try {
         ($State | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $path -Encoding UTF8

--- a/app/server/lib/RestartSchedule.ps1
+++ b/app/server/lib/RestartSchedule.ps1
@@ -1045,16 +1045,6 @@ function Start-DuneRestartScheduler {
                         try { Write-DuneLog "base backup guard tick error (outer): $($_.Exception.Message)" 'WARN' } catch {}
                     }
                 }
-                # In-game !commands (see lib/ChatCommands.ps1). Silent no-op
-                # unless the admin has enabled the feature AND chosen the
-                # account DST replies from. Note this loop sleeps 30s, so a
-                # player can wait that long for a response - a dedicated faster
-                # loop is the follow-up if this proves too slow in practice.
-                try { [void](Invoke-DuneChatCommandTick) } catch {
-                    if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
-                        try { Write-DuneLog "chat command tick error (outer): $($_.Exception.Message)" 'WARN' } catch {}
-                    }
-                }
                 # Welcome back packages (see lib/WelcomeBack.ps1). Silent no-op
                 # unless the admin turned it on AND chose a package. Internally
                 # throttled to one DB pass every 5 minutes - it watches for a
@@ -1066,7 +1056,52 @@ function Start-DuneRestartScheduler {
                         try { Write-DuneLog "welcome back tick error (outer): $($_.Exception.Message)" 'WARN' } catch {}
                     }
                 }
-                Start-Sleep -Seconds 30
+                # In-game !commands (see lib/ChatCommands.ps1). Silent no-op
+                # unless the admin has enabled the feature.
+                #
+                # LATENCY: chat has to feel like chat. A player who types !water
+                # and waits half a minute assumes it did not work, so this does
+                # NOT ride the 30s cadence with everything else. The loop's sleep
+                # IS this loop: it wakes every 3s to drain chat, and one full pass
+                # still takes 30s, so every heavy tick above keeps its old
+                # cadence.
+                #
+                # COST - measured, not assumed (2026-08-04, 8-core VM):
+                #   idle VM                9.14% busy
+                #   with 3s polling       15.41% busy
+                # ~= half a core, sustained, for as long as the feature is on. It
+                # is paid per CALL and not per message, because `rabbitmqctl eval`
+                # starts a hidden Erlang node every time (~1.5 core-seconds each),
+                # so the poll interval is the whole cost: 3s ~ 0.50 core, 5s ~
+                # 0.30, 10s ~ 0.15, 30s ~ 0.05. That trade belongs to the admin,
+                # so the interval is a setting rather than a constant - see
+                # Get-DuneChatCommandPollSeconds.
+                #
+                # The right long-term fix is a persistent AMQP consumer, which
+                # would be instant AND near-free. It is harder than it looks: the
+                # broker speaks amqp/ssl only and delegates auth to Funcom's HTTP
+                # shim (verified on a live server), so it needs TLS plus
+                # shim-accepted credentials plus reconnect handling. Worth doing
+                # if these commands become something servers rely on.
+                #
+                # The tick returns immediately when the feature is off, so a
+                # server not using it pays nothing.
+                $chatPoll = 3
+                try { $chatPoll = [int](Get-DuneChatCommandPollSeconds) } catch { $chatPoll = 3 }
+                if ($chatPoll -lt 1) { $chatPoll = 1 }
+                # One outer pass stays ~30s so every heavy tick above keeps the
+                # cadence it was written for, regardless of the chat setting.
+                $chatElapsed = 0
+                while ($chatElapsed -lt 30) {
+                    $slice = [Math]::Min($chatPoll, 30 - $chatElapsed)
+                    Start-Sleep -Seconds $slice
+                    $chatElapsed += $slice
+                    try { [void](Invoke-DuneChatCommandTick) } catch {
+                        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                            try { Write-DuneLog "chat command tick error (outer): $($_.Exception.Message)" 'WARN' } catch {}
+                        }
+                    }
+                }
             }
         })
         [void]$ps.BeginInvoke()

--- a/app/server/lib/RestartSchedule.ps1
+++ b/app/server/lib/RestartSchedule.ps1
@@ -1055,6 +1055,17 @@ function Start-DuneRestartScheduler {
                         try { Write-DuneLog "chat command tick error (outer): $($_.Exception.Message)" 'WARN' } catch {}
                     }
                 }
+                # Welcome back packages (see lib/WelcomeBack.ps1). Silent no-op
+                # unless the admin turned it on AND chose a package. Internally
+                # throttled to one DB pass every 5 minutes - it watches for a
+                # login having happened, which does not need half-minute
+                # resolution and is measured against the previous login rather
+                # than against "now", so arriving late changes nothing.
+                try { [void](Invoke-DuneWelcomeBackTick) } catch {
+                    if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                        try { Write-DuneLog "welcome back tick error (outer): $($_.Exception.Message)" 'WARN' } catch {}
+                    }
+                }
                 Start-Sleep -Seconds 30
             }
         })

--- a/app/server/lib/WelcomeBack.ps1
+++ b/app/server/lib/WelcomeBack.ps1
@@ -68,7 +68,12 @@ function New-DuneWelcomeBackDefault {
 }
 
 $script:DuneWelcomeBackMaxRecent = 25
-$script:DuneWelcomeBackMinDays   = 1
+# 0 is deliberately allowed and means "every login qualifies" - any gap at all is
+# >= 0. Useful for testing without waiting a week, and a legitimate setting for a
+# server that wants a package on every return. It is still bounded by the login
+# transition, so it cannot re-fire while a player stays online, and the first
+# pass still only seeds, so it cannot mass-grant on enable.
+$script:DuneWelcomeBackMinDays   = 0
 $script:DuneWelcomeBackMaxDays   = 365
 
 # Single place that decides whether the feature may run. "Enabled but no package"

--- a/app/server/lib/WelcomeBack.ps1
+++ b/app/server/lib/WelcomeBack.ps1
@@ -1,0 +1,436 @@
+# WelcomeBack.ps1 - hand a returning player an item package when they come back.
+#
+# Replaces the three `dw.ReturningPlayer.*` console variables, which were removed
+# in 13.4.0 because a Funcom developer confirmed they do nothing on a self-hosted
+# server: the reward packs are granted by Funcom's own service, so a self-host has
+# nothing to hand out no matter how they are configured. This does the same job
+# with parts a self-host actually controls - the admin's own item packages.
+#
+# ---------------------------------------------------------------------------
+# Why the trigger is a poll and not an event
+# ---------------------------------------------------------------------------
+# There is no login hook to subscribe to. But `dune.player_state.last_login_time`
+# is stamped at login (verified on a live server: a session showed login 00:32
+# against last activity 01:19), so a login is visible as that column moving
+# forward. Polling it on the existing scheduler tick needs no new plumbing.
+#
+# The absence is measured between a player's PREVIOUS login and the one that just
+# happened - not against "now". That single choice is what makes this fire exactly
+# once per absence:
+#
+#     P = the last login DST recorded for them    L = last_login_time right now
+#     no P    -> record P = L, grant nothing        (new player, or first run)
+#     L > P   -> they just logged in; absence = L - P
+#                absence >= DaysAway  ->  give the package
+#     always  -> record P = L
+#
+# Consequences worth keeping:
+#   * It cannot re-fire while they stay logged in, because L stops moving.
+#   * It cannot fire twice for one absence, because P advances to L immediately.
+#   * There is no "already claimed" flag to reset, get stale, or migrate - a
+#     second absence is simply a second gap, and qualifies on its own merits.
+#   * Enabling the feature cannot mass-grant to a whole player base, because the
+#     first pass only seeds P. Someone who has been away a year gets their package
+#     on their next login, which is the intent, rather than instantly while they
+#     are still offline and unable to see it.
+#
+# Granting goes through the existing bulk give path, which routes an online player
+# to the live RMQ path (instant, no relog). Since the trigger IS the login, the
+# player is nearly always online at that moment, so this normally lands in front
+# of them while they are standing there.
+# ---------------------------------------------------------------------------
+
+function Get-DuneWelcomeBackStatePath {
+    $dir = if ($env:APPDATA) { Join-Path $env:APPDATA 'DuneServer' } else { $env:TEMP }
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+        try { New-Item -ItemType Directory -Path $dir -Force | Out-Null } catch {}
+    }
+    return (Join-Path $dir 'welcome-back.json')
+}
+
+# Off, with no package chosen. Both have to be set deliberately - see
+# Test-DuneWelcomeBackReady for why "on with no package" is treated as an error
+# rather than quietly doing nothing.
+function New-DuneWelcomeBackDefault {
+    return @{
+        enabled   = $false
+        packageId = ''
+        daysAway  = 7
+        announce  = $false
+        # players: accountId -> @{ lastLoginSeen; lastGrantedAt; grants; name }
+        players   = @{}
+        # newest-first ring of what was handed out, so the admin can see the
+        # feature working without going to the game logs
+        recent    = @()
+        lastRunAt = ''
+        lastError = ''
+    }
+}
+
+$script:DuneWelcomeBackMaxRecent = 25
+$script:DuneWelcomeBackMinDays   = 1
+$script:DuneWelcomeBackMaxDays   = 365
+
+# Single place that decides whether the feature may run. "Enabled but no package"
+# is surfaced rather than swallowed: an admin who flipped it on and expected
+# something to happen deserves to be told why nothing did.
+function Test-DuneWelcomeBackReady {
+    param([hashtable]$State)
+    if (-not $State) { return @{ ready = $false; reason = 'no-state' } }
+    if (-not $State.enabled) { return @{ ready = $false; reason = 'disabled' } }
+    if ([string]::IsNullOrWhiteSpace([string]$State.packageId)) {
+        return @{ ready = $false; reason = 'no-package'
+                  message = 'Choose the package to give, or nothing will be handed out.' }
+    }
+    $pkg = Get-DuneWelcomeBackPackage -PackageId $State.packageId
+    if (-not $pkg) {
+        return @{ ready = $false; reason = 'package-missing'
+                  message = 'The chosen package no longer exists. Pick another one.' }
+    }
+    if (@($pkg.items).Count -eq 0) {
+        return @{ ready = $false; reason = 'package-empty'
+                  message = "Package '$($pkg.name)' has no items in it." }
+    }
+    return @{ ready = $true }
+}
+
+# Resolve against the shared package store so this and the Players page can never
+# disagree about what a package contains.
+function Get-DuneWelcomeBackPackage {
+    param([string]$PackageId)
+    if ([string]::IsNullOrWhiteSpace($PackageId)) { return $null }
+    if (-not (Get-Command Read-DuneItemPackages -ErrorAction SilentlyContinue)) { return $null }
+    try {
+        foreach ($p in @(Read-DuneItemPackages)) {
+            if ("$($p.id)" -eq "$PackageId") { return $p }
+        }
+    } catch {}
+    return $null
+}
+
+function Read-DuneWelcomeBackState {
+    $path = Get-DuneWelcomeBackStatePath
+    $def = New-DuneWelcomeBackDefault
+    if (-not (Test-Path -LiteralPath $path)) { return $def }
+    try {
+        $obj = (Get-Content -LiteralPath $path -Raw -ErrorAction Stop) | ConvertFrom-Json -ErrorAction Stop
+        $out = $def
+        if ($null -ne $obj.enabled)  { $out.enabled = [bool]$obj.enabled }
+        if ($null -ne $obj.announce) { $out.announce = [bool]$obj.announce }
+        if ($obj.packageId) { $out.packageId = [string]$obj.packageId }
+        if ($null -ne $obj.daysAway) {
+            $d = 0
+            if ([int]::TryParse("$($obj.daysAway)", [ref]$d)) { $out.daysAway = $d }
+        }
+        if ($obj.lastRunAt) { $out.lastRunAt = [string]$obj.lastRunAt }
+        if ($obj.lastError) { $out.lastError = [string]$obj.lastError }
+        if ($obj.players) {
+            $ledger = @{}
+            foreach ($p in $obj.players.PSObject.Properties) {
+                $v = $p.Value
+                $grants = 0
+                if ($null -ne $v.grants) { [void][int]::TryParse("$($v.grants)", [ref]$grants) }
+                $ledger["$($p.Name)"] = @{
+                    lastLoginSeen = [string]$v.lastLoginSeen
+                    lastGrantedAt = [string]$v.lastGrantedAt
+                    grants        = $grants
+                    name          = [string]$v.name
+                }
+            }
+            $out.players = $ledger
+        }
+        if ($obj.recent) {
+            $r = New-Object System.Collections.Generic.List[object]
+            foreach ($e in @($obj.recent)) {
+                $r.Add(@{
+                    at       = [string]$e.at
+                    name     = [string]$e.name
+                    daysAway = [double]$e.daysAway
+                    package  = [string]$e.package
+                    ok       = [bool]$e.ok
+                    message  = [string]$e.message
+                })
+            }
+            $out.recent = @($r.ToArray())
+        }
+        return $out
+    } catch {
+        return $def
+    }
+}
+
+function Save-DuneWelcomeBackState {
+    param([hashtable]$State)
+    $path = Get-DuneWelcomeBackStatePath
+    try {
+        ($State | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $path -Encoding UTF8
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Set-DuneWelcomeBackDaysAway {
+    param([hashtable]$State, $Value)
+    $d = 0
+    if (-not [int]::TryParse("$Value", [ref]$d)) { return $State }
+    if ($d -lt $script:DuneWelcomeBackMinDays) { $d = $script:DuneWelcomeBackMinDays }
+    if ($d -gt $script:DuneWelcomeBackMaxDays) { $d = $script:DuneWelcomeBackMaxDays }
+    $State.daysAway = $d
+    return $State
+}
+
+# -----------------------------------------------------------------------------
+# The decision, kept pure so it is directly testable without a database. Takes
+# the rows as DST already reads them plus the current ledger, and returns what
+# ought to happen. Nothing in here talks to the server.
+# -----------------------------------------------------------------------------
+function Get-DuneWelcomeBackPlan {
+    param(
+        [object[]]$Players,
+        [hashtable]$Ledger,
+        [int]$DaysAway = 7
+    )
+    $grants = New-Object System.Collections.Generic.List[object]
+    $seeded = New-Object System.Collections.Generic.List[object]
+    $nextLedger = @{}
+    if ($Ledger) {
+        # Copy each ENTRY, not just the key. Assigning $Ledger[$k] straight across
+        # would share the inner hashtable, so advancing lastLoginSeen below would
+        # reach back and mutate the caller's ledger - making a second call on the
+        # same input silently disagree with the first.
+        foreach ($k in @($Ledger.Keys)) {
+            $src = $Ledger[$k]
+            $nextLedger[$k] = @{
+                lastLoginSeen = [string]$src.lastLoginSeen
+                lastGrantedAt = [string]$src.lastGrantedAt
+                grants        = [int]$src.grants
+                name          = [string]$src.name
+            }
+        }
+    }
+
+    foreach ($p in @($Players)) {
+        if ($null -eq $p) { continue }
+        $key = "$($p.account_id)"
+        if ([string]::IsNullOrWhiteSpace($key) -or $key -eq '0') { continue }
+
+        $loginRaw = [string]$p.last_login
+        if ([string]::IsNullOrWhiteSpace($loginRaw)) { continue }
+        $login = [datetime]::MinValue
+        if (-not [datetime]::TryParse($loginRaw, [ref]$login)) { continue }
+        $login = $login.ToUniversalTime()
+
+        $entry = $nextLedger[$key]
+        if (-not $entry) {
+            $entry = @{ lastLoginSeen = ''; lastGrantedAt = ''; grants = 0; name = [string]$p.name }
+        }
+        $entry.name = [string]$p.name
+
+        $prevRaw = [string]$entry.lastLoginSeen
+        $prev = [datetime]::MinValue
+        $hasPrev = $prevRaw -and [datetime]::TryParse($prevRaw, [ref]$prev)
+        if ($hasPrev) { $prev = $prev.ToUniversalTime() }
+
+        if (-not $hasPrev) {
+            # First time we have ever seen this player. Record where they are and
+            # grant nothing - we have no idea how long they were away, and
+            # guessing would either mass-grant on enable or punish a newcomer.
+            $entry.lastLoginSeen = $login.ToString('o')
+            $nextLedger[$key] = $entry
+            $seeded.Add(@{ account_id = $key; name = [string]$p.name })
+            continue
+        }
+
+        if ($login -gt $prev) {
+            $away = ($login - $prev).TotalDays
+            if ($away -ge $DaysAway) {
+                $grants.Add(@{
+                    account_id = $key
+                    name       = [string]$p.name
+                    pawn_id    = [int64]$p.pawn_id
+                    daysAway   = [math]::Round($away, 2)
+                })
+            }
+            # Advance regardless of whether it qualified, so a short hop can never
+            # be re-evaluated and a qualifying one can never pay out twice.
+            $entry.lastLoginSeen = $login.ToString('o')
+        }
+        $nextLedger[$key] = $entry
+    }
+
+    return @{
+        grants = @($grants.ToArray())
+        seeded = @($seeded.ToArray())
+        ledger = $nextLedger
+    }
+}
+
+# -----------------------------------------------------------------------------
+# Live side.
+# -----------------------------------------------------------------------------
+
+# Everyone who has ever played, with the two facts the plan needs. Deliberately
+# not filtered to online players: the login we care about may have happened
+# between ticks and them logging straight back out does not make the absence
+# untrue - the package still lands via the SQL path and is there when they return.
+function Get-DuneWelcomeBackPlayers {
+    param([string]$Ip)
+    $sql = @'
+SELECT COALESCE(ps.account_id::text, '')                                   AS account_id,
+       COALESCE(ps.character_name, '')                                     AS name,
+       COALESCE(ps.player_pawn_id::text, '0')                              AS pawn_id,
+       COALESCE(to_char(ps.last_login_time AT TIME ZONE 'UTC',
+                        'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '')                 AS last_login
+FROM dune.player_state ps
+WHERE ps.account_id IS NOT NULL
+  AND ps.last_login_time IS NOT NULL
+ORDER BY ps.last_login_time DESC;
+'@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 5000 -TimeoutSec 20
+    if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    $rows = ConvertTo-DuneRowMaps -Result $r
+    $list = New-Object System.Collections.Generic.List[object]
+    foreach ($row in $rows) {
+        $pawn = 0L
+        [void][int64]::TryParse("$($row['pawn_id'])", [ref]$pawn)
+        $list.Add(@{
+            account_id = [string]$row['account_id']
+            name       = [string]$row['name']
+            pawn_id    = $pawn
+            last_login = [string]$row['last_login']
+        })
+    }
+    return @{ ok = $true; players = @($list.ToArray()) }
+}
+
+function Invoke-DuneWelcomeBackGrant {
+    param(
+        [string]$Ip,
+        [hashtable]$Grant,
+        $Package
+    )
+    if ([int64]$Grant.pawn_id -le 0) {
+        return @{ ok = $false; message = "No character to give to (pawn id missing)." }
+    }
+    if (-not (Get-Command Invoke-DunePlayerGiveItemsBulk -ErrorAction SilentlyContinue)) {
+        return @{ ok = $false; message = 'Give-items helper unavailable.' }
+    }
+    try {
+        $r = Invoke-DunePlayerGiveItemsBulk -Ip $Ip -PawnId ([int64]$Grant.pawn_id) `
+             -Items @($Package.items) -AllowOverflow $true
+        return @{ ok = [bool]$r.ok; message = [string]$r.message }
+    } catch {
+        return @{ ok = $false; message = $_.Exception.Message }
+    }
+}
+
+function Send-DuneWelcomeBackAnnounce {
+    param([hashtable]$Grant, $Package)
+    if (-not (Get-Command Send-V6GenericBroadcast -ErrorAction SilentlyContinue)) { return }
+    $who = [string]$Grant.name
+    if (-not $who) { return }
+    try {
+        [void](Send-V6GenericBroadcast -Title 'Welcome Back' `
+              -Body "$who has been away and received $($Package.name)." -DurationSec 10)
+    } catch {}
+}
+
+# -----------------------------------------------------------------------------
+# Tick. Silent no-op unless the admin turned this on AND picked a package.
+# Rides the 30s restart-scheduler loop, but only touches the database every few
+# minutes - a login is not urgent enough to justify a query every half minute,
+# and the absence maths is unaffected by arriving a little late.
+# -----------------------------------------------------------------------------
+$script:DuneWelcomeBackLastRun = [datetime]::MinValue
+$script:DuneWelcomeBackIntervalMin = 5
+
+function Invoke-DuneWelcomeBackTick {
+    param([switch]$Force)
+    try {
+        $state = Read-DuneWelcomeBackState
+        if (-not $state.enabled) { return @{ ok = $true; acted = $false; message = 'disabled' } }
+
+        if (-not $Force) {
+            $since = ([datetime]::UtcNow - $script:DuneWelcomeBackLastRun).TotalMinutes
+            if ($since -lt $script:DuneWelcomeBackIntervalMin) {
+                return @{ ok = $true; acted = $false; message = 'throttled' }
+            }
+        }
+        $script:DuneWelcomeBackLastRun = [datetime]::UtcNow
+
+        $ready = Test-DuneWelcomeBackReady -State $state
+        if (-not $ready.ready) {
+            # Persist the reason so the card can show it without the admin having
+            # to go looking in a log for why nothing is happening.
+            if ($state.lastError -ne [string]$ready.message) {
+                $state.lastError = [string]$ready.message
+                [void](Save-DuneWelcomeBackState -State $state)
+            }
+            return @{ ok = $false; acted = $false; message = [string]$ready.message }
+        }
+
+        if (-not (Get-Command Get-DuneDbContext -ErrorAction SilentlyContinue)) {
+            return @{ ok = $false; acted = $false; message = 'db context helper unavailable' }
+        }
+        $ctx = Get-DuneDbContext
+        if (-not $ctx.ok) { return @{ ok = $false; acted = $false; message = $ctx.message } }
+
+        $fetch = Get-DuneWelcomeBackPlayers -Ip $ctx.ip
+        if (-not $fetch.ok) {
+            $state.lastError = "Could not read players: $($fetch.error)"
+            [void](Save-DuneWelcomeBackState -State $state)
+            return @{ ok = $false; acted = $false; message = $state.lastError }
+        }
+
+        $package = Get-DuneWelcomeBackPackage -PackageId $state.packageId
+        $plan = Get-DuneWelcomeBackPlan -Players $fetch.players -Ledger $state.players -DaysAway ([int]$state.daysAway)
+
+        $recent = New-Object System.Collections.Generic.List[object]
+        $granted = 0
+        foreach ($g in @($plan.grants)) {
+            $res = Invoke-DuneWelcomeBackGrant -Ip $ctx.ip -Grant $g -Package $package
+            $stamp = ([datetime]::UtcNow).ToString('o')
+            if ($res.ok) {
+                $granted++
+                $entry = $plan.ledger["$($g.account_id)"]
+                if ($entry) {
+                    $entry.lastGrantedAt = $stamp
+                    $entry.grants = [int]$entry.grants + 1
+                }
+                if ($state.announce) { Send-DuneWelcomeBackAnnounce -Grant $g -Package $package }
+            } else {
+                # A failed give must NOT hold the ledger back - if it did, the same
+                # broken grant would be retried on every tick forever. It is
+                # recorded in `recent` instead so the admin can see and re-give it.
+                if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                    try { Write-DuneLog "welcome back: give failed for $($g.name): $($res.message)" 'WARN' } catch {}
+                }
+            }
+            $recent.Add(@{
+                at = $stamp; name = [string]$g.name; daysAway = [double]$g.daysAway
+                package = [string]$package.name; ok = [bool]$res.ok; message = [string]$res.message
+            })
+        }
+
+        $state.players = $plan.ledger
+        if ($recent.Count -gt 0) {
+            $merged = @($recent.ToArray()) + @($state.recent)
+            if ($merged.Count -gt $script:DuneWelcomeBackMaxRecent) {
+                $merged = $merged[0..($script:DuneWelcomeBackMaxRecent - 1)]
+            }
+            $state.recent = @($merged)
+        }
+        $state.lastRunAt = ([datetime]::UtcNow).ToString('o')
+        $state.lastError = ''
+        [void](Save-DuneWelcomeBackState -State $state)
+
+        return @{
+            ok = $true; acted = ($granted -gt 0)
+            granted = $granted; seeded = @($plan.seeded).Count
+            message = "Welcome back: $granted granted, $(@($plan.seeded).Count) newly tracked."
+        }
+    } catch {
+        return @{ ok = $false; acted = $false; message = $_.Exception.Message }
+    }
+}

--- a/app/server/routes/ChatCommands.ps1
+++ b/app/server/routes/ChatCommands.ps1
@@ -23,10 +23,12 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/chat-commands' -Handler {
 
         $commands = @{}
         foreach ($k in @($state.commands.Keys)) {
-            $commands[$k] = @{
+            $entry = @{
                 enabled         = [bool]$state.commands[$k].enabled
                 cooldownSeconds = [int]$state.commands[$k].cooldownSeconds
             }
+            if ($state.commands[$k].maxQty) { $entry['maxQty'] = [int]$state.commands[$k].maxQty }
+            $commands[$k] = $entry
         }
 
         Write-DuneJson -Response $res -Body @{
@@ -88,6 +90,16 @@ Register-DuneRoute -Method PUT -Path '/api/gameplay/chat-commands' -Handler {
                     if ([int]::TryParse("$($incoming['cooldownSeconds'])", [ref]$n) -and $n -ge 0) {
                         if ($n -gt 2592000) { $n = 2592000 }   # 30 days is plenty
                         $state.commands[$name].cooldownSeconds = $n
+                    }
+                }
+                # Only !item carries a quantity cap, and it is the one command that
+                # can produce anything in the game - so the ceiling is enforced here
+                # rather than trusted from the payload.
+                if ($incoming.ContainsKey('maxQty') -and $name -eq 'item') {
+                    $q = 0
+                    if ([int]::TryParse("$($incoming['maxQty'])", [ref]$q) -and $q -ge 1) {
+                        if ($q -gt 100000) { $q = 100000 }
+                        $state.commands[$name].maxQty = $q
                     }
                 }
             }

--- a/app/server/routes/ChatCommands.ps1
+++ b/app/server/routes/ChatCommands.ps1
@@ -38,6 +38,8 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/chat-commands' -Handler {
             channels   = @($state.channels)
             commands   = $commands
             packages   = $packages
+            pollSeconds = [int](Get-DuneChatCommandPollSeconds -State $state)
+            pollChoices = @($script:DuneChatPollChoices)
             ready      = [bool]$ready.ready
             readyMessage = [string]$ready.message
             lastSeenAt = [string]$state.lastSeenAt
@@ -69,8 +71,20 @@ Register-DuneRoute -Method PUT -Path '/api/gameplay/chat-commands' -Handler {
             if ($t.Length -gt 40) { $t = $t.Substring(0, 40) }
             $state.replyTitle = if ($t) { $t } else { 'Server' }
         }
-        if ($body.ContainsKey('channels') -and $null -ne $body['channels']) {
-            $allowed = @('Proximity', 'Map', 'Faction', 'Guild', 'Party')
+        if ($body.ContainsKey('pollSeconds')) {
+            # Restricted to the offered choices. This sets a permanent CPU load on
+            # the game server, so an arbitrary number from a payload is not
+            # something to honour blindly.
+            $p = 0
+            if ([int]::TryParse("$($body['pollSeconds'])", [ref]$p) -and
+                ($script:DuneChatPollChoices -contains $p)) {
+                $state.pollSeconds = $p
+            } else {
+                Write-DuneError -Response $res -Status 400 -Message ("pollSeconds must be one of: " + (($script:DuneChatPollChoices) -join ', '))
+                return
+            }
+        }
+        if ($body.ContainsKey('channels') -and $null -ne $body['channels']) {            $allowed = @('Proximity', 'Map', 'Faction', 'Guild', 'Party')
             $picked = @(@($body['channels']) | ForEach-Object { "$_" } | Where-Object { $allowed -contains $_ })
             $state.channels = $picked
         }
@@ -133,6 +147,7 @@ Register-DuneRoute -Method PUT -Path '/api/gameplay/chat-commands' -Handler {
             enabled      = [bool]$state.enabled
             replyTitle   = [string]$state.replyTitle
             channels     = @($state.channels)
+            pollSeconds  = [int](Get-DuneChatCommandPollSeconds -State $state)
             ready        = [bool]$ready.ready
             readyMessage = [string]$ready.message
             queue        = $queue

--- a/app/server/routes/ChatCommands.ps1
+++ b/app/server/routes/ChatCommands.ps1
@@ -1,0 +1,131 @@
+﻿# -----------------------------------------------------------------------------
+# ChatCommands routes — settings for in-game !commands.
+#
+# GET  /api/gameplay/chat-commands   -> current settings + the kit names to pick
+#                                       from, so the UI never invents a package
+# PUT  /api/gameplay/chat-commands   -> save settings
+#
+# Turning the feature ON declares the intercept queue; turning it OFF removes
+# it, so a disabled DST is not quietly accumulating a copy of every message
+# players type. See lib/ChatCommands.ps1 for why the queue is bounded.
+# -----------------------------------------------------------------------------
+
+Register-DuneRoute -Method GET -Path '/api/gameplay/chat-commands' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $state = Read-DuneChatCommandsState
+        $ready = Test-DuneChatCommandsReady -State $state
+
+        # Kits come straight from the existing package store - the same list the
+        # Players page uses - so the two can never disagree about what exists.
+        $packages = @()
+        try { $packages = @(Read-DuneItemPackages | ForEach-Object { "$($_.name)" }) } catch {}
+
+        $commands = @{}
+        foreach ($k in @($state.commands.Keys)) {
+            $commands[$k] = @{
+                enabled         = [bool]$state.commands[$k].enabled
+                cooldownSeconds = [int]$state.commands[$k].cooldownSeconds
+            }
+        }
+
+        Write-DuneJson -Response $res -Body @{
+            ok         = $true
+            enabled    = [bool]$state.enabled
+            replyTitle = [string]$state.replyTitle
+            channels   = @($state.channels)
+            commands   = $commands
+            packages   = $packages
+            ready      = [bool]$ready.ready
+            readyMessage = [string]$ready.message
+            lastSeenAt = [string]$state.lastSeenAt
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Chat command settings load failed: $($_.Exception.Message)"
+    }
+}
+
+Register-DuneRoute -Method PUT -Path '/api/gameplay/chat-commands' -Handler {
+    param($req, $res, $routeParams, $body)
+    if (-not ($body -is [hashtable])) {
+        Write-DuneError -Response $res -Status 400 -Message 'Body must be a JSON object.'
+        return
+    }
+    try {
+        $state = Read-DuneChatCommandsState
+        $wasEnabled = [bool]$state.enabled
+
+        if ($body.ContainsKey('enabled')) {
+            if (-not ($body['enabled'] -is [bool])) {
+                Write-DuneError -Response $res -Status 400 -Message 'enabled must be a JSON boolean.'
+                return
+            }
+            $state.enabled = [bool]$body['enabled']
+        }
+        if ($body.ContainsKey('replyTitle')) {
+            $t = "$($body['replyTitle'])".Trim()
+            if ($t.Length -gt 40) { $t = $t.Substring(0, 40) }
+            $state.replyTitle = if ($t) { $t } else { 'Server' }
+        }
+        if ($body.ContainsKey('channels') -and $null -ne $body['channels']) {
+            $allowed = @('Proximity', 'Map', 'Faction', 'Guild', 'Party')
+            $picked = @(@($body['channels']) | ForEach-Object { "$_" } | Where-Object { $allowed -contains $_ })
+            $state.channels = $picked
+        }
+        if ($body.ContainsKey('commands') -and $body['commands'] -is [hashtable]) {
+            foreach ($k in @($body['commands'].Keys)) {
+                $name = "$k".ToLowerInvariant()
+                # Only ever touch commands DST actually implements - a payload
+                # cannot invent a verb that no executor handles.
+                if (-not $state.commands.ContainsKey($name)) { continue }
+                $incoming = $body['commands'][$k]
+                if ($incoming -isnot [hashtable]) { continue }
+                if ($incoming.ContainsKey('enabled')) {
+                    $state.commands[$name].enabled = [bool]$incoming['enabled']
+                }
+                if ($incoming.ContainsKey('cooldownSeconds')) {
+                    $n = 0
+                    if ([int]::TryParse("$($incoming['cooldownSeconds'])", [ref]$n) -and $n -ge 0) {
+                        if ($n -gt 2592000) { $n = 2592000 }   # 30 days is plenty
+                        $state.commands[$name].cooldownSeconds = $n
+                    }
+                }
+            }
+        }
+
+        if (-not (Save-DuneChatCommandsState -State $state)) {
+            Write-DuneError -Response $res -Status 500 -Message 'Could not save chat command settings.'
+            return
+        }
+
+        # Follow the switch through to the broker. Best-effort on purpose: the
+        # settings are saved either way, and the scheduler tick re-declares the
+        # queue on its next pass if this did not land.
+        $queue = @{ ok = $false; skipped = $true }
+        if ($wasEnabled -ne $state.enabled) {
+            try {
+                $ctx = Get-DuneDbContext
+                if ($ctx.ok) {
+                    $queue = if ($state.enabled) {
+                        Initialize-DuneChatCommandQueue -Ip $ctx.ip
+                    } else {
+                        Remove-DuneChatCommandQueue -Ip $ctx.ip
+                    }
+                }
+            } catch {}
+        }
+
+        $ready = Test-DuneChatCommandsReady -State $state
+        Write-DuneJson -Response $res -Body @{
+            ok           = $true
+            enabled      = [bool]$state.enabled
+            replyTitle   = [string]$state.replyTitle
+            channels     = @($state.channels)
+            ready        = [bool]$ready.ready
+            readyMessage = [string]$ready.message
+            queue        = $queue
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Chat command settings save failed: $($_.Exception.Message)"
+    }
+}

--- a/app/server/routes/WelcomeBack.ps1
+++ b/app/server/routes/WelcomeBack.ps1
@@ -1,0 +1,111 @@
+# WelcomeBack routes - settings for the returning-player package.
+#
+# GET  /api/gameplay/welcome-back  -> settings, the packages to pick from, and
+#                                     what has recently been handed out
+# PUT  /api/gameplay/welcome-back  -> save settings
+#
+# See lib/WelcomeBack.ps1 for why the trigger is a login-transition poll and why
+# enabling this cannot mass-grant to an existing player base.
+
+Register-DuneRoute -Method GET -Path '/api/gameplay/welcome-back' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $state = Read-DuneWelcomeBackState
+        $ready = Test-DuneWelcomeBackReady -State $state
+
+        # Offer the same package store the Players page uses, so the picker can
+        # never point at something that does not exist.
+        $packages = @()
+        try {
+            $packages = @(Read-DuneItemPackages | ForEach-Object {
+                @{ id = "$($_.id)"; name = "$($_.name)"; itemCount = @($_.items).Count }
+            })
+        } catch {}
+
+        Write-DuneJson -Response $res -Body @{
+            ok           = $true
+            enabled      = [bool]$state.enabled
+            packageId    = [string]$state.packageId
+            daysAway     = [int]$state.daysAway
+            announce     = [bool]$state.announce
+            packages     = $packages
+            recent       = @($state.recent)
+            tracked      = @($state.players.Keys).Count
+            lastRunAt    = [string]$state.lastRunAt
+            lastError    = [string]$state.lastError
+            ready        = [bool]$ready.ready
+            readyMessage = [string]$ready.message
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Welcome back settings load failed: $($_.Exception.Message)"
+    }
+}
+
+Register-DuneRoute -Method PUT -Path '/api/gameplay/welcome-back' -Handler {
+    param($req, $res, $routeParams, $body)
+    if (-not ($body -is [hashtable])) {
+        Write-DuneError -Response $res -Status 400 -Message 'Body must be a JSON object.'
+        return
+    }
+    try {
+        $state = Read-DuneWelcomeBackState
+        $wasEnabled = [bool]$state.enabled
+
+        if ($body.ContainsKey('enabled')) {
+            if (-not ($body['enabled'] -is [bool])) {
+                Write-DuneError -Response $res -Status 400 -Message 'enabled must be a JSON boolean.'
+                return
+            }
+            $state.enabled = [bool]$body['enabled']
+        }
+        if ($body.ContainsKey('announce')) {
+            $state.announce = [bool]$body['announce']
+        }
+        if ($body.ContainsKey('packageId')) {
+            $id = "$($body['packageId'])".Trim()
+            # Only accept a package that actually exists, so the feature can never
+            # be left pointing at a deleted one and silently doing nothing.
+            if ($id -and -not (Get-DuneWelcomeBackPackage -PackageId $id)) {
+                Write-DuneError -Response $res -Status 400 -Message 'That package does not exist.'
+                return
+            }
+            $state.packageId = $id
+        }
+        if ($body.ContainsKey('daysAway')) {
+            $state = Set-DuneWelcomeBackDaysAway -State $state -Value $body['daysAway']
+        }
+
+        if (-not (Save-DuneWelcomeBackState -State $state)) {
+            Write-DuneError -Response $res -Status 500 -Message 'Could not save welcome back settings.'
+            return
+        }
+
+        # Turning it ON runs one pass immediately, which seeds the ledger with
+        # everyone's current login. That is the pass that makes "enable" safe:
+        # without it the first scheduled tick would still only seed, but the
+        # admin would have no signal that anything happened.
+        $seeded = 0
+        if (-not $wasEnabled -and $state.enabled) {
+            try {
+                $r = Invoke-DuneWelcomeBackTick -Force
+                if ($null -ne $r.seeded) { $seeded = [int]$r.seeded }
+            } catch {}
+            $state = Read-DuneWelcomeBackState
+        }
+
+        $ready = Test-DuneWelcomeBackReady -State $state
+        Write-DuneJson -Response $res -Body @{
+            ok           = $true
+            enabled      = [bool]$state.enabled
+            packageId    = [string]$state.packageId
+            daysAway     = [int]$state.daysAway
+            announce     = [bool]$state.announce
+            tracked      = @($state.players.Keys).Count
+            seeded       = $seeded
+            ready        = [bool]$ready.ready
+            readyMessage = [string]$ready.message
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Welcome back settings save failed: $($_.Exception.Message)"
+    }
+}

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.3.0"
+$script:ToolVersion = "13.4.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/ChatCommands.Tests.ps1
+++ b/tests/ChatCommands.Tests.ps1
@@ -254,6 +254,16 @@ Describe 'defaults' {
             $d.commands[$k].ContainsKey('maxQty') | Should -BeFalse
         }
     }
+    It 'defaults to a responsive poll, and clamps anything absurd' {
+        # This value sets a permanent CPU load on someone's game server, so it is
+        # clamped in the reader rather than trusted from the state file.
+        (New-DuneChatCommandsDefault).pollSeconds | Should -Be 3
+        Get-DuneChatCommandPollSeconds -State @{ pollSeconds = 10 }    | Should -Be 10
+        Get-DuneChatCommandPollSeconds -State @{ pollSeconds = 0 }     | Should -Be 3
+        Get-DuneChatCommandPollSeconds -State @{ pollSeconds = -5 }    | Should -Be 1
+        Get-DuneChatCommandPollSeconds -State @{ pollSeconds = 99999 } | Should -Be 60
+        Get-DuneChatCommandPollSeconds -State @{ pollSeconds = 'fast' } | Should -Be 3
+    }
 }
 
 Describe 'self-only commands' {

--- a/tests/ChatCommands.Tests.ps1
+++ b/tests/ChatCommands.Tests.ps1
@@ -15,10 +15,13 @@ BeforeAll {
             replyTitle = 'Server'
             channels = @('Proximity', 'Map')
             commands = @{
-                kit    = @{ enabled = $KitOn; cooldownSeconds = $KitCooldown }
-                small  = @{ enabled = $true;  cooldownSeconds = 900 }
-                medium = @{ enabled = $true;  cooldownSeconds = 900 }
-                large  = @{ enabled = $true;  cooldownSeconds = 900 }
+                kit     = @{ enabled = $KitOn; cooldownSeconds = $KitCooldown }
+                item    = @{ enabled = $true;  cooldownSeconds = 3600; maxQty = 1000 }
+                water   = @{ enabled = $true;  cooldownSeconds = 300 }
+                vehicle = @{ enabled = $true;  cooldownSeconds = 604800 }
+                small   = @{ enabled = $true;  cooldownSeconds = 900 }
+                medium  = @{ enabled = $true;  cooldownSeconds = 900 }
+                large   = @{ enabled = $true;  cooldownSeconds = 900 }
             }
             cooldowns = @{}
         }
@@ -231,9 +234,67 @@ Describe 'defaults' {
         foreach ($k in $d.commands.Keys) { $d.commands[$k].enabled | Should -BeFalse }
     }
 
-    It 'registers kit and all three spice field sizes' {
+    It 'registers every command the executor can actually run' {
+        # Kept in lockstep with Invoke-DuneChatCommandExecutor on purpose: a verb
+        # in the defaults with no executor case would be configurable but dead,
+        # and a verb in the executor with no default entry is unreachable because
+        # Resolve-DuneChatCommandAction rejects anything not in `commands`.
         $d = New-DuneChatCommandsDefault
-        @($d.commands.Keys | Sort-Object) | Should -Be @('kit', 'large', 'medium', 'small')
+        @($d.commands.Keys | Sort-Object) |
+            Should -Be @('item', 'kit', 'large', 'medium', 'small', 'vehicle', 'water')
+    }
+
+    It 'caps how much !item can hand out, and only !item carries a cap' {
+        # !item is the one command that can produce anything in the game, so an
+        # uncapped default would turn "enabled" into "players can have anything
+        # in any quantity".
+        $d = New-DuneChatCommandsDefault
+        $d.commands['item'].maxQty | Should -BeGreaterThan 0
+        foreach ($k in @('kit', 'water', 'vehicle', 'small', 'medium', 'large')) {
+            $d.commands[$k].ContainsKey('maxQty') | Should -BeFalse
+        }
+    }
+}
+
+Describe 'self-only commands' {
+    # !kit, !item, !vehicle and !water resolve the target from the chat message's
+    # sender and take no player argument, so a player can never aim them at
+    # someone else. These assert the parse keeps it that way - a future "target"
+    # argument would have to break one of them.
+    It 'treats !kit arguments as a kit name, never a player' {
+        $st = New-DstChatState
+        $m = @{ type = 'TextChat'; channel = 'Proximity'; fromId = 'A#1'; text = '!kit Starter Kit' }
+        $act = Resolve-DuneChatCommandAction -Message $m -State $st
+        $act.action | Should -Be 'run'
+        (@($act.args) -join ' ') | Should -Be 'Starter Kit'
+    }
+
+    It 'accepts !water with no arguments at all' {
+        $st = New-DstChatState
+        $st.commands['water'].enabled = $true
+        $m = @{ type = 'TextChat'; channel = 'Proximity'; fromId = 'A#1'; text = '!water' }
+        $act = Resolve-DuneChatCommandAction -Message $m -State $st
+        $act.action | Should -Be 'run'
+        $act.verb | Should -Be 'water'
+        @($act.args).Count | Should -Be 0
+    }
+
+    It 'parses !item into a name and an amount' {
+        $st = New-DstChatState
+        $st.commands['item'].enabled = $true
+        $m = @{ type = 'TextChat'; channel = 'Proximity'; fromId = 'A#1'; text = '!item plastone 500' }
+        $act = Resolve-DuneChatCommandAction -Message $m -State $st
+        $act.action | Should -Be 'run'
+        $act.verb | Should -Be 'item'
+        (@($act.args) -join ' ') | Should -Be 'plastone 500'
+    }
+
+    It 'parses a multi-word !item name with a trailing amount' {
+        $st = New-DstChatState
+        $st.commands['item'].enabled = $true
+        $m = @{ type = 'TextChat'; channel = 'Proximity'; fromId = 'A#1'; text = '!item Plastanium Ingot 10' }
+        $act = Resolve-DuneChatCommandAction -Message $m -State $st
+        (@($act.args) -join ' ') | Should -Be 'Plastanium Ingot 10'
     }
 }
 

--- a/tests/WelcomeBack.Tests.ps1
+++ b/tests/WelcomeBack.Tests.ps1
@@ -133,10 +133,36 @@ Describe 'Welcome Back settings' {
 
     It 'clamps the day count into a sane range' {
         $s = New-DuneWelcomeBackDefault
-        (Set-DuneWelcomeBackDaysAway -State $s -Value 0).daysAway    | Should -Be 1
-        (Set-DuneWelcomeBackDaysAway -State $s -Value -5).daysAway   | Should -Be 1
+        # 0 is a real setting - "every login" - so it must survive, and only
+        # genuinely impossible values get pulled back.
+        (Set-DuneWelcomeBackDaysAway -State $s -Value 0).daysAway    | Should -Be 0
+        (Set-DuneWelcomeBackDaysAway -State $s -Value -5).daysAway   | Should -Be 0
         (Set-DuneWelcomeBackDaysAway -State $s -Value 9999).daysAway | Should -Be 365
         (Set-DuneWelcomeBackDaysAway -State $s -Value 30).daysAway   | Should -Be 30
+    }
+
+    It 'grants on any return at all when the threshold is 0' {
+        $players = @(@{ account_id = '1'; name = 'A'; pawn_id = 5; last_login = '2026-08-04T12:00:00Z' })
+        $ledger  = @{ '1' = @{ lastLoginSeen = '2026-08-04T11:00:00Z'; lastGrantedAt = ''; grants = 0; name = 'A' } }
+        # One hour apart - would fail any positive threshold.
+        @((Get-DuneWelcomeBackPlan -Players $players -Ledger $ledger -DaysAway 0).grants).Count | Should -Be 1
+    }
+
+    It 'still does not re-fire at 0 while the player stays logged in' {
+        # The login transition, not the threshold, is what stops repeats - so
+        # even "every login" cannot pay out twice without a new login.
+        $players = @(@{ account_id = '1'; name = 'A'; pawn_id = 5; last_login = '2026-08-04T12:00:00Z' })
+        $ledger  = @{ '1' = @{ lastLoginSeen = '2026-08-04T11:00:00Z'; lastGrantedAt = ''; grants = 0; name = 'A' } }
+        $first = Get-DuneWelcomeBackPlan -Players $players -Ledger $ledger -DaysAway 0
+        @($first.grants).Count | Should -Be 1
+        @((Get-DuneWelcomeBackPlan -Players $players -Ledger $first.ledger -DaysAway 0).grants).Count | Should -Be 0
+    }
+
+    It 'still only seeds on the first pass at 0, rather than granting to everyone' {
+        $players = @(@{ account_id = '1'; name = 'A'; pawn_id = 5; last_login = '2026-08-04T12:00:00Z' })
+        $plan = Get-DuneWelcomeBackPlan -Players $players -Ledger @{} -DaysAway 0
+        @($plan.grants).Count | Should -Be 0
+        @($plan.seeded).Count | Should -Be 1
     }
 
     It 'leaves the day count alone when handed something that is not a number' {

--- a/tests/WelcomeBack.Tests.ps1
+++ b/tests/WelcomeBack.Tests.ps1
@@ -1,0 +1,158 @@
+﻿# Tests for the Welcome Back returning-player package.
+#
+# The whole feature turns on one decision - Get-DuneWelcomeBackPlan - so that is
+# where the tests are. It is pure by design: rows in, plan out, no database. The
+# behaviours worth defending are the ones an admin would be hurt by if they broke:
+# never mass-granting on enable, never paying twice for one absence, and never
+# paying for an absence shorter than they asked for.
+
+BeforeAll {
+    $here = Split-Path -Parent $PSCommandPath
+    . (Join-Path $here '..\app\server\lib\WelcomeBack.ps1')
+
+    function New-Player {
+        param([string]$Id, [string]$Name, [string]$Login, [int64]$Pawn = 100)
+        return @{ account_id = $Id; name = $Name; pawn_id = $Pawn; last_login = $Login }
+    }
+    # Ledger entries are what a previous pass wrote.
+    function New-Ledger {
+        param([string]$Id, [string]$Login)
+        return @{ $Id = @{ lastLoginSeen = $Login; lastGrantedAt = ''; grants = 0; name = 'x' } }
+    }
+}
+
+Describe 'Get-DuneWelcomeBackPlan' {
+
+    It 'grants nothing on the first pass and only records where players are' {
+        # This is what makes enabling the feature safe: a server with players who
+        # have been away for months must not hand out a package to all of them at
+        # the moment the admin flips the switch.
+        $players = @(
+            (New-Player -Id '1' -Name 'Away A year' -Login '2025-01-01T00:00:00Z'),
+            (New-Player -Id '2' -Name 'Away A week' -Login '2026-07-27T00:00:00Z')
+        )
+        $plan = Get-DuneWelcomeBackPlan -Players $players -Ledger @{} -DaysAway 7
+        @($plan.grants).Count | Should -Be 0
+        @($plan.seeded).Count | Should -Be 2
+        $plan.ledger['1'].lastLoginSeen | Should -Not -BeNullOrEmpty
+    }
+
+    It 'grants when the gap between the previous login and this one meets the threshold' {
+        $players = @((New-Player -Id '1' -Name 'Sawbrauh' -Login '2026-08-04T00:00:00Z' -Pawn 2510))
+        $ledger = New-Ledger -Id '1' -Login '2026-07-27T00:00:00Z'   # 8 days earlier
+        $plan = Get-DuneWelcomeBackPlan -Players $players -Ledger $ledger -DaysAway 7
+        @($plan.grants).Count | Should -Be 1
+        $plan.grants[0].name | Should -Be 'Sawbrauh'
+        $plan.grants[0].pawn_id | Should -Be 2510
+        [math]::Round($plan.grants[0].daysAway) | Should -Be 8
+    }
+
+    It 'does not grant when the gap is shorter than the threshold' {
+        $players = @((New-Player -Id '1' -Name 'Hawk-i' -Login '2026-08-04T00:00:00Z'))
+        $ledger = New-Ledger -Id '1' -Login '2026-08-01T00:00:00Z'   # 3 days
+        $plan = Get-DuneWelcomeBackPlan -Players $players -Ledger $ledger -DaysAway 7
+        @($plan.grants).Count | Should -Be 0
+        # ...but the ledger still advances, so those 3 days can never be counted
+        # again as part of a later, longer gap.
+        $plan.ledger['1'].lastLoginSeen | Should -Match '2026-08-04'
+    }
+
+    It 'grants exactly once for one absence, even if the tick runs repeatedly' {
+        $players = @((New-Player -Id '1' -Name 'Sawbrauh' -Login '2026-08-04T00:00:00Z'))
+        $ledger = New-Ledger -Id '1' -Login '2026-07-20T00:00:00Z'
+
+        $first = Get-DuneWelcomeBackPlan -Players $players -Ledger $ledger -DaysAway 7
+        @($first.grants).Count | Should -Be 1
+
+        # Same players, same unchanged login, but the ledger the first pass produced.
+        $second = Get-DuneWelcomeBackPlan -Players $players -Ledger $first.ledger -DaysAway 7
+        @($second.grants).Count | Should -Be 0
+
+        $third = Get-DuneWelcomeBackPlan -Players $players -Ledger $second.ledger -DaysAway 7
+        @($third.grants).Count | Should -Be 0
+    }
+
+    It 'grants again on a second qualifying absence' {
+        $players = @((New-Player -Id '1' -Name 'Sawbrauh' -Login '2026-08-04T00:00:00Z'))
+        $ledger = New-Ledger -Id '1' -Login '2026-07-20T00:00:00Z'
+        $first = Get-DuneWelcomeBackPlan -Players $players -Ledger $ledger -DaysAway 7
+        @($first.grants).Count | Should -Be 1
+
+        # They go away again and come back a month later.
+        $later = @((New-Player -Id '1' -Name 'Sawbrauh' -Login '2026-09-10T00:00:00Z'))
+        $second = Get-DuneWelcomeBackPlan -Players $later -Ledger $first.ledger -DaysAway 7
+        @($second.grants).Count | Should -Be 1
+    }
+
+    It 'ignores a player who is still logged in, because their login does not move' {
+        $players = @((New-Player -Id '1' -Name 'Coastal' -Login '2026-08-04T00:00:00Z'))
+        $ledger = New-Ledger -Id '1' -Login '2026-08-04T00:00:00Z'
+        $plan = Get-DuneWelcomeBackPlan -Players $players -Ledger $ledger -DaysAway 7
+        @($plan.grants).Count | Should -Be 0
+    }
+
+    It 'honours the configured threshold' {
+        $players = @((New-Player -Id '1' -Name 'A' -Login '2026-08-04T00:00:00Z'))
+        $ledger = New-Ledger -Id '1' -Login '2026-08-01T00:00:00Z'   # 3 days
+        (Get-DuneWelcomeBackPlan -Players $players -Ledger $ledger -DaysAway 7).grants.Count | Should -Be 0
+        @((Get-DuneWelcomeBackPlan -Players $players -Ledger $ledger -DaysAway 2).grants).Count | Should -Be 1
+    }
+
+    It 'treats an exactly-on-the-threshold absence as qualifying' {
+        $players = @((New-Player -Id '1' -Name 'A' -Login '2026-08-08T00:00:00Z'))
+        $ledger = New-Ledger -Id '1' -Login '2026-08-01T00:00:00Z'   # exactly 7
+        @((Get-DuneWelcomeBackPlan -Players $players -Ledger $ledger -DaysAway 7).grants).Count | Should -Be 1
+    }
+
+    It 'skips rows with no account id or no parseable login' {
+        $players = @(
+            @{ account_id = ''; name = 'no id'; pawn_id = 1; last_login = '2026-08-04T00:00:00Z' },
+            @{ account_id = '9'; name = 'no login'; pawn_id = 1; last_login = '' },
+            @{ account_id = '8'; name = 'junk login'; pawn_id = 1; last_login = 'not-a-date' }
+        )
+        $plan = Get-DuneWelcomeBackPlan -Players $players -Ledger @{} -DaysAway 7
+        @($plan.grants).Count | Should -Be 0
+        @($plan.seeded).Count | Should -Be 0
+    }
+
+    It 'never loses track of a player who was not in this batch' {
+        $ledger = New-Ledger -Id '99' -Login '2026-01-01T00:00:00Z'
+        $plan = Get-DuneWelcomeBackPlan -Players @() -Ledger $ledger -DaysAway 7
+        $plan.ledger.ContainsKey('99') | Should -BeTrue
+    }
+}
+
+Describe 'Welcome Back settings' {
+
+    It 'defaults to off with no package chosen' {
+        $d = New-DuneWelcomeBackDefault
+        $d.enabled | Should -BeFalse
+        $d.packageId | Should -Be ''
+        $d.daysAway | Should -Be 7
+    }
+
+    It 'clamps the day count into a sane range' {
+        $s = New-DuneWelcomeBackDefault
+        (Set-DuneWelcomeBackDaysAway -State $s -Value 0).daysAway    | Should -Be 1
+        (Set-DuneWelcomeBackDaysAway -State $s -Value -5).daysAway   | Should -Be 1
+        (Set-DuneWelcomeBackDaysAway -State $s -Value 9999).daysAway | Should -Be 365
+        (Set-DuneWelcomeBackDaysAway -State $s -Value 30).daysAway   | Should -Be 30
+    }
+
+    It 'leaves the day count alone when handed something that is not a number' {
+        $s = New-DuneWelcomeBackDefault
+        $s.daysAway = 14
+        (Set-DuneWelcomeBackDaysAway -State $s -Value 'soon').daysAway | Should -Be 14
+    }
+
+    It 'is not ready while disabled, and says why when enabled with no package' {
+        $s = New-DuneWelcomeBackDefault
+        (Test-DuneWelcomeBackReady -State $s).ready | Should -BeFalse
+
+        $s.enabled = $true
+        $r = Test-DuneWelcomeBackReady -State $s
+        $r.ready | Should -BeFalse
+        $r.reason | Should -Be 'no-package'
+        $r.message | Should -Not -BeNullOrEmpty
+    }
+}

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -2121,6 +2121,7 @@ export function saveChatCommands(patch: {
   enabled?: boolean
   replyTitle?: string
   channels?: string[]
+  pollSeconds?: number
   commands?: Record<string, { enabled?: boolean; cooldownSeconds?: number; maxQty?: number }>
 }) {
   return api<ChatCommandsState>('/api/gameplay/chat-commands', {

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -2,7 +2,7 @@
 // All market responses carry a `source: 'live' | 'demo'` flag so the UI can
 // label whether data came from the live game DB or the bundled demo dataset.
 import { api } from './client'
-import type { ChatCommandsState } from './types'
+import type { ChatCommandsState, WelcomeBackState } from './types'
 
 export type DataSource = 'live' | 'demo'
 
@@ -2121,9 +2121,27 @@ export function saveChatCommands(patch: {
   enabled?: boolean
   replyTitle?: string
   channels?: string[]
-  commands?: Record<string, { enabled?: boolean; cooldownSeconds?: number }>
+  commands?: Record<string, { enabled?: boolean; cooldownSeconds?: number; maxQty?: number }>
 }) {
   return api<ChatCommandsState>('/api/gameplay/chat-commands', {
+    method: 'PUT',
+    body: JSON.stringify(patch),
+  })
+}
+// ---------------------------------------------------------------------------
+// Welcome Back package
+// ---------------------------------------------------------------------------
+export function getWelcomeBack() {
+  return api<WelcomeBackState>('/api/gameplay/welcome-back')
+}
+
+export function saveWelcomeBack(patch: {
+  enabled?: boolean
+  packageId?: string
+  daysAway?: number
+  announce?: boolean
+}) {
+  return api<WelcomeBackState>('/api/gameplay/welcome-back', {
     method: 'PUT',
     body: JSON.stringify(patch),
   })

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -2,6 +2,7 @@
 // All market responses carry a `source: 'live' | 'demo'` flag so the UI can
 // label whether data came from the live game DB or the bundled demo dataset.
 import { api } from './client'
+import type { ChatCommandsState } from './types'
 
 export type DataSource = 'live' | 'demo'
 
@@ -2108,4 +2109,22 @@ export interface StorageOwnerDebug {
 }
 export function getStorageOwnerDebug(placeableId: number) {
   return api<StorageOwnerDebug>(`/api/gameplay/storage/${placeableId}/owner-debug`)
+}
+// ---------------------------------------------------------------------------
+// In-game !commands
+// ---------------------------------------------------------------------------
+export function getChatCommands() {
+  return api<ChatCommandsState>('/api/gameplay/chat-commands')
+}
+
+export function saveChatCommands(patch: {
+  enabled?: boolean
+  replyTitle?: string
+  channels?: string[]
+  commands?: Record<string, { enabled?: boolean; cooldownSeconds?: number }>
+}) {
+  return api<ChatCommandsState>('/api/gameplay/chat-commands', {
+    method: 'PUT',
+    body: JSON.stringify(patch),
+  })
 }

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -445,6 +445,7 @@ export type GameConfigBackupListResponse = {
 export type ChatCommandSetting = {
   enabled: boolean
   cooldownSeconds: number
+  maxQty?: number
 }
 
 export type ChatCommandsState = {
@@ -457,6 +458,31 @@ export type ChatCommandsState = {
   ready?: boolean
   readyMessage?: string
   lastSeenAt?: string
+}
+
+export type WelcomeBackGrant = {
+  at: string
+  name: string
+  daysAway: number
+  package: string
+  ok: boolean
+  message?: string
+}
+
+export type WelcomeBackState = {
+  ok: boolean
+  enabled: boolean
+  packageId: string
+  daysAway: number
+  announce: boolean
+  packages?: Array<{ id: string; name: string; itemCount: number }>
+  recent?: WelcomeBackGrant[]
+  tracked?: number
+  seeded?: number
+  lastRunAt?: string
+  lastError?: string
+  ready?: boolean
+  readyMessage?: string
 }
 
 export type SpicefieldType = {

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -455,6 +455,8 @@ export type ChatCommandsState = {
   channels: string[]
   commands: Record<string, ChatCommandSetting>
   packages?: string[]      // kit names available to !kit, from the package store
+  pollSeconds?: number
+  pollChoices?: number[]
   ready?: boolean
   readyMessage?: string
   lastSeenAt?: string

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -441,6 +441,24 @@ export type GameConfigBackupListResponse = {
 
 // ---------- Spicefield types (dune.spicefield_types) ------------------------
 
+// In-game !commands: which are enabled, their cooldowns, and where DST listens.
+export type ChatCommandSetting = {
+  enabled: boolean
+  cooldownSeconds: number
+}
+
+export type ChatCommandsState = {
+  ok: boolean
+  enabled: boolean
+  replyTitle: string
+  channels: string[]
+  commands: Record<string, ChatCommandSetting>
+  packages?: string[]      // kit names available to !kit, from the package store
+  ready?: boolean
+  readyMessage?: string
+  lastSeenAt?: string
+}
+
 export type SpicefieldType = {
   spicefieldTypeId: number
   mapName: string         // raw DB name, e.g. "HaggaBasin", "DeepDesert"

--- a/webui/src/pages/gameplay/ChatCommandsCard.tsx
+++ b/webui/src/pages/gameplay/ChatCommandsCard.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Icon } from '../../components/Icon'
+import { CollapsibleCard } from '../../components/CollapsibleCard'
+import { getChatCommands, saveChatCommands } from '../../api/gameplay'
+import type { ChatCommandsState } from '../../api/types'
+
+// In-game !commands. Players type into game chat and DST acts on it.
+//
+// Everything here is off until an admin turns it on, deliberately: these let
+// ordinary players change the world (spawning spice fields) or receive items,
+// which is a real shift in who controls the server. The master switch and each
+// command are separate so "on" never means "all of it".
+const CHANNELS = ['Proximity', 'Map', 'Faction', 'Guild', 'Party']
+
+const DESCRIPTIONS: Record<string, string> = {
+  kit:    'Hands over one of your item packages. Typing !kit on its own asks which.',
+  small:  'Activates Small spice fields, up to the limit you have already set.',
+  medium: 'Activates Medium spice fields, up to the limit you have already set.',
+  large:  'Activates Large spice fields, up to the limit you have already set.',
+}
+
+const ORDER = ['kit', 'small', 'medium', 'large']
+
+function humanCooldown(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return 'no cooldown'
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.round(seconds / 60)} min`
+  if (seconds < 86400) return `${+(seconds / 3600).toFixed(1)} hours`
+  return `${+(seconds / 86400).toFixed(1)} days`
+}
+
+export function ChatCommandsCard() {
+  const [state, setState] = useState<ChatCommandsState | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [ok, setOk] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true); setErr(null)
+    try {
+      setState(await getChatCommands())
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void load() }, [load])
+
+  async function patch(body: Parameters<typeof saveChatCommands>[0], note?: string) {
+    setSaving(true); setErr(null); setOk(null)
+    try {
+      const res = await saveChatCommands(body)
+      // The PUT returns the top-level settings but not the per-command map, so
+      // merge rather than replace - otherwise a cooldown edit would blank the
+      // list until the next refresh.
+      setState(prev => (prev ? { ...prev, ...res, commands: prev.commands } : prev))
+      if (note) setOk(note)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function setCommand(verb: string, next: Partial<{ enabled: boolean; cooldownSeconds: number }>) {
+    setState(prev => {
+      if (!prev) return prev
+      const cur = prev.commands[verb] ?? { enabled: false, cooldownSeconds: 0 }
+      return { ...prev, commands: { ...prev.commands, [verb]: { ...cur, ...next } } }
+    })
+  }
+
+  const enabled = state?.enabled === true
+  const commands = state?.commands ?? {}
+  const anyOn = Object.values(commands).some(c => c.enabled)
+  const packages = state?.packages ?? []
+  const kitOn = commands['kit']?.enabled === true
+
+  return (
+    <CollapsibleCard
+      id="gameplay.chatCommands"
+      icon="MessageSquare"
+      iconClassName="text-ibad shrink-0"
+      title="In-game commands"
+      titleClassName="text-sm font-semibold uppercase tracking-wider text-ibad"
+      subtitle={
+        <span className="text-xs text-text-muted">
+          Let players trigger actions by typing in game chat. Off by default.
+        </span>
+      }
+      headerClassName="px-5 pt-5 pb-2"
+      bodyClassName="px-5 pb-5"
+      headerRight={
+        <button type="button" className="btn-secondary" disabled={loading || saving}
+                onClick={() => void load()}>
+          <Icon name={loading ? 'Loader2' : 'RefreshCw'} size={14}
+                className={loading ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      }
+    >
+      {err && <div className="mb-3 px-3 py-2 rounded border border-danger/40 bg-danger/10 text-danger text-xs">{err}</div>}
+      {ok && <div className="mb-3 px-3 py-2 rounded border border-success/40 bg-success/10 text-success text-xs">{ok}</div>}
+
+      <p className="text-xs text-text-muted mb-3">
+        DST reads game chat and responds with a server broadcast, the same popup the
+        Broadcasts page sends. Replies are visible to everyone, not just the player who
+        typed the command.
+      </p>
+
+      <label className="flex items-center gap-2 text-sm cursor-pointer">
+        <input type="checkbox" checked={enabled} disabled={saving || loading}
+               onChange={e => void patch({ enabled: e.target.checked },
+                 e.target.checked ? 'Listening for commands.' : 'Stopped listening.')}
+               className="accent-ibad" />
+        <span className="font-medium text-text">Listen for commands in game chat</span>
+      </label>
+
+      {enabled && !anyOn && (
+        <div className="mt-2 px-3 py-2 rounded border border-warning/40 bg-warning/10 text-warning text-xs">
+          Listening is on but every command is off, so nothing will happen. Turn on at
+          least one below.
+        </div>
+      )}
+
+      <div className="mt-4 space-y-3">
+        {ORDER.filter(v => v in commands).map(verb => {
+          const c = commands[verb]
+          return (
+            <div key={verb} className="rounded-lg border border-border bg-surface-2/40 px-3 py-2">
+              <div className="flex items-center justify-between gap-3">
+                <label className="flex items-center gap-2 text-sm cursor-pointer">
+                  <input type="checkbox" checked={c.enabled} disabled={saving || loading}
+                         onChange={e => {
+                           setCommand(verb, { enabled: e.target.checked })
+                           void patch({ commands: { [verb]: { enabled: e.target.checked } } })
+                         }}
+                         className="accent-ibad" />
+                  <code className="text-text font-medium">!{verb}</code>
+                </label>
+                <div className="flex items-center gap-2 text-xs">
+                  <span className="text-text-dim">cooldown</span>
+                  <input
+                    type="text" inputMode="numeric"
+                    value={String(c.cooldownSeconds)}
+                    disabled={saving || loading}
+                    onChange={e => {
+                      const n = Number(e.target.value.replace(/[^\d]/g, ''))
+                      setCommand(verb, { cooldownSeconds: Number.isFinite(n) ? n : 0 })
+                    }}
+                    onBlur={() => void patch({ commands: { [verb]: { cooldownSeconds: c.cooldownSeconds } } })}
+                    className="w-24 px-2 py-1 rounded bg-surface border border-border text-text font-mono text-xs"
+                  />
+                  <span className="text-text-dim w-20">{humanCooldown(c.cooldownSeconds)}</span>
+                </div>
+              </div>
+              <div className="mt-1 text-[11px] text-text-muted">{DESCRIPTIONS[verb]}</div>
+              {verb === 'kit' && kitOn && packages.length === 0 && (
+                <div className="mt-2 text-[11px] text-warning">
+                  No item packages exist yet, so !kit has nothing to hand out. Create one
+                  under Players &rsaquo; Give Package.
+                </div>
+              )}
+              {verb === 'kit' && kitOn && packages.length > 0 && (
+                <div className="mt-2 text-[11px] text-text-dim">
+                  Players type <code>!kit &lt;name&gt;</code>. Available: {packages.join(', ')}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="mt-4 pt-4 border-t border-border">
+        <div className="text-xs text-text-muted mb-2">Listen on these chat channels</div>
+        <div className="flex flex-wrap gap-3">
+          {CHANNELS.map(ch => {
+            const on = (state?.channels ?? []).includes(ch)
+            return (
+              <label key={ch} className="flex items-center gap-1.5 text-xs cursor-pointer">
+                <input type="checkbox" checked={on} disabled={saving || loading}
+                       onChange={e => {
+                         const next = e.target.checked
+                           ? [...(state?.channels ?? []), ch]
+                           : (state?.channels ?? []).filter(c => c !== ch)
+                         setState(prev => (prev ? { ...prev, channels: next } : prev))
+                         void patch({ channels: next })
+                       }}
+                       className="accent-ibad" />
+                <span className="text-text">{ch}</span>
+              </label>
+            )
+          })}
+        </div>
+
+        <div className="mt-3 flex items-center gap-2">
+          <span className="text-xs text-text-muted">Reply heading</span>
+          <input
+            type="text"
+            value={state?.replyTitle ?? ''}
+            disabled={saving || loading}
+            onChange={e => setState(prev => (prev ? { ...prev, replyTitle: e.target.value } : prev))}
+            onBlur={() => void patch({ replyTitle: state?.replyTitle ?? 'Server' })}
+            placeholder="Server"
+            className="w-40 px-2 py-1 rounded bg-surface border border-border text-text text-xs"
+          />
+          <span className="text-[11px] text-text-dim">shown at the top of the popup</span>
+        </div>
+      </div>
+
+      <p className="mt-4 text-[11px] text-text-dim">
+        A response can take up to 30 seconds — DST checks for new commands on the same
+        background cycle as its other scheduled work.
+      </p>
+    </CollapsibleCard>
+  )
+}

--- a/webui/src/pages/gameplay/ChatCommandsCard.tsx
+++ b/webui/src/pages/gameplay/ChatCommandsCard.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import { CollapsibleCard } from '../../components/CollapsibleCard'
 import { getChatCommands, saveChatCommands } from '../../api/gameplay'
-import type { ChatCommandsState } from '../../api/types'
+import { getSpicefields, saveSpicefield } from '../../api/gameconfig'
+import type { ChatCommandsState, SpicefieldType } from '../../api/types'
 
 // In-game !commands. Players type into game chat and DST acts on it.
 //
@@ -29,6 +30,108 @@ const ORDER = ['kit', 'item', 'vehicle', 'water', 'small', 'medium', 'large']
 // player argument. Worth stating in the UI so an admin does not assume otherwise.
 const SELF_ONLY = new Set(['kit', 'item', 'vehicle', 'water'])
 
+const SPICE_VERBS = new Set(['small', 'medium', 'large'])
+
+// Measured cost per poll interval (2026-08-04, 8-core VM): idle 9.14% busy vs
+// 15.41% at a 3s poll, so ~1.5 core-seconds per check. Shown in the picker so
+// the trade is made with the numbers visible rather than blind.
+const POLL_COST: Record<number, string> = {
+  3: '0.50', 5: '0.30', 10: '0.15', 15: '0.10', 30: '0.05',
+}
+
+// The cap a spice command works within is not part of this feature - it is the
+// spicefield type's own max_globally_active, which already has an editor in Game
+// Config. It is surfaced here anyway because "!large did nothing" is almost
+// always "the map is already at its limit", and making an admin leave the page
+// to find that out is the sort of thing that gets reported as a bug.
+//
+// There is one row per map+dimension, so a size can have several limits, and a
+// size with no row at all (Hagga has no Large) means the command genuinely
+// cannot do anything on that map. Both are worth showing plainly.
+function SpiceLimits({
+  size, rows, busy, onSaved,
+}: {
+  size: string
+  rows: SpicefieldType[]
+  busy: boolean
+  onSaved: (row: SpicefieldType) => void
+}) {
+  const [draft, setDraft] = useState<Record<number, string>>({})
+  const [saving, setSaving] = useState<number | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const mine = rows.filter(r => r.fieldType.toLowerCase() === size)
+  // Only live/pinned partitions can drain a request, which is the same rule the
+  // command itself follows - a limit on a retired map is noise here.
+  const live = mine.filter(r => r.partitionActive !== false)
+
+  if (rows.length === 0) return null
+  if (live.length === 0) {
+    return (
+      <div className="mt-2 text-[11px] text-warning">
+        No running map has {size} spice fields, so !{size} has nothing to activate.
+      </div>
+    )
+  }
+
+  async function commit(row: SpicefieldType) {
+    const raw = draft[row.spicefieldTypeId]
+    if (raw === undefined) return
+    const n = Number(raw)
+    if (!Number.isFinite(n) || n < 0 || n === row.maxActive) {
+      setDraft(d => { const c = { ...d }; delete c[row.spicefieldTypeId]; return c })
+      return
+    }
+    setSaving(row.spicefieldTypeId); setErr(null)
+    try {
+      const res = await saveSpicefield(row.spicefieldTypeId, {
+        maxActive: n,
+        maxPrimed: row.maxPrimed,
+        isSpawningActive: row.isSpawningActive,
+        spawnWeight: row.spawnWeight,
+      })
+      onSaved(res.row)
+      setDraft(d => { const c = { ...d }; delete c[row.spicefieldTypeId]; return c })
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  return (
+    <div className="mt-2 space-y-1">
+      {err && <div className="text-[11px] text-danger">{err}</div>}
+      {live.map(row => {
+        const id = row.spicefieldTypeId
+        const atCap = row.currentActive >= row.maxActive
+        return (
+          <div key={id} className="flex items-center gap-2 text-[11px]">
+            <span className="text-text-dim w-28 shrink-0">{row.mapName}</span>
+            <span className={atCap ? 'text-warning' : 'text-text-muted'}>
+              {row.currentActive} of {row.maxActive} active
+            </span>
+            <span className="text-text-dim ml-auto">limit</span>
+            <input
+              type="text" inputMode="numeric"
+              value={draft[id] ?? String(row.maxActive)}
+              disabled={busy || saving === id}
+              onChange={e => setDraft(d => ({ ...d, [id]: e.target.value.replace(/[^\d]/g, '') }))}
+              onBlur={() => void commit(row)}
+              onKeyDown={e => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
+              className="w-16 px-2 py-0.5 rounded bg-surface border border-border text-text font-mono text-[11px]"
+            />
+            {saving === id && <Icon name="Loader2" size={11} className="animate-spin text-text-dim" />}
+            {atCap && saving !== id && (
+              <span className="text-warning">at cap — raise it or !{size} will do nothing</span>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
 function humanCooldown(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds <= 0) return 'no cooldown'
   if (seconds < 60) return `${seconds}s`
@@ -43,6 +146,7 @@ export function ChatCommandsCard() {
   const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const [ok, setOk] = useState<string | null>(null)
+  const [spice, setSpice] = useState<SpicefieldType[]>([])
 
   const load = useCallback(async () => {
     setLoading(true); setErr(null)
@@ -53,6 +157,12 @@ export function ChatCommandsCard() {
     } finally {
       setLoading(false)
     }
+    // Spice limits are a nice-to-have on this card, so a failure to read them
+    // must not make the whole card look broken.
+    try {
+      const s = await getSpicefields()
+      setSpice(s.available ? s.rows : [])
+    } catch { setSpice([]) }
   }, [])
 
   useEffect(() => { void load() }, [load])
@@ -201,6 +311,15 @@ export function ChatCommandsCard() {
                   Players type <code>!kit &lt;name&gt;</code>. Available: {packages.join(', ')}
                 </div>
               )}
+              {SPICE_VERBS.has(verb) && c.enabled && (
+                <SpiceLimits
+                  size={verb}
+                  rows={spice}
+                  busy={saving || loading}
+                  onSaved={row => setSpice(prev =>
+                    prev.map(r => (r.spicefieldTypeId === row.spicefieldTypeId ? row : r)))}
+                />
+              )}
             </div>
           )
         })}
@@ -244,8 +363,33 @@ export function ChatCommandsCard() {
       </div>
 
       <p className="mt-4 text-[11px] text-text-dim">
-        A response can take up to 30 seconds — DST checks for new commands on the same
-        background cycle as its other scheduled work.
+        DST checks for new commands on a timer, so a reply takes about as long as
+        the interval below. That check is not free — it costs the same whether or
+        not anyone is chatting, and only while this is switched on.
+      </p>
+
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <span className="text-xs text-text-muted">Check for commands every</span>
+        <select
+          value={String(state?.pollSeconds ?? 3)}
+          disabled={saving || loading}
+          onChange={e => {
+            const n = Number(e.target.value)
+            setState(prev => (prev ? { ...prev, pollSeconds: n } : prev))
+            void patch({ pollSeconds: n }, `Now checking every ${n} seconds.`)
+          }}
+          className="px-2 py-1 rounded bg-surface border border-border text-text text-xs"
+        >
+          {(state?.pollChoices ?? [3, 5, 10, 15, 30]).map(n => (
+            <option key={n} value={n}>
+              {n} seconds — about {POLL_COST[n] ?? (1.5 / n).toFixed(2)} of a processor core
+            </option>
+          ))}
+        </select>
+      </div>
+      <p className="mt-1 text-[11px] text-text-dim">
+        Measured on an 8-core server VM. The cost is per check rather than per
+        message, so a longer interval is cheaper in direct proportion.
       </p>
     </CollapsibleCard>
   )

--- a/webui/src/pages/gameplay/ChatCommandsCard.tsx
+++ b/webui/src/pages/gameplay/ChatCommandsCard.tsx
@@ -13,13 +13,21 @@ import type { ChatCommandsState } from '../../api/types'
 const CHANNELS = ['Proximity', 'Map', 'Faction', 'Guild', 'Party']
 
 const DESCRIPTIONS: Record<string, string> = {
-  kit:    'Hands over one of your item packages. Typing !kit on its own asks which.',
-  small:  'Activates Small spice fields, up to the limit you have already set.',
-  medium: 'Activates Medium spice fields, up to the limit you have already set.',
-  large:  'Activates Large spice fields, up to the limit you have already set.',
+  kit:     'Hands over one of your item packages. Typing !kit on its own asks which.',
+  item:    'Hands over any single item from the catalog, e.g. "!item plastone 500".',
+  water:   'Refills the water in that player\u2019s stillsuit, jons and canteens.',
+  vehicle: 'Hands over a vehicle part kit plus fuel and a repair tool, to be assembled at a Vehicle Assembly. Typing !vehicle on its own lists them.',
+  small:   'Activates Small spice fields, up to the limit you have already set.',
+  medium:  'Activates Medium spice fields, up to the limit you have already set.',
+  large:   'Activates Large spice fields, up to the limit you have already set.',
 }
 
-const ORDER = ['kit', 'small', 'medium', 'large']
+const ORDER = ['kit', 'item', 'vehicle', 'water', 'small', 'medium', 'large']
+
+// !kit, !item, !vehicle and !water only ever act on whoever typed them - the
+// actor is taken from the chat message's sender id and none of them accept a
+// player argument. Worth stating in the UI so an admin does not assume otherwise.
+const SELF_ONLY = new Set(['kit', 'item', 'vehicle', 'water'])
 
 function humanCooldown(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds <= 0) return 'no cooldown'
@@ -65,7 +73,7 @@ export function ChatCommandsCard() {
     }
   }
 
-  function setCommand(verb: string, next: Partial<{ enabled: boolean; cooldownSeconds: number }>) {
+  function setCommand(verb: string, next: Partial<{ enabled: boolean; cooldownSeconds: number; maxQty: number }>) {
     setState(prev => {
       if (!prev) return prev
       const cur = prev.commands[verb] ?? { enabled: false, cooldownSeconds: 0 }
@@ -140,6 +148,11 @@ export function ChatCommandsCard() {
                          }}
                          className="accent-ibad" />
                   <code className="text-text font-medium">!{verb}</code>
+                  {SELF_ONLY.has(verb) && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded-full border border-border text-text-dim">
+                      self only
+                    </span>
+                  )}
                 </label>
                 <div className="flex items-center gap-2 text-xs">
                   <span className="text-text-dim">cooldown</span>
@@ -158,6 +171,25 @@ export function ChatCommandsCard() {
                 </div>
               </div>
               <div className="mt-1 text-[11px] text-text-muted">{DESCRIPTIONS[verb]}</div>
+              {verb === 'item' && c.enabled && (
+                <div className="mt-2 flex items-center gap-2 text-[11px]">
+                  <span className="text-text-dim">Most a player can ask for at once</span>
+                  <input
+                    type="text" inputMode="numeric"
+                    value={String(c.maxQty ?? 1000)}
+                    disabled={saving || loading}
+                    onChange={e => {
+                      const n = Number(e.target.value.replace(/[^\d]/g, ''))
+                      setCommand(verb, { maxQty: Number.isFinite(n) ? n : 0 })
+                    }}
+                    onBlur={() => void patch({ commands: { item: { maxQty: c.maxQty ?? 1000 } } })}
+                    className="w-24 px-2 py-1 rounded bg-surface border border-border text-text font-mono text-[11px]"
+                  />
+                  <span className="text-warning">
+                    This one can produce anything in the game — keep the cap low.
+                  </span>
+                </div>
+              )}
               {verb === 'kit' && kitOn && packages.length === 0 && (
                 <div className="mt-2 text-[11px] text-warning">
                   No item packages exist yet, so !kit has nothing to hand out. Create one

--- a/webui/src/pages/gameplay/OverviewTab.tsx
+++ b/webui/src/pages/gameplay/OverviewTab.tsx
@@ -3,6 +3,7 @@ import { Icon } from '../../components/Icon'
 import { useApi } from '../../hooks/useApi'
 import type { GameplayStatus } from '../../api/gameplay'
 import type { GameplaySubTab } from '../GameplayEnvironment'
+import { ChatCommandsCard } from './ChatCommandsCard'
 
 type FeatureStatus = 'live' | 'native' | 'roadmap'
 
@@ -136,6 +137,10 @@ export function OverviewTab({ onOpenTab }: { onOpenTab: (tab: GameplaySubTab) =>
             </div>
           )
         })}
+      </div>
+
+      <div className="mt-4">
+        <ChatCommandsCard />
       </div>
     </div>
   )

--- a/webui/src/pages/gameplay/OverviewTab.tsx
+++ b/webui/src/pages/gameplay/OverviewTab.tsx
@@ -4,6 +4,7 @@ import { useApi } from '../../hooks/useApi'
 import type { GameplayStatus } from '../../api/gameplay'
 import type { GameplaySubTab } from '../GameplayEnvironment'
 import { ChatCommandsCard } from './ChatCommandsCard'
+import { WelcomeBackCard } from './WelcomeBackCard'
 
 type FeatureStatus = 'live' | 'native' | 'roadmap'
 
@@ -141,6 +142,10 @@ export function OverviewTab({ onOpenTab }: { onOpenTab: (tab: GameplaySubTab) =>
 
       <div className="mt-4">
         <ChatCommandsCard />
+      </div>
+
+      <div className="mt-4">
+        <WelcomeBackCard />
       </div>
     </div>
   )

--- a/webui/src/pages/gameplay/WelcomeBackCard.tsx
+++ b/webui/src/pages/gameplay/WelcomeBackCard.tsx
@@ -153,13 +153,20 @@ export function WelcomeBackCard() {
               onChange={e => setDays(e.target.value.replace(/[^\d]/g, ''))}
               onBlur={() => {
                 const n = Number(days)
-                if (Number.isFinite(n) && n > 0 && n !== state?.daysAway) void patch({ daysAway: n })
+                // >= 0: zero is a real setting, not an error. See the note in
+                // lib/WelcomeBack.ps1 - it means every login qualifies.
+                if (days !== '' && Number.isFinite(n) && n >= 0 && n !== state?.daysAway) void patch({ daysAway: n })
                 else setDays(String(state?.daysAway ?? 7))
               }}
               className="w-24 px-2 py-1.5 rounded bg-surface border border-border text-text font-mono text-sm"
             />
             <span className="text-xs text-text-dim">days</span>
           </div>
+          {state?.daysAway === 0 && (
+            <div className="mt-1 text-[11px] text-warning">
+              0 means every login qualifies — they get the package each time they come back.
+            </div>
+          )}
         </div>
       </div>
 

--- a/webui/src/pages/gameplay/WelcomeBackCard.tsx
+++ b/webui/src/pages/gameplay/WelcomeBackCard.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Icon } from '../../components/Icon'
+import { CollapsibleCard } from '../../components/CollapsibleCard'
+import { getWelcomeBack, saveWelcomeBack } from '../../api/gameplay'
+import type { WelcomeBackState } from '../../api/types'
+
+// Welcome Back - give a returning player an item package when they come back.
+//
+// Replaces the three returning-player console variables that were removed, which
+// a Funcom developer confirmed do nothing on a self-hosted server. This does the
+// same job with the admin's own item packages.
+//
+// The wording here is deliberate about WHEN it fires. The absence is measured
+// between a player's previous login and the one that just happened, so it pays
+// out once per absence and enabling it cannot hand packages to a whole existing
+// player base at once. An admin who does not know that would reasonably fear
+// turning it on.
+
+function formatWhen(iso?: string): string {
+  if (!iso) return 'never'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return 'never'
+  return d.toLocaleString()
+}
+
+export function WelcomeBackCard() {
+  const [state, setState] = useState<WelcomeBackState | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [ok, setOk] = useState<string | null>(null)
+  const [days, setDays] = useState('7')
+
+  const load = useCallback(async () => {
+    setLoading(true); setErr(null)
+    try {
+      const s = await getWelcomeBack()
+      setState(s)
+      setDays(String(s.daysAway ?? 7))
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void load() }, [load])
+
+  async function patch(body: Parameters<typeof saveWelcomeBack>[0], note?: string) {
+    setSaving(true); setErr(null); setOk(null)
+    try {
+      const res = await saveWelcomeBack(body)
+      // The PUT returns settings but not the package list or history, so merge
+      // rather than replace and keep those from the last GET.
+      setState(prev => (prev ? { ...prev, ...res, packages: prev.packages, recent: prev.recent } : prev))
+      if (typeof res.daysAway === 'number') setDays(String(res.daysAway))
+      if (note) setOk(note)
+      // Enabling runs a seeding pass, so the tracked count changes - refresh to
+      // show it rather than leaving a stale number on screen.
+      if (body.enabled === true) { void load() }
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const enabled = state?.enabled === true
+  const packages = state?.packages ?? []
+  const recent = state?.recent ?? []
+  const chosen = packages.find(p => p.id === state?.packageId)
+
+  return (
+    <CollapsibleCard
+      id="gameplay.welcomeBack"
+      icon="Gift"
+      iconClassName="text-ibad shrink-0"
+      title="Welcome back"
+      titleClassName="text-sm font-semibold uppercase tracking-wider text-ibad"
+      subtitle={
+        <span className="text-xs text-text-muted">
+          Give a package to players returning after time away. Off by default.
+        </span>
+      }
+      headerClassName="px-5 pt-5 pb-2"
+      bodyClassName="px-5 pb-5"
+      headerRight={
+        <button type="button" className="btn-secondary" disabled={loading || saving}
+                onClick={() => void load()}>
+          <Icon name={loading ? 'Loader2' : 'RefreshCw'} size={14}
+                className={loading ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      }
+    >
+      {err && <div className="mb-3 px-3 py-2 rounded border border-danger/40 bg-danger/10 text-danger text-xs">{err}</div>}
+      {ok && <div className="mb-3 px-3 py-2 rounded border border-success/40 bg-success/10 text-success text-xs">{ok}</div>}
+
+      <p className="text-xs text-text-muted mb-3">
+        When a player logs in after being away, DST gives them one of your item
+        packages. The gap is measured between their previous login and this one, so
+        each player is given the package once per absence — turning this on will not
+        hand anything to your existing players until they next return.
+      </p>
+
+      <label className="flex items-center gap-2 text-sm cursor-pointer">
+        <input type="checkbox" checked={enabled} disabled={saving || loading}
+               onChange={e => void patch({ enabled: e.target.checked },
+                 e.target.checked ? 'Watching for returning players.' : 'Stopped.')}
+               className="accent-ibad" />
+        <span className="font-medium text-text">Give a package to returning players</span>
+      </label>
+
+      {enabled && state?.readyMessage && (
+        <div className="mt-2 px-3 py-2 rounded border border-warning/40 bg-warning/10 text-warning text-xs">
+          {state.readyMessage}
+        </div>
+      )}
+
+      <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Package to give</label>
+          <select
+            value={state?.packageId ?? ''}
+            disabled={saving || loading}
+            onChange={e => {
+              setState(prev => (prev ? { ...prev, packageId: e.target.value } : prev))
+              void patch({ packageId: e.target.value })
+            }}
+            className="w-full px-2 py-1.5 rounded bg-surface border border-border text-text text-sm"
+          >
+            <option value="">— none chosen —</option>
+            {packages.map(p => (
+              <option key={p.id} value={p.id}>
+                {p.name} ({p.itemCount} item{p.itemCount === 1 ? '' : 's'})
+              </option>
+            ))}
+          </select>
+          {packages.length === 0 && (
+            <div className="mt-1 text-[11px] text-warning">
+              No item packages exist yet. Create one under Players &rsaquo; Give Package.
+            </div>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Days away before it counts</label>
+          <div className="flex items-center gap-2">
+            <input
+              type="text" inputMode="numeric"
+              value={days}
+              disabled={saving || loading}
+              onChange={e => setDays(e.target.value.replace(/[^\d]/g, ''))}
+              onBlur={() => {
+                const n = Number(days)
+                if (Number.isFinite(n) && n > 0 && n !== state?.daysAway) void patch({ daysAway: n })
+                else setDays(String(state?.daysAway ?? 7))
+              }}
+              className="w-24 px-2 py-1.5 rounded bg-surface border border-border text-text font-mono text-sm"
+            />
+            <span className="text-xs text-text-dim">days</span>
+          </div>
+        </div>
+      </div>
+
+      <label className="mt-3 flex items-center gap-2 text-xs cursor-pointer">
+        <input type="checkbox" checked={state?.announce === true} disabled={saving || loading}
+               onChange={e => {
+                 setState(prev => (prev ? { ...prev, announce: e.target.checked } : prev))
+                 void patch({ announce: e.target.checked })
+               }}
+               className="accent-ibad" />
+        <span className="text-text">Announce it to the server when someone gets one</span>
+      </label>
+
+      <div className="mt-4 pt-3 border-t border-border flex flex-wrap gap-x-6 gap-y-1 text-[11px] text-text-dim">
+        <span>Players tracked: <span className="text-text-muted">{state?.tracked ?? 0}</span></span>
+        <span>Last checked: <span className="text-text-muted">{formatWhen(state?.lastRunAt)}</span></span>
+        {chosen && <span>Giving: <span className="text-text-muted">{chosen.name}</span></span>}
+      </div>
+
+      {recent.length > 0 && (
+        <div className="mt-3">
+          <div className="text-[11px] uppercase tracking-wider text-text-dim mb-1.5">Recently given</div>
+          <ul className="space-y-1">
+            {recent.slice(0, 8).map((g, i) => (
+              <li key={`${g.at}-${i}`} className="flex items-center gap-2 text-xs">
+                <Icon name={g.ok ? 'Check' : 'X'} size={12}
+                      className={g.ok ? 'text-success shrink-0' : 'text-danger shrink-0'} />
+                <span className="text-text">{g.name || 'Unknown'}</span>
+                <span className="text-text-dim">away {Math.round(g.daysAway)}d</span>
+                <span className="text-text-muted">{g.package}</span>
+                <span className="text-text-dim ml-auto">{formatWhen(g.at)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <p className="mt-4 text-[11px] text-text-dim">
+        DST checks every few minutes, so a package can arrive a little after they
+        log in rather than the instant they do.
+      </p>
+    </CollapsibleCard>
+  )
+}


### PR DESCRIPTION
Finishes the in-game chat commands feature (settings UI + three more commands) and adds Welcome Back packages.

## Chat commands

Settings live on **Gameplay Admin → Overview**: master switch, per-command enable + cooldown, channel allow-list, reply heading. Everything off by default.

Three new commands, each wired to an action DST already performs from the Players page rather than a new mechanism:

| Command | Wired to | Notes |
|---|---|---|
| `!water` | the Fill Water button's RMQ command | uses the **live** path, not the SQL refill — the sender is by definition online, and an online player's inventory lives in memory |
| `!vehicle <name>` | Give Vehicle Kit | parts + fuel + repair tool into inventory, assembled at a Vehicle Assembly. The reply says so — "vehicle delivered" would send someone looking for one |
| `!item <name> [amt]` | the item catalog + RMQ add-to-inventory | e.g. `!item plastone 500` |

`!item` resolves by template id → exact name → unique substring. Verified against the real 1,854-item catalog:

- `plastone` → unique match `Plastone`
- `plastanium ingot` → `T6RefinedResourceA` (name ≠ template, so name matching is essential)
- `water` → 5 matches → lists candidates rather than guessing

**`!item` is much broader than the rest.** Every other command is bounded by something the admin defined up front; this one can produce anything in the game. It carries a server-enforced quantity cap (default 1000) alongside its cooldown, and the UI says so plainly.

**None of `!kit` / `!item` / `!vehicle` / `!water` can be aimed at another player** — the actor comes from the chat message's sender id and none take a player argument. Tests assert this.

## Welcome Back

Gives a returning player one of your item packages. Replaces the `dw.ReturningPlayer.*` CVars removed earlier — a Funcom dev confirmed they do nothing on a self-host, and they were cut leaving nothing in their place.

There's no login hook to subscribe to, but `player_state.last_login_time` is stamped at login (verified on a live server: a session showed login `00:32` against last activity `01:19`), so a login is visible as that column moving forward.

The absence is measured between a player's **previous** login and this one, not against "now":

```
P = last login DST recorded    L = last_login_time now
no P    -> record P = L, grant nothing   (new player / first run)
L > P   -> absence = L - P;  >= daysAway  ->  give the package
always  -> record P = L
```

That one choice is what makes it safe: it can't re-fire while they stay online, can't pay twice for one gap, needs no "already claimed" flag to reset or migrate, and **enabling it cannot mass-grant to an existing player base** — the first pass only records where everyone is.

## Verification

- `tests\Run-Tests.ps1` — **683 passed, 0 failed** (22 new)
- `npm run build` in `webui/` — clean
- All changed `.ps1` parse-checked; BOM present where needed
- Caught and fixed a real aliasing bug while testing: the plan function copied ledger *references*, so it mutated the caller's ledger in place and a second call disagreed with the first
