### PR TITLE
Restore player base cistern fill with safe restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- Players → Server Overview can fill every small, medium, and large cistern
+  across one selected player's owned bases. DST creates a safety backup, stops
+  the battlegroup so live map state cannot overwrite the database, fills and
+  verifies the exact cistern classes, then starts the battlegroup again.
+  Windtraps and blood-water extractors are excluded.
+
 ## [13.6.5] - 2026-08-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -364,6 +364,11 @@ browser and keeps the server running in the background.
   ![Players → Landsraad](docs/img/gameplay-landsraad.png)
 - **Per-item water editor** on Players → Inventory for water containers
   (literjons / canteens).
+- **Fill Base Water** on Players → Server Overview fills every small, medium,
+  and large cistern across one selected player's owned bases. It creates a
+  safety backup, stops the battlegroup, fills and verifies the cisterns, then
+  starts the battlegroup again; windtraps and blood-water extractors are
+  intentionally excluded.
 - **Per-field "Default" button** on every Game Config setting — resetting
   *removes* the key from the INI instead of writing the default, keeping files
   clean. The "apply to my client" flow shows an **Add / Update / Remove** badge

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -337,22 +337,260 @@ function Invoke-DunePlayerGiveScrip {
     }
 }
 
-# ----- Base water removed -------------------------------------------------
+# ----- Base water ---------------------------------------------------------
 #
-# Fill Base Water was investigated for v12.1.2 and removed before release.
-# The map pod loads cistern water into RAM on cistern spawn and writes back
-# to dune.fgl_entities.components on its periodic save tick, which means
-# any DB UPDATE we make to FWaterStorageComponent.m_WaterStored gets
-# overwritten before a player ever sees it. We verified end-to-end against
-# the live VM: drained four cisterns to 250-331, ran the DB UPDATE to
-# 100000, restarted the deepdesert pod, and the pod wrote the old in-RAM
-# values straight back to the DB on shutdown. The legacy RMQ
-# UpdateAllWaterFillables ServerCommand only refills carried fillables
-# (Decker's original complaint), so there is no working path today.
+# Cisterns are map-owned world entities. A write made while a map pod is live
+# gets overwritten when that pod next saves or shuts down. The durable sequence
+# is therefore backup -> stop BG -> write -> verify -> start BG. This was
+# field-proven against the in-game cistern UI.
 #
