### PR TITLE
Lazy-load Experimental Lab and optimize restart injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ here cover everything those tags shipped.
 ### Added
 
 - **Settings now shows the Dune Server Tool install folder.** The host-only card can copy the path or open it in Explorer for antivirus exclusions, file verification, and troubleshooting.
-- **Experimental is now Experimental Lab.** It exposes the complete recovered Dune and Unreal Engine CVar inventory plus every remaining live DefaultGame.ini / DefaultEngine.ini setting that DST does not already surface. Search, source/risk filters, modified-only mode, compact pagination, risk badges, safe string-valued CVar startup injection, and array/struct editing keep the expanded catalog usable.
+- **Experimental is now Experimental Lab.** It exposes the complete recovered Dune and Unreal Engine CVar inventory plus every remaining live DefaultGame.ini / DefaultEngine.ini setting that DST does not already surface. Search, source/risk filters, modified-only mode, category-cached 25-item pagination, risk badges, safe string-valued CVar startup injection, and array/struct editing keep the expanded catalog usable without loading the full catalog at DST startup. Restart injection processes only configured and stale managed CVars rather than scanning every blank catalog entry per partition.
 
 ### Fixed
 

--- a/app/lib/K8s.ps1
+++ b/app/lib/K8s.ps1
@@ -463,12 +463,15 @@ function Set-V6ConsoleVariableOverrides {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Ip,
-        [Parameter(Mandatory)][string[]]$Names,
-        [hashtable]$Values = @{}
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$Names,
+        [hashtable]$Values = @{},
+        [hashtable]$ManagedNames = @{}
     )
 
     $normalized = @{}
