### PR TITLE
Release v13.6.1: global Experimental Lab search

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,7 +76,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.6.0"
+      placeholder: "v13.6.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.6.1] - 2026-08-10
+
+### Changed
+
+- Experimental Lab restores the opt-in **All** category and searches the full
+  settings catalog regardless of the selected category, while still opening on
+  a smaller category so the complete catalog is not loaded at page startup.
+
+### Fixed
+
+- Experimental Lab search results remain a collection when only one setting
+  matches, preventing the page from crashing on searches such as `fuel`.
+
 ## [13.6.0] - 2026-08-10
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.6.0'
+$script:DuneToolVersion = '13.6.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.6.0',
+    [string]$Version = '13.6.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.6.0</Version>
+    <Version>13.6.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.6.0"
+#define MyAppVersion "13.6.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -566,9 +566,26 @@ function Get-DuneAdvancedCvarCategoriesApi {
 
 function Get-DuneAdvancedCvarCategoryApi {
     param([Parameter(Mandatory)][string]$Category)
+    if ($Category -eq 'All') {
+        return @(Get-DuneAdvancedCvarCatalog | Sort-Object key)
+    }
     return @(
         Get-DuneAdvancedCvarCatalog |
             Where-Object { "$($_.group)" -eq $Category } |
+            Sort-Object key
+    )
+}
+
+function Search-DuneAdvancedCvarCatalogApi {
+    param([Parameter(Mandatory)][string]$Query)
+    $needle = $Query.Trim()
+    if (-not $needle) { return @() }
+    return @(
+        Get-DuneAdvancedCvarCatalog |
+            Where-Object {
+                $haystack = @($_.key, $_.label, $_.help, $_.group) -join "`n"
+                $haystack.IndexOf($needle, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+            } |
             Sort-Object key
     )
 }

--- a/app/server/routes/GameConfig.ps1
+++ b/app/server/routes/GameConfig.ps1
@@ -39,6 +39,23 @@ Register-DuneRoute -Method GET -Path '/api/gameconfig/experimental/category' -Ha
     }
 }
 
