### PR TITLE
Fit Wick Maps to the app viewport

### DIFF
--- a/webui/src/pages/WickMaps.tsx
+++ b/webui/src/pages/WickMaps.tsx
@@ -175,11 +175,14 @@ export function WickMaps() {
             </span>
           </div>
 
-          <div className="relative w-full">
+          <div className="relative w-full flex justify-center">
             <svg
               viewBox={`0 0 ${SIZE} ${SIZE}`}
-              className="w-full h-auto rounded-lg select-none"
-              style={{ background: '#4a3220' }}
+              className="h-auto max-w-full rounded-lg select-none"
+              style={{
+                background: '#4a3220',
+                width: 'min(100%, calc(100dvh - 19rem))',
+              }}
               role="img"
               aria-label={`Deep Desert point-of-interest map for world seed ${entry.seed}`}
               onMouseLeave={() => setHover(null)}


### PR DESCRIPTION
## Summary
- cap the square Wick Maps renderer to available viewport height
- center the map when its height limit is narrower than the map column
- preserve responsive width behavior on smaller windows

## Validation
- web UI production build passes
- full map fits without scrolling at 1600×900
- full map fits without scrolling at 2000×1156