### PR TITLE
Fix Experimental Lab catalog loading on PowerShell 5.1

### DIFF
--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -496,8 +496,11 @@ try {
         }
     }
     if (Test-Path -LiteralPath $script:DuneAdvancedCvarCatalogPath) {
-        $catalog = @(Get-Content -LiteralPath $script:DuneAdvancedCvarCatalogPath -Raw -ErrorAction Stop |
-            ConvertFrom-Json -ErrorAction Stop)
+        # Windows PowerShell 5.1 emits a top-level JSON array as one pipeline
+        # object. Wrapping that pipeline in @() creates a nested array, causing
+        # every catalog property to concatenate into one enormous field.
+        $catalog = Get-Content -LiteralPath $script:DuneAdvancedCvarCatalogPath -Raw -ErrorAction Stop |
+            ConvertFrom-Json -ErrorAction Stop
         foreach ($entry in $catalog) {
             $key = "$($entry.key)".Trim()
             if (-not $key -or $existingCvars.ContainsKey($key) -or $advancedAliasesAlreadySurfaced -contains $key) { continue }

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -840,6 +840,17 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         (Get-DuneExperimentalGroup -Key 'Totally.MadeUpKey') | Should -Be 'Uncategorized'
     }
 
+    It 'loads the advanced catalog as individual fields under Windows PowerShell 5.1' -Skip:($env:OS -ne 'Windows_NT') {
+        $gameConfigPath = (Resolve-Path (Join-Path $PSScriptRoot '..\app\server\lib\GameConfig.ps1')).Path.Replace("'", "''")
+        $command = ". '$gameConfigPath'; " +
+            '$lab = @($script:DuneGameConfigSchema | Where-Object Category -eq ''Experimental Lab''); ' +
+            'Write-Output $lab.Count; Write-Output ([string]$lab[0].Key).Length'
+        $result = @(& powershell.exe -NoProfile -ExecutionPolicy Bypass -Command $command)
+
+        [int]$result[0] | Should -BeGreaterThan 4900
+        [int]$result[1] | Should -BeLessThan 256
+    }
+
     It 'promotes field-confirmed controls out of Experimental without losing startup injection' {
         # Promotion is a metadata flip: a proven control leaves the Experimental
         # pages for a real category. Startup=$true must travel with it, because


### PR DESCRIPTION
## Root cause
Windows PowerShell 5.1 emits a top-level `ConvertFrom-Json` array as one pipeline object. Wrapping that pipeline in `@(...)` nested the 5,134-entry catalog, so DST generated one enormous field with concatenated keys, help text, and badges.

## Fix
- assign the parsed JSON array directly so `foreach` enumerates individual catalog records on the production PowerShell 5.1 host
- add a PowerShell 5.1 subprocess regression test that asserts thousands of individual fields and a normal key length

## Validation
- PowerShell 5.1: 4,982 unsurfaced Experimental Lab fields; first key length 29
- GameConfig Pester: 107 passed
- final v13.5.4 installer rebuilt successfully