### PR TITLE
Finalize v13.6.4 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,9 @@ here cover everything those tags shipped.
 
 ### Changed
 
-- Experimental Lab now uses the current `Bgd.*` names for three travel retry
-  controls renamed by Funcom.
-
-### Fixed
-
-- Restart injection removes stale commands that used the retired `Travel.*`
-  names without deleting their saved `UserEngine.ini` values.
+- Experimental features.
+- One-shot Start/Restart commands return without waiting for an unused Director
+  link lookup after the battlegroup command has completed.
 
 ## [13.6.3] - 2026-08-12
 


### PR DESCRIPTION
## Summary
- keep unconfirmed Experimental changes generic in public release wording
- include the user-visible one-shot restart wait cleanup in v13.6.4 notes

Documentation-only release copy adjustment; no runtime behavior changes.