### PR TITLE
Fix manual relay IP persistence on reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ here cover everything those tags shipped.
 ### Fixed
 
 - **Public IP Apply no longer has to capture a co-hosted VPN or relay endpoint.** The Public IP / DDNS card now keeps the existing same-PC public-IP loopback route enabled by default, but provides an explicit opt-out for WireGuard, VPN, and VPS relay hosts. Applying with the option off removes only the matching public-IP `/32` route through the Dune VM and leaves unrelated Windows routes unchanged.
-- **Saved manual relay addresses remain authoritative across restarts and connection repairs.** Public IP Apply now pins K3s startup to the applied address instead of rediscovering another address from the VM interface, and the P34 diagnostic no longer replaces a deliberate manual VPN or VPS relay address with the host's detected WAN IP.
+- **Saved manual relay addresses remain authoritative across restarts and connection repairs.** Public IP Apply now pins both K3s startup inputs to the applied address, overriding a stale `settings.conf` external IP immediately before K3s starts, and the P34 diagnostic no longer replaces a deliberate manual VPN or VPS relay address with the host's detected WAN IP.
 
 ## [13.5.3] - 2026-08-08
 

--- a/app/server/lib/PublicIp.ps1
+++ b/app/server/lib/PublicIp.ps1
@@ -927,10 +927,35 @@ runner=/usr/local/bin/k3s-custom-runner.sh
 target="dynamic_ip=$NEW_IP"
 if [ -f "$runner" ]; then
   sudo cp "$runner" "$runner.bak.$(date -u +%Y%m%d%H%M%S)"
-  awk -v target="$target" 'BEGIN{done=0} /^dynamic_ip=/{print target; done=1; next} {print} END{if(!done) print target}' "$runner" > /tmp/dst-runner
+  # DST_K3S_RUNNER_AWK_BEGIN
+  awk -v target="$target" '
+    BEGIN { dynamic_done=0; exec_done=0 }
+    /^dynamic_ip=/ {
+      print target
+      dynamic_done=1
+      next
+    }
+    /# DST_MANAGED_EXTERNAL_IP$/ { next }
+    /^exec[[:space:]]+\/usr\/local\/bin\/k3s[[:space:]]+server/ {
+      if (!dynamic_done) {
+        print target
+        dynamic_done=1
+      }
+      print "external_ip=$dynamic_ip # DST_MANAGED_EXTERNAL_IP"
+      print
+      exec_done=1
+      next
+    }
+    { print }
+    END {
+      if (!exec_done) exit 4
+    }
+  ' "$runner" > /tmp/dst-runner
+  # DST_K3S_RUNNER_AWK_END
   sudo install -m 0755 /tmp/dst-runner "$runner"
   rm -f /tmp/dst-runner
   grep -F "$target" "$runner"
+  grep -F 'external_ip=$dynamic_ip # DST_MANAGED_EXTERNAL_IP' "$runner"
 fi
 
 step k3s

--- a/tests/PublicIp.Tests.ps1
+++ b/tests/PublicIp.Tests.ps1
@@ -182,10 +182,58 @@ Describe 'Public IP diagnostic target selection' {
         $target.source | Should -Be 'vm'
     }
 
