### PR TITLE
Shrink short Experimental Lab category cards

### DIFF
--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -1852,7 +1852,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
                       />
                     ) : null
                   ))}
-                  {experimentalPage && (cat.fields ?? []).length > 0 && Array.from({
+                  {experimentalPage && experimentalFilteredFields.length > EXPERIMENTAL_PAGE_SIZE && (cat.fields ?? []).length > 0 && Array.from({
                     length: EXPERIMENTAL_PAGE_SIZE - (cat.fields ?? []).length,
                   }).map((_, index) => (
                     <div key={`empty-slot-${index}`} className="h-32 invisible" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- let category/filter results with 25 or fewer controls shrink to their actual content height
- retain 25-slot padding only for multi-page results, keeping navigation anchored across every page including the final partial page

## Validation
- WebUI tests: 120 passed
- WebUI production build passed
- ESLint passed for `GameConfig.tsx`