### PR TITLE
Show DST install location in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- **Settings now shows the Dune Server Tool install folder.** The host-only card can copy the path or open it in Explorer for antivirus exclusions, file verification, and troubleshooting.
+
 ### Fixed
 
 - **Public IP Apply no longer has to capture a co-hosted VPN or relay endpoint.** The Public IP / DDNS card now keeps the existing same-PC public-IP loopback route enabled by default, but provides an explicit opt-out for WireGuard, VPN, and VPS relay hosts. Applying with the option off removes only the matching public-IP `/32` route through the Dune VM and leaves unrelated Windows routes unchanged.

--- a/app/server/routes/System.ps1
+++ b/app/server/routes/System.ps1
@@ -6,6 +6,62 @@
 #
 # Detection + the detached winget runner live in lib/Dependencies.ps1.
 
+function Test-DuneSystemLoopbackRequest {
+    param($req)
+    try {
+        $remote = $req.RemoteEndPoint.Address
+        if ($remote) { return [System.Net.IPAddress]::IsLoopback($remote) }
+    } catch {}
+    return $false
+}
+
+# GET /api/system/install-location
+# Host-only: filesystem paths are useful only on the DST PC and should not be
+# disclosed through the LAN/remote portal.
+Register-DuneRoute -Method GET -Path '/api/system/install-location' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        if (-not (Test-DuneSystemLoopbackRequest $req)) {
+            Write-DuneError -Response $res -Status 403 -Message 'The DST install location is available only from the host machine.'
+            return
+        }
+        if (-not $script:AppDir) {
+            throw 'DST application directory is unavailable.'
+        }
+        $path = [IO.Path]::GetFullPath([string]$script:AppDir)
+        Write-DuneJson -Response $res -Body @{
+            ok        = $true
+            path      = $path
+            installed = [bool]$script:DuneIsCompiledExe
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+# POST /api/system/install-location/open
+Register-DuneRoute -Method POST -Path '/api/system/install-location/open' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        if (-not (Test-DuneSystemLoopbackRequest $req)) {
+            Write-DuneError -Response $res -Status 403 -Message 'The DST install folder can be opened only from the host machine.'
+            return
+        }
+        if (-not $script:AppDir) {
+            throw 'DST application directory is unavailable.'
+        }
+        $path = [IO.Path]::GetFullPath([string]$script:AppDir)
+        if (-not (Test-Path -LiteralPath $path -PathType Container)) {
+            Write-DuneError -Response $res -Status 404 -Message "DST application directory was not found: $path"
+            return
+        }
+        Start-Process -FilePath 'explorer.exe' -ArgumentList "`"$path`"" -ErrorAction Stop | Out-Null
+        Write-DuneJson -Response $res -Body @{ ok=$true; path=$path }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Failed to open the DST install folder: $($_.Exception.Message)"
+    }
+}
+
 # GET /api/system/dependencies[?names=<dependency>]
 Register-DuneRoute -Method GET -Path '/api/system/dependencies' -Handler {
     param($req, $res, $routeParams, $body)

--- a/tests/SystemRoutes.Tests.ps1
+++ b/tests/SystemRoutes.Tests.ps1
@@ -1,0 +1,30 @@
+BeforeAll {
+    . "$PSScriptRoot\_TestHelpers.ps1"
+    Import-DstRoute 'System.ps1'
+}
+
+Describe 'System route host access' {
+    It 'accepts IPv4 loopback requests' {
+        $request = [pscustomobject]@{
+            RemoteEndPoint = [pscustomobject]@{ Address = [System.Net.IPAddress]::Loopback }
+        }
+
+        Test-DuneSystemLoopbackRequest $request | Should -BeTrue
+    }
+
+    It 'accepts IPv6 loopback requests' {
+        $request = [pscustomobject]@{
+            RemoteEndPoint = [pscustomobject]@{ Address = [System.Net.IPAddress]::IPv6Loopback }
+        }
+
+        Test-DuneSystemLoopbackRequest $request | Should -BeTrue
+    }
+
+    It 'rejects remote requests' {
+        $request = [pscustomobject]@{
+            RemoteEndPoint = [pscustomobject]@{ Address = [System.Net.IPAddress]::Parse('192.0.2.10') }
+        }
+
+        Test-DuneSystemLoopbackRequest $request | Should -BeFalse
+    }
+}

--- a/webui/src/api/system.ts
+++ b/webui/src/api/system.ts
@@ -1,0 +1,17 @@
+import { api } from './client'
+
+export interface InstallLocation {
+  ok: boolean
+  path: string
+  installed: boolean
+}
+
+export function getInstallLocation() {
+  return api<InstallLocation>('/api/system/install-location')
+}
+
+export function openInstallLocation() {
+  return api<{ ok: boolean; path: string }>('/api/system/install-location/open', {
+    method: 'POST',
+  })
+}

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -15,6 +15,7 @@ import { RemoteAccessCard } from './settings/RemoteAccessCard'
 import { MobileAppCard } from './settings/MobileAppCard'
 import { FlsTokenCard } from './settings/FlsTokenCard'
 import { FreshStartSnapshotsCard } from './settings/FreshStartSnapshotsCard'
+import { InstallLocationCard } from './settings/InstallLocationCard'
 import { SectionErrorBoundary } from '../components/SectionErrorBoundary'
 import { CollapsibleCard, useCardCollapse } from '../components/CollapsibleCard'
 
@@ -690,6 +691,8 @@ export function Settings() {
         )}
       </div>
       </SectionErrorBoundary>
+
+      <SectionErrorBoundary name="Dune Server Tool installation"><InstallLocationCard /></SectionErrorBoundary>
 
       <SectionErrorBoundary name="Appearance"><AppearanceCard /></SectionErrorBoundary>
 

--- a/webui/src/pages/settings/InstallLocationCard.tsx
+++ b/webui/src/pages/settings/InstallLocationCard.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react'
+import { Icon } from '../../components/Icon'
+import { CollapsibleCard } from '../../components/CollapsibleCard'
+import { getInstallLocation, openInstallLocation } from '../../api/system'
+
+export function InstallLocationCard() {
+  const [path, setPath] = useState('')
+  const [installed, setInstalled] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [opening, setOpening] = useState(false)
+  const [error, setError] = useState('')
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    getInstallLocation()
+      .then(result => {
+        setPath(result.path || '')
+        setInstalled(!!result.installed)
+      })
+      .catch(err => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setLoading(false))
+  }, [])
+
+  async function copyPath() {
+    if (!path) return
+    setError('')
+    try {
+      await navigator.clipboard.writeText(path)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  async function openFolder() {
+    setOpening(true)
+    setError('')
+    try {
+      await openInstallLocation()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setOpening(false)
+    }
+  }
+
+  return (
+    <CollapsibleCard
+      id="settings.installLocation"
+      icon="FolderOpen"
+      title="Dune Server Tool installation"
+      titleClassName="text-lg font-semibold"
+      headerClassName="px-4 md:px-6 pt-4 md:pt-6 pb-2"
+      bodyClassName="px-4 md:px-6 pb-4 md:pb-6 space-y-3"
+    >
+      <p className="text-sm text-text-dim">
+        Location of DST itself on this PC. Use this path for antivirus exclusions,
+        manual file checks, or troubleshooting.
+      </p>
+      {loading ? (
+        <div className="text-text-dim text-sm flex items-center gap-2">
+          <Icon name="Loader2" size={13} className="animate-spin" /> Loading...
+        </div>
+      ) : error && !path ? (
+        <div className="text-danger text-sm">{error}</div>
+      ) : (
+        <>
+          <div className="text-[11px] uppercase tracking-wider text-text-dim">
+            {installed ? 'Install folder' : 'Development folder'}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <code className="basis-full lg:basis-auto lg:flex-1 min-w-0 px-2 py-1.5 rounded bg-surface-2 border border-border/50 text-text text-xs break-all">
+              {path}
+            </code>
+            <button
+              type="button"
+              className="btn-secondary shrink-0"
+              onClick={() => void copyPath()}
+              title="Copy install path"
+            >
+              <Icon name={copied ? 'Check' : 'Copy'} size={14} />
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+            <button
+              type="button"
+              className="btn-secondary shrink-0"
+              onClick={() => void openFolder()}
+              disabled={opening}
+            >
+              <Icon name={opening ? 'Loader2' : 'FolderOpen'} size={14} className={opening ? 'animate-spin' : ''} />
+              {opening ? 'Opening...' : 'Open folder'}
+            </button>
+          </div>
+          {error && <div className="text-danger text-xs">{error}</div>}
+        </>
+      )}
+    </CollapsibleCard>
+  )
+}

--- a/webui/tests/components/InstallLocationCard.test.tsx
+++ b/webui/tests/components/InstallLocationCard.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { InstallLocationCard } from '../../src/pages/settings/InstallLocationCard'
+import { api } from '../../src/api/client'
+
+vi.mock('../../src/api/client', () => ({
+  ApiError: class ApiError extends Error {
+    body?: unknown
+  },
+  api: vi.fn(),
+}))
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.mocked(api).mockImplementation(async (path, init) => {
+    if (path === '/api/system/install-location') {
+      return { ok: true, path: 'C:\\Program Files\\Dune Server Tool', installed: true }
+    }
+    if (path === '/api/system/install-location/open' && init?.method === 'POST') {
+      return { ok: true, path: 'C:\\Program Files\\Dune Server Tool' }
+    }
+    throw new Error(`Unexpected API call: ${path}`)
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('InstallLocationCard', () => {
+  it('shows and opens the DST install folder', async () => {
+    const user = userEvent.setup()
+    render(<InstallLocationCard />)
+
+    expect(await screen.findByText('C:\\Program Files\\Dune Server Tool')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /open folder/i }))
+
+    await waitFor(() => {
+      expect(api).toHaveBeenCalledWith('/api/system/install-location/open', { method: 'POST' })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- expose DST application directory through host-only system routes
- add Settings card with copy and Explorer actions
- cover loopback access and UI behavior

## Validation
- 101 focused Pester tests passed
- InstallLocationCard Vitest passed
- WebUI production build passed
- full installer build passed