-    It 'pins the K3s startup runner to the applied public IP' {
+    It 'pins both K3s startup IP inputs to the applied public IP' {
         $source = Get-Content -LiteralPath (Join-Path $PSScriptRoot '..\app\server\lib\PublicIp.ps1') -Raw
         $source | Should -Match 'target="dynamic_ip=\$NEW_IP"'
+        $source | Should -Match 'external_ip=\$dynamic_ip # DST_MANAGED_EXTERNAL_IP'
+        $source | Should -Match '(?s)/# DST_MANAGED_EXTERNAL_IP\$/ \{ next \}.*?external_ip=\$dynamic_ip # DST_MANAGED_EXTERNAL_IP.*?exec_done=1'
         $source | Should -Not -Match "target='dynamic_ip=\$\(/sbin/ip addr show eth0"
+    }
+
+    It 'overrides a stale settings.conf external IP immediately before K3s starts' {
+        $awk = Get-Command awk -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+        if (-not $awk) {
+            $gitAwk = Join-Path $env:ProgramFiles 'Git\usr\bin\awk.exe'
+            if (Test-Path -LiteralPath $gitAwk) { $awk = Get-Item -LiteralPath $gitAwk }
+        }
+        if (-not $awk) {
+            Set-ItResult -Skipped -Because 'awk is unavailable on this test host'
+            return
+        }
+
+        $source = Get-Content -LiteralPath (Join-Path $PSScriptRoot '..\app\server\lib\PublicIp.ps1') -Raw
+        $match = [regex]::Match(
+            $source,
+            "(?s)# DST_K3S_RUNNER_AWK_BEGIN\s+awk -v target=`"\`$target`" '(?<program>.*?)'\s+`"\`$runner`" > /tmp/dst-runner\s+# DST_K3S_RUNNER_AWK_END"
+        )
+        $match.Success | Should -BeTrue
+
+        $programPath = Join-Path $TestDrive 'pin-runner.awk'
+        $runnerPath = Join-Path $TestDrive 'k3s-custom-runner.sh'
+        Set-Content -LiteralPath $programPath -Value $match.Groups['program'].Value -NoNewline
+        @'
+#!/bin/sh
+{ read -r bg_name; read -r image; read -r internal_ip; read -r external_ip; } < /home/dune/.dune/settings.conf
+dynamic_ip=203.0.113.9
+if [[ "$internal_ip" == "$external_ip" ]]; then
+  external_ip=$dynamic_ip
+fi
+exec /usr/local/bin/k3s server --node-external-ip=${external_ip} --advertise-address=${dynamic_ip}
+'@ | Set-Content -LiteralPath $runnerPath -NoNewline
+
+        $awkPath = if ($awk.Source) { $awk.Source } else { $awk.FullName }
+        $result = & $awkPath -v 'target=dynamic_ip=198.51.100.44' -f $programPath $runnerPath
+        $LASTEXITCODE | Should -Be 0
+        $result | Should -Contain 'dynamic_ip=198.51.100.44'
+        $result | Should -Contain 'external_ip=$dynamic_ip # DST_MANAGED_EXTERNAL_IP'
+        [array]::IndexOf([string[]]$result, 'external_ip=$dynamic_ip # DST_MANAGED_EXTERNAL_IP') |
+            Should -BeLessThan ([array]::IndexOf([string[]]$result, 'exec /usr/local/bin/k3s server --node-external-ip=${external_ip} --advertise-address=${dynamic_ip}'))
+        @($result | Where-Object { $_ -eq 'external_ip=$dynamic_ip # DST_MANAGED_EXTERNAL_IP' }).Count | Should -Be 1
+
+        $result | Set-Content -LiteralPath $runnerPath
+        $secondResult = & $awkPath -v 'target=dynamic_ip=198.51.100.44' -f $programPath $runnerPath
+        $LASTEXITCODE | Should -Be 0
+        @($secondResult | Where-Object { $_ -eq 'external_ip=$dynamic_ip # DST_MANAGED_EXTERNAL_IP' }).Count | Should -Be 1
     }
 }
 


### PR DESCRIPTION
## Summary
- make the saved/applied manual IP authoritative for both K3s runner inputs
- override stale `settings.conf` `external_ip` immediately before K3s starts
- keep runner rewrites idempotent across repeated Public IP Apply operations
- add executable regression coverage reproducing Dragonstar's stale-settings restart case

## Validation
- `tests/PublicIp.Tests.ps1`: 47 passed, 0 failed, 0 skipped
- PowerShell parse and encoding checks passed
- full installer build passed
- diff gitleaks scan found no leaks

## Live context
PR #667 correctly pinned `dynamic_ip`, but Dragonstar's live Reboot All test showed the vendor runner still preferred stale `settings.conf` `external_ip`, reverting K3s and advertised state to the ISP address. This patch overrides that stale value at the final runner boundary.