### PR TITLE
Add Hawk as optional PR reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically request Hawk-i5 for optional review on every pull request.
+* @Hawk-i5


### PR DESCRIPTION
## Summary
- automatically request `@Hawk-i5` as a reviewer on every pull request
- keep review optional: main has no required pull-request approvals or CODEOWNER approval gate

## Access
A separate GitHub collaborator invitation grants Hawk-i5 read access, sufficient to review without repository write permission.