### PR TITLE
Fix Coriolis per-map and per-partition seed apply failing with in_server_info error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Coriolis storm seeds can be set for a single map or a single partition again.** Clicking Apply on one map row or one partition row failed with a raw database error; only "Apply to all" worked. The game's own helper routines for the map and partition cases are broken in the shipped database, so DST now writes the seed values directly instead of asking the game to do it. Setting a map's seed still applies that seed to every partition on that map, and "Apply to all" is unchanged.
+
 ## [13.4.1] - 2026-08-04
 
 ### Fixed

--- a/app/server/lib/CoriolisAdmin.ps1
+++ b/app/server/lib/CoriolisAdmin.ps1
@@ -1,8 +1,19 @@
 ﻿# Coriolis Admin — v11.5.7
 #
-# Wraps dune.debug_get_coriolis_seeds() + dune.debug_set_farm_seed() /
-# debug_set_map_seed() / debug_set_partition_seed() so admins can inspect and
-# override the world-reset (Coriolis storm) seeds without resetting state.
+# Wraps dune.debug_get_coriolis_seeds() + dune.debug_set_farm_seed() so admins
+# can inspect and override the world-reset (Coriolis storm) seeds without
+# resetting state.
+#
+# Map- and partition-scoped writes go DIRECTLY to dune.world_map_reset_seed /
+# dune.world_partition_reset_seed instead of through the game's
+# dune.debug_set_map_seed() / dune.debug_set_partition_seed(). Those two stored
+# functions are broken in the shipped DB: both reference an undeclared
+# `in_server_info` variable, so every call aborts with
+# `missing FROM-clause entry for table "in_server_info"`. debug_set_map_seed()
+# additionally filters world_partition_reset_seed by a `map` column that table
+# does not have — the map->partition cascade has to join through
+# dune.world_partition. dune.debug_set_farm_seed() is clean, so the farm path
+# still calls it.
 #
 # Background: every map + partition has a "world_reset_seed" that determines
 # the next Coriolis storm layout. The game updates it automatically on storm