+    $namesToApply = New-Object 'System.Collections.Generic.List[string]'
     foreach ($name in $Names) {
+        if (-not $namesToApply.Contains($name)) { $namesToApply.Add($name) }
         $raw = if ($Values.ContainsKey($name)) { "$($Values[$name])".Trim() } else { '' }
         if ([string]::IsNullOrWhiteSpace($raw)) {
             $normalized[$name] = $null
@@ -498,6 +501,29 @@ function Set-V6ConsoleVariableOverrides {
     $info = Get-V6Battlegroup -Ip $Ip
     $sets = $info.Bg.spec.serverGroup.template.spec.sets
 
+    # Add only stale DST-managed commands that already exist in pod specs. This
+    # removes cleared overrides without walking every blank catalog key for every
+    # partition. Unrelated ExecCmds entries remain untouched.
+    if ($ManagedNames.Count -gt 0) {
+        foreach ($set in @($sets)) {
+            foreach ($podSpec in @($set.podSpecs)) {
+                foreach ($argument in @($podSpec.arguments)) {
+                    $payload = $null
+                    if ("$argument" -match '^(?i)-execcmds="(.*)"$') { $payload = $Matches[1] }
+                    elseif ("$argument" -match '^(?i)-execcmds=(.*)$') { $payload = $Matches[1] }
+                    if ($null -eq $payload) { continue }
+                    foreach ($command in @(_Split-V6ExecCommands -Payload $payload)) {
+                        if ("$command" -notmatch '^\s*(\S+)') { continue }
+                        $existingName = $Matches[1]
+                        if ($ManagedNames.ContainsKey($existingName) -and -not $normalized.ContainsKey($existingName)) {
+                            $normalized[$existingName] = $null
+                            $namesToApply.Add($existingName)
+                        }
+                    }
+                }
+            }
+        }
+    }
     # Live instances, used to find partition ids for director-managed sets. A
     # dedicatedScaling set (the Deep Desert) carries an EMPTY partitions array
     # and replicas=0 even while its pod is running, so status.servers[] is the
@@ -543,7 +569,7 @@ function Set-V6ConsoleVariableOverrides {
             }
             $arguments = @($podSpec.arguments)
             $before = ($arguments -join "`u{1}")
-            foreach ($name in $Names) {
+            foreach ($name in $namesToApply) {
                 $command = if ($null -ne $normalized[$name]) { "$name $($normalized[$name])" } else { $null }
                 $arguments = @(_Set-V6ExecCommand -Arguments $arguments `
                     -CommandName $name -Command $command)

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -478,13 +478,21 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecSandworm; Key='m_GiantWormMinimumPlayersOnSpiceField'; File='game'; Type='int'; Min=0; Unit='players'; Default='4'; Label='Giant Worm Min Players on Field'; Help='Minimum number of players on a spice field to trigger a giant sandworm spawn. Also needs client-side apply.'; ClientApply=$true; Category='Sandworm' }
 )
 
-# Append the complete recovered CVar inventory to Experimental Lab. Curated DST
-# fields win: any key already surfaced elsewhere is skipped, including the older
-# Experimental controls. Unknown defaults intentionally remain blank so clearing
-# a Lab value removes the override rather than inventing a default.
+# Experimental Lab catalog is intentionally lazy. Normal DST startup and Game
+# Config schema requests must not parse or serialize 5,000+ recovered controls.
+# The first Lab category request loads the catalog once; later category requests
+# reuse the process cache.
 $script:DuneAdvancedCvarCatalogPath = Join-Path $PSScriptRoot '..\..\data\advanced-cvars.json'
-$script:DuneAdvancedCvarLoadError = ''
-try {
+$script:DuneAdvancedCvarCatalogCache = $null
+$script:DuneAdvancedCvarKeyMapCache = $null
+
+function Initialize-DuneAdvancedCvarCatalog {
+    if ($null -ne $script:DuneAdvancedCvarCatalogCache) { return }
+
+    if (-not (Test-Path -LiteralPath $script:DuneAdvancedCvarCatalogPath)) {
+        throw "Advanced CVar catalog not found: $script:DuneAdvancedCvarCatalogPath"
+    }
+
     $advancedAliasesAlreadySurfaced = @(
         'Dune.PlayerDeathLootEnabled'
         'Sandworm.SandwormHibernationActive'
@@ -495,37 +503,74 @@ try {
             $existingCvars["$($field.Key)"] = $true
         }
     }
-    if (Test-Path -LiteralPath $script:DuneAdvancedCvarCatalogPath) {
-        # Windows PowerShell 5.1 emits a top-level JSON array as one pipeline
-        # object. Wrapping that pipeline in @() creates a nested array, causing
-        # every catalog property to concatenate into one enormous field.
-        $catalog = Get-Content -LiteralPath $script:DuneAdvancedCvarCatalogPath -Raw -ErrorAction Stop |
-            ConvertFrom-Json -ErrorAction Stop
-        foreach ($entry in $catalog) {
-            $key = "$($entry.key)".Trim()
-            if (-not $key -or $existingCvars.ContainsKey($key) -or $advancedAliasesAlreadySurfaced -contains $key) { continue }
-            $script:DuneGameConfigSchema += @{
-                Section  = $script:DuneGcSecConsole
-                Key      = $key
-                File     = 'engine'
-                Type     = 'string'
-                Default  = ''
-                Label    = if ($entry.label) { [string]$entry.label } else { $key }
-                Help     = [string]$entry.help
-                Category = 'Experimental Lab'
-                Group    = [string]$entry.group
-                Status   = [string]$entry.status
-                Source   = [string]$entry.source
-                Scope    = [string]$entry.scope
-                Risk     = [string]$entry.risk
-            }
-            $existingCvars[$key] = $true
-        }
-    } else {
-        $script:DuneAdvancedCvarLoadError = "Advanced CVar catalog not found: $script:DuneAdvancedCvarCatalogPath"
+
+    # Windows PowerShell 5.1 emits a top-level JSON array as one pipeline object.
+    # Direct assignment preserves its enumerable shape; @(... | ConvertFrom-Json)
+    # would nest it and concatenate every property into one enormous field.
+    $catalog = Get-Content -LiteralPath $script:DuneAdvancedCvarCatalogPath -Raw -ErrorAction Stop |
+        ConvertFrom-Json -ErrorAction Stop
+    $fields = New-Object 'System.Collections.Generic.List[object]'
+    $keyMap = @{}
+    foreach ($entry in $catalog) {
+        $key = "$($entry.key)".Trim()
+        if (-not $key -or $existingCvars.ContainsKey($key) -or $advancedAliasesAlreadySurfaced -contains $key) { continue }
+        $fields.Add(@{
+            section    = $script:DuneGcSecConsole
+            key        = $key
+            file       = 'engine'
+            type       = 'string'
+            default    = ''
+            label      = if ($entry.label) { [string]$entry.label } else { $key }
+            help       = [string]$entry.help
+            group      = [string]$entry.group
+            status     = [string]$entry.status
+            source     = [string]$entry.source
+            scope      = [string]$entry.scope
+            risk       = [string]$entry.risk
+            consoleVar = $true
+        })
+        $keyMap[$key] = $true
+        $existingCvars[$key] = $true
     }
-} catch {
-    $script:DuneAdvancedCvarLoadError = $_.Exception.Message
+    $script:DuneAdvancedCvarCatalogCache = $fields.ToArray()
+    $script:DuneAdvancedCvarKeyMapCache = $keyMap
+}
+
+function Get-DuneAdvancedCvarCatalog {
+    Initialize-DuneAdvancedCvarCatalog
+    return $script:DuneAdvancedCvarCatalogCache
+}
+
+function Get-DuneAdvancedCvarKeyMap {
+    Initialize-DuneAdvancedCvarCatalog
+    return $script:DuneAdvancedCvarKeyMapCache
+}
+
+function Test-DuneAdvancedCvarKey {
+    param([string]$Key)
+    if (-not $Key) { return $false }
+    return (Get-DuneAdvancedCvarKeyMap).ContainsKey($Key)
+}
+
+function Get-DuneAdvancedCvarCategoriesApi {
+    $groups = @{}
+    foreach ($field in @(Get-DuneAdvancedCvarCatalog)) {
+        $group = if ($field.group) { [string]$field.group } else { 'Uncategorized' }
+        if (-not $groups.ContainsKey($group)) { $groups[$group] = 0 }
+        $groups[$group]++
+    }
+    return @($groups.Keys | Sort-Object | ForEach-Object {
+        @{ category = $_; count = [int]$groups[$_] }
+    })
+}
+
+function Get-DuneAdvancedCvarCategoryApi {
+    param([Parameter(Mandatory)][string]$Category)
+    return @(
+        Get-DuneAdvancedCvarCatalog |
+            Where-Object { "$($_.group)" -eq $Category } |
+            Sort-Object key
+    )
 }
 
 # Console variables are applied to the SERVER by the Hagga startup command, not
@@ -600,6 +645,20 @@ $script:DuneStartupConsoleVariableKeys = @(
         ForEach-Object { $_.Key } |
         Sort-Object -Unique
 )
+
+function Get-DuneManagedStartupConsoleVariableKeyMap {
+    $managed = @{}
+    foreach ($key in $script:DuneStartupConsoleVariableKeys) { $managed[$key] = $true }
+    foreach ($key in (Get-DuneAdvancedCvarKeyMap).Keys) { $managed[$key] = $true }
+    return $managed
+}
+
+function Test-DuneStartupConsoleVariableKey {
+    param([string]$Key)
+    if ($script:DuneStartupConsoleVariableKeys -contains $Key) { return $true }
+    if ($script:DuneGameConfigSchema.Key -contains $Key) { return $false }
+    return (Test-DuneAdvancedCvarKey -Key $Key)
+}
 
 # Experimental controls live on their own page, grouped by what they affect
 # rather than by which decode pass found them. Namespace rules come first
@@ -1666,8 +1725,9 @@ function Set-DuneStartupConsoleVariableOverrides {
         throw 'Battlegroup helper unavailable (K8s.ps1 not loaded).'
     }
     $result = Set-V6ConsoleVariableOverrides -Ip $Ip `
-        -Names $script:DuneStartupConsoleVariableKeys `
-        -Values $Values
+        -Names @($Values.Keys | Sort-Object) `
+        -Values $Values `
+        -ManagedNames (Get-DuneManagedStartupConsoleVariableKeyMap)
     if (-not $result.Success) {
         $why = if ($result.Error) { $result.Error } else { $result.Raw }
         throw "Startup CVar override failed: $why"
@@ -1679,7 +1739,9 @@ function Sync-DuneStartupConsoleVariableOverrides {
     param([Parameter(Mandatory)][string]$Ip)
     $config = Get-DuneGameConfig -Ip $Ip
     $values = @{}
-    foreach ($key in $script:DuneStartupConsoleVariableKeys) {
+    $managed = Get-DuneManagedStartupConsoleVariableKeyMap
+    foreach ($key in @($config.engine.effectiveByKey.Keys)) {
+        if (-not $managed.ContainsKey($key)) { continue }
         if ($config.engine.effectiveByKey.ContainsKey($key)) {
             $candidate = "$($config.engine.effectiveByKey[$key])".Trim()
             if (-not (Test-DuneGameConfigValueIsDefault -Key $key -Value $candidate)) {

--- a/app/server/routes/GameConfig.ps1
+++ b/app/server/routes/GameConfig.ps1
@@ -11,6 +11,34 @@ Register-DuneRoute -Method GET -Path '/api/gameconfig/schema' -Handler {
     Write-DuneJson -Response $res -Body @{ schema = Get-DuneGameConfigSchemaApi }
 }
 
+# Experimental Lab metadata and category fields are separate from the normal
+# schema so opening DST or Game Config never loads the 5,000-control catalog.
+Register-DuneRoute -Method GET -Path '/api/gameconfig/experimental/categories' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Write-DuneJson -Response $res -Body @{ categories = Get-DuneAdvancedCvarCategoriesApi }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Experimental Lab catalog load failed: $($_.Exception.Message)"
+    }
+}
+
+Register-DuneRoute -Method GET -Path '/api/gameconfig/experimental/category' -Handler {
+    param($req, $res, $routeParams, $body)
+    $category = "$($req.QueryString['name'])".Trim()
+    if (-not $category) {
+        Write-DuneError -Response $res -Status 400 -Message 'Category name is required.'
+        return
+    }
+    try {
+        Write-DuneJson -Response $res -Body @{
+            category = $category
+            fields   = @(Get-DuneAdvancedCvarCategoryApi -Category $category)
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Experimental Lab category load failed: $($_.Exception.Message)"
+    }
+}
+
 # -----------------------------------------------------------------------------
 # GET /api/gameconfig/defaults — full settings catalog from the live image.
 # Reads DefaultGame.ini + DefaultEngine.ini out of a running game-server pod
@@ -144,9 +172,14 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig' -Handler {
         # Schema-keyed object form: resolve section/file from the schema.
         $keys = if ($updates -is [hashtable]) { $updates.Keys } else { $updates.PSObject.Properties.Name }
         foreach ($k in $keys) {
-            if (-not $schemaMap.ContainsKey($k)) { continue }
             $v = if ($updates -is [hashtable]) { $updates[$k] } else { $updates.$k }
-            $rm = (Test-DuneGameConfigValueIsDefault -Key $k -Value "$v")
+            $isAdvanced = $false
+            if (-not $schemaMap.ContainsKey($k)) {
+                if (-not (Test-DuneAdvancedCvarKey -Key $k)) { continue }
+                $schemaMap[$k] = @{ file = 'engine'; section = $script:DuneGcSecConsole }
+                $isAdvanced = $true
+            }
+            $rm = if ($isAdvanced) { [string]::IsNullOrWhiteSpace("$v") } else { Test-DuneGameConfigValueIsDefault -Key $k -Value "$v" }
             $structured.Add(@{ file = $schemaMap[$k].file; section = $schemaMap[$k].section; key = $k; value = "$v"; remove = $rm })
         }
     }
@@ -156,7 +189,7 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig' -Handler {
         return
     }
     foreach ($update in $structured) {
-        if ($update.key -in $script:DuneStartupConsoleVariableKeys -and
+        if ((Test-DuneStartupConsoleVariableKey -Key "$($update.key)") -and
             -not $update.remove -and
             -not (Test-DuneStartupConsoleVariableValue -Value "$($update.value)")) {
             Write-DuneError -Response $res -Status 400 -Message "$($update.key) contains a comma, quote, control character, or exceeds 512 characters and cannot be encoded in the saved startup payload."
@@ -171,7 +204,7 @@ Register-DuneRoute -Method PUT -Path '/api/gameconfig' -Handler {
         # at the start of every battlegroup restart. Patching pod specs on save
         # would make the operator replace the Hagga pod and disconnect its players
         # the moment someone hits Save.
-        $restartRequired = [bool]($structured | Where-Object { $_.key -in $script:DuneStartupConsoleVariableKeys } | Select-Object -First 1)
+        $restartRequired = [bool]($structured | Where-Object { Test-DuneStartupConsoleVariableKey -Key "$($_.key)" } | Select-Object -First 1)
         $cfg = Get-DuneGameConfig -Ip $ctx.ip
         $clientApply = Get-DuneGameConfigClientApplyNotice -Updates $structured.ToArray()
 

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -274,6 +274,51 @@ Describe 'Fuel burning startup override' -Tag 'GameConfig' {
             Should -Throw '*cannot be encoded in ExecCmds*'
     }
 
+    It 'processes configured and stale managed CVars without scanning blank catalog names' {
+        Mock Get-V6Battlegroup {
+            [pscustomobject]@{
+                Name = 'bg'; Ns = 'dune'
+                Bg = [pscustomobject]@{
+                    spec = [pscustomobject]@{
+                        serverGroup = [pscustomobject]@{
+                            template = [pscustomobject]@{
+                                spec = [pscustomobject]@{ sets = @(
+                                    [pscustomobject]@{
+                                        map = 'Survival_1'
+                                        partitions = @(1)
+                                        podSpecs = @(
+                                            [pscustomobject]@{
+                                                index = 1
+                                                arguments = @('-execcmds="Old.Advanced 1,Bgd.ServerDisplayName ''Hagga''"')
+                                            }
+                                        )
+                                    }
+                                ) }
+                            }
+                        }
+                    }
+                    status = [pscustomobject]@{ servers = @() }
+                }
+            }
+        }
+        $script:optimizedPatches = $null
+        Mock _Invoke-V6BgJsonPatch {
+            param($Ip, $Info, $Patches)
+            $script:optimizedPatches = $Patches
+            @{ Success = $true; Raw = ''; Error = $null }
+        }
+
+        $result = Set-V6ConsoleVariableOverrides -Ip '192.0.2.1' `
+            -Names @('New.Advanced') `
+            -Values @{ 'New.Advanced' = '2' } `
+            -ManagedNames @{ 'New.Advanced' = $true; 'Old.Advanced' = $true; 'Never.Configured' = $true }
+
+        $result.Success | Should -BeTrue
+        @($result.Values.Keys | Sort-Object) | Should -Be @('New.Advanced', 'Old.Advanced')
+        $arguments = @($script:optimizedPatches[0].value[0].arguments)
+        $arguments | Should -Contain '-execcmds="Bgd.ServerDisplayName ''Hagga'',New.Advanced 2"'
+    }
+
     It 'merges fuel and a per-sietch name into one ExecCmds argument' {
         $arguments = @(_Set-V6ExecCommand `
             -Arguments @('-log', '-execcmds="Bgd.ServerDisplayName ''Hagga, Prime''"') `
@@ -811,15 +856,18 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             $fields[$key].Category | Should -BeLike 'Experimental*'
             @($script:DuneStartupConsoleVariableKeys) | Should -Contain $key
         }
-        $lab = @($script:DuneGameConfigSchema | Where-Object Category -eq 'Experimental Lab')
+        @($script:DuneGameConfigSchema | Where-Object Category -eq 'Experimental Lab').Count | Should -Be 0
+        (Test-DuneStartupConsoleVariableKey -Key 'm_TaskGoalAmount') | Should -BeFalse
+        $script:DuneAdvancedCvarCatalogCache | Should -BeNullOrEmpty
+        @($script:DuneStartupConsoleVariableKeys).Count | Should -Be 149
+
+        $lab = @(Get-DuneAdvancedCvarCatalog)
         $lab.Count | Should -BeGreaterThan 4900
-        $script:DuneAdvancedCvarLoadError | Should -BeNullOrEmpty
-        @($script:DuneStartupConsoleVariableKeys).Count | Should -BeGreaterThan 5000
-        ($lab | Where-Object Key -eq 'ak.soundengine.executeActionOnEvent').Group |
+        ($lab | Where-Object key -eq 'ak.soundengine.executeActionOnEvent').group |
             Should -Be 'Audio - engine/internal'
-        ($lab | Where-Object Key -eq 'au.adpcm.DisableSeeking').Group |
+        ($lab | Where-Object key -eq 'au.adpcm.DisableSeeking').group |
             Should -Be 'Audio - engine/internal'
-        ($lab | Where-Object Key -eq 'Ai.Dune.EnableBudgetingSystem').Group |
+        ($lab | Where-Object key -eq 'Ai.Dune.EnableBudgetingSystem').group |
             Should -Be 'AI - engine/internal'
     }
 
@@ -829,13 +877,16 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         # Uncategorized rather than being forced into a neighbouring group.
         $api = @(Get-DuneGameConfigSchemaApi)
         $fields = @($api | Where-Object { $_.category -like 'Experimental*' } | ForEach-Object { $_.fields })
-        $fields.Count | Should -BeGreaterThan 5000
+        $fields.Count | Should -Be 127
         foreach ($f in $fields) {
             $f.group | Should -Not -BeNullOrEmpty
             $f.status | Should -BeIn @('Confirmed', 'Unconfirmed')
             $f.source | Should -BeIn @('Dune', 'Engine')
             $f.risk | Should -BeIn @('experimental', 'diagnostic', 'high', 'critical')
         }
+        $categories = @(Get-DuneAdvancedCvarCategoriesApi)
+        ($categories | Measure-Object count -Sum).Sum | Should -BeGreaterThan 4900
+        @(Get-DuneAdvancedCvarCategoryApi -Category 'Dune gameplay').Count | Should -BeGreaterThan 500
         # Namespace rules must win over keyword ones: a sandworm control that
         # mentions vehicles is a sandworm control.
         (Get-DuneExperimentalGroup -Key 'Sandworm.SandwormCheckIfBreachLocationIsFreeOfVehicles') | Should -Be 'Sandworm'
@@ -849,7 +900,7 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
     It 'loads the advanced catalog as individual fields under Windows PowerShell 5.1' -Skip:($env:OS -ne 'Windows_NT') {
         $gameConfigPath = (Resolve-Path (Join-Path $PSScriptRoot '..\app\server\lib\GameConfig.ps1')).Path.Replace("'", "''")
         $command = ". '$gameConfigPath'; " +
-            '$lab = @($script:DuneGameConfigSchema | Where-Object Category -eq ''Experimental Lab''); ' +
+            '$lab = @(Get-DuneAdvancedCvarCatalog); ' +
             'Write-Output $lab.Count; Write-Output ([string]$lab[0].Key).Length'
         $result = @(& powershell.exe -NoProfile -ExecutionPolicy Bypass -Command $command)
 
@@ -988,6 +1039,7 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
     }
 
     It 'surfaces dangerous controls with critical risk metadata' {
+        $catalog = @(Get-DuneAdvancedCvarCatalog)
         foreach ($key in @(
             'Hazard.DehydrationZonesEnabled'
             'dw.igw.EnableAuthConfirmGainingCrash'
@@ -998,9 +1050,9 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
             'SecurityZones.ForceEnablePvp'
             'dw.EnableDeveloperMode'
         )) {
-            $field = @($script:DuneGameConfigSchema | Where-Object Key -eq $key)
+            $field = @($catalog | Where-Object key -eq $key)
             $field.Count | Should -Be 1
-            $field[0].Risk | Should -Be 'critical'
+            $field[0].risk | Should -Be 'critical'
         }
     }
 
@@ -1168,6 +1220,31 @@ $script:DstManagedEnd
         Test-DuneStartupConsoleVariableValue -Value 'unsafe"value' | Should -BeFalse
     }
 
+    It 'rebuilds restart injection from configured managed CVars only' {
+        Mock Get-DuneGameConfig {
+            @{
+                engine = @{
+                    effectiveByKey = @{
+                        'ak.soundengine.executeActionOnEvent' = '1'
+                        'dw.FuelBurningMultiplier' = '6'
+                        'User.HandEditedSetting' = '9'
+                    }
+                }
+            }
+        }
+        $script:optimizedSyncValues = $null
+        Mock Set-DuneStartupConsoleVariableOverrides {
+            param($Ip, $Values)
+            $script:optimizedSyncValues = $Values
+            @{ Success = $true }
+        }
+
+        Sync-DuneStartupConsoleVariableOverrides -Ip '192.0.2.1' | Out-Null
+
+        @($script:optimizedSyncValues.Keys | Sort-Object) |
+            Should -Be @('ak.soundengine.executeActionOnEvent', 'dw.FuelBurningMultiplier')
+    }
+
     It 'keeps experimental CVars out of local client changes' {
         # Experimental controls are unproven console variables; nothing shows the
         # client reads them, and the server applies them through the startup
@@ -1213,11 +1290,10 @@ $script:DstManagedEnd
         $field[0].ClientApply | Should -BeTrue
     }
 
-    It 'places the Experimental catalogs last in the curated schema API, in order' {
+    It 'places the curated Experimental catalogs last in the schema API, in order' {
         $cats = @((Get-DuneGameConfigSchemaApi) | ForEach-Object { $_.category })
-        $cats[-3] | Should -Be 'Experimental'
-        $cats[-2] | Should -Be 'Experimental 2'
-        $cats[-1] | Should -Be 'Experimental Lab'
+        $cats[-2] | Should -Be 'Experimental'
+        $cats[-1] | Should -Be 'Experimental 2'
     }
 
     It 'persists experimental controls in the UserEngine ConsoleVariables section' {

--- a/webui/src/api/gameconfig.ts
+++ b/webui/src/api/gameconfig.ts
@@ -2,6 +2,8 @@
 import { api, withOnlinePlayerGuard } from './client'
 import type {
   GameConfigSchemaResponse,
+  GameConfigExperimentalCategoriesResponse,
+  GameConfigExperimentalCategoryResponse,
   GameConfigResponse,
   GameConfigSaveResponse,
   GameConfigBackupResponse,
@@ -26,6 +28,16 @@ const fq = (force: boolean) => (force ? '?force=true' : '')
 
 export function getGameConfigSchema() {
   return api<GameConfigSchemaResponse>('/api/gameconfig/schema')
+}
+
+export function getGameConfigExperimentalCategories() {
+  return api<GameConfigExperimentalCategoriesResponse>('/api/gameconfig/experimental/categories')
+}
+
+export function getGameConfigExperimentalCategory(category: string) {
+  return api<GameConfigExperimentalCategoryResponse>(
+    `/api/gameconfig/experimental/category?name=${encodeURIComponent(category)}`,
+  )
 }
 
 export function getGameConfig() {

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -160,6 +160,15 @@ export type GameConfigSchemaResponse = {
   schema: GameConfigCategory[]
 }
 
+export type GameConfigExperimentalCategoriesResponse = {
+  categories: Array<{ category: string; count: number }>
+}
+
+export type GameConfigExperimentalCategoryResponse = {
+  category: string
+  fields: GameConfigField[]
+}
+
 export type GameConfigIniKey = {
   key: string
   value: string

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -9,6 +9,8 @@ import { api } from '../api/client'
 import { ServerNameCard } from './gameconfig/ServerNameCard'
 import {
   getGameConfigSchema,
+  getGameConfigExperimentalCategories,
+  getGameConfigExperimentalCategory,
   getGameConfig,
   saveGameConfig,
   reloadGameConfigPods,
@@ -382,6 +384,10 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
   const [sandwormModalOpen, setSandwormModalOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [experimentalGroup, setExperimentalGroup] = useState<string | null>(null)
+  const [experimentalCatalogCategories, setExperimentalCatalogCategories] = useState<Array<{ category: string; count: number }>>([])
+  const [experimentalCategoryCache, setExperimentalCategoryCache] = useState<Record<string, GameConfigField[]>>({})
+  const [experimentalCategoryLoading, setExperimentalCategoryLoading] = useState<string | null>(null)
+  const [experimentalCategoryError, setExperimentalCategoryError] = useState<string | null>(null)
   const [experimentalSource, setExperimentalSource] = useState<'all' | 'Dune' | 'Engine'>('all')
   const [experimentalRisk, setExperimentalRisk] = useState<'all' | 'experimental' | 'diagnostic' | 'high' | 'critical'>('all')
   const [experimentalModifiedOnly, setExperimentalModifiedOnly] = useState(false)
@@ -919,6 +925,19 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [vmRunning])
 
+  useEffect(() => {
+    if (!experimentalPage) return
+    let cancelled = false
+    void getGameConfigExperimentalCategories()
+      .then(response => {
+        if (!cancelled) setExperimentalCatalogCategories(response.categories ?? [])
+      })
+      .catch(error => {
+        if (!cancelled) setExperimentalCategoryError(error instanceof Error ? error.message : String(error))
+      })
+    return () => { cancelled = true }
+  }, [experimentalPage])
+
   const dirtyKeys = useMemo(() => {
     const keys: string[] = []
     for (const k of Object.keys(values)) {
@@ -927,16 +946,27 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
     return keys
   }, [values, originals])
 
+  const loadedExperimentalFields = useMemo(
+    () => Object.values(experimentalCategoryCache).flat(),
+    [experimentalCategoryCache],
+  )
+  const schemaWithLoadedExperimental = useMemo(
+    () => loadedExperimentalFields.length > 0
+      ? [...(schema ?? []), { category: 'Experimental Lab', fields: loadedExperimentalFields }]
+      : (schema ?? []),
+    [schema, loadedExperimentalFields],
+  )
+
   // Flat key -> field lookup (for default values, struct flags, etc.).
   const fieldByKey = useMemo(() => {
     const m: Record<string, GameConfigField> = {}
-    for (const cat of schema ?? []) for (const f of cat?.fields ?? []) if (f?.key) m[f.key] = f
+    for (const cat of schemaWithLoadedExperimental) for (const f of cat?.fields ?? []) if (f?.key) m[f.key] = f
     return m
-  }, [schema])
+  }, [schemaWithLoadedExperimental])
 
   const surfacedIniTargets = useMemo(() => {
     const keys = new Set<string>()
-    for (const category of schema ?? []) {
+    for (const category of schemaWithLoadedExperimental) {
       for (const field of category.fields ?? []) {
         if (!field?.key) continue
         keys.add(`${field.file}||${field.section}||${field.key}`.toLowerCase())
@@ -946,18 +976,18 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
       }
     }
     return keys
-  }, [schema])
+  }, [schemaWithLoadedExperimental])
 
   const experimentalStartupKeys = useMemo(() => {
     const keys = new Set<string>()
-    for (const category of schema ?? []) {
+    for (const category of schemaWithLoadedExperimental) {
       if (!isExperimentalCategory(category.category)) continue
       for (const field of category.fields ?? []) {
         if (field.file === 'engine') keys.add(field.key)
       }
     }
     return keys
-  }, [schema])
+  }, [schemaWithLoadedExperimental])
   const experimentalStartupDirtyKeys = useMemo(
     () => dirtyKeys.filter(k => experimentalStartupKeys.has(k)),
     [dirtyKeys, experimentalStartupKeys],
@@ -986,26 +1016,79 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
 
   // Everything a player must add locally — built from the WHOLE schema, not just
   // this page, so Game Config and Experimental show the identical list.
-  const playerConfig = useMemo(() => buildAllClientBlocks(schema, cfg), [schema, cfg])
-
-  const experimentalGroups = useMemo(
-    () => experimentalPage
-      ? (visibleSchema ?? []).map(category => ({
-          name: category.category,
-          count: (category.fields ?? []).length,
-        }))
-      : [],
-    [experimentalPage, visibleSchema],
+  const playerConfig = useMemo(
+    () => buildAllClientBlocks(schemaWithLoadedExperimental, cfg),
+    [schemaWithLoadedExperimental, cfg],
   )
-  const selectedExperimentalGroup = experimentalGroup ?? experimentalGroups[0]?.name ?? 'all'
+
+  const experimentalGroups = useMemo(() => {
+    if (!experimentalPage) return []
+    const counts = new Map<string, number>()
+    for (const category of visibleSchema ?? []) {
+      counts.set(category.category, (counts.get(category.category) ?? 0) + (category.fields ?? []).length)
+    }
+    for (const category of experimentalCatalogCategories) {
+      counts.set(category.category, (counts.get(category.category) ?? 0) + category.count)
+    }
+    return [...counts.entries()]
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => experimentalGroupRank(a.name) - experimentalGroupRank(b.name) || a.name.localeCompare(b.name))
+  }, [experimentalPage, visibleSchema, experimentalCatalogCategories])
+  const selectedExperimentalGroup = experimentalGroup ?? experimentalGroups[0]?.name ?? ''
+
+  useEffect(() => {
+    if (!experimentalPage || !selectedExperimentalGroup) return
+    if (Object.prototype.hasOwnProperty.call(experimentalCategoryCache, selectedExperimentalGroup)) return
+    let cancelled = false
+    setExperimentalCategoryLoading(selectedExperimentalGroup)
+    setExperimentalCategoryError(null)
+    void getGameConfigExperimentalCategory(selectedExperimentalGroup)
+      .then(response => {
+        if (!cancelled) {
+          setExperimentalCategoryCache(previous => ({
+            ...previous,
+            [selectedExperimentalGroup]: response.fields ?? [],
+          }))
+        }
+      })
+      .catch(error => {
+        if (!cancelled) setExperimentalCategoryError(error instanceof Error ? error.message : String(error))
+      })
+      .finally(() => {
+        if (!cancelled) setExperimentalCategoryLoading(null)
+      })
+    return () => { cancelled = true }
+  }, [experimentalPage, selectedExperimentalGroup, experimentalCategoryCache])
+
+  useEffect(() => {
+    const fields = experimentalCategoryCache[selectedExperimentalGroup]
+    if (!fields || loadState === 'idle' || loadState === 'loading') return
+    const seeded: Record<string, string> = {}
+    for (const field of fields) seeded[field.key] = currentValue(cfg, field)
+    setValues(previous => {
+      const next = { ...previous }
+      for (const [key, value] of Object.entries(seeded)) {
+        if (!(key in next)) next[key] = value
+      }
+      return next
+    })
+    setOriginals(previous => {
+      const next = { ...previous }
+      for (const [key, value] of Object.entries(seeded)) {
+        if (!(key in next)) next[key] = value
+      }
+      return next
+    })
+  }, [experimentalCategoryCache, selectedExperimentalGroup, loadState, cfg])
 
   const experimentalFilteredFields = useMemo(() => {
     if (!experimentalPage || !visibleSchema) return [] as GameConfigField[]
     const q = search.trim().toLowerCase()
-    return visibleSchema
-      .flatMap(category => category.fields ?? [])
+    return [
+      ...(visibleSchema.find(category => category.category === selectedExperimentalGroup)?.fields ?? []),
+      ...(experimentalCategoryCache[selectedExperimentalGroup] ?? []),
+    ]
       .filter(field => {
-        if (selectedExperimentalGroup !== 'all' && (field.group || 'Uncategorized') !== selectedExperimentalGroup) return false
         if (experimentalSource !== 'all' && field.source !== experimentalSource) return false
         if (experimentalRisk !== 'all' && field.risk !== experimentalRisk) return false
         if (experimentalModifiedOnly && !isCustomized(cfg, field)) return false
@@ -1015,8 +1098,8 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
           || (field.help ?? '').toLowerCase().includes(q)
           || (field.group ?? '').toLowerCase().includes(q)
       })
-      .sort((a, b) => (a.group ?? '').localeCompare(b.group ?? '') || a.key.localeCompare(b.key))
-  }, [experimentalPage, visibleSchema, selectedExperimentalGroup, search, experimentalSource, experimentalRisk, experimentalModifiedOnly, cfg])
+      .sort((a, b) => a.key.localeCompare(b.key))
+  }, [experimentalPage, visibleSchema, experimentalCategoryCache, selectedExperimentalGroup, search, experimentalSource, experimentalRisk, experimentalModifiedOnly, cfg])
 
   useEffect(() => {
     setExperimentalPageIndex(0)
@@ -1027,7 +1110,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
     if (experimentalPage) {
       const start = experimentalPageIndex * EXPERIMENTAL_PAGE_SIZE
       return [{
-        category: selectedExperimentalGroup === 'all' ? 'All categories' : selectedExperimentalGroup,
+        category: selectedExperimentalGroup,
         fields: experimentalFilteredFields.slice(start, start + EXPERIMENTAL_PAGE_SIZE),
       }]
     }
@@ -1075,7 +1158,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
       const out = await saveGameConfig(updates)
       const next: GameConfigResponse = { available: true, source: out.source, game: out.game, engine: out.engine }
       setCfg(next)
-      const seeded = seedValues(schema ?? [], next)
+      const seeded = seedValues(schemaWithLoadedExperimental, next)
       setValues(seeded)
       setOriginals(seeded)
       const n = out.applied ?? dirtyKeys.length
@@ -1771,7 +1854,6 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
                 className="min-w-52 px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-xs"
                 aria-label="Experimental category"
               >
-                <option value="all">All categories</option>
                 {experimentalGroups.map(group => (
                   <option key={group.name} value={group.name}>
                     {group.name} ({group.count.toLocaleString()})
@@ -1809,9 +1891,14 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
                 Modified only
               </label>
               <span className="text-xs text-text-dim ml-auto">
-                {experimentalFilteredFields.length.toLocaleString()} recovered controls
+                {experimentalCategoryLoading === selectedExperimentalGroup
+                  ? 'Loading category...'
+                  : `${experimentalFilteredFields.length.toLocaleString()} recovered controls`}
               </span>
             </div>
+          )}
+          {experimentalPage && experimentalCategoryError && (
+            <div className="mb-4 text-xs text-danger">{experimentalCategoryError}</div>
           )}
 
           <div className="space-y-5">
@@ -1857,7 +1944,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
                   }).map((_, index) => (
                     <div key={`empty-slot-${index}`} className="h-32 invisible" aria-hidden="true" />
                   ))}
-                  {experimentalPage && (cat.fields ?? []).length === 0 && (
+                  {experimentalPage && (cat.fields ?? []).length === 0 && experimentalCategoryLoading !== selectedExperimentalGroup && (
                     <div className="md:col-span-2 text-sm text-text-muted">No recovered controls match these filters.</div>
                   )}
                 </div>

--- a/webui/tests/api/gameconfig.test.ts
+++ b/webui/tests/api/gameconfig.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getDeepDesertPvp, reloadGameConfigPods, saveDeepDesertPvp } from '../../src/api/gameconfig'
+import {
+  getDeepDesertPvp,
+  getGameConfigExperimentalCategories,
+  getGameConfigExperimentalCategory,
+  reloadGameConfigPods,
+  saveDeepDesertPvp,
+} from '../../src/api/gameconfig'
 
 interface FetchCall {
   url: string
@@ -64,5 +70,17 @@ describe('Game Config pod reload API', () => {
       method: 'POST',
       body: undefined,
     })
+  })
+})
+
+describe('Experimental Lab lazy catalog API', () => {
+  it('loads category metadata separately from the normal schema', async () => {
+    await getGameConfigExperimentalCategories()
+    expect(calls.at(-1)?.url).toBe('/api/gameconfig/experimental/categories')
+  })
+
+  it('loads and URL-encodes only the selected category', async () => {
+    await getGameConfigExperimentalCategory('Audio - engine/internal')
+    expect(calls.at(-1)?.url).toBe('/api/gameconfig/experimental/category?name=Audio%20-%20engine%2Finternal')
   })
 })


### PR DESCRIPTION
## Problem
The full 5,134-record catalog was parsed into the process schema at DST startup, serialized in every Game Config schema response, seeded into React state, and scanned for every gameplay partition during restart synchronization—even when no Lab controls were configured.

## Fix
- keep the normal curated schema catalog-free
- add lazy Experimental Lab category metadata and selected-category endpoints
- load only the selected dropdown category in the browser and cache visited categories for the session
- preserve saved advanced values across category switches and saves
- accept lazy advanced keys through the existing safe Game Config save path
- rebuild restart injection from configured managed CVars only
- discover and remove stale managed commands already present in pod specs while preserving unrelated `ExecCmds`
- keep deterministic command ordering

## Measured impact
- PowerShell 5.1 schema fields: 5,219 → 237
- normal schema payload: ~1.8 MB → ~87 KB
- measured GameConfig library startup: ~831 ms → ~119–167 ms
- first Lab catalog/category index load: ~218 ms, then process-cached
- Audio category payload: 328 controls / ~111 KB, browser-cached after selection

## Validation
- full Pester suite: 767 passed
- focused GameConfig Pester: 109 passed
- WebUI suite: 122 passed
- WebUI production build and ESLint passed
- PowerShell 5.1 parse preflight passed
- final v13.5.4 installer built successfully
- staged gitleaks scan passed