### PR TITLE
Repair missing Reset Journey starter tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,7 +76,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.6.4"
+      placeholder: "v13.6.5"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.6.5] - 2026-08-12
+
+### Fixed
+
+- Reset Journey recognizes legacy starter-class tags and stops safely before
+  wiping when the tag is missing.
+- Set Starter Class recreates and verifies a missing starter-class tag while
+  the player is offline.
+
 ## [13.6.4] - 2026-08-12
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.6.4'
+$script:DuneToolVersion = '13.6.5'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.6.4',
+    [string]$Version = '13.6.5',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.6.4</Version>
+    <Version>13.6.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.6.4"
+#define MyAppVersion "13.6.5"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/PlayersRead.ps1
+++ b/app/server/lib/PlayersRead.ps1
@@ -796,7 +796,10 @@ FROM (
 WHERE md IS NOT NULL
 UNION ALL
 SELECT 'starter'::text AS kind,
-       fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName' AS val
+       CASE jsonb_typeof(fe.components->'FLevelComponent'->1->'StarterSkillTreeTag')
+           WHEN 'object' THEN fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
+           WHEN 'string' THEN fe.components->'FLevelComponent'->1->>'StarterSkillTreeTag'
+       END AS val
 FROM dune.fgl_entities fe
 JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
 WHERE afe.actor_id = $pawnID::bigint AND afe.slot_name = 'DuneCharacter';

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1428,7 +1428,10 @@ function Invoke-DunePlayerResetJourneyNodes {
     $pawnId = Get-DunePlayerPawnFromAccount -Ip $Ip -AccountId $AccountId
     if ($pawnId -le 0) { return @{ ok = $false; error = "no pawn for account $AccountId." } }
     $starterSql = @"
-SELECT fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName' AS starter_tag
+SELECT CASE jsonb_typeof(fe.components->'FLevelComponent'->1->'StarterSkillTreeTag')
+           WHEN 'object' THEN fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
+           WHEN 'string' THEN fe.components->'FLevelComponent'->1->>'StarterSkillTreeTag'
+       END AS starter_tag
 FROM dune.fgl_entities fe
 JOIN dune.actor_fgl_entities afe ON afe.entity_id=fe.entity_id
 WHERE afe.actor_id=$pawnId::bigint AND afe.slot_name='DuneCharacter'
@@ -1439,6 +1442,9 @@ LIMIT 1;
     $starterRows = @(ConvertTo-DuneRowMaps -Result $starterResult)
     if ($starterRows.Count -ne 1) { return @{ ok = $false; error = 'starter skill tree query returned no result.' } }
     $starterTag = [string]$starterRows[0]['starter_tag']
+    if (-not $starterTag) {
+        return @{ ok = $false; error = 'starter skill tree tag is missing. Use Set Starter Class while the player is offline, then retry Reset Journey.' }
+    }
     if ($starterTag -notmatch '^Skills\.Key\.(.+)1$') {
         return @{ ok = $false; error = "unsupported starter skill tree tag '$starterTag'." }
     }
@@ -2658,6 +2664,8 @@ function Invoke-DunePlayerSetStarterClass {
     param([string]$Ip, [long]$AccountId, [string]$Job)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
     if (-not $Job) { return @{ ok = $false; error = 'job is required.' } }
+    $off = Test-DunePlayerOfflineByAccount -Ip $Ip -AccountId $AccountId
+    if (-not $off.ok) { return @{ ok = $false; error = "Player must be offline to set starter class. $($off.reason)" } }
     _Load-DuneTagsData
     _Load-DuneProgressionNodesCatalog
     if (-not $script:DuneTagsData.jobSkillBlocks.ContainsKey($Job)) {
@@ -2672,7 +2680,10 @@ function Invoke-DunePlayerSetStarterClass {
     if ($pawnID -le 0) { return @{ ok = $false; error = "no pawn for account $AccountId." } }
 
     $oldSql = @"
-SELECT fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName' AS old_tag
+SELECT CASE jsonb_typeof(fe.components->'FLevelComponent'->1->'StarterSkillTreeTag')
+           WHEN 'object' THEN fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
+           WHEN 'string' THEN fe.components->'FLevelComponent'->1->>'StarterSkillTreeTag'
+       END AS old_tag
 FROM dune.fgl_entities fe
 JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
 WHERE afe.actor_id = $pawnID::bigint AND afe.slot_name = 'DuneCharacter'
@@ -2681,7 +2692,7 @@ LIMIT 1;
     $or = Invoke-DuneSqlQuery -Ip $Ip -Sql $oldSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
     $oldTag = ''
     if ($or.ok) {
-        $omaps = ConvertTo-DuneRowMaps -Result $or
+        $omaps = @(ConvertTo-DuneRowMaps -Result $or)
         if ($omaps.Count -ge 1) { $oldTag = [string]$omaps[0]['old_tag'] }
     }
 
@@ -2707,6 +2718,7 @@ LIMIT 1;
     $safeAbKey = ConvertTo-DuneSqlString $newAbilityKey
 
     $sql = @"
+WITH updated AS (
 UPDATE dune.fgl_entities fe
 SET components = jsonb_set(
     jsonb_set(
@@ -2715,8 +2727,8 @@ SET components = jsonb_set(
                 fe.components,
                 ARRAY['FLevelComponent','1','ModuleData'],
                 (fe.components->'FLevelComponent'->1->'ModuleData') - $removeArr),
-            ARRAY['FLevelComponent','1','StarterSkillTreeTag','TagName'],
-            to_jsonb('$safeNewTag'::text)),
+            ARRAY['FLevelComponent','1','StarterSkillTreeTag'],
+            jsonb_build_object('TagName', '$safeNewTag'::text)),
         ARRAY['FLevelComponent','1','ModuleData','$safeNewKey'],
         '{"SkillPointsSpent": 1}'::jsonb,
         true),
@@ -2726,10 +2738,23 @@ SET components = jsonb_set(
 WHERE fe.entity_id = (
     SELECT entity_id FROM dune.actor_fgl_entities
     WHERE actor_id = $pawnID::bigint AND slot_name = 'DuneCharacter'
-);
+)
+RETURNING components
+)
+SELECT CASE jsonb_typeof(components->'FLevelComponent'->1->'StarterSkillTreeTag')
+           WHEN 'object' THEN components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
+           WHEN 'string' THEN components->'FLevelComponent'->1->>'StarterSkillTreeTag'
+       END AS starter_tag
+FROM updated;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $r.ok) { return @{ ok = $false; error = "set starter tag: $($r.error)" } }
+    $updatedRows = @(ConvertTo-DuneRowMaps -Result $r)
+    if ($updatedRows.Count -ne 1) { return @{ ok = $false; error = 'set starter tag updated no matching character.' } }
+    $persistedTag = [string]$updatedRows[0]['starter_tag']
+    if ($persistedTag -ne $newStarterTag) {
+        return @{ ok = $false; error = "set starter tag verification failed: expected '$newStarterTag', found '$persistedTag'." }
+    }
     $msg = "Starter class set to $Job ($newStarterTag + $newAbility active)"
     if ($keysToRemove.Count -gt 0) { $msg += ", cleared previous starter ($($keysToRemove.Count) module(s))" }
     return @{ ok = $true; message = $msg }

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1449,6 +1449,11 @@ LIMIT 1;
         return @{ ok = $false; error = "unsupported starter skill tree tag '$starterTag'." }
     }
     $starterJob = [string]$Matches[1]
+    _Load-DuneProgressionNodesCatalog
+    if (-not $script:DuneProgressionNodesCatalog.starterAbilityByJob.ContainsKey($starterJob)) {
+        return @{ ok = $false; error = "no starter ability mapping for '$starterJob'." }
+    }
+    $starterAbility = [string]$script:DuneProgressionNodesCatalog.starterAbilityByJob[$starterJob]
 
     $wipe = Invoke-DunePlayerWipeJourneyNodes -Ip $Ip -AccountId $AccountId
     if (-not $wipe.ok) { return $wipe }
@@ -1457,8 +1462,16 @@ LIMIT 1;
     if (-not $stillOffline.ok) {
         return @{ ok = $false; error = "Journey was wiped, but starter-tree reset stopped because the player logged in: $($stillOffline.reason)" }
     }
-    $skillReset = Invoke-DunePlayerResetJobSkills -Ip $Ip -AccountId $AccountId -Job $starterJob
+    $skillReset = Invoke-DunePlayerResetJobSkills `
+        -Ip $Ip `
+        -AccountId $AccountId `
+        -Job $starterJob `
+        -PreserveModules @($starterTag, $starterAbility)
     if (-not $skillReset.ok) { return @{ ok = $false; error = "Journey wiped, but $starterJob skill reset failed: $($skillReset.error)" } }
+    $starterRestore = Invoke-DunePlayerSetStarterClass -Ip $Ip -AccountId $AccountId -Job $starterJob
+    if (-not $starterRestore.ok) {
+        return @{ ok = $false; error = "Journey and $starterJob skills were reset, but starter modules could not be restored: $($starterRestore.error)" }
+    }
 
     $charSql = "SELECT id::text AS character_id FROM dune.player_state WHERE account_id=$AccountId::bigint LIMIT 1;"
     $cr = Invoke-DuneSqlQuery -Ip $Ip -Sql $charSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
@@ -1483,6 +1496,7 @@ LIMIT 1;
         npe_marked = $true
         npe_nodes = [int]$npe.nodes_touched
         starter_job_reset = $starterJob
+        starter_modules_restored = $true
         refunded_skill_points = [int]$skillReset.refunded_points
     }
 }
