### PR TITLE
Release 13.5.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.4.1"
+      placeholder: "v13.5.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.5.0] - 2026-08-07
+
 ### Added
 - **Wick Maps** — the DD Map page is now a per-seed Deep Desert point-of-interest map. Pick any of the 12 Coriolis world seeds (0–11) and the map redraws with that layout's caves, wrecks, testing stations, taxis, titanium and stravidium nodes, and large spice fields. The page opens on whichever seed the server is currently running and marks it in the selector, the legend doubles as a per-type filter, and each seed lists its large spice sectors and total POI count. Layout data is drawn in-app rather than shipped as images, so it adds well under a megabyte. The data was compiled from publicly archived community sources rather than read from your server — a card on the page says so and asks for corrections, and every seed carries a low, medium or high confidence label explaining how well its layout is evidenced.
 
@@ -20,7 +22,6 @@ here cover everything those tags shipped.
 
 ### Fixed
 - Bumped the transitive `js-yaml` dependency in the mobile and marketing-site lockfiles to 4.3.1, clearing a high-severity advisory (quadratic CPU consumption when resolving `!!omap`).
-
 
 - **Coriolis storm seeds can be set for a single map or a single partition again.** Clicking Apply on one map row or one partition row failed with a raw database error; only "Apply to all" worked. The game's own helper routines for the map and partition cases are broken in the shipped database, so DST now writes the seed values directly instead of asking the game to do it. Setting a map's seed still applies that seed to every partition on that map, and "Apply to all" is unchanged.
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.4.1'
+$script:DuneToolVersion = '13.5.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.4.1',
+    [string]$Version = '13.5.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.4.1</Version>
+    <Version>13.5.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.4.1"
+#define MyAppVersion "13.5.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.4.1"
+$script:ToolVersion = "13.5.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/WickMaps.tsx
+++ b/webui/src/pages/WickMaps.tsx
@@ -88,19 +88,37 @@ export function WickMaps() {
   // two naming schemes: partition names (Survival_1 / DeepDesert_1) are what an
   // admin requested, friendly names (DeepDesert) are what the game wrote back
   // after loading the map. The friendly row is the truth, so prefer it.
+  //
+  // The endpoint answers with sample data when the live database is unreachable,
+  // so the source is checked first - showing a stand-in seed and calling it live
+  // would be worse than admitting the seed is unknown.
   useEffect(() => {
     let alive = true
     getCoriolisSeeds()
       .then(r => {
         if (!alive) return
+        if (r.source !== 'live') {
+          setLiveErr(r.liveError || 'The live database is not reachable.')
+          return
+        }
         const maps = r.maps || []
         const friendly = maps.find(m => m.map === 'DeepDesert')
         const fallback = maps.find(m => m.map.startsWith('DeepDesert'))
         const live = friendly?.seed ?? fallback?.seed ?? null
-        if (live !== null && live >= 0 && live <= 11) {
-          setLiveSeed(live)
-          if (PAYLOAD.availableSeeds.includes(live)) setSeed(live)
+        if (live === null) {
+          setLiveErr('No Deep Desert row in the seed table.')
+          return
         }
+        if (live < 0 || live > 11) {
+          // -1 means no seed is forced; anything else is out of range for the
+          // twelve preset layouts and there is no map to show for it.
+          setLiveErr(live === -1
+            ? 'No seed is forced, so the game picks a layout each cycle.'
+            : `The server reports seed ${live}, which is outside 0-11.`)
+          return
+        }
+        setLiveSeed(live)
+        if (PAYLOAD.availableSeeds.includes(live)) setSeed(live)
       })
       .catch(e => { if (alive) setLiveErr(e instanceof Error ? e.message : String(e)) })
     return () => { alive = false }
@@ -328,8 +346,11 @@ export function WickMaps() {
                   )}
                 </span>
               ) : liveErr ? (
-                <span className="flex items-center gap-1.5 text-warning">
-                  <Icon name="AlertTriangle" size={12} /> Couldn't read the live seed.
+                <span className="flex items-start gap-1.5 text-warning">
+                  <Icon name="AlertTriangle" size={12} className="mt-0.5 shrink-0" />
+                  <span>
+                    Couldn't read the live seed. <span className="text-text-dim">{liveErr}</span>
+                  </span>
                 </span>
               ) : (
                 <span>Reading the live seed…</span>


### PR DESCRIPTION
## Summary
- release Wick Maps with per-seed Deep Desert POI layouts, confidence labels, filtering, attribution, and accuracy disclaimer
- expose the forced Coriolis world-seed setting and improve seed-write reporting
- prevent demo seed data from being presented as the server's live seed
- include Coriolis seed fixes and the `js-yaml` dependency update merged since 13.4.1
- update release version stamps, changelog, and bug-report template for 13.5.0

## Validation
- installed 13.5.0 test installer accepted
- web UI build passes
- 113 web UI tests pass
- installer build succeeds
- live/demo/error seed-source cases verified

## Release artifact
`DuneServerSetup.exe` will be rebuilt from merged `main` and attached as the sole asset to the v13.5.0 release.