@@ -88,8 +99,9 @@ function Get-DuneCoriolisSeedsDemo {
 
 # ----------------------------------------------------------------------------
 # Writes — set seed at farm / map / partition scope.
-# These call dune.debug_set_* functions, which also cascade cleanup (corpses,
-# coriolis-affected partition state) when the seed actually changes.
+# Farm scope calls dune.debug_set_farm_seed, which also cascades cleanup
+# (corpses, coriolis-affected partition state) when the seed actually changes.
+# Map / partition scope write the reset-seed tables directly (see header).
 # ----------------------------------------------------------------------------
 function Invoke-DuneCoriolisSetFarmSeed {
     param([string]$Ip, [int]$Seed)
@@ -105,7 +117,19 @@ function Invoke-DuneCoriolisSetMapSeed {
     if (-not $Map) { return @{ ok = $false; error = 'map name is required.' } }
     if ($Seed -lt -1 -or $Seed -gt 11) { return @{ ok = $false; error = 'Seed must be -1 (auto) or 0-11 (one of the 12 Coriolis world layouts).' } }
     $safeMap = ConvertTo-DuneSqlString $Map
-    $sql = "SELECT dune.debug_set_map_seed('$safeMap'::text, $Seed::int);"
+    # Upsert the map's own seed, then cascade to every partition on that map.
+    # world_partition_reset_seed has no `map` column, so the partition list has
+    # to come from dune.world_partition.
+    $sql = @"
+BEGIN;
+INSERT INTO dune.world_map_reset_seed (map, world_reset_seed)
+VALUES ('$safeMap'::text, $Seed::int)
+ON CONFLICT (map) DO UPDATE SET world_reset_seed = EXCLUDED.world_reset_seed;
+INSERT INTO dune.world_partition_reset_seed (partition_id, world_reset_seed)
+SELECT DISTINCT wp.partition_id, $Seed::int FROM dune.world_partition wp WHERE wp.map = '$safeMap'::text
+ON CONFLICT (partition_id) DO UPDATE SET world_reset_seed = EXCLUDED.world_reset_seed;
+COMMIT;
+"@
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
     return @{ ok = $true; scope = 'map'; map = $Map; seed = $Seed; message = "Set map '$Map' (+ its partitions) to seed $Seed." }
@@ -115,7 +139,11 @@ function Invoke-DuneCoriolisSetPartitionSeed {
     param([string]$Ip, [long]$PartitionId, [int]$Seed)
     if ($PartitionId -le 0) { return @{ ok = $false; error = 'partition_id is required.' } }
     if ($Seed -lt -1 -or $Seed -gt 11) { return @{ ok = $false; error = 'Seed must be -1 (auto) or 0-11 (one of the 12 Coriolis world layouts).' } }
-    $sql = "SELECT dune.debug_set_partition_seed($PartitionId::bigint, $Seed::int);"
+    $sql = @"
+INSERT INTO dune.world_partition_reset_seed (partition_id, world_reset_seed)
+VALUES ($PartitionId::int, $Seed::int)
+ON CONFLICT (partition_id) DO UPDATE SET world_reset_seed = EXCLUDED.world_reset_seed;
+"@
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
     return @{ ok = $true; scope = 'partition'; partition_id = $PartitionId; seed = $Seed; message = "Set partition $PartitionId to seed $Seed." }

--- a/tests/CoriolisSeeds.Tests.ps1
+++ b/tests/CoriolisSeeds.Tests.ps1
@@ -1,0 +1,177 @@
+# Tests the Coriolis seed writes in lib/CoriolisAdmin.ps1.
+#
+# Background: the game DB ships two broken stored functions,
+# dune.debug_set_map_seed() and dune.debug_set_partition_seed(). Both reference
+# an undeclared `in_server_info` variable, so calling either aborts with
+# `missing FROM-clause entry for table "in_server_info"` and the per-map /
+# per-partition Apply buttons fail. debug_set_map_seed() has a second bug: it
+# filters dune.world_partition_reset_seed by a `map` column that table does not
+# have. DST therefore writes the reset-seed tables directly and cascades a map
+# to its partitions by joining dune.world_partition.
+#
+# dune.debug_set_farm_seed() is clean, so the farm path still calls it — these
+# tests pin that split so a future refactor does not quietly reintroduce the
+# broken calls.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+
+    $script:lastWriteSql = $null
+    $script:writeCount   = 0
+    $script:lastReadOnly = $null
+
+    function global:Invoke-DuneSqlQuery {
+        param([string] $Ip, [string] $Sql, [bool] $ReadOnly, [int] $MaxRows, [int] $TimeoutSec)
+        $script:lastWriteSql = $Sql
+        $script:lastReadOnly = $ReadOnly
+        $script:writeCount   = $script:writeCount + 1
+        return @{ ok = $true; maps = @(); message = 'INSERT 0 1' }
+    }
+    function global:ConvertTo-DuneSqlString {
+        param($Value)
+        return ([string]$Value) -replace "'", "''"
+    }
+
+    Import-DstLib 'CoriolisAdmin.ps1'
+}
+
+AfterAll {
+    Remove-Item function:global:Invoke-DuneSqlQuery    -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneSqlString -ErrorAction SilentlyContinue
+}
+
+Describe 'Invoke-DuneCoriolisSetMapSeed (per-map seed)' -Tag 'Coriolis' {
+    BeforeEach {
+        $script:lastWriteSql = $null
+        $script:writeCount   = 0
+        $script:lastReadOnly = $null
+    }
+
+    It 'never calls the broken dune.debug_set_map_seed function' {
+        $r = Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map 'HaggaBasin' -Seed 7
+        $r.ok | Should -BeTrue
+        $script:lastWriteSql | Should -Not -Match 'debug_set_map_seed'
+    }
+
+    It 'upserts the map row and cascades to that map partitions via world_partition' {
+        $null = Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map 'HaggaBasin' -Seed 7
+        $script:lastWriteSql | Should -Match 'INSERT INTO dune\.world_map_reset_seed'
+        $script:lastWriteSql | Should -Match 'ON CONFLICT \(map\) DO UPDATE'
+        $script:lastWriteSql | Should -Match 'INSERT INTO dune\.world_partition_reset_seed'
+        $script:lastWriteSql | Should -Match 'FROM dune\.world_partition'
+        $script:lastWriteSql | Should -Match 'ON CONFLICT \(partition_id\) DO UPDATE'
+        $script:lastWriteSql | Should -Match "'HaggaBasin'::text"
+        $script:lastWriteSql | Should -Match '7::int'
+    }
+
+    It 'does not filter world_partition_reset_seed by a map column (that column does not exist)' {
+        $null = Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map 'HaggaBasin' -Seed 3
+        $script:lastWriteSql | Should -Not -Match 'UPDATE\s+dune\.world_partition_reset_seed'
+        $script:lastWriteSql | Should -Not -Match 'world_partition_reset_seed[\s\S]*?WHERE\s+map'
+    }
+
+    It 'runs both writes in one transaction' {
+        $null = Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map 'HaggaBasin' -Seed 3
+        $script:lastWriteSql | Should -Match 'BEGIN;'
+        $script:lastWriteSql | Should -Match 'COMMIT;'
+        $script:writeCount | Should -Be 1
+    }
+
+    It 'sends the statement as a write, not a read-only query' {
+        $null = Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map 'HaggaBasin' -Seed 0
+        $script:lastReadOnly | Should -BeFalse
+    }
+
+    It 'escapes apostrophes in the map name' {
+        $null = Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map "Arrakis'Deep" -Seed 1
+        $script:lastWriteSql | Should -Match "Arrakis''Deep"
+    }
+
+    It 'requires a map name and sends no SQL without one' {
+        $r = Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map '' -Seed 5
+        $r.ok | Should -BeFalse
+        $script:writeCount | Should -Be 0
+    }
+
+    It 'rejects out-of-range seeds without sending SQL' {
+        (Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map 'HaggaBasin' -Seed 12).ok | Should -BeFalse
+        (Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map 'HaggaBasin' -Seed -2).ok | Should -BeFalse
+        $script:writeCount | Should -Be 0
+    }
+
+    It 'accepts the -1 (auto) and 11 boundary seeds' {
+        (Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map 'HaggaBasin' -Seed -1).ok | Should -BeTrue
+        (Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map 'HaggaBasin' -Seed 11).ok | Should -BeTrue
+    }
+
+    It 'preserves the response shape the routes and UI expect' {
+        $r = Invoke-DuneCoriolisSetMapSeed -Ip '1.2.3.4' -Map 'DeepDesert' -Seed 4
+        $r.ok | Should -BeTrue
+        $r.scope | Should -Be 'map'
+        $r.map | Should -Be 'DeepDesert'
+        $r.seed | Should -Be 4
+        $r.message | Should -Match '4'
+    }
+}
+
+Describe 'Invoke-DuneCoriolisSetPartitionSeed (per-partition seed)' -Tag 'Coriolis' {
+    BeforeEach {
+        $script:lastWriteSql = $null
+        $script:writeCount   = 0
+        $script:lastReadOnly = $null
+    }
+
+    It 'never calls the broken dune.debug_set_partition_seed function' {
+        $r = Invoke-DuneCoriolisSetPartitionSeed -Ip '1.2.3.4' -PartitionId 101 -Seed 6
+        $r.ok | Should -BeTrue
+        $script:lastWriteSql | Should -Not -Match 'debug_set_partition_seed'
+    }
+
+    It 'upserts world_partition_reset_seed keyed on partition_id only' {
+        $null = Invoke-DuneCoriolisSetPartitionSeed -Ip '1.2.3.4' -PartitionId 101 -Seed 6
+        $script:lastWriteSql | Should -Match 'INSERT INTO dune\.world_partition_reset_seed'
+        $script:lastWriteSql | Should -Match '101::int'
+        $script:lastWriteSql | Should -Match '6::int'
+        $script:lastWriteSql | Should -Match 'ON CONFLICT \(partition_id\) DO UPDATE'
+        $script:lastWriteSql | Should -Not -Match 'world_map_reset_seed'
+        $script:lastReadOnly | Should -BeFalse
+    }
+
+    It 'requires a positive partition id and sends no SQL otherwise' {
+        (Invoke-DuneCoriolisSetPartitionSeed -Ip '1.2.3.4' -PartitionId 0 -Seed 5).ok | Should -BeFalse
+        $script:writeCount | Should -Be 0
+    }
+
+    It 'rejects out-of-range seeds without sending SQL' {
+        (Invoke-DuneCoriolisSetPartitionSeed -Ip '1.2.3.4' -PartitionId 101 -Seed 12).ok | Should -BeFalse
+        (Invoke-DuneCoriolisSetPartitionSeed -Ip '1.2.3.4' -PartitionId 101 -Seed -2).ok | Should -BeFalse
+        $script:writeCount | Should -Be 0
+    }
+
+    It 'preserves the response shape the routes and UI expect' {
+        $r = Invoke-DuneCoriolisSetPartitionSeed -Ip '1.2.3.4' -PartitionId 201 -Seed 2
+        $r.ok | Should -BeTrue
+        $r.scope | Should -Be 'partition'
+        $r.partition_id | Should -Be 201
+        $r.seed | Should -Be 2
+    }
+}
+
+Describe 'Invoke-DuneCoriolisSetFarmSeed (unchanged farm path)' -Tag 'Coriolis' {
+    BeforeEach {
+        $script:lastWriteSql = $null
+        $script:writeCount   = 0
+    }
+
+    It 'still calls dune.debug_set_farm_seed, which is not broken' {
+        $r = Invoke-DuneCoriolisSetFarmSeed -Ip '1.2.3.4' -Seed 9
+        $r.ok | Should -BeTrue
+        $r.scope | Should -Be 'farm'
+        $script:lastWriteSql | Should -Match 'dune\.debug_set_farm_seed\(9::int\)'
+    }
+
+    It 'rejects out-of-range seeds without sending SQL' {
+        (Invoke-DuneCoriolisSetFarmSeed -Ip '1.2.3.4' -Seed 12).ok | Should -BeFalse
+        $script:writeCount | Should -Be 0
+    }
+}


### PR DESCRIPTION
## The bug

In **Gameplay Admin → Coriolis storm seeds**, clicking **Apply** on a single **map** row or a single **partition** row fails with a raw PostgreSQL error surfaced in the toast:

```
missing FROM-clause entry for table "in_server_info"
```

**Apply to all** (farm scope) still works, which is why this went unnoticed.

## Why

It is the game database's own SQL, not DST's. Two stored functions are broken as shipped:

- `dune.debug_set_map_seed(text, integer)` and `dune.debug_set_partition_seed(bigint, integer)` both `INSERT ... VALUES(in_server_info.<col>, ...)`, but `in_server_info` is not a parameter or any in-scope relation — hence the error, on every call.
- `dune.debug_set_map_seed()` has a **second** bug: it does `UPDATE world_partition_reset_seed ... WHERE map = in_map`, but that table has no `map` column. A map → partition cascade has to join through `dune.world_partition`.

`dune.debug_set_farm_seed(integer)` is clean.

## The fix

Stop calling the two broken functions and do what they were meant to do, writing the reset-seed tables directly from `app/server/lib/CoriolisAdmin.ps1`:

- **Per map** — upsert `dune.world_map_reset_seed (map, world_reset_seed)`, then upsert `dune.world_partition_reset_seed` for every `partition_id` belonging to that map, sourced from `dune.world_partition`. Both statements run inside one `BEGIN … COMMIT` so a map and its partitions cannot end up half-applied.
- **Per partition** — upsert `dune.world_partition_reset_seed (partition_id, world_reset_seed)`.
- **Farm scope is untouched** and still calls `dune.debug_set_farm_seed`, which works.

Direct writes rather than "try the function, fall back on failure": the functions are broken at the definition level, so an attempt is a guaranteed failed round-trip on every click, and a dual code path would make any future failure ambiguous to diagnose. The direct upserts remain correct regardless of whether the stored functions are ever fixed upstream.

Existing behaviour is preserved: seed validation (`-1` for auto, or `0`–`11`), the write path through `Invoke-DuneSqlQuery -ReadOnly $false`, `ConvertTo-DuneSqlString` escaping of the map name, and the `@{ ok; scope; map|partition_id; seed; message }` response shape — so the routes and web UI need no changes.

## Tests

New `tests/CoriolisSeeds.Tests.ps1`, following the existing pattern in `tests/SetSpecLevel.Tests.ps1` (stub `Invoke-DuneSqlQuery`, assert the emitted SQL). It pins that the map and partition paths never reference the broken functions, never filter `world_partition_reset_seed` by a `map` column, cascade via `dune.world_partition`, run as one transaction, escape apostrophes in map names, reject out-of-range seeds without touching the DB, accept the `-1` / `11` boundaries, keep the response shape — and that the farm path still calls `dune.debug_set_farm_seed`.

- New tests: 17 passed.
- Full suite: **704 passed, 0 failed**.
- PowerShell parse check clean on both changed `.ps1` files; `CoriolisAdmin.ps1` still UTF-8 with BOM.

No version bump and no release in this PR; `CHANGELOG.md` gains a `Fixed` entry under `[Unreleased]`.