-# Leaving the placeable->totem->permission_actor_rank chain notes here for
-# the next attempt: if a future game build exposes a per-cistern RPC, the
-# scope query is permission_actor_rank.player_id=<controller> AND rank=1.
+# Scope is one selected player's rank-1-owned totems. Match the three exact
+# cistern classes because blood-water extractors and windtraps also carry an
+# FWaterStorageComponent but must not be filled by this action.
+
+$script:DuneBaseWaterFillRunning = $false
+
+function New-DunePlayerBaseCisternCteSql {
+    param([long]$ControllerId)
+    if ($ControllerId -le 0) { throw 'controller_id is required.' }
+
+    return @"
+WITH player_totems AS (
+  SELECT permission_actor_id AS totem_id
+  FROM dune.permission_actor_rank
+  WHERE player_id = $ControllerId::bigint
+    AND rank = 1
+),
+player_cisterns AS (
+  SELECT DISTINCT
+         a.id AS actor_id,
+         a.class,
+         afe.entity_id,
+         CASE a.class
+           WHEN '/Game/Dune/Systems/Building/Pieces/BP_WaterCistern.BP_WaterCistern_C' THEN 5000
+           WHEN '/Game/Dune/Systems/Building/Pieces/BP_MediumWaterCistern.BP_MediumWaterCistern_C' THEN 25000
+           WHEN '/Game/Dune/Systems/Building/Pieces/BP_LargeWaterCistern.BP_LargeWaterCistern_C' THEN 100000
+         END AS capacity,
+         COALESCE((fe.components #>> '{FWaterStorageComponent,1,m_WaterStored}')::int, 0) AS current_water
+  FROM player_totems pt
+  JOIN dune.actor_fgl_entities totem_fgl
+    ON totem_fgl.actor_id = pt.totem_id
+   AND totem_fgl.slot_name = 'Actor'
+  JOIN dune.placeables p
+    ON p.owner_entity_id = totem_fgl.entity_id
+  JOIN dune.actors a
+    ON a.id = p.id
+  JOIN dune.actor_fgl_entities afe
+    ON afe.actor_id = a.id
+   AND afe.slot_name = 'Actor'
+  JOIN dune.fgl_entities fe
+    ON fe.entity_id = afe.entity_id
+   AND fe.components ? 'FWaterStorageComponent'
+  WHERE a.class IN (
+    '/Game/Dune/Systems/Building/Pieces/BP_WaterCistern.BP_WaterCistern_C',
+    '/Game/Dune/Systems/Building/Pieces/BP_MediumWaterCistern.BP_MediumWaterCistern_C',
+    '/Game/Dune/Systems/Building/Pieces/BP_LargeWaterCistern.BP_LargeWaterCistern_C'
+  )
+)
+"@
+}
+
+function Get-DunePlayerBaseCisternSummary {
+    param([string]$Ip, [long]$ControllerId)
+    if ($ControllerId -le 0) { return @{ ok = $false; error = 'controller_id is required.' } }
+
+    $sql = (New-DunePlayerBaseCisternCteSql -ControllerId $ControllerId) + @"
+SELECT COUNT(*)::text AS total,
+       COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_WaterCistern.BP_WaterCistern_C')::text AS small_n,
+       COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_MediumWaterCistern.BP_MediumWaterCistern_C')::text AS medium_n,
+       COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_LargeWaterCistern.BP_LargeWaterCistern_C')::text AS large_n,
+       COUNT(*) FILTER (WHERE current_water >= capacity)::text AS full_n,
+       COALESCE(SUM(GREATEST(capacity - current_water, 0)), 0)::text AS missing_water
+FROM player_cisterns;
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 30
+    if (-not $r.ok) { return @{ ok = $false; error = "Base cistern read failed: $($r.error)" } }
+    $rows = ConvertTo-DuneRowMaps -Result $r
+    if ($rows.Count -lt 1) { return @{ ok = $false; error = 'Base cistern read returned no summary row.' } }
+    $row = $rows[0]
+    return @{
+        ok           = $true
+        controllerId = $ControllerId
+        total        = [int](ConvertTo-DuneInt $row['total'])
+        small        = [int](ConvertTo-DuneInt $row['small_n'])
+        medium       = [int](ConvertTo-DuneInt $row['medium_n'])
+        large        = [int](ConvertTo-DuneInt $row['large_n'])
+        full         = [int](ConvertTo-DuneInt $row['full_n'])
+        missingWater = [int64](ConvertTo-DuneInt $row['missing_water'])
+    }
+}
+
+function Set-DunePlayerBaseCisternsFull {
+    param([string]$Ip, [long]$ControllerId)
+    if ($ControllerId -le 0) { return @{ ok = $false; error = 'controller_id is required.' } }
+
+    $sql = (New-DunePlayerBaseCisternCteSql -ControllerId $ControllerId) + @"
+, updated AS (
+  UPDATE dune.fgl_entities fe
+  SET components = jsonb_set(
+    fe.components,
+    '{FWaterStorageComponent,1,m_WaterStored}',
+    to_jsonb(pc.capacity),
+    false
+  )
+  FROM player_cisterns pc
+  WHERE fe.entity_id = pc.entity_id
+  RETURNING pc.actor_id, pc.class, pc.capacity,
+            (fe.components #>> '{FWaterStorageComponent,1,m_WaterStored}')::int AS water
+)
+SELECT COUNT(*)::text AS total,
+       COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_WaterCistern.BP_WaterCistern_C')::text AS small_n,
+       COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_MediumWaterCistern.BP_MediumWaterCistern_C')::text AS medium_n,
+       COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_LargeWaterCistern.BP_LargeWaterCistern_C')::text AS large_n,
+       COUNT(*) FILTER (WHERE water = capacity)::text AS verified_n
+FROM updated;
+"@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 45
+    if (-not $r.ok) { return @{ ok = $false; error = "Base cistern write failed: $($r.error)" } }
+    $rows = ConvertTo-DuneRowMaps -Result $r
+    if ($rows.Count -lt 1) { return @{ ok = $false; error = 'Base cistern write returned no summary row.' } }
+    $row = $rows[0]
+    $total = [int](ConvertTo-DuneInt $row['total'])
+    $verified = [int](ConvertTo-DuneInt $row['verified_n'])
+    if ($total -ne $verified) {
+        return @{ ok = $false; error = "Base cistern verification failed: $verified of $total rows reached capacity." }
+    }
+    return @{
+        ok       = $true
+        total    = $total
+        small    = [int](ConvertTo-DuneInt $row['small_n'])
+        medium   = [int](ConvertTo-DuneInt $row['medium_n'])
+        large    = [int](ConvertTo-DuneInt $row['large_n'])
+        verified = $verified
+    }
+}
+
+function Invoke-DuneBaseWaterBgCommand {
+    param(
+        [string]$Ip,
+        [Parameter(Mandatory)][ValidateSet('backup','stop','start')][string]$Command
+    )
+    if (-not (Get-Command Invoke-DuneBackupShell -ErrorAction SilentlyContinue)) {
+        return @{ ok = $false; error = 'Battlegroup shell helper is unavailable.' }
+    }
+    $timeout = if ($Command -eq 'backup') { 700 } elseif ($Command -eq 'stop') { 180 } else { 120 }
+    try {
+        $r = Invoke-DuneBackupShell -Ip $Ip -Script "/home/dune/.dune/bin/battlegroup $Command" -TimeoutSec $timeout
+    } catch {
+        return @{ ok = $false; error = "Battlegroup $Command failed: $($_.Exception.Message)" }
+    }
+    if ($null -eq $r -or [int]$r.rc -ne 0) {
+        $rc = if ($null -eq $r) { -1 } else { [int]$r.rc }
+        $out = if ($null -eq $r) { '' } else { ([string]$r.out).Trim() }
+        return @{ ok = $false; error = "Battlegroup $Command exited $rc. $out".Trim() }
+    }
+    $out = ([string]$r.out).Trim()
+    $backupPath = ''
+    if ($Command -eq 'backup') {
+        $m = [regex]::Match($out, 'Backup file \(on this host\):\s*(\S+)')
+        if ($m.Success) { $backupPath = $m.Groups[1].Value }
+    }
+    return @{ ok = $true; command = $Command; output = $out; backupPath = $backupPath }
+}
+
+function Invoke-DuneFillPlayerBaseWaterCore {
+    param([string]$Ip, [long]$ControllerId)
+
+    $before = Get-DunePlayerBaseCisternSummary -Ip $Ip -ControllerId $ControllerId
+    if (-not $before.ok) { return $before }
+    if ($before.total -le 0) {
+        return @{ ok = $false; error = "No supported cisterns were found on player $ControllerId's owned bases." }
+    }
+
+    $backup = Invoke-DuneBaseWaterBgCommand -Ip $Ip -Command 'backup'
+    if (-not $backup.ok) {
+        return @{ ok = $false; error = "No changes made because the safety backup failed. $($backup.error)" }
+    }
+
+    $stop = Invoke-DuneBaseWaterBgCommand -Ip $Ip -Command 'stop'
+    if (-not $stop.ok) {
+        $recoveryStart = Invoke-DuneBaseWaterBgCommand -Ip $Ip -Command 'start'
+        $recoveryMessage = if ($recoveryStart.ok) {
+            'A recovery start command was launched.'
+        } else {
+            "$($recoveryStart.error) Start the battlegroup manually."
+        }
+        return @{
+            ok         = $false
+            error      = "No cisterns changed because the battlegroup did not stop cleanly. $($stop.error) $recoveryMessage"
+            backupPath = $backup.backupPath
+        }
+    }
+
+    $fill = $null
+    $verify = $null
+    $operationError = ''
+    $start = $null
+    try {
+        $fill = Set-DunePlayerBaseCisternsFull -Ip $Ip -ControllerId $ControllerId
+        if (-not $fill.ok) {
+            $operationError = $fill.error
+        } else {
+            $verify = Get-DunePlayerBaseCisternSummary -Ip $Ip -ControllerId $ControllerId
+            if (-not $verify.ok) {
+                $operationError = $verify.error
+            } elseif ($verify.total -ne $fill.total -or $verify.full -ne $verify.total) {
+                $operationError = "Post-write verification failed: $($verify.full) of $($verify.total) cisterns are full."
+            }
+        }
+    } catch {
+        $operationError = "Base cistern operation failed: $($_.Exception.Message)"
+    } finally {
+        $start = Invoke-DuneBaseWaterBgCommand -Ip $Ip -Command 'start'
+    }
+
+    if (-not $start.ok) {
+        $prefix = if ($operationError) { "$operationError " } else { "Cisterns were filled, but " }
+        return @{
+            ok         = $false
+            error      = "$prefix$($start.error) Start the battlegroup manually."
+            backupPath = $backup.backupPath
+            fill       = $fill
+        }
+    }
+    if ($operationError) {
+        return @{
+            ok         = $false
+            error      = "$operationError The battlegroup start command was launched."
+            backupPath = $backup.backupPath
+        }
+    }
+
+    return @{
+        ok         = $true
+        controller = $ControllerId
+        total      = $fill.total
+        small      = $fill.small
+        medium     = $fill.medium
+        large      = $fill.large
+        backupPath = $backup.backupPath
+        message    = "Filled $($fill.total) owned base cistern(s) ($($fill.small) small, $($fill.medium) medium, $($fill.large) large). Safety backup completed; battlegroup start launched."
+    }
+}
+
+function Invoke-DuneFillPlayerBaseWater {
+    param([string]$Ip, [long]$ControllerId)
+    if ($ControllerId -le 0) { return @{ ok = $false; error = 'controller_id is required.' } }
+    if ($script:DuneBaseWaterFillRunning) {
+        return @{ ok = $false; error = 'Another Fill Base Water operation is already running.' }
+    }
+    $script:DuneBaseWaterFillRunning = $true
+    try {
+        return Invoke-DuneFillPlayerBaseWaterCore -Ip $Ip -ControllerId $ControllerId
+    } finally {
+        $script:DuneBaseWaterFillRunning = $false
+    }
+}
 
 
 

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -546,10 +546,23 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/fill-water' -Handle
     }
 }
 
-# v12.1.2: Fill Base Water removed - cistern water is owned by the live pod
-# and overwrites DB writes. Stub kept to return 410 Gone for any cached UI
-# references; safe to delete once UIs roll. This feature will not be offered.
-Register-DuneRoute -Method POST -Path '/api/gameplay/players/fill-base-water-removed-in-v12.1.2' -Handler {
+# Fill every supported cistern on one player's rank-1-owned bases. The backend
+# creates a safety backup, stops the battlegroup so map RAM cannot overwrite the
+# DB write, fills exact small/medium/large cistern classes, verifies, then starts
+# the battlegroup again.
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/fill-base-water' -Handler {
     param($req, $res, $routeParams, $body)
-    Write-DuneError -Response $res -Status 410 -Message 'Fill Base Water was removed in v12.1.2 - cistern water is owned by the live pod and overwrites DB writes. See CHANGELOG for details.'
+    try {
+        $controller = Get-DuneBodyInt -Body $body -Name 'controller_id'
+        if ($null -eq $controller -or $controller -le 0) {
+            Write-DuneError -Response $res -Status 400 -Message 'controller_id is required.'
+            return
+        }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            Invoke-DuneFillPlayerBaseWater -Ip $ip -ControllerId ([long]$controller)
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Fill base water failed: $($_.Exception.Message)"
+    }
 }

--- a/tests/FillBaseWater.Tests.ps1
+++ b/tests/FillBaseWater.Tests.ps1
@@ -1,0 +1,173 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+
+    function global:Invoke-DuneSqlQuery { throw 'Test must mock Invoke-DuneSqlQuery.' }
+    function global:Invoke-DuneBackupShell { throw 'Test must mock Invoke-DuneBackupShell.' }
+    function global:ConvertTo-DuneRowMaps {
+        param($Result)
+        $maps = if ($Result -and $Result.maps) { $Result.maps } else { @() }
+        return ,@($maps)
+    }
+    function global:ConvertTo-DuneInt {
+        param($Value)
+        if ($null -eq $Value -or "$Value" -eq '') { return 0 }
+        return [int64]$Value
+    }
+
+    Import-DstLib 'PlayersAdmin.ps1'
+}
+
+AfterAll {
+    Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+    Remove-Item function:global:Invoke-DuneBackupShell -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneInt -ErrorAction SilentlyContinue
+}
+
+Describe 'Fill Base Water SQL scope' -Tag 'PlayersAdmin' {
+    It 'matches only exact cistern classes and rank-1-owned totems' {
+        $sql = New-DunePlayerBaseCisternCteSql -ControllerId 42
+        $sql | Should -Match 'player_id = 42::bigint'
+        $sql | Should -Match 'rank = 1'
+        $sql | Should -Match 'BP_WaterCistern\.BP_WaterCistern_C'
+        $sql | Should -Match 'BP_MediumWaterCistern\.BP_MediumWaterCistern_C'
+        $sql | Should -Match 'BP_LargeWaterCistern\.BP_LargeWaterCistern_C'
+        $sql | Should -Not -Match 'BloodWaterExtractor'
+        $sql | Should -Not -Match 'Windtrap'
+        $sql | Should -Not -Match "ILIKE '%Water"
+    }
+
+    It 'uses the field-proven capacity for each exact class' {
+        $sql = New-DunePlayerBaseCisternCteSql -ControllerId 42
+        $sql | Should -Match 'BP_WaterCistern\.BP_WaterCistern_C'' THEN 5000'
+        $sql | Should -Match 'BP_MediumWaterCistern\.BP_MediumWaterCistern_C'' THEN 25000'
+        $sql | Should -Match 'BP_LargeWaterCistern\.BP_LargeWaterCistern_C'' THEN 100000'
+    }
+
+    It 'writes only the water leaf on selected dune.fgl_entities rows' {
+        $script:capturedWriteSql = ''
+        Mock Invoke-DuneSqlQuery {
+            $script:capturedWriteSql = $Sql
+            return @{
+                ok = $true
+                maps = @(@{
+                    total = '3'; small_n = '1'; medium_n = '1'; large_n = '1'; verified_n = '3'
+                })
+            }
+        }
+
+        $r = Set-DunePlayerBaseCisternsFull -Ip 'x' -ControllerId 42
+        $r.ok | Should -BeTrue
+        ([regex]::Matches($script:capturedWriteSql, '(?im)^\s*(UPDATE|INSERT|DELETE)\b')).Count | Should -Be 1
+        $script:capturedWriteSql | Should -Match 'UPDATE dune\.fgl_entities fe'
+        $script:capturedWriteSql | Should -Match "SET components = jsonb_set\("
+        $script:capturedWriteSql | Should -Match '\{FWaterStorageComponent,1,m_WaterStored\}'
+        $script:capturedWriteSql | Should -Match 'WHERE fe\.entity_id = pc\.entity_id'
+        $script:capturedWriteSql | Should -Not -Match '(?im)^\s*UPDATE dune\.(actors|placeables|permission_actor_rank|items|inventories)\b'
+        $script:capturedWriteSql | Should -Not -Match '(?im)^\s*(INSERT|DELETE)\b'
+    }
+}
+
+Describe 'Invoke-DuneFillPlayerBaseWater' -Tag 'PlayersAdmin' {
+    BeforeEach {
+        $script:steps = @()
+        $script:summaryReads = 0
+        $script:DuneBaseWaterFillRunning = $false
+
+        Mock Get-DunePlayerBaseCisternSummary {
+            $script:summaryReads++
+            if ($script:summaryReads -eq 1) {
+                return @{ ok=$true; total=3; small=1; medium=1; large=1; full=0; missingWater=130000 }
+            }
+            return @{ ok=$true; total=3; small=1; medium=1; large=1; full=3; missingWater=0 }
+        }
+        Mock Set-DunePlayerBaseCisternsFull {
+            $script:steps += 'write'
+            return @{ ok=$true; total=3; small=1; medium=1; large=1; verified=3 }
+        }
+        Mock Invoke-DuneBackupShell {
+            param($Ip, $Script, $TimeoutSec)
+            if ($Script -match 'battlegroup backup') {
+                $script:steps += 'backup'
+                return @{ rc=0; out='Backup file (on this host): /backups/test.backup' }
+            }
+            if ($Script -match 'battlegroup stop') {
+                $script:steps += 'stop'
+                return @{ rc=0; out='Battlegroup stopped.' }
+            }
+            if ($Script -match 'battlegroup start') {
+                $script:steps += 'start'
+                return @{ rc=0; out='Battlegroup is starting.' }
+            }
+            throw "Unexpected shell command: $Script"
+        }
+    }
+
+    It 'runs backup, stop, write, verify, then start in order' {
+        $r = Invoke-DuneFillPlayerBaseWater -Ip 'x' -ControllerId 42
+        $r.ok | Should -BeTrue
+        $r.total | Should -Be 3
+        $r.backupPath | Should -Be '/backups/test.backup'
+        ($script:steps -join ',') | Should -Be 'backup,stop,write,start'
+        $script:summaryReads | Should -Be 2
+    }
+
+    It 'starts the battlegroup even when the DB write fails' {
+        Mock Set-DunePlayerBaseCisternsFull {
+            $script:steps += 'write'
+            return @{ ok=$false; error='write failed' }
+        }
+        $r = Invoke-DuneFillPlayerBaseWater -Ip 'x' -ControllerId 42
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'write failed'
+        $r.error | Should -Match 'start command was launched'
+        ($script:steps -join ',') | Should -Be 'backup,stop,write,start'
+    }
+
+    It 'does not stop the battlegroup when the safety backup fails' {
+        Mock Invoke-DuneBackupShell {
+            param($Ip, $Script, $TimeoutSec)
+            $script:steps += 'backup'
+            return @{ rc=1; out='backup failed' }
+        }
+        $r = Invoke-DuneFillPlayerBaseWater -Ip 'x' -ControllerId 42
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'safety backup failed'
+        ($script:steps -join ',') | Should -Be 'backup'
+        Assert-MockCalled Set-DunePlayerBaseCisternsFull -Times 0
+    }
+
+    It 'launches a recovery start when stop is ambiguous or fails' {
+        Mock Invoke-DuneBackupShell {
+            param($Ip, $Script, $TimeoutSec)
+            if ($Script -match 'battlegroup backup') {
+                $script:steps += 'backup'
+                return @{ rc=0; out='Backup file (on this host): /backups/test.backup' }
+            }
+            if ($Script -match 'battlegroup stop') {
+                $script:steps += 'stop'
+                return @{ rc=-1; out='SSH channel closed' }
+            }
+            if ($Script -match 'battlegroup start') {
+                $script:steps += 'start'
+                return @{ rc=0; out='Battlegroup is starting.' }
+            }
+        }
+        $r = Invoke-DuneFillPlayerBaseWater -Ip 'x' -ControllerId 42
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'did not stop cleanly'
+        $r.error | Should -Match 'recovery start command was launched'
+        ($script:steps -join ',') | Should -Be 'backup,stop,start'
+        Assert-MockCalled Set-DunePlayerBaseCisternsFull -Times 0
+    }
+
+    It 'does not disrupt the server when the player owns no supported cisterns' {
+        Mock Get-DunePlayerBaseCisternSummary {
+            return @{ ok=$true; total=0; small=0; medium=0; large=0; full=0; missingWater=0 }
+        }
+        $r = Invoke-DuneFillPlayerBaseWater -Ip 'x' -ControllerId 42
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'No supported cisterns'
+        $script:steps.Count | Should -Be 0
+    }
+}

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1508,6 +1508,23 @@ export function fillWater(pawnId: number): Promise<FillWaterResponse> {
   })
 }
 