+Register-DuneRoute -Method GET -Path '/api/gameconfig/experimental/search' -Handler {
+    param($req, $res, $routeParams, $body)
+    $query = "$($req.QueryString['q'])".Trim()
+    try {
+        $fields = [object[]]@()
+        if ($query) {
+            $fields = [object[]]@(Search-DuneAdvancedCvarCatalogApi -Query $query)
+        }
+        Write-DuneJson -Response $res -Body @{
+            query  = $query
+            fields = $fields
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Experimental Lab search failed: $($_.Exception.Message)"
+    }
+}
+
 # -----------------------------------------------------------------------------
 # GET /api/gameconfig/defaults — full settings catalog from the live image.
 # Reads DefaultGame.ini + DefaultEngine.ini out of a running game-server pod

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.6.0"
+$script:ToolVersion = "13.6.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -887,6 +887,15 @@ Describe 'DuneGameConfigSchema: experimental binary CVars' -Tag 'GameConfig' {
         $categories = @(Get-DuneAdvancedCvarCategoriesApi)
         ($categories | Measure-Object count -Sum).Sum | Should -BeGreaterThan 4900
         @(Get-DuneAdvancedCvarCategoryApi -Category 'Dune gameplay').Count | Should -BeGreaterThan 500
+        $fullCatalog = @(Get-DuneAdvancedCvarCatalog)
+        @(Get-DuneAdvancedCvarCategoryApi -Category 'All').Count | Should -Be $fullCatalog.Count
+        $searchResults = @(Search-DuneAdvancedCvarCatalogApi -Query 'EXECUTEACTIONONEVENT')
+        @($searchResults.key) | Should -Contain 'ak.soundengine.executeActionOnEvent'
+        @($searchResults.group | Select-Object -Unique).Count | Should -BeGreaterThan 0
+        @(Search-DuneAdvancedCvarCatalogApi -Query '  ').Count | Should -Be 0
+        $singleResult = [object[]]@(Search-DuneAdvancedCvarCatalogApi -Query 'fuel')
+        $singleResult.Count | Should -Be 1
+        (@{ fields = $singleResult } | ConvertTo-Json -Compress) | Should -Match '"fields":\['
         # Namespace rules must win over keyword ones: a sandworm control that
         # mentions vehicles is a sandworm control.
         (Get-DuneExperimentalGroup -Key 'Sandworm.SandwormCheckIfBreachLocationIsFreeOfVehicles') | Should -Be 'Sandworm'

--- a/webui/src/api/gameconfig.ts
+++ b/webui/src/api/gameconfig.ts
@@ -4,6 +4,8 @@ import type {
   GameConfigSchemaResponse,
   GameConfigExperimentalCategoriesResponse,
   GameConfigExperimentalCategoryResponse,
+  GameConfigExperimentalSearchResponse,
+  GameConfigField,
   GameConfigResponse,
   GameConfigSaveResponse,
   GameConfigBackupResponse,
@@ -34,10 +36,30 @@ export function getGameConfigExperimentalCategories() {
   return api<GameConfigExperimentalCategoriesResponse>('/api/gameconfig/experimental/categories')
 }
 
-export function getGameConfigExperimentalCategory(category: string) {
-  return api<GameConfigExperimentalCategoryResponse>(
+function isGameConfigField(value: unknown): value is GameConfigField {
+  return typeof value === 'object'
+    && value !== null
+    && 'key' in value
+    && typeof value.key === 'string'
+}
+
+function normalizeGameConfigFields(value: unknown): GameConfigField[] {
+  if (Array.isArray(value)) return value.filter(isGameConfigField)
+  return isGameConfigField(value) ? [value] : []
+}
+
+export async function getGameConfigExperimentalCategory(category: string) {
+  const response = await api<GameConfigExperimentalCategoryResponse>(
     `/api/gameconfig/experimental/category?name=${encodeURIComponent(category)}`,
   )
+  return { ...response, fields: normalizeGameConfigFields(response.fields) }
+}
+
+export async function searchGameConfigExperimental(query: string) {
+  const response = await api<GameConfigExperimentalSearchResponse>(
+    `/api/gameconfig/experimental/search?q=${encodeURIComponent(query)}`,
+  )
+  return { ...response, fields: normalizeGameConfigFields(response.fields) }
 }
 
 export function getGameConfig() {

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -169,6 +169,11 @@ export type GameConfigExperimentalCategoryResponse = {
   fields: GameConfigField[]
 }
 
+export type GameConfigExperimentalSearchResponse = {
+  query: string
+  fields: GameConfigField[]
+}
+
 export type GameConfigIniKey = {
   key: string
   value: string

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -11,6 +11,7 @@ import {
   getGameConfigSchema,
   getGameConfigExperimentalCategories,
   getGameConfigExperimentalCategory,
+  searchGameConfigExperimental,
   getGameConfig,
   saveGameConfig,
   reloadGameConfigPods,
@@ -388,6 +389,9 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
   const [experimentalCategoryCache, setExperimentalCategoryCache] = useState<Record<string, GameConfigField[]>>({})
   const [experimentalCategoryLoading, setExperimentalCategoryLoading] = useState<string | null>(null)
   const [experimentalCategoryError, setExperimentalCategoryError] = useState<string | null>(null)
+  const [experimentalSearchFields, setExperimentalSearchFields] = useState<GameConfigField[]>([])
+  const [experimentalSearchLoading, setExperimentalSearchLoading] = useState(false)
+  const [experimentalSearchError, setExperimentalSearchError] = useState<string | null>(null)
   const [experimentalSource, setExperimentalSource] = useState<'all' | 'Dune' | 'Engine'>('all')
   const [experimentalRisk, setExperimentalRisk] = useState<'all' | 'experimental' | 'diagnostic' | 'high' | 'critical'>('all')
   const [experimentalModifiedOnly, setExperimentalModifiedOnly] = useState(false)
@@ -947,8 +951,14 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
   }, [values, originals])
 
   const loadedExperimentalFields = useMemo(
-    () => Object.values(experimentalCategoryCache).flat(),
-    [experimentalCategoryCache],
+    () => {
+      const fields = [...Object.values(experimentalCategoryCache).flat(), ...experimentalSearchFields]
+      return [...new Map(fields.map(field => [
+        `${field.file}||${field.section}||${field.key}`.toLowerCase(),
+        field,
+      ] as const)).values()]
+    },
+    [experimentalCategoryCache, experimentalSearchFields],
   )
   const schemaWithLoadedExperimental = useMemo(
     () => loadedExperimentalFields.length > 0
@@ -1030,11 +1040,16 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
     for (const category of experimentalCatalogCategories) {
       counts.set(category.category, (counts.get(category.category) ?? 0) + category.count)
     }
-    return [...counts.entries()]
+    counts.delete('All')
+    const groups = [...counts.entries()]
       .map(([name, count]) => ({ name, count }))
       .sort((a, b) => experimentalGroupRank(a.name) - experimentalGroupRank(b.name) || a.name.localeCompare(b.name))
+    return [{ name: 'All', count: groups.reduce((total, group) => total + group.count, 0) }, ...groups]
   }, [experimentalPage, visibleSchema, experimentalCatalogCategories])
-  const selectedExperimentalGroup = experimentalGroup ?? experimentalGroups[0]?.name ?? ''
+  const selectedExperimentalGroup = experimentalGroup
+    ?? experimentalGroups.find(group => group.name !== 'All')?.name
+    ?? ''
+  const experimentalSearchActive = search.trim() !== ''
 
   useEffect(() => {
     if (!experimentalPage || !selectedExperimentalGroup) return
@@ -1061,10 +1076,44 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
   }, [experimentalPage, selectedExperimentalGroup, experimentalCategoryCache])
 
   useEffect(() => {
-    const fields = experimentalCategoryCache[selectedExperimentalGroup]
-    if (!fields || loadState === 'idle' || loadState === 'loading') return
+    if (!experimentalPage) return
+    const query = search.trim()
+    if (!query) {
+      setExperimentalSearchFields([])
+      setExperimentalSearchLoading(false)
+      setExperimentalSearchError(null)
+      return
+    }
+    let cancelled = false
+    setExperimentalSearchFields([])
+    setExperimentalSearchLoading(true)
+    setExperimentalSearchError(null)
+    const timer = window.setTimeout(() => {
+      void searchGameConfigExperimental(query)
+        .then(response => {
+          if (!cancelled) setExperimentalSearchFields(response.fields ?? [])
+        })
+        .catch(error => {
+          if (!cancelled) setExperimentalSearchError(error instanceof Error ? error.message : String(error))
+        })
+        .finally(() => {
+          if (!cancelled) setExperimentalSearchLoading(false)
+        })
+    }, 250)
+    return () => {
+      cancelled = true
+      window.clearTimeout(timer)
+    }
+  }, [experimentalPage, search])
+
+  const experimentalFieldsToSeed = experimentalSearchActive
+    ? experimentalSearchFields
+    : (experimentalCategoryCache[selectedExperimentalGroup] ?? [])
+
+  useEffect(() => {
+    if (experimentalFieldsToSeed.length === 0 || loadState === 'idle' || loadState === 'loading') return
     const seeded: Record<string, string> = {}
-    for (const field of fields) seeded[field.key] = currentValue(cfg, field)
+    for (const field of experimentalFieldsToSeed) seeded[field.key] = currentValue(cfg, field)
     setValues(previous => {
       const next = { ...previous }
       for (const [key, value] of Object.entries(seeded)) {
@@ -1079,15 +1128,22 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
       }
       return next
     })
-  }, [experimentalCategoryCache, selectedExperimentalGroup, loadState, cfg])
+  }, [experimentalFieldsToSeed, loadState, cfg])
 
   const experimentalFilteredFields = useMemo(() => {
     if (!experimentalPage || !visibleSchema) return [] as GameConfigField[]
     const q = search.trim().toLowerCase()
-    return [
-      ...(visibleSchema.find(category => category.category === selectedExperimentalGroup)?.fields ?? []),
-      ...(experimentalCategoryCache[selectedExperimentalGroup] ?? []),
-    ]
+    const schemaFields = experimentalSearchActive || selectedExperimentalGroup === 'All'
+      ? visibleSchema.flatMap(category => category.fields ?? [])
+      : (visibleSchema.find(category => category.category === selectedExperimentalGroup)?.fields ?? [])
+    const catalogFields = experimentalSearchActive
+      ? experimentalSearchFields
+      : (experimentalCategoryCache[selectedExperimentalGroup] ?? [])
+    const candidates = [...new Map([...schemaFields, ...catalogFields].map(field => [
+      `${field.file}||${field.section}||${field.key}`.toLowerCase(),
+      field,
+    ] as const)).values()]
+    return candidates
       .filter(field => {
         if (experimentalSource !== 'all' && field.source !== experimentalSource) return false
         if (experimentalRisk !== 'all' && field.risk !== experimentalRisk) return false
@@ -1099,7 +1155,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
           || (field.group ?? '').toLowerCase().includes(q)
       })
       .sort((a, b) => a.key.localeCompare(b.key))
-  }, [experimentalPage, visibleSchema, experimentalCategoryCache, selectedExperimentalGroup, search, experimentalSource, experimentalRisk, experimentalModifiedOnly, cfg])
+  }, [experimentalPage, visibleSchema, experimentalCategoryCache, experimentalSearchFields, experimentalSearchActive, selectedExperimentalGroup, search, experimentalSource, experimentalRisk, experimentalModifiedOnly, cfg])
 
   useEffect(() => {
     setExperimentalPageIndex(0)
@@ -1110,7 +1166,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
     if (experimentalPage) {
       const start = experimentalPageIndex * EXPERIMENTAL_PAGE_SIZE
       return [{
-        category: selectedExperimentalGroup,
+        category: experimentalSearchActive ? 'Search results' : selectedExperimentalGroup,
         fields: experimentalFilteredFields.slice(start, start + EXPERIMENTAL_PAGE_SIZE),
       }]
     }
@@ -1841,7 +1897,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
               type="text"
               value={search}
               onChange={e => setSearch(e.target.value)}
-              placeholder="Filter settings…"
+              placeholder={experimentalPage ? 'Search all Experimental Lab settings…' : 'Filter settings…'}
               className="w-full pl-9 pr-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50"
             />
           </div>
@@ -1891,14 +1947,18 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
                 Modified only
               </label>
               <span className="text-xs text-text-dim ml-auto">
-                {experimentalCategoryLoading === selectedExperimentalGroup
-                  ? 'Loading category...'
-                  : `${experimentalFilteredFields.length.toLocaleString()} recovered controls`}
+                {experimentalSearchActive && experimentalSearchLoading
+                  ? 'Searching all categories...'
+                  : !experimentalSearchActive && experimentalCategoryLoading === selectedExperimentalGroup
+                    ? 'Loading category...'
+                    : `${experimentalFilteredFields.length.toLocaleString()} recovered controls${experimentalSearchActive ? ' across all categories' : ''}`}
               </span>
             </div>
           )}