@@ -2303,7 +2317,12 @@ function Invoke-DunePlayerGrantJobSkills {
 }
 
 function Invoke-DunePlayerResetJobSkills {
-    param([string]$Ip, [long]$AccountId, [string]$Job)
+    param(
+        [string]$Ip,
+        [long]$AccountId,
+        [string]$Job,
+        [string[]]$PreserveModules = @()
+    )
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
     if (-not $Job) { return @{ ok = $false; error = 'job is required.' } }
     _Load-DuneTagsData
@@ -2311,7 +2330,21 @@ function Invoke-DunePlayerResetJobSkills {
         return @{ ok = $false; error = "unknown job '$Job' (check dune-tags.json job_all_modules)." }
     }
     $modules = @($script:DuneTagsData.jobAllModules[$Job] | ForEach-Object { [string]$_ })
-    if ($modules.Count -eq 0) { return @{ ok = $false; error = "job '$Job' has no modules listed." } }
+    if ($PreserveModules.Count -gt 0) {
+        $preserved = @{}
+        foreach ($module in $PreserveModules) {
+            if ($module) { $preserved[[string]$module] = $true }
+        }
+        $modules = @($modules | Where-Object { -not $preserved.ContainsKey($_) })
+    }
+    if ($modules.Count -eq 0) {
+        return @{
+            ok = $true
+            message = "Reset $Job skill tree - no purchased modules to remove"
+            modules = 0
+            refunded_points = 0
+        }
+    }
 
     $pawnID = Get-DunePlayerPawnFromAccount -Ip $Ip -AccountId $AccountId
     if ($pawnID -le 0) { return @{ ok = $false; error = "no pawn for account $AccountId." } }

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -2725,7 +2725,7 @@ LIMIT 1;
     $or = Invoke-DuneSqlQuery -Ip $Ip -Sql $oldSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
     $oldTag = ''
     if ($or.ok) {
-        $omaps = @(ConvertTo-DuneRowMaps -Result $or)
+        $omaps = ConvertTo-DuneRowMaps -Result $or
         if ($omaps.Count -ge 1) { $oldTag = [string]$omaps[0]['old_tag'] }
     }
 
@@ -2782,7 +2782,7 @@ SELECT COUNT(*)::int AS updated FROM updated;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $r.ok) { return @{ ok = $false; error = "set starter tag: $($r.error)" } }
-    $updatedRows = @(ConvertTo-DuneRowMaps -Result $r)
+    $updatedRows = ConvertTo-DuneRowMaps -Result $r
     if ($updatedRows.Count -ne 1 -or [int](ConvertTo-DuneInt $updatedRows[0]['updated']) -ne 1) {
         return @{ ok = $false; error = 'set starter tag found no writable FLevelComponent for the character.' }
     }
