### PR TITLE
Prevent Set Starter Class from nulling missing module data

### DIFF
--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -2725,7 +2725,7 @@ LIMIT 1;
     $or = Invoke-DuneSqlQuery -Ip $Ip -Sql $oldSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
     $oldTag = ''
     if ($or.ok) {
-        $omaps = @(ConvertTo-DuneRowMaps -Result $or)
+        $omaps = ConvertTo-DuneRowMaps -Result $or
         if ($omaps.Count -ge 1) { $oldTag = [string]$omaps[0]['old_tag'] }
     }
 
@@ -2782,7 +2782,7 @@ SELECT COUNT(*)::int AS updated FROM updated;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $r.ok) { return @{ ok = $false; error = "set starter tag: $($r.error)" } }
-    $updatedRows = @(ConvertTo-DuneRowMaps -Result $r)
+    $updatedRows = ConvertTo-DuneRowMaps -Result $r
     if ($updatedRows.Count -ne 1 -or [int](ConvertTo-DuneInt $updatedRows[0]['updated']) -ne 1) {
         return @{ ok = $false; error = 'set starter tag found no writable FLevelComponent for the character.' }
     }
@@ -2799,7 +2799,7 @@ LIMIT 1;
 "@
     $vr = Invoke-DuneSqlQuery -Ip $Ip -Sql $verifySql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
     if (-not $vr.ok) { return @{ ok = $false; error = "verify starter tag: $($vr.error)" } }
-    $verifiedRows = @(ConvertTo-DuneRowMaps -Result $vr)
+    $verifiedRows = ConvertTo-DuneRowMaps -Result $vr
     $persistedTag = if ($verifiedRows.Count -eq 1) { [string]$verifiedRows[0]['starter_tag'] } else { '' }
     if ($persistedTag -ne $newStarterTag) {
         return @{ ok = $false; error = "set starter tag verification failed: expected '$newStarterTag', found '$persistedTag'." }

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -2759,9 +2759,11 @@ SET components = jsonb_set(
             jsonb_set(
                 fe.components,
                 ARRAY['FLevelComponent','1','ModuleData'],
-                (fe.components->'FLevelComponent'->1->'ModuleData') - $removeArr),
+                COALESCE(fe.components->'FLevelComponent'->1->'ModuleData', '{}'::jsonb) - $removeArr,
+                true),
             ARRAY['FLevelComponent','1','StarterSkillTreeTag'],
-            jsonb_build_object('TagName', '$safeNewTag'::text)),
+            jsonb_build_object('TagName', '$safeNewTag'::text),
+            true),
         ARRAY['FLevelComponent','1','ModuleData','$safeNewKey'],
         '{"SkillPointsSpent": 1}'::jsonb,
         true),
@@ -2772,19 +2774,33 @@ WHERE fe.entity_id = (
     SELECT entity_id FROM dune.actor_fgl_entities
     WHERE actor_id = $pawnID::bigint AND slot_name = 'DuneCharacter'
 )
-RETURNING components
+AND fe.components IS NOT NULL
+AND jsonb_typeof(fe.components->'FLevelComponent'->1) = 'object'
+RETURNING 1
 )
-SELECT CASE jsonb_typeof(components->'FLevelComponent'->1->'StarterSkillTreeTag')
-           WHEN 'object' THEN components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
-           WHEN 'string' THEN components->'FLevelComponent'->1->>'StarterSkillTreeTag'
-       END AS starter_tag
-FROM updated;
+SELECT COUNT(*)::int AS updated FROM updated;
 "@
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $r.ok) { return @{ ok = $false; error = "set starter tag: $($r.error)" } }
     $updatedRows = @(ConvertTo-DuneRowMaps -Result $r)