+export interface FillBaseWaterResponse extends WriteResult {
+  result?: {
+    controller?: number
+    total?: number
+    small?: number
+    medium?: number
+    large?: number
+    backupPath?: string
+  }
+}
+
+export function fillBaseWater(controllerId: number): Promise<FillBaseWaterResponse> {
+  return api<FillBaseWaterResponse>('/api/gameplay/players/fill-base-water', {
+    method: 'POST', body: JSON.stringify({ controller_id: controllerId }),
+  })
+}
+
 export interface CoriolisMap       { map: string; seed: number }
 export interface CoriolisPartition { partition_id: number; map: string; seed: number }
 

--- a/webui/src/pages/gameplay/PlayersTab.tsx
+++ b/webui/src/pages/gameplay/PlayersTab.tsx
@@ -14,6 +14,7 @@ import {
   SECTIONS, SECTION_COMPONENTS, type SectionId,
 } from './players/sections'
 import { CoriolisAdmin } from './players/coriolis'
+import { BaseWaterAdmin } from './players/base-water'
 
 type OnlineFilter = '' | 'online' | 'offline'
 
@@ -327,6 +328,13 @@ export function PlayersTab() {
               <ServerOverview summary={displaySummary} />
               <div className="mt-3">
                 <CoriolisAdmin flash={(msg, kind = 'ok') => setFlash({ msg, kind })} />
+              </div>
+              <div className="mt-3">
+                <BaseWaterAdmin
+                  players={visiblePlayers}
+                  canWrite={source === 'live'}
+                  flash={(msg, kind = 'ok') => setFlash({ msg, kind })}
+                />
               </div>
             </>
           )}