@@ -2799,7 +2799,7 @@ LIMIT 1;
 "@
     $vr = Invoke-DuneSqlQuery -Ip $Ip -Sql $verifySql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
     if (-not $vr.ok) { return @{ ok = $false; error = "verify starter tag: $($vr.error)" } }
-    $verifiedRows = @(ConvertTo-DuneRowMaps -Result $vr)
+    $verifiedRows = ConvertTo-DuneRowMaps -Result $vr
     $persistedTag = if ($verifiedRows.Count -eq 1) { [string]$verifiedRows[0]['starter_tag'] } else { '' }
     if ($persistedTag -ne $newStarterTag) {
         return @{ ok = $false; error = "set starter tag verification failed: expected '$newStarterTag', found '$persistedTag'." }

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -2759,9 +2759,11 @@ SET components = jsonb_set(
             jsonb_set(
                 fe.components,
                 ARRAY['FLevelComponent','1','ModuleData'],
-                (fe.components->'FLevelComponent'->1->'ModuleData') - $removeArr),
+                COALESCE(fe.components->'FLevelComponent'->1->'ModuleData', '{}'::jsonb) - $removeArr,
+                true),
             ARRAY['FLevelComponent','1','StarterSkillTreeTag'],
-            jsonb_build_object('TagName', '$safeNewTag'::text)),
+            jsonb_build_object('TagName', '$safeNewTag'::text),
+            true),
         ARRAY['FLevelComponent','1','ModuleData','$safeNewKey'],
         '{"SkillPointsSpent": 1}'::jsonb,
         true),
@@ -2772,19 +2774,33 @@ WHERE fe.entity_id = (
     SELECT entity_id FROM dune.actor_fgl_entities
     WHERE actor_id = $pawnID::bigint AND slot_name = 'DuneCharacter'
 )
-RETURNING components
+AND fe.components IS NOT NULL
+AND jsonb_typeof(fe.components->'FLevelComponent'->1) = 'object'
+RETURNING 1
 )
-SELECT CASE jsonb_typeof(components->'FLevelComponent'->1->'StarterSkillTreeTag')
-           WHEN 'object' THEN components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
-           WHEN 'string' THEN components->'FLevelComponent'->1->>'StarterSkillTreeTag'
-       END AS starter_tag
-FROM updated;
+SELECT COUNT(*)::int AS updated FROM updated;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $r.ok) { return @{ ok = $false; error = "set starter tag: $($r.error)" } }
     $updatedRows = @(ConvertTo-DuneRowMaps -Result $r)