-    if ($updatedRows.Count -ne 1) { return @{ ok = $false; error = 'set starter tag updated no matching character.' } }
-    $persistedTag = [string]$updatedRows[0]['starter_tag']
+    if ($updatedRows.Count -ne 1 -or [int](ConvertTo-DuneInt $updatedRows[0]['updated']) -ne 1) {
+        return @{ ok = $false; error = 'set starter tag found no writable FLevelComponent for the character.' }
+    }
+
+    $verifySql = @"
+SELECT CASE jsonb_typeof(fe.components->'FLevelComponent'->1->'StarterSkillTreeTag')
+           WHEN 'object' THEN fe.components->'FLevelComponent'->1->'StarterSkillTreeTag'->>'TagName'
+           WHEN 'string' THEN fe.components->'FLevelComponent'->1->>'StarterSkillTreeTag'
+       END AS starter_tag
+FROM dune.fgl_entities fe
+JOIN dune.actor_fgl_entities afe ON afe.entity_id = fe.entity_id
+WHERE afe.actor_id = $pawnID::bigint AND afe.slot_name = 'DuneCharacter'
+LIMIT 1;
+"@
+    $vr = Invoke-DuneSqlQuery -Ip $Ip -Sql $verifySql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $vr.ok) { return @{ ok = $false; error = "verify starter tag: $($vr.error)" } }
+    $verifiedRows = @(ConvertTo-DuneRowMaps -Result $vr)
+    $persistedTag = if ($verifiedRows.Count -eq 1) { [string]$verifiedRows[0]['starter_tag'] } else { '' }
     if ($persistedTag -ne $newStarterTag) {
         return @{ ok = $false; error = "set starter tag verification failed: expected '$newStarterTag', found '$persistedTag'." }
     }

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -408,6 +408,7 @@ Describe 'Invoke-DunePlayerResetJourneyNodes orchestration' -Tag 'Pure' {
 Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
     BeforeEach {
         $script:starterClassUpdateSql = ''
+        $script:starterClassVerifySql = ''
         $script:DuneTagsData = @{ jobSkillBlocks = @{ Swordmaster = @('Skills.Key.Swordmaster1') } }
         $script:DuneProgressionNodesCatalog = @{
             starterAbilityByJob = @{ Swordmaster = 'Skills.Ability.BattleCry' }
@@ -421,10 +422,15 @@ Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
             param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
             if ($Sql -match 'WITH updated AS') {
                 $script:starterClassUpdateSql = $Sql
+                return @{ ok = $true; maps = @(@{ updated = '1' }) }
+            }
+            if ($Sql -match 'END AS starter_tag') {
+                $script:starterClassVerifySql = $Sql
                 return @{ ok = $true; maps = @(@{ starter_tag = 'Skills.Key.Swordmaster1' }) }
             }
             return @{ ok = $true; maps = @(@{ old_tag = '' }) }
         }
+        function global:ConvertTo-DuneInt { param($Value) return [int64]$Value }
     }
 
     AfterEach {
@@ -435,17 +441,39 @@ Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
         Remove-Item function:global:Test-DunePlayerOfflineByAccount -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DunePlayerPawnFromAccount -ErrorAction SilentlyContinue
         Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+        Remove-Item function:global:ConvertTo-DuneInt -ErrorAction SilentlyContinue
         Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
     }
 
-    It 'recreates a missing starter tag object and verifies the persisted value' {
+    It 'recreates missing ModuleData and verifies the persisted starter tag in a separate read' {
         $r = Invoke-DunePlayerSetStarterClass -Ip '1.2.3.4' -AccountId 605 -Job 'Swordmaster'
 
         $r.ok | Should -BeTrue -Because ([string]$r.error)
         $script:starterClassUpdateSql | Should -Match "ARRAY\['FLevelComponent','1','StarterSkillTreeTag'\]"
         $script:starterClassUpdateSql | Should -Not -Match "ARRAY\['FLevelComponent','1','StarterSkillTreeTag','TagName'\]"
+        $script:starterClassUpdateSql | Should -Match "COALESCE\(fe\.components->'FLevelComponent'->1->'ModuleData', '\{\}'::jsonb\)"
         $script:starterClassUpdateSql | Should -Match "jsonb_build_object\('TagName', 'Skills\.Key\.Swordmaster1'"
-        $script:starterClassUpdateSql | Should -Match 'RETURNING components'
+        $script:starterClassUpdateSql | Should -Match "jsonb_typeof\(fe\.components->'FLevelComponent'->1\) = 'object'"
+        $script:starterClassUpdateSql | Should -Match 'SELECT COUNT\(\*\)::int AS updated FROM updated'
+        $script:starterClassVerifySql | Should -Match 'END AS starter_tag'
+        $script:starterClassVerifySql | Should -Match 'LIMIT 1'
+    }
+
+    It 'fails safely when the character has no writable FLevelComponent' {
+        function global:Invoke-DuneSqlQuery {
+            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
+            if ($Sql -match 'WITH updated AS') {
+                $script:starterClassUpdateSql = $Sql
+                return @{ ok = $true; maps = @(@{ updated = '0' }) }
+            }
+            return @{ ok = $true; maps = @(@{ old_tag = '' }) }
+        }
+
+        $r = Invoke-DunePlayerSetStarterClass -Ip '1.2.3.4' -AccountId 605 -Job 'Swordmaster'
+
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'no writable FLevelComponent'
+        $script:starterClassVerifySql | Should -BeNullOrEmpty
     }
 
     It 'refuses to change the starter class while the player is online' {

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
     Import-DstLib 'GameplayPlayers.ps1'
     Import-DstLib 'PlayersWrites.ps1'
     $script:realRowMaps = (Get-Command ConvertTo-DuneRowMaps).ScriptBlock
+    $script:realDuneInt = (Get-Command ConvertTo-DuneInt).ScriptBlock
 }
 
 Describe 'ConvertTo-DuneSqlString' -Tag 'Pure' {
@@ -417,20 +418,20 @@ Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
         function global:_Load-DuneProgressionNodesCatalog {}
         function global:Test-DunePlayerOfflineByAccount { return @{ ok = $true; reason = $null } }
         function global:Get-DunePlayerPawnFromAccount { return 3946L }
-        function global:ConvertTo-DuneRowMaps { param($Result) return @($Result.maps) }
+        Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
+        Set-Item function:global:ConvertTo-DuneInt $script:realDuneInt
         function global:Invoke-DuneSqlQuery {
             param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
             if ($Sql -match 'WITH updated AS') {
                 $script:starterClassUpdateSql = $Sql
-                return @{ ok = $true; maps = @(@{ updated = '1' }) }
+                return @{ ok = $true; columns = @('updated'); rows = @(,@('1')) }
             }
             if ($Sql -match 'END AS starter_tag') {
                 $script:starterClassVerifySql = $Sql
-                return @{ ok = $true; maps = @(@{ starter_tag = 'Skills.Key.Swordmaster1' }) }
+                return @{ ok = $true; columns = @('starter_tag'); rows = @(,@('Skills.Key.Swordmaster1')) }
             }
-            return @{ ok = $true; maps = @(@{ old_tag = '' }) }
+            return @{ ok = $true; columns = @('old_tag'); rows = @(,@('')) }
         }
-        function global:ConvertTo-DuneInt { param($Value) return [int64]$Value }
     }
 
     AfterEach {
@@ -440,12 +441,10 @@ Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
         Remove-Item function:global:_Load-DuneProgressionNodesCatalog -ErrorAction SilentlyContinue
         Remove-Item function:global:Test-DunePlayerOfflineByAccount -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DunePlayerPawnFromAccount -ErrorAction SilentlyContinue
-        Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
-        Remove-Item function:global:ConvertTo-DuneInt -ErrorAction SilentlyContinue
         Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
     }
 
-    It 'recreates missing ModuleData and verifies the persisted starter tag in a separate read' {
+    It 'handles the real row-map array shape while recreating and verifying the starter tag' {
         $r = Invoke-DunePlayerSetStarterClass -Ip '1.2.3.4' -AccountId 605 -Job 'Swordmaster'
 
         $r.ok | Should -BeTrue -Because ([string]$r.error)
@@ -464,9 +463,9 @@ Describe 'Invoke-DunePlayerSetStarterClass persistence' -Tag 'Pure' {
             param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
             if ($Sql -match 'WITH updated AS') {
                 $script:starterClassUpdateSql = $Sql
-                return @{ ok = $true; maps = @(@{ updated = '0' }) }
+                return @{ ok = $true; columns = @('updated'); rows = @(,@('0')) }
             }
-            return @{ ok = $true; maps = @(@{ old_tag = '' }) }
+            return @{ ok = $true; columns = @('old_tag'); rows = @(,@('')) }
         }
 
         $r = Invoke-DunePlayerSetStarterClass -Ip '1.2.3.4' -AccountId 605 -Job 'Swordmaster'


### PR DESCRIPTION
## Summary
- Read Set Starter Class query results without wrapping `ConvertTo-DuneRowMaps` a second time.
- Initialize absent `FLevelComponent[1].ModuleData` as an empty JSON object before adding starter modules.
- Refuse malformed or null component rows instead of allowing nested `jsonb_set` calls to produce SQL NULL.
- Verify the committed starter tag with a separate read after the update.

## Root cause
The test4 write persisted `StarterSkillTreeTag` correctly, but verification wrapped the already collection-preserving `ConvertTo-DuneRowMaps` result in `@()`. That made row zero an inner `Object[]`; string-key lookup returned null and produced a false failure.

A second destructive edge case existed for damaged shapes with no `ModuleData`: subtracting keys from the missing value returns SQL NULL, which can propagate through nested `jsonb_set` and null the nullable `components` column. The update now coalesces missing `ModuleData` and rejects malformed component roots.

## Validation
- `tests/PlayersWrites.Tests.ps1`: 61 passed, including real `ConvertTo-DuneRowMaps` return-shape coverage
- Full `app/installer/Build-Installer.ps1` build completed
- Read-only PostgreSQL projection confirmed the missing-field repair retains components and creates the tag plus starter modules