### PR TITLE
Add the Base Backup Tool to the item catalog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.4.0"
+      placeholder: "v13.4.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.4.1] - 2026-08-04
+
+### Fixed
+
+- **The Base Backup Tool can now be given to players.** It was missing from DST's item list, so it could not be handed out through Give Item, added to a package, or asked for with `!item` — even though it is a real item players carry. Its cosmetic emotes and swatches are still absent from that list on purpose: those are granted through Grant Cosmetic rather than as inventory items.
+
 ## [13.4.0] - 2026-08-04
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.4.0'
+$script:DuneToolVersion = '13.4.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.4.0',
+    [string]$Version = '13.4.1',
     [switch]$Quiet
 )
 

--- a/app/data/item-catalog.json
+++ b/app/data/item-catalog.json
@@ -411,6 +411,10 @@
       "name": "Basalt Stone",
       "category": "Resources"
     },
+    "BaseBackupTool": {
+      "name": "Base Backup Tool",
+      "category": "Tools"
+    },
     "LMG_Unique_RapidFire_06": {
       "name": "Bashar's Command",
       "category": "Weapons - Ranged",

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.4.0</Version>
+    <Version>13.4.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.4.0"
+#define MyAppVersion "13.4.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.4.0"
+$script:ToolVersion = "13.4.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
`BaseBackupTool` is a real item that players carry, but it was absent from `app/data/item-catalog.json`.

That catalog backs **Give Item**, **item packages**, and the new **`!item`** command, so the tool couldn't be handed out by any of them.

## How it was found

Diffed the distinct `template_id` values in use on a running server against the catalog. 24 ids were missing, but only this one belongs here:

| Missing | Verdict |
|---|---|
| `BaseBackupTool` | ✅ real inventory item — added |
| 20 × `Emote_*` | ❌ granted via Grant Cosmetic, not as items |
| 2 × `*_Swatch` | ❌ cosmetics, same |
| `ContractItem` | ❌ internal quest plumbing |

Adding the cosmetics would invite admins to hand out things that wouldn't work, so they're deliberately left out.

## Verification

- JSON re-parsed after the edit; 1854 → 1855 items
- Resolves through `Get-DuneItemCatalog` — the same lookup `!item` and Give Item use
- Diff is 4 lines, inserted in the file's existing name-sorted order with matching formatting/encoding
- Version stamped 13.4.1 across all five files; changelog and bug-report template updated
