### PR TITLE
Enable Copilot remote control

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -5,4 +5,4 @@ instructions: |-
   always popup a clickable box when requesting a response from the user
 automation:
   auto_issue_session: true
-  remote_control: false
+  remote_control: true


### PR DESCRIPTION
## Summary
- enable Copilot Remote Control for DST project sessions

## Why
GitHub Mobile can discover local sessions, but steering is rejected while repository configuration keeps Remote Control disabled.