--- a/webui/src/pages/gameplay/players/base-water.tsx
+++ b/webui/src/pages/gameplay/players/base-water.tsx
@@ -1,0 +1,99 @@
+import { useMemo, useState } from 'react'
+import { Icon } from '../../../components/Icon'
+import { fillBaseWater, type Player } from '../../../api/gameplay'
+
+type Flash = (msg: string, kind?: 'ok' | 'err') => void
+
+export function BaseWaterAdmin({
+  players,
+  canWrite,
+  flash,
+}: {
+  players: Player[]
+  canWrite: boolean
+  flash: Flash
+}) {
+  const [controllerId, setControllerId] = useState('')
+  const [busy, setBusy] = useState(false)
+  const options = useMemo(
+    () => [...players]
+      .filter(p => p.controller_id > 0)
+      .sort((a, b) => (a.name || '').localeCompare(b.name || '')),
+    [players],
+  )
+  const selected = options.find(p => String(p.controller_id) === controllerId)
+
+  const run = async () => {
+    if (!selected) return
+    const name = selected.name || `controller ${selected.controller_id}`
+    const confirmed = window.confirm(
+      `Fill every small, medium, and large cistern on ${name}'s owned bases?\n\n` +
+      'DST will create a database backup, stop the battlegroup, disconnect every online player, ' +
+      'fill only this player\'s owned cisterns, then start the battlegroup again. ' +
+      'Blood-water extractors and windtraps are not changed.\n\nThis can take several minutes.',
+    )
+    if (!confirmed) return
+
+    setBusy(true)
+    try {
+      const result = await fillBaseWater(selected.controller_id)
+      flash(result.message)
+    } catch (e) {
+      flash(e instanceof Error ? e.message : String(e), 'err')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="card p-4 space-y-3">
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-text-dim">
+        <Icon name="Droplets" size={13} /> Fill Base Water
+      </div>
+
+      <p className="text-xs text-text-dim">
+        Fill every supported cistern on one player's owned bases. Small, medium, and large
+        cisterns are set to their exact capacities; windtraps and blood-water extractors are excluded.
+      </p>
+
+      <div className="rounded-lg border border-warning/40 bg-warning/10 p-3 text-xs space-y-1.5">
+        <div className="flex items-center gap-2 font-semibold text-warning">
+          <Icon name="AlertTriangle" size={14} /> Battlegroup restart required
+        </div>
+        <p className="text-text-dim">
+          Cistern state is cached by the map servers. DST must back up the database, stop the entire
+          battlegroup, apply the fill while every map is offline, then start it again. All connected
+          players will be disconnected, even though only the selected player's cisterns are changed.
+        </p>
+      </div>
+
+      <label className="block text-xs">
+        <span className="block text-text-dim mb-1">Base owner</span>
+        <select
+          aria-label="Base owner"
+          value={controllerId}
+          disabled={busy || !canWrite}
+          onChange={e => setControllerId(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm"
+        >
+          <option value="">Select a player...</option>
+          {options.map(p => (
+            <option key={p.controller_id} value={String(p.controller_id)}>
+              {p.name || `Player ${p.id}`} - controller {p.controller_id}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <button
+        type="button"
+        className="btn-primary"
+        disabled={busy || !canWrite || !selected}
+        onClick={() => { void run() }}
+      >
+        <Icon name={busy ? 'Loader2' : 'Droplets'} size={13} className={busy ? 'animate-spin' : ''} />
+        {busy ? 'Backing up, filling, and restarting...' : 'Fill selected player\'s base cisterns'}
+      </button>
+    </div>
+  )
+}

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -92,6 +92,12 @@ describe('Phase A — currency / progression writes', () => {
 })
 
 describe('Phase C/D/E/F — items, vehicles, teleport, progression, jobs', () => {
+  it('fillBaseWater targets one player controller', async () => {
+    await gp.fillBaseWater(42)
+    expect(last().url).toBe('/api/gameplay/players/fill-base-water')
+    expect(last().body).toEqual({ controller_id: 42 })
+  })
+
   it('giveItems forwards the items array and overflow flag', async () => {
     const items = [
       { template: 'sword', qty: 1, quality: 5 },

--- a/webui/tests/components/BaseWaterAdmin.test.tsx
+++ b/webui/tests/components/BaseWaterAdmin.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { BaseWaterAdmin } from '../../src/pages/gameplay/players/base-water'
+import { fillBaseWater, type Player } from '../../src/api/gameplay'
+
+vi.mock('../../src/api/gameplay', () => ({
+  fillBaseWater: vi.fn(),
+}))
+
+const players: Player[] = [
+  {
+    id: 7,
+    account_id: 3,
+    controller_id: 5,
+    name: 'Test Player',
+    class: '',
+    map: 'HaggaBasin',
+    faction_id: 0,
+    faction_name: '',
+    online_status: 'Online',
+  },
+]
+
+beforeEach(() => {
+  vi.mocked(fillBaseWater).mockResolvedValue({
+    ok: true,
+    message: 'Filled 3 owned base cisterns.',
+    result: { controller: 5, total: 3, small: 1, medium: 1, large: 1 },
+  })
+  vi.stubGlobal('confirm', vi.fn(() => true))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('BaseWaterAdmin', () => {
+  it('targets one explicit player and warns about the server-wide restart', async () => {
+    const user = userEvent.setup()
+    const flash = vi.fn()
+    render(<BaseWaterAdmin players={players} canWrite flash={flash} />)
+
+    expect(screen.getByText(/all connected players will be disconnected/i)).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /all players/i })).not.toBeInTheDocument()
+
+    await user.selectOptions(screen.getByRole('combobox', { name: /base owner/i }), '5')
+    await user.click(screen.getByRole('button', { name: /fill selected player/i }))
+
+    await waitFor(() => expect(fillBaseWater).toHaveBeenCalledWith(5))
+    expect(vi.mocked(confirm).mock.calls[0]?.[0]).toMatch(/disconnect every online player/i)
+    expect(flash).toHaveBeenCalledWith('Filled 3 owned base cisterns.')
+  })
+
+  it('disables writes when live data is unavailable', () => {
+    render(<BaseWaterAdmin players={players} canWrite={false} flash={vi.fn()} />)
+    expect(screen.getByRole('combobox', { name: /base owner/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /fill selected player/i })).toBeDisabled()
+  })
+})


### PR DESCRIPTION
## Summary

- Add **Fill Base Water** below Coriolis Storm Seeds on Players → Server Overview, targeting one explicitly selected player.
- Create a safety backup, stop the battlegroup, fill and verify that player’s owned cisterns, then start the battlegroup again.
- Match only the exact small, medium, and large cistern classes and clamp each to its game capacity; windtraps and blood-water extractors remain untouched.
- Attempt a recovery start after any stop/write failure and clearly warn that all connected players will be disconnected.

## Safety boundary

The only database mutation updates `dune.fgl_entities.components` at `FWaterStorageComponent[1].m_WaterStored` for entity IDs reached through the selected controller’s rank-1-owned totems. Existing player inventory water, actor, placeable, permission, and inventory SQL paths are unchanged.

## Validation

- 811 Pester tests
- 129 Vitest tests
- Production WebUI build and changed-file ESLint
- Full installer build, including PowerShell 5.1 parsing and UTF-8 BOM checks
- Staged-patch gitleaks scan

Refs #221

Prepared for the next release; this PR does not publish one.