-          {experimentalPage && experimentalCategoryError && (
-            <div className="mb-4 text-xs text-danger">{experimentalCategoryError}</div>
+          {experimentalPage && (experimentalSearchActive ? experimentalSearchError : experimentalCategoryError) && (
+            <div className="mb-4 text-xs text-danger">
+              {experimentalSearchActive ? experimentalSearchError : experimentalCategoryError}
+            </div>
           )}
 
           <div className="space-y-5">
@@ -1944,7 +2004,7 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
                   }).map((_, index) => (
                     <div key={`empty-slot-${index}`} className="h-32 invisible" aria-hidden="true" />
                   ))}
-                  {experimentalPage && (cat.fields ?? []).length === 0 && experimentalCategoryLoading !== selectedExperimentalGroup && (
+                  {experimentalPage && (cat.fields ?? []).length === 0 && !experimentalSearchLoading && experimentalCategoryLoading !== selectedExperimentalGroup && (
                     <div className="md:col-span-2 text-sm text-text-muted">No recovered controls match these filters.</div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- restore opt-in **All** category without making it page default
- search every Experimental Lab category regardless of selected category
- keep single-result searches such as **fuel** from crashing
- release as v13.6.1

## Validation
- 778 Pester tests passed
- WebUI production build passed
- full installer build passed