-    if ($updatedRows.Count -ne 1) { return @{ ok = $false; error = 'set starter tag updated no matching character.' } }
-    $persistedTag = [string]$updatedRows[0]['starter_tag']
+    if ($updatedRows.Count -ne 1 -or [int](ConvertTo-DuneInt $updatedRows[0]['updated']) -ne 1) {
+        return @{ ok = $false; error = 'set starter tag found no writable FLevelComponent for the character.' }
+    }
+
+    $verifySql = @"
+SELECT CASE jsonb_typeof(fe.components->'FLevelComponent'->1->'StarterSkillTreeTag')
+           WHEN 'object' THEN fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
+           WHEN 'string' THEN fe.components->'FLevelComponent'->1->>'StarterSkillTreeTag'
+       END AS starter_tag
+FROM dune.fgl_entities fe
+JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
+WHERE afe.actor_id = $pawnID::bigint AND afe.slot_name = 'DuneCharacter'
+LIMIT 1;
+"@
+    $vr = Invoke-DuneSqlQuery -Ip $Ip -Sql $verifySql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $vr.ok) { return @{ ok = $false; error = "verify starter tag: $($vr.error)" } }
+    $verifiedRows = @(ConvertTo-DuneRowMaps -Result $vr)
+    $persistedTag = if ($verifiedRows.Count -eq 1) { [string]$verifiedRows[0]['starter_tag'] } else { '' }
     if ($persistedTag -ne $newStarterTag) {
         return @{ ok = $false; error = "set starter tag verification failed: expected '$newStarterTag', found '$persistedTag'." }
     }

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1439,7 +1439,7 @@ LIMIT 1;
 "@
     $starterResult = Invoke-DuneSqlQuery -Ip $Ip -Sql $starterSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
     if (-not $starterResult.ok) { return @{ ok = $false; error = "read starter skill tree: $($starterResult.error)" } }
