### PR TITLE
Remove map rename from release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ here cover everything those tags shipped.
 
 ### Changed
 
-- **Renamed Wick Maps to DD Seed Maps.**
-
 - **The Pods page now keeps stale director history out of the way.** Completed and failed director pods are hidden by default, can still be shown when needed, and can be removed with the new Clean history action. DST also clears this terminal history automatically at backend startup and during Start All. Restart counts are now labelled "Lifetime restarts" so old restarts are not mistaken for a current fault.
 
 ### Fixed


### PR DESCRIPTION
Removes the DD Seed Maps rename from the v13.5.1 changelog so public release surfaces match the requested wording.