### PR TITLE
Bump transitive js-yaml to 4.3.1 to clear a high-severity advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ here cover everything those tags shipped.
 ## [Unreleased]
 
 ### Fixed
+- Bumped the transitive `js-yaml` dependency in the mobile and marketing-site lockfiles to 4.3.1, clearing a high-severity advisory (quadratic CPU consumption when resolving `!!omap`).
+
 
 - **Coriolis storm seeds can be set for a single map or a single partition again.** Clicking Apply on one map row or one partition row failed with a raw database error; only "Apply to all" worked. The game's own helper routines for the map and partition cases are broken in the shipped database, so DST now writes the seed values directly instead of asking the game to do it. Setting a map's seed still applies that seed to every partition on that map, and "Apply to all" is unchanged.
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -5168,9 +5168,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -4134,9 +4134,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

Bumps the transitive `js-yaml` dependency from **4.3.0 → 4.3.1** in the `mobile/` and `site/` lockfiles.

## Why

Trivy flags `js-yaml@4.3.0` as **GHSA-5p4m-2wfm-xmqj** (HIGH) — quadratic CPU consumption when resolving `!!omap`. It appears in `mobile/package-lock.json` and `site/package-lock.json`; `webui/` is unaffected.

This is unrelated to any recent feature work — it surfaced on an unrelated PR's Trivy run, which is why it is split out on its own rather than folded into that change.

## Scope

Lockfile-only. The existing semver ranges (`^4.1.0` / `^4.1.1`) already permit the fixed release, so no manifest edits and no source changes were needed:

```
mobile/package-lock.json | 6 +++---
site/package-lock.json   | 6 +++---
```

`js-yaml` is not imported directly anywhere in the repo — it arrives through the dependency trees of both projects.

## Notes

- Trivy is not currently a required status check on `main`, so this does not unblock anything by itself; it just clears the advisory.
- No version bump and no release in this PR. `CHANGELOG.md` gains a `Fixed` entry under `[Unreleased]`.