-    $starterRows = @(ConvertTo-DuneRowMaps -Result $starterResult)
+    $starterRows = ConvertTo-DuneRowMaps -Result $starterResult
     if ($starterRows.Count -ne 1) { return @{ ok = $false; error = 'starter skill tree query returned no result.' } }
     $starterTag = [string]$starterRows[0]['starter_tag']
     if (-not $starterTag) {
@@ -1463,7 +1463,7 @@ LIMIT 1;
     $charSql = "SELECT id::text AS character_id FROM dune.player_state WHERE account_id=$AccountId::bigint LIMIT 1;"
     $cr = Invoke-DuneSqlQuery -Ip $Ip -Sql $charSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
     if (-not $cr.ok) { return @{ ok = $false; error = "Journey wiped, but character lookup failed: $($cr.error)" } }
-    $charRows = @(ConvertTo-DuneRowMaps -Result $cr)
+    $charRows = ConvertTo-DuneRowMaps -Result $cr
     if ($charRows.Count -ne 1) { return @{ ok = $false; error = 'Journey wiped, but character lookup returned no result.' } }
     $characterId = [int64](ConvertTo-DuneInt $charRows[0]['character_id'])
     if ($characterId -le 0) { return @{ ok = $false; error = 'Journey wiped, but character id was invalid.' } }
@@ -1551,7 +1551,7 @@ SELECT
 "@
     $vr = Invoke-DuneSqlQuery -Ip $Ip -Sql $verifySql -ReadOnly $true -MaxRows 1 -TimeoutSec 30
     if (-not $vr.ok) { return @{ ok = $false; error = "wipe journey verification: $($vr.error)" } }
-    $rows = @(ConvertTo-DuneRowMaps -Result $vr)
+    $rows = ConvertTo-DuneRowMaps -Result $vr
     if ($rows.Count -ne 1) { return @{ ok = $false; error = 'wipe journey verification returned no result.' } }
     $journeyRows = [int64](ConvertTo-DuneInt $rows[0]['journey_rows'])
     $storyTags = [int64](ConvertTo-DuneInt $rows[0]['story_tags'])
@@ -2352,7 +2352,7 @@ SELECT refund FROM updated;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $r.ok) { return @{ ok = $false; error = "reset $Job tree: $($r.error)" } }
-    $rows = @(ConvertTo-DuneRowMaps -Result $r)
+    $rows = ConvertTo-DuneRowMaps -Result $r
     if ($rows.Count -ne 1) { return @{ ok = $false; error = "reset $Job tree returned no refund result." } }
     $refund = [int](ConvertTo-DuneInt $rows[0]['refund'])
     return @{

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.6.4"
+$script:ToolVersion = "13.6.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -408,6 +408,7 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
 Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
     BeforeEach {
         $script:starterClassUpdateSql = ''
+        $script:starterClassVerifySql = ''
         $script:DuneTagsData = @{ jobSkillBlocks = @{ Swordmaster = @('Skills.Key.Swordmaster1') } }
         $script:DuneProgressionNodesCatalog = @{
             starterAbilityByJob = @{ Swordmaster = 'Skills.Ability.BattleCry' }
@@ -421,10 +422,15 @@ Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
             param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
             if ($Sql -match 'WITH updated AS') {
                 $script:starterClassUpdateSql = $Sql
+                return @{ ok = $true; maps = @(@{ updated = '1' }) }
+            }
+            if ($Sql -match 'END AS starter_tag') {
+                $script:starterClassVerifySql = $Sql
                 return @{ ok = $true; maps = @(@{ starter_tag = 'Skills.Key.Swordmaster1' }) }
             }
             return @{ ok = $true; maps = @(@{ old_tag = '' }) }
         }
+        function global:ConvertTo-DuneInt { param($Value) return [int64]$Value }
     }
 
     AfterEach {
@@ -435,17 +441,39 @@ Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
         Remove-Item function:global:Test-DunePlayerOfflineByAccount -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DunePlayerPawnFromAccount -ErrorAction SilentlyContinue
         Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+        Remove-Item function:global:ConvertTo-DuneInt -ErrorAction SilentlyContinue
         Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
     }
 
-    It 'recreates a missing starter tag object and verifies the persisted value' {
+    It 'recreates missing ModuleData and verifies the persisted starter tag in a separate read' {
         $r = Invoke-DunePlayerSetStarterClass -Ip '1.2.3.4' -AccountId 605 -Job 'Swordmaster'
 
         $r.ok | Should -BeTrue -Because ([string]$r.error)
         $script:starterClassUpdateSql | Should -Match "ARRAY\['FLevelComponent','1','StarterSkillTreeTag'\]"
         $script:starterClassUpdateSql | Should -Not -Match "ARRAY\['FLevelComponent','1','StarterSkillTreeTag','TagName'\]"
+        $script:starterClassUpdateSql | Should -Match "COALESCE\(fe\.components->'FLevelComponent'->1->'ModuleData', '\{\}'::jsonb\)"
         $script:starterClassUpdateSql | Should -Match "jsonb_build_object\('TagName', 'Skills\.Key\.Swordmaster1'"
-        $script:starterClassUpdateSql | Should -Match 'RETURNING components'
+        $script:starterClassUpdateSql | Should -Match "jsonb_typeof\(fe\.components->'FLevelComponent'->1\) = 'object'"
+        $script:starterClassUpdateSql | Should -Match 'SELECT COUNT\(\*\)::int AS updated FROM updated'
+        $script:starterClassVerifySql | Should -Match 'END AS starter_tag'
+        $script:starterClassVerifySql | Should -Match 'LIMIT 1'
+    }
+
+    It 'fails safely when the character has no writable FLevelComponent' {
+        function global:Invoke-DuneSqlQuery {
+            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
+            if ($Sql -match 'WITH updated AS') {
+                $script:starterClassUpdateSql = $Sql
+                return @{ ok = $true; maps = @(@{ updated = '0' }) }
+            }
+            return @{ ok = $true; maps = @(@{ old_tag = '' }) }
+        }
+
+        $r = Invoke-DunePlayerSetStarterClass -Ip '1.2.3.4' -AccountId 605 -Job 'Swordmaster'
+
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'no writable FLevelComponent'
+        $script:starterClassVerifySql | Should -BeNullOrEmpty
     }
 
     It 'refuses to change the starter class while the player is online' {

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -313,6 +313,7 @@ Describe 'Invoke-DunePlayerWipeJourneyNodes' -Tag 'Pure' {
 Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
     BeforeEach {
         $script:resetJob = ''
+        $script:wipeCalls = 0
         $script:originalWipeJourney = (Get-Command Invoke-DunePlayerWipeJourneyNodes).ScriptBlock
         $script:originalResetJob = (Get-Command Invoke-DunePlayerResetJobSkills).ScriptBlock
         $script:originalMarkNpe = (Get-Command Invoke-DunePlayerMarkNpeCompleted).ScriptBlock
@@ -322,7 +323,10 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
         function global:Invoke-DuneSqlQuery {
             return @{ ok = $true; maps = @(@{ starter_tag = 'Skills.Key.Swordmaster1'; character_id = '8' }) }
         }
-        function global:Invoke-DunePlayerWipeJourneyNodes { return @{ ok = $true } }
+        function global:Invoke-DunePlayerWipeJourneyNodes {
+            $script:wipeCalls++
+            return @{ ok = $true }
+        }
         function global:Invoke-DunePlayerResetJobSkills {
             param($Ip, $AccountId, $Job)
             $script:resetJob = $Job
@@ -351,6 +355,20 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
         $r.npe_marked | Should -BeTrue
         $r.npe_nodes | Should -Be 153
         $r.message | Should -Match 'Find the Fremen'
+        $script:wipeCalls | Should -Be 1
+    }
+
+    It 'stops before the wipe and directs missing starter tags to Set Starter Class' {
+        function global:Invoke-DuneSqlQuery {
+            return @{ ok = $true; maps = @(@{ starter_tag = ''; character_id = '8' }) }
+        }
+
+        $r = Invoke-DunePlayerResetJourneyNodes -Ip '1.2.3.4' -AccountId 605
+
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'starter skill tree tag is missing'
+        $r.error | Should -Match 'Set Starter Class'
+        $script:wipeCalls | Should -Be 0
     }
 
     It 'stops after the wipe if the player logs in before starter-tree reset' {
@@ -361,6 +379,60 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
         $r.ok | Should -BeFalse
         $r.error | Should -Match 'starter-tree reset stopped'
         $script:resetJob | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
+    BeforeEach {
+        $script:starterClassUpdateSql = ''
+        $script:DuneTagsData = @{ jobSkillBlocks = @{ Swordmaster = @('Skills.Key.Swordmaster1') } }
+        $script:DuneProgressionNodesCatalog = @{
+            starterAbilityByJob = @{ Swordmaster = 'Skills.Ability.BattleCry' }
+        }
+        function global:_Load-DuneTagsData {}
+        function global:_Load-DuneProgressionNodesCatalog {}
+        function global:Test-DunePlayerOfflineByAccount { return @{ ok = $true; reason = $null } }
+        function global:Get-DunePlayerPawnFromAccount { return 3946L }
+        function global:ConvertTo-DuneRowMaps { param($Result) return @($Result.maps) }
+        function global:Invoke-DuneSqlQuery {
+            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
+            if ($Sql -match 'WITH updated AS') {
+                $script:starterClassUpdateSql = $Sql
+                return @{ ok = $true; maps = @(@{ starter_tag = 'Skills.Key.Swordmaster1' }) }
+            }
+            return @{ ok = $true; maps = @(@{ old_tag = '' }) }
+        }
+    }
+
+    AfterEach {
+        $script:DuneTagsData = $null
+        $script:DuneProgressionNodesCatalog = $null
+        Remove-Item function:global:_Load-DuneTagsData -ErrorAction SilentlyContinue
+        Remove-Item function:global:_Load-DuneProgressionNodesCatalog -ErrorAction SilentlyContinue
+        Remove-Item function:global:Test-DunePlayerOfflineByAccount -ErrorAction SilentlyContinue
+        Remove-Item function:global:Get-DunePlayerPawnFromAccount -ErrorAction SilentlyContinue
+        Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+    }
+
+    It 'recreates a missing starter tag object and verifies the persisted value' {
+        $r = Invoke-DunePlayerSetStarterClass -Ip '1.2.3.4' -AccountId 605 -Job 'Swordmaster'
+
+        $r.ok | Should -BeTrue -Because ([string]$r.error)
+        $script:starterClassUpdateSql | Should -Match "ARRAY\['FLevelComponent','1','StarterSkillTreeTag'\]"
+        $script:starterClassUpdateSql | Should -Not -Match "ARRAY\['FLevelComponent','1','StarterSkillTreeTag','TagName'\]"
+        $script:starterClassUpdateSql | Should -Match "jsonb_build_object\('TagName', 'Skills\.Key\.Swordmaster1'"
+        $script:starterClassUpdateSql | Should -Match 'RETURNING components'
+    }
+
+    It 'refuses to change the starter class while the player is online' {
+        Mock Test-DunePlayerOfflineByAccount { return @{ ok = $false; reason = 'player is Online' } }
+
+        $r = Invoke-DunePlayerSetStarterClass -Ip '1.2.3.4' -AccountId 605 -Job 'Swordmaster'
+
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'must be offline'
+        $script:starterClassUpdateSql | Should -BeNullOrEmpty
     }
 }
 

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -308,11 +308,18 @@ Describe 'Invoke-DunePlayerWipeJourneyNodes' -Tag 'Pure' {
 Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
     BeforeEach {
         $script:resetJob = ''
+        $script:preservedModules = @()
+        $script:restoredStarterJob = ''
         $script:wipeCalls = 0
         $script:originalWipeJourney = (Get-Command Invoke-DunePlayerWipeJourneyNodes).ScriptBlock
         $script:originalResetJob = (Get-Command Invoke-DunePlayerResetJobSkills).ScriptBlock
         $script:originalMarkNpe = (Get-Command Invoke-DunePlayerMarkNpeCompleted).ScriptBlock
+        $script:originalSetStarter = (Get-Command Invoke-DunePlayerSetStarterClass).ScriptBlock
+        $script:DuneProgressionNodesCatalog = @{
+            starterAbilityByJob = @{ Swordmaster = 'Skills.Ability.BattleCry' }
+        }
         Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
+        function global:_Load-DuneProgressionNodesCatalog {}
         function global:Test-DunePlayerOfflineByAccount { return @{ ok = $true; reason = $null } }
         function global:Get-DunePlayerPawnFromAccount { return 3946L }
         function global:Invoke-DuneSqlQuery {
@@ -327,9 +334,15 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
             return @{ ok = $true }
         }
         function global:Invoke-DunePlayerResetJobSkills {
-            param($Ip, $AccountId, $Job)
+            param($Ip, $AccountId, $Job, $PreserveModules)
             $script:resetJob = $Job
-            return @{ ok = $true; refunded_points = 186 }
+            $script:preservedModules = @($PreserveModules)
+            return @{ ok = $true; refunded_points = 184 }
+        }
+        function global:Invoke-DunePlayerSetStarterClass {
+            param($Ip, $AccountId, $Job)
+            $script:restoredStarterJob = $Job
+            return @{ ok = $true }
         }
         function global:Invoke-DunePlayerMarkNpeCompleted { return @{ ok = $true; nodes_touched = 153 } }
     }
@@ -338,6 +351,9 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
         Set-Item function:global:Invoke-DunePlayerWipeJourneyNodes $script:originalWipeJourney
         Set-Item function:global:Invoke-DunePlayerResetJobSkills $script:originalResetJob
         Set-Item function:global:Invoke-DunePlayerMarkNpeCompleted $script:originalMarkNpe
+        Set-Item function:global:Invoke-DunePlayerSetStarterClass $script:originalSetStarter
+        $script:DuneProgressionNodesCatalog = $null
+        Remove-Item function:global:_Load-DuneProgressionNodesCatalog -ErrorAction SilentlyContinue
         Remove-Item function:global:Test-DunePlayerOfflineByAccount -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DunePlayerPawnFromAccount -ErrorAction SilentlyContinue
         Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
@@ -349,8 +365,12 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
 
         $r.ok | Should -BeTrue -Because ([string]$r.error)
         $script:resetJob | Should -Be 'Swordmaster'
+        $script:preservedModules | Should -Contain 'Skills.Key.Swordmaster1'
+        $script:preservedModules | Should -Contain 'Skills.Ability.BattleCry'
+        $script:restoredStarterJob | Should -Be 'Swordmaster'
         $r.starter_job_reset | Should -Be 'Swordmaster'
-        $r.refunded_skill_points | Should -Be 186
+        $r.starter_modules_restored | Should -BeTrue
+        $r.refunded_skill_points | Should -Be 184
         $r.npe_marked | Should -BeTrue
         $r.npe_nodes | Should -Be 153
         $r.message | Should -Match 'Find the Fremen'
@@ -472,6 +492,25 @@ Describe 'Invoke-DunePlayerResetJobSkills refund' -Tag 'Pure' {
         $script:resetJobSql | Should -Match 'SkillPointsSpent'
         $script:resetJobSql | Should -Match 'UnspentSkillPoints'
         $r.refunded_points | Should -Be 16
+    }
+
+    It 'preserves requested starter modules while resetting purchased progression' {
+        $script:DuneTagsData.jobAllModules.Swordmaster = @(
+            'Skills.Ability.BattleCry',
+            'Skills.Key.Swordmaster1',
+            'Skills.Passive.SwordmasterTest'
+        )
+
+        $r = Invoke-DunePlayerResetJobSkills `
+            -Ip '1.2.3.4' `
+            -AccountId 605 `
+            -Job 'Swordmaster' `
+            -PreserveModules @('Skills.Ability.BattleCry', 'Skills.Key.Swordmaster1')
+
+        $r.ok | Should -BeTrue -Because ([string]$r.error)
+        $script:resetJobSql | Should -Match 'Skills\.Passive\.SwordmasterTest'
+        $script:resetJobSql | Should -Not -Match 'Skills\.Ability\.BattleCry'
+        $script:resetJobSql | Should -Not -Match 'Skills\.Key\.Swordmaster1'
     }
 }
 

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -3,8 +3,10 @@
 
 BeforeAll {
     . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'Gameplay.ps1'
     Import-DstLib 'GameplayPlayers.ps1'
     Import-DstLib 'PlayersWrites.ps1'
+    $script:realRowMaps = (Get-Command ConvertTo-DuneRowMaps).ScriptBlock
 }
 
 Describe 'ConvertTo-DuneSqlString' -Tag 'Pure' {
@@ -226,16 +228,9 @@ Describe 'Invoke-DunePlayerMaxAugmentAttributes' -Tag 'Pure' {
 Describe 'Invoke-DunePlayerWipeJourneyNodes' -Tag 'Pure' {
     BeforeEach {
         $script:capturedSql = New-Object System.Collections.Generic.List[string]
+        Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
         function global:Test-DunePlayerOfflineByAccount { return @{ ok = $true; reason = $null } }
         function global:Get-DunePlayerPawnFromAccount { return 3946L }
-        function global:ConvertTo-DuneRowMaps {
-            param($Result)
-            return @(@{
-                journey_rows = $Result.rows[0][0]
-                story_tags = $Result.rows[0][1]
-                contract_items = $Result.rows[0][2]
-            })
-        }
         function global:ConvertTo-DuneInt { param($Value) return [int64]$Value }
         function global:Invoke-DuneSqlQuery {
             param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
@@ -254,7 +249,7 @@ Describe 'Invoke-DunePlayerWipeJourneyNodes' -Tag 'Pure' {
     AfterEach {
         Remove-Item function:global:Test-DunePlayerOfflineByAccount -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DunePlayerPawnFromAccount -ErrorAction SilentlyContinue
-        Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+        Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
         Remove-Item function:global:ConvertTo-DuneInt -ErrorAction SilentlyContinue
         Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
     }
@@ -317,11 +312,15 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
         $script:originalWipeJourney = (Get-Command Invoke-DunePlayerWipeJourneyNodes).ScriptBlock
         $script:originalResetJob = (Get-Command Invoke-DunePlayerResetJobSkills).ScriptBlock
         $script:originalMarkNpe = (Get-Command Invoke-DunePlayerMarkNpeCompleted).ScriptBlock
+        Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
         function global:Test-DunePlayerOfflineByAccount { return @{ ok = $true; reason = $null } }
         function global:Get-DunePlayerPawnFromAccount { return 3946L }
-        function global:ConvertTo-DuneRowMaps { param($Result) return @($Result.maps) }
         function global:Invoke-DuneSqlQuery {
-            return @{ ok = $true; maps = @(@{ starter_tag = 'Skills.Key.Swordmaster1'; character_id = '8' }) }
+            return @{
+                ok = $true
+                columns = @('starter_tag', 'character_id')
+                rows = ,@('Skills.Key.Swordmaster1', '8')
+            }
         }
         function global:Invoke-DunePlayerWipeJourneyNodes {
             $script:wipeCalls++
@@ -341,7 +340,7 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
         Set-Item function:global:Invoke-DunePlayerMarkNpeCompleted $script:originalMarkNpe
         Remove-Item function:global:Test-DunePlayerOfflineByAccount -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DunePlayerPawnFromAccount -ErrorAction SilentlyContinue
-        Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+        Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
         Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
     }
 
@@ -360,7 +359,11 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
 
     It 'stops before the wipe and directs missing starter tags to Set Starter Class' {
         function global:Invoke-DuneSqlQuery {
-            return @{ ok = $true; maps = @(@{ starter_tag = ''; character_id = '8' }) }
+            return @{
+                ok = $true
+                columns = @('starter_tag', 'character_id')
+                rows = ,@('', '8')
+            }
         }
 
         $r = Invoke-DunePlayerResetJourneyNodes -Ip '1.2.3.4' -AccountId 605
@@ -440,21 +443,21 @@ Describe 'Invoke-DunePlayerResetJobSkills refund' -Tag 'Pure' {
     BeforeEach {
         $script:DuneTagsData = @{ jobAllModules = @{ Swordmaster = @('Skills.Ability.BattleCry', 'Skills.Key.Swordmaster1') } }
         $script:resetJobSql = ''
+        Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
         function global:_Load-DuneTagsData {}
         function global:Get-DunePlayerPawnFromAccount { return 3946L }
-        function global:ConvertTo-DuneRowMaps { param($Result) return @($Result.maps) }
         function global:ConvertTo-DuneInt { param($Value) return [int64]$Value }
         function global:Invoke-DuneSqlQuery {
             param($Ip, $Sql)
             $script:resetJobSql = $Sql
-            return @{ ok = $true; maps = @(@{ refund = '16' }) }
+            return @{ ok = $true; columns = @('refund'); rows = ,@('16') }
         }
     }
 
     AfterEach {
         Remove-Item function:global:_Load-DuneTagsData -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DunePlayerPawnFromAccount -ErrorAction SilentlyContinue
-        Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+        Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
         Remove-Item function:global:ConvertTo-DuneInt -ErrorAction SilentlyContinue
         Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
     }

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
     Import-DstLib 'GameplayPlayers.ps1'
     Import-DstLib 'PlayersWrites.ps1'
     $script:realRowMaps = (Get-Command ConvertTo-DuneRowMaps).ScriptBlock
+    $script:realDuneInt = (Get-Command ConvertTo-DuneInt).ScriptBlock
 }
 
 Describe 'ConvertTo-DuneSqlString' -Tag 'Pure' {
@@ -417,20 +418,20 @@ Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
         function global:_Load-DuneProgressionNodesCatalog {}
         function global:Test-DunePlayerOfflineByAccount { return @{ ok = $true; reason = $null } }
         function global:Get-DunePlayerPawnFromAccount { return 3946L }
-        function global:ConvertTo-DuneRowMaps { param($Result) return @($Result.maps) }
+        Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
+        Set-Item function:global:ConvertTo-DuneInt $script:realDuneInt
         function global:Invoke-DuneSqlQuery {
             param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
             if ($Sql -match 'WITH updated AS') {
                 $script:starterClassUpdateSql = $Sql
-                return @{ ok = $true; maps = @(@{ updated = '1' }) }
+                return @{ ok = $true; columns = @('updated'); rows = @(,@('1')) }
             }
             if ($Sql -match 'END AS starter_tag') {
                 $script:starterClassVerifySql = $Sql
-                return @{ ok = $true; maps = @(@{ starter_tag = 'Skills.Key.Swordmaster1' }) }
+                return @{ ok = $true; columns = @('starter_tag'); rows = @(,@('Skills.Key.Swordmaster1')) }
             }
-            return @{ ok = $true; maps = @(@{ old_tag = '' }) }
+            return @{ ok = $true; columns = @('old_tag'); rows = @(,@('')) }
         }
-        function global:ConvertTo-DuneInt { param($Value) return [int64]$Value }
     }
 
     AfterEach {
@@ -440,12 +441,10 @@ Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
         Remove-Item function:global:_Load-DuneProgressionNodesCatalog -ErrorAction SilentlyContinue
         Remove-Item function:global:Test-DunePlayerOfflineByAccount -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DunePlayerPawnFromAccount -ErrorAction SilentlyContinue
-        Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
-        Remove-Item function:global:ConvertTo-DuneInt -ErrorAction SilentlyContinue
         Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
     }
 
-    It 'recreates missing ModuleData and verifies the persisted starter tag in a separate read' {
+    It 'handles the real row-map array shape while recreating and verifying the starter tag' {
         $r = Invoke-DunePlayerSetStarterClass -Ip '1.2.3.4' -AccountId 605 -Job 'Swordmaster'
 
         $r.ok | Should -BeTrue -Because ([string]$r.error)
@@ -464,9 +463,9 @@ Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
             param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
             if ($Sql -match 'WITH updated AS') {
                 $script:starterClassUpdateSql = $Sql
-                return @{ ok = $true; maps = @(@{ updated = '0' }) }
+                return @{ ok = $true; columns = @('updated'); rows = @(,@('0')) }
             }
-            return @{ ok = $true; maps = @(@{ old_tag = '' }) }
+            return @{ ok = $true; columns = @('old_tag'); rows = @(,@('')) }
         }
 
         $r = Invoke-DunePlayerSetStarterClass -Ip '1.2.3.4' -AccountId 605 -Job 'Swordmaster'


### PR DESCRIPTION
## Summary
- read legacy string and current object starter-class tag shapes
- stop Reset Journey before wiping when the starter tag is missing
- make Set Starter Class offline-only, recreate the missing tag object, and verify persistence

## Validation
- 60 focused PlayersWrites Pester tests
- full installer build including PowerShell 5.1 parse and UTF-8 BOM preflight

Reporter-specific test branch. Do not merge until field confirmation.