### PR TITLE
Add guarded all-player base cistern fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ here cover everything those tags shipped.
 ### Added
 
 - Players → Server Overview can fill every small, medium, and large cistern
-  across one selected player's owned bases. DST creates a safety backup, stops
-  the battlegroup so live map state cannot overwrite the database, fills and
-  verifies the exact cistern classes, then starts the battlegroup again.
-  Windtraps and blood-water extractors are excluded.
+  across one selected player's owned bases or, with stronger confirmation, all
+  player-owned bases in one restart. DST previews affected owners/cisterns,
+  creates a safety backup, stops the battlegroup so live map state cannot
+  overwrite the database, fills and verifies the exact cistern classes, then
+  starts the battlegroup again. Orphaned structures, windtraps, and blood-water
+  extractors are excluded.
 
 ## [13.6.5] - 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -365,10 +365,11 @@ browser and keeps the server running in the background.
 - **Per-item water editor** on Players → Inventory for water containers
   (literjons / canteens).
 - **Fill Base Water** on Players → Server Overview fills every small, medium,
-  and large cistern across one selected player's owned bases. It creates a
-  safety backup, stops the battlegroup, fills and verifies the cisterns, then
-  starts the battlegroup again; windtraps and blood-water extractors are
-  intentionally excluded.
+  and large cistern across one selected player's owned bases, or all
+  player-owned bases with stronger confirmation. It previews the affected
+  owners/cisterns, creates a safety backup, stops the battlegroup, fills and
+  verifies the cisterns, then starts the battlegroup again; orphaned structures,
+  windtraps, and blood-water extractors are intentionally excluded.
 - **Per-field "Default" button** on every Game Config setting — resetting
   *removes* the key from the INI instead of writing the default, keeping files
   clean. The "apply to my client" flow shows an **Add / Update / Remove** badge

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -344,25 +344,31 @@ function Invoke-DunePlayerGiveScrip {
 # is therefore backup -> stop BG -> write -> verify -> start BG. This was
 # field-proven against the in-game cistern UI.
 #
-# Scope is one selected player's rank-1-owned totems. Match the three exact
-# cistern classes because blood-water extractors and windtraps also carry an
-# FWaterStorageComponent but must not be filled by this action.
+# Scope is either one selected player's rank-1-owned totems or every rank-1
+# owner. Match the three exact cistern classes because blood-water extractors
+# and windtraps also carry an FWaterStorageComponent but must not be filled.
 
 $script:DuneBaseWaterFillRunning = $false
 
 function New-DunePlayerBaseCisternCteSql {
-    param([long]$ControllerId)
-    if ($ControllerId -le 0) { throw 'controller_id is required.' }
+    param([long]$ControllerId, [switch]$AllPlayers)
+    if (-not $AllPlayers -and $ControllerId -le 0) { throw 'controller_id is required.' }
+    $ownerWhere = if ($AllPlayers) {
+        'rank = 1'
+    } else {
+        "player_id = $ControllerId::bigint`n    AND rank = 1"
+    }
 
     return @"
 WITH player_totems AS (
-  SELECT permission_actor_id AS totem_id
+  SELECT player_id AS controller_id,
+         permission_actor_id AS totem_id
   FROM dune.permission_actor_rank
-  WHERE player_id = $ControllerId::bigint
-    AND rank = 1
+  WHERE $ownerWhere
 ),
 player_cisterns AS (
-  SELECT DISTINCT
+  SELECT DISTINCT ON (afe.entity_id)
+         pt.controller_id,
          a.id AS actor_id,
          a.class,
          afe.entity_id,
@@ -391,16 +397,18 @@ player_cisterns AS (
     '/Game/Dune/Systems/Building/Pieces/BP_MediumWaterCistern.BP_MediumWaterCistern_C',
     '/Game/Dune/Systems/Building/Pieces/BP_LargeWaterCistern.BP_LargeWaterCistern_C'
   )
+  ORDER BY afe.entity_id, pt.controller_id
 )
 "@
 }
 
 function Get-DunePlayerBaseCisternSummary {
-    param([string]$Ip, [long]$ControllerId)
-    if ($ControllerId -le 0) { return @{ ok = $false; error = 'controller_id is required.' } }
+    param([string]$Ip, [long]$ControllerId, [switch]$AllPlayers)
+    if (-not $AllPlayers -and $ControllerId -le 0) { return @{ ok = $false; error = 'controller_id is required.' } }
 
-    $sql = (New-DunePlayerBaseCisternCteSql -ControllerId $ControllerId) + @"
+    $sql = (New-DunePlayerBaseCisternCteSql -ControllerId $ControllerId -AllPlayers:$AllPlayers) + @"
 SELECT COUNT(*)::text AS total,
+       COUNT(DISTINCT controller_id)::text AS owner_n,
        COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_WaterCistern.BP_WaterCistern_C')::text AS small_n,
        COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_MediumWaterCistern.BP_MediumWaterCistern_C')::text AS medium_n,
        COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_LargeWaterCistern.BP_LargeWaterCistern_C')::text AS large_n,
@@ -416,6 +424,8 @@ FROM player_cisterns;
     return @{
         ok           = $true
         controllerId = $ControllerId
+        allPlayers   = [bool]$AllPlayers
+        owners       = [int](ConvertTo-DuneInt $row['owner_n'])
         total        = [int](ConvertTo-DuneInt $row['total'])
         small        = [int](ConvertTo-DuneInt $row['small_n'])
         medium       = [int](ConvertTo-DuneInt $row['medium_n'])
@@ -426,10 +436,10 @@ FROM player_cisterns;
 }
 
 function Set-DunePlayerBaseCisternsFull {
-    param([string]$Ip, [long]$ControllerId)
-    if ($ControllerId -le 0) { return @{ ok = $false; error = 'controller_id is required.' } }
+    param([string]$Ip, [long]$ControllerId, [switch]$AllPlayers)
+    if (-not $AllPlayers -and $ControllerId -le 0) { return @{ ok = $false; error = 'controller_id is required.' } }
 
-    $sql = (New-DunePlayerBaseCisternCteSql -ControllerId $ControllerId) + @"
+    $sql = (New-DunePlayerBaseCisternCteSql -ControllerId $ControllerId -AllPlayers:$AllPlayers) + @"
 , updated AS (
   UPDATE dune.fgl_entities fe
   SET components = jsonb_set(
@@ -440,10 +450,11 @@ function Set-DunePlayerBaseCisternsFull {
   )
   FROM player_cisterns pc
   WHERE fe.entity_id = pc.entity_id
-  RETURNING pc.actor_id, pc.class, pc.capacity,
+  RETURNING pc.controller_id, pc.actor_id, pc.class, pc.capacity,
             (fe.components #>> '{FWaterStorageComponent,1,m_WaterStored}')::int AS water
 )
 SELECT COUNT(*)::text AS total,
+       COUNT(DISTINCT controller_id)::text AS owner_n,
        COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_WaterCistern.BP_WaterCistern_C')::text AS small_n,
        COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_MediumWaterCistern.BP_MediumWaterCistern_C')::text AS medium_n,
        COUNT(*) FILTER (WHERE class = '/Game/Dune/Systems/Building/Pieces/BP_LargeWaterCistern.BP_LargeWaterCistern_C')::text AS large_n,
@@ -462,6 +473,7 @@ FROM updated;
     }
     return @{
         ok       = $true
+        owners   = [int](ConvertTo-DuneInt $row['owner_n'])
         total    = $total
         small    = [int](ConvertTo-DuneInt $row['small_n'])
         medium   = [int](ConvertTo-DuneInt $row['medium_n'])
@@ -499,12 +511,13 @@ function Invoke-DuneBaseWaterBgCommand {
 }
 
 function Invoke-DuneFillPlayerBaseWaterCore {
-    param([string]$Ip, [long]$ControllerId)
+    param([string]$Ip, [long]$ControllerId, [switch]$AllPlayers)
 
-    $before = Get-DunePlayerBaseCisternSummary -Ip $Ip -ControllerId $ControllerId
+    $before = Get-DunePlayerBaseCisternSummary -Ip $Ip -ControllerId $ControllerId -AllPlayers:$AllPlayers
     if (-not $before.ok) { return $before }
     if ($before.total -le 0) {
-        return @{ ok = $false; error = "No supported cisterns were found on player $ControllerId's owned bases." }
+        $scope = if ($AllPlayers) { 'any player-owned bases' } else { "player $ControllerId's owned bases" }
+        return @{ ok = $false; error = "No supported cisterns were found on $scope." }
     }
 
     $backup = Invoke-DuneBaseWaterBgCommand -Ip $Ip -Command 'backup'
@@ -532,11 +545,11 @@ function Invoke-DuneFillPlayerBaseWaterCore {
     $operationError = ''
     $start = $null
     try {
-        $fill = Set-DunePlayerBaseCisternsFull -Ip $Ip -ControllerId $ControllerId
+        $fill = Set-DunePlayerBaseCisternsFull -Ip $Ip -ControllerId $ControllerId -AllPlayers:$AllPlayers
         if (-not $fill.ok) {
             $operationError = $fill.error
         } else {
-            $verify = Get-DunePlayerBaseCisternSummary -Ip $Ip -ControllerId $ControllerId
+            $verify = Get-DunePlayerBaseCisternSummary -Ip $Ip -ControllerId $ControllerId -AllPlayers:$AllPlayers
             if (-not $verify.ok) {
                 $operationError = $verify.error
             } elseif ($verify.total -ne $fill.total -or $verify.full -ne $verify.total) {
@@ -569,24 +582,30 @@ function Invoke-DuneFillPlayerBaseWaterCore {
     return @{
         ok         = $true
         controller = $ControllerId
+        allPlayers = [bool]$AllPlayers
+        owners     = $fill.owners
         total      = $fill.total
         small      = $fill.small
         medium     = $fill.medium
         large      = $fill.large
         backupPath = $backup.backupPath
-        message    = "Filled $($fill.total) owned base cistern(s) ($($fill.small) small, $($fill.medium) medium, $($fill.large) large). Safety backup completed; battlegroup start launched."
+        message    = if ($AllPlayers) {
+            "Filled $($fill.total) base cistern(s) across $($fill.owners) owner(s) ($($fill.small) small, $($fill.medium) medium, $($fill.large) large). Safety backup completed; battlegroup start launched."
+        } else {
+            "Filled $($fill.total) owned base cistern(s) ($($fill.small) small, $($fill.medium) medium, $($fill.large) large). Safety backup completed; battlegroup start launched."
+        }
     }
 }
 
 function Invoke-DuneFillPlayerBaseWater {
-    param([string]$Ip, [long]$ControllerId)
-    if ($ControllerId -le 0) { return @{ ok = $false; error = 'controller_id is required.' } }
+    param([string]$Ip, [long]$ControllerId, [switch]$AllPlayers)
+    if (-not $AllPlayers -and $ControllerId -le 0) { return @{ ok = $false; error = 'controller_id is required.' } }
     if ($script:DuneBaseWaterFillRunning) {
         return @{ ok = $false; error = 'Another Fill Base Water operation is already running.' }
     }
     $script:DuneBaseWaterFillRunning = $true
     try {
-        return Invoke-DuneFillPlayerBaseWaterCore -Ip $Ip -ControllerId $ControllerId
+        return Invoke-DuneFillPlayerBaseWaterCore -Ip $Ip -ControllerId $ControllerId -AllPlayers:$AllPlayers
     } finally {
         $script:DuneBaseWaterFillRunning = $false
     }

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -546,21 +546,42 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/fill-water' -Handle
     }
 }
 
-# Fill every supported cistern on one player's rank-1-owned bases. The backend
-# creates a safety backup, stops the battlegroup so map RAM cannot overwrite the
-# DB write, fills exact small/medium/large cistern classes, verifies, then starts
-# the battlegroup again.
+# Preview the exact owner/cistern count before the disruptive fill.
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/base-water-summary' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $allPlayers = ((Get-DuneQ $req 'all_players') -eq '1')
+        $controller = 0L
+        [void][Int64]::TryParse((Get-DuneQ $req 'controller_id'), [ref]$controller)
+        if (-not $allPlayers -and $controller -le 0) {
+            Write-DuneError -Response $res -Status 400 -Message 'controller_id is required unless all_players=1.'
+            return
+        }
+        $ctx = Get-DuneDbContext
+        if (-not $ctx.ok) { Write-DuneError -Response $res -Status 503 -Message $ctx.message; return }
+        $result = Get-DunePlayerBaseCisternSummary -Ip $ctx.ip -ControllerId $controller -AllPlayers:$allPlayers
+        if (-not $result.ok) { Write-DuneError -Response $res -Status 503 -Message $result.error; return }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Base water summary failed: $($_.Exception.Message)"
+    }
+}
+
+# Fill exact supported cistern classes for one rank-1 owner or every rank-1
+# owner. The backend creates a safety backup, stops the battlegroup so map RAM
+# cannot overwrite the DB write, verifies, then starts the battlegroup again.
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/fill-base-water' -Handler {
     param($req, $res, $routeParams, $body)
     try {
         $controller = Get-DuneBodyInt -Body $body -Name 'controller_id'
-        if ($null -eq $controller -or $controller -le 0) {
-            Write-DuneError -Response $res -Status 400 -Message 'controller_id is required.'
+        $allPlayers = [bool](Get-DuneBodyValue -Body $body -Name 'all_players')
+        if (-not $allPlayers -and ($null -eq $controller -or $controller -le 0)) {
+            Write-DuneError -Response $res -Status 400 -Message 'controller_id is required unless all_players is true.'
             return
         }
         Invoke-DunePlayerWriteRoute -Response $res -Action {
             param($ip)
-            Invoke-DuneFillPlayerBaseWater -Ip $ip -ControllerId ([long]$controller)
+            Invoke-DuneFillPlayerBaseWater -Ip $ip -ControllerId ([long]$controller) -AllPlayers:$allPlayers
         }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Fill base water failed: $($_.Exception.Message)"

--- a/tests/FillBaseWater.Tests.ps1
+++ b/tests/FillBaseWater.Tests.ps1
@@ -37,6 +37,16 @@ Describe 'Fill Base Water SQL scope' -Tag 'PlayersAdmin' {
         $sql | Should -Not -Match "ILIKE '%Water"
     }
 
+    It 'all-player scope includes every rank-1 owner but no orphaned cisterns' {
+        $sql = New-DunePlayerBaseCisternCteSql -AllPlayers
+        $sql | Should -Match 'SELECT player_id AS controller_id'
+        $sql | Should -Match 'WHERE rank = 1'
+        $sql | Should -Not -Match 'player_id = \d+::bigint'
+        $sql | Should -Match 'DISTINCT ON \(afe\.entity_id\)'
+        $sql | Should -Match 'JOIN dune\.placeables p'
+        $sql | Should -Match 'ON p\.owner_entity_id = totem_fgl\.entity_id'
+    }
+
     It 'uses the field-proven capacity for each exact class' {
         $sql = New-DunePlayerBaseCisternCteSql -ControllerId 42
         $sql | Should -Match 'BP_WaterCistern\.BP_WaterCistern_C'' THEN 5000'
@@ -51,7 +61,7 @@ Describe 'Fill Base Water SQL scope' -Tag 'PlayersAdmin' {
             return @{
                 ok = $true
                 maps = @(@{
-                    total = '3'; small_n = '1'; medium_n = '1'; large_n = '1'; verified_n = '3'
+                    total = '3'; owner_n = '1'; small_n = '1'; medium_n = '1'; large_n = '1'; verified_n = '3'
                 })
             }
         }
@@ -75,15 +85,17 @@ Describe 'Invoke-DuneFillPlayerBaseWater' -Tag 'PlayersAdmin' {
         $script:DuneBaseWaterFillRunning = $false
 
         Mock Get-DunePlayerBaseCisternSummary {
+            param($Ip, $ControllerId, $AllPlayers)
             $script:summaryReads++
             if ($script:summaryReads -eq 1) {
-                return @{ ok=$true; total=3; small=1; medium=1; large=1; full=0; missingWater=130000 }
+                return @{ ok=$true; owners=1; total=3; small=1; medium=1; large=1; full=0; missingWater=130000 }
             }
-            return @{ ok=$true; total=3; small=1; medium=1; large=1; full=3; missingWater=0 }
+            return @{ ok=$true; owners=1; total=3; small=1; medium=1; large=1; full=3; missingWater=0 }
         }
         Mock Set-DunePlayerBaseCisternsFull {
+            param($Ip, $ControllerId, $AllPlayers)
             $script:steps += 'write'
-            return @{ ok=$true; total=3; small=1; medium=1; large=1; verified=3 }
+            return @{ ok=$true; owners=1; total=3; small=1; medium=1; large=1; verified=3 }
         }
         Mock Invoke-DuneBackupShell {
             param($Ip, $Script, $TimeoutSec)
@@ -114,6 +126,7 @@ Describe 'Invoke-DuneFillPlayerBaseWater' -Tag 'PlayersAdmin' {
 
     It 'starts the battlegroup even when the DB write fails' {
         Mock Set-DunePlayerBaseCisternsFull {
+            param($Ip, $ControllerId, $AllPlayers)
             $script:steps += 'write'
             return @{ ok=$false; error='write failed' }
         }
@@ -135,6 +148,32 @@ Describe 'Invoke-DuneFillPlayerBaseWater' -Tag 'PlayersAdmin' {
         $r.error | Should -Match 'safety backup failed'
         ($script:steps -join ',') | Should -Be 'backup'
         Assert-MockCalled Set-DunePlayerBaseCisternsFull -Times 0
+    }
+
+    It 'fills every rank-1 owner in one backup and restart cycle' {
+        Mock Get-DunePlayerBaseCisternSummary {
+            param($Ip, $ControllerId, $AllPlayers)
+            $script:summaryReads++
+            if ($script:summaryReads -eq 1) {
+                return @{ ok=$true; owners=4; total=12; small=3; medium=4; large=5; full=2; missingWater=400000 }
+            }
+            return @{ ok=$true; owners=4; total=12; small=3; medium=4; large=5; full=12; missingWater=0 }
+        }
+        Mock Set-DunePlayerBaseCisternsFull {
+            param($Ip, $ControllerId, $AllPlayers)
+            $script:steps += 'write'
+            return @{ ok=$true; owners=4; total=12; small=3; medium=4; large=5; verified=12 }
+        }
+
+        $r = Invoke-DuneFillPlayerBaseWater -Ip 'x' -AllPlayers
+        $r.ok | Should -BeTrue
+        $r.allPlayers | Should -BeTrue
+        $r.owners | Should -Be 4
+        $r.total | Should -Be 12
+        $r.message | Should -Match 'across 4 owner'
+        ($script:steps -join ',') | Should -Be 'backup,stop,write,start'
+        Assert-MockCalled Get-DunePlayerBaseCisternSummary -Times 2 -ParameterFilter { $AllPlayers }
+        Assert-MockCalled Set-DunePlayerBaseCisternsFull -Times 1 -ParameterFilter { $AllPlayers }
     }
 
     It 'launches a recovery start when stop is ambiguous or fails' {
@@ -163,6 +202,7 @@ Describe 'Invoke-DuneFillPlayerBaseWater' -Tag 'PlayersAdmin' {
 
     It 'does not disrupt the server when the player owns no supported cisterns' {
         Mock Get-DunePlayerBaseCisternSummary {
+            param($Ip, $ControllerId, $AllPlayers)
             return @{ ok=$true; total=0; small=0; medium=0; large=0; full=0; missingWater=0 }
         }
         $r = Invoke-DuneFillPlayerBaseWater -Ip 'x' -ControllerId 42

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1511,6 +1511,8 @@ export function fillWater(pawnId: number): Promise<FillWaterResponse> {
 export interface FillBaseWaterResponse extends WriteResult {
   result?: {
     controller?: number
+    allPlayers?: boolean
+    owners?: number
     total?: number
     small?: number
     medium?: number
@@ -1519,9 +1521,31 @@ export interface FillBaseWaterResponse extends WriteResult {
   }
 }
 
-export function fillBaseWater(controllerId: number): Promise<FillBaseWaterResponse> {
+export interface BaseWaterSummary {
+  ok: boolean
+  controllerId: number
+  allPlayers: boolean
+  owners: number
+  total: number
+  small: number
+  medium: number
+  large: number
+  full: number
+  missingWater: number
+}
+
+export function getBaseWaterSummary(controllerId?: number, allPlayers = false): Promise<BaseWaterSummary> {
+  return api<BaseWaterSummary>(`/api/gameplay/players/base-water-summary${qs({
+    controller_id: allPlayers ? undefined : controllerId,
+    all_players: allPlayers ? 1 : undefined,
+  })}`)
+}
+
+export function fillBaseWater(controllerId?: number, allPlayers = false): Promise<FillBaseWaterResponse> {
   return api<FillBaseWaterResponse>('/api/gameplay/players/fill-base-water', {
-    method: 'POST', body: JSON.stringify({ controller_id: controllerId }),
+    method: 'POST', body: JSON.stringify(allPlayers
+      ? { all_players: true }
+      : { controller_id: controllerId }),
   })
 }
 

--- a/webui/src/pages/gameplay/players/base-water.tsx
+++ b/webui/src/pages/gameplay/players/base-water.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { Icon } from '../../../components/Icon'
-import { fillBaseWater, type Player } from '../../../api/gameplay'
+import { fillBaseWater, getBaseWaterSummary, type Player } from '../../../api/gameplay'
 
 type Flash = (msg: string, kind?: 'ok' | 'err') => void
 
@@ -21,22 +21,42 @@ export function BaseWaterAdmin({
       .sort((a, b) => (a.name || '').localeCompare(b.name || '')),
     [players],
   )
+  const allPlayers = controllerId === 'all'
   const selected = options.find(p => String(p.controller_id) === controllerId)
 
   const run = async () => {
-    if (!selected) return
-    const name = selected.name || `controller ${selected.controller_id}`
-    const confirmed = window.confirm(
-      `Fill every small, medium, and large cistern on ${name}'s owned bases?\n\n` +
-      'DST will create a database backup, stop the battlegroup, disconnect every online player, ' +
-      'fill only this player\'s owned cisterns, then start the battlegroup again. ' +
-      'Blood-water extractors and windtraps are not changed.\n\nThis can take several minutes.',
-    )
-    if (!confirmed) return
-
     setBusy(true)
     try {
-      const result = await fillBaseWater(selected.controller_id)
+      if (!allPlayers && !selected) return
+      const summary = await getBaseWaterSummary(selected?.controller_id, allPlayers)
+      if (summary.total <= 0) {
+        flash('No supported cisterns were found for this scope.', 'err')
+        return
+      }
+
+      const counts = `${summary.total} cisterns across ${summary.owners} owner${summary.owners === 1 ? '' : 's'} ` +
+        `(${summary.small} small, ${summary.medium} medium, ${summary.large} large)`
+      if (allPlayers) {
+        const typed = window.prompt(
+          `Fill ALL player-owned base cisterns?\n\nAffected: ${counts}.\n\n` +
+          'DST will create a database backup, stop the battlegroup, disconnect every online player, ' +
+          'fill every supported cistern attached to a rank-1-owned totem, then start the battlegroup again. ' +
+          'Orphaned/unowned structures, blood-water extractors, and windtraps are not changed.\n\n' +
+          'Type FILL ALL to continue.',
+        )
+        if (typed !== 'FILL ALL') return
+      } else {
+        const name = selected!.name || `controller ${selected!.controller_id}`
+        const confirmed = window.confirm(
+          `Fill every small, medium, and large cistern on ${name}'s owned bases?\n\nAffected: ${counts}.\n\n` +
+          'DST will create a database backup, stop the battlegroup, disconnect every online player, ' +
+          'fill only this player\'s owned cisterns, then start the battlegroup again. ' +
+          'Blood-water extractors and windtraps are not changed.\n\nThis can take several minutes.',
+        )
+        if (!confirmed) return
+      }
+
+      const result = await fillBaseWater(selected?.controller_id, allPlayers)
       flash(result.message)
     } catch (e) {
       flash(e instanceof Error ? e.message : String(e), 'err')
@@ -52,8 +72,9 @@ export function BaseWaterAdmin({
       </div>
 
       <p className="text-xs text-text-dim">
-        Fill every supported cistern on one player's owned bases. Small, medium, and large
-        cisterns are set to their exact capacities; windtraps and blood-water extractors are excluded.
+        Fill every supported cistern on one player's owned bases, or deliberately fill every
+        player-owned base in one restart. Small, medium, and large cisterns are set to their exact
+        capacities; orphaned structures, windtraps, and blood-water extractors are excluded.
       </p>
 
       <div className="rounded-lg border border-warning/40 bg-warning/10 p-3 text-xs space-y-1.5">
@@ -63,7 +84,7 @@ export function BaseWaterAdmin({
         <p className="text-text-dim">
           Cistern state is cached by the map servers. DST must back up the database, stop the entire
           battlegroup, apply the fill while every map is offline, then start it again. All connected
-          players will be disconnected, even though only the selected player's cisterns are changed.
+          players will be disconnected. Only the selected scope's cisterns are changed.
         </p>
       </div>
 
@@ -77,6 +98,7 @@ export function BaseWaterAdmin({
           className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm"
         >
           <option value="">Select a player...</option>
+          <option value="all">All players - every owned base</option>
           {options.map(p => (
             <option key={p.controller_id} value={String(p.controller_id)}>
               {p.name || `Player ${p.id}`} - controller {p.controller_id}
@@ -88,11 +110,15 @@ export function BaseWaterAdmin({
       <button
         type="button"
         className="btn-primary"
-        disabled={busy || !canWrite || !selected}
+        disabled={busy || !canWrite || (!selected && !allPlayers)}
         onClick={() => { void run() }}
       >
         <Icon name={busy ? 'Loader2' : 'Droplets'} size={13} className={busy ? 'animate-spin' : ''} />
-        {busy ? 'Backing up, filling, and restarting...' : 'Fill selected player\'s base cisterns'}
+        {busy
+          ? 'Reading scope, backing up, filling, and restarting...'
+          : allPlayers
+            ? 'Fill all player-owned base cisterns'
+            : 'Fill selected player\'s base cisterns'}
       </button>
     </div>
   )

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -98,6 +98,15 @@ describe('Phase C/D/E/F — items, vehicles, teleport, progression, jobs', () =>
     expect(last().body).toEqual({ controller_id: 42 })
   })
 
+  it('base-water summary and fill support explicit all-player scope', async () => {
+    await gp.getBaseWaterSummary(undefined, true)
+    expect(last().url).toBe('/api/gameplay/players/base-water-summary?all_players=1')
+
+    await gp.fillBaseWater(undefined, true)
+    expect(last().url).toBe('/api/gameplay/players/fill-base-water')
+    expect(last().body).toEqual({ all_players: true })
+  })
+
   it('giveItems forwards the items array and overflow flag', async () => {
     const items = [
       { template: 'sword', qty: 1, quality: 5 },

--- a/webui/tests/components/BaseWaterAdmin.test.tsx
+++ b/webui/tests/components/BaseWaterAdmin.test.tsx
@@ -3,10 +3,11 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { BaseWaterAdmin } from '../../src/pages/gameplay/players/base-water'
-import { fillBaseWater, type Player } from '../../src/api/gameplay'
+import { fillBaseWater, getBaseWaterSummary, type Player } from '../../src/api/gameplay'
 
 vi.mock('../../src/api/gameplay', () => ({
   fillBaseWater: vi.fn(),
+  getBaseWaterSummary: vi.fn(),
 }))
 
 const players: Player[] = [
@@ -24,12 +25,25 @@ const players: Player[] = [
 ]
 
 beforeEach(() => {
+  vi.mocked(getBaseWaterSummary).mockResolvedValue({
+    ok: true,
+    controllerId: 5,
+    allPlayers: false,
+    owners: 1,
+    total: 3,
+    small: 1,
+    medium: 1,
+    large: 1,
+    full: 0,
+    missingWater: 130000,
+  })
   vi.mocked(fillBaseWater).mockResolvedValue({
     ok: true,
     message: 'Filled 3 owned base cisterns.',
     result: { controller: 5, total: 3, small: 1, medium: 1, large: 1 },
   })
   vi.stubGlobal('confirm', vi.fn(() => true))
+  vi.stubGlobal('prompt', vi.fn(() => 'FILL ALL'))
 })
 
 afterEach(() => {
@@ -45,14 +59,58 @@ describe('BaseWaterAdmin', () => {
     render(<BaseWaterAdmin players={players} canWrite flash={flash} />)
 
     expect(screen.getByText(/all connected players will be disconnected/i)).toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: /all players/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /all players/i })).toBeInTheDocument()
 
     await user.selectOptions(screen.getByRole('combobox', { name: /base owner/i }), '5')
     await user.click(screen.getByRole('button', { name: /fill selected player/i }))
 
-    await waitFor(() => expect(fillBaseWater).toHaveBeenCalledWith(5))
+    await waitFor(() => expect(getBaseWaterSummary).toHaveBeenCalledWith(5, false))
+    expect(fillBaseWater).toHaveBeenCalledWith(5, false)
     expect(vi.mocked(confirm).mock.calls[0]?.[0]).toMatch(/disconnect every online player/i)
+    expect(vi.mocked(confirm).mock.calls[0]?.[0]).toMatch(/3 cisterns across 1 owner/i)
     expect(flash).toHaveBeenCalledWith('Filled 3 owned base cisterns.')
+  })
+
+  it('requires typed confirmation before filling all player-owned bases', async () => {
+    const user = userEvent.setup()
+    const flash = vi.fn()
+    vi.mocked(getBaseWaterSummary).mockResolvedValue({
+      ok: true,
+      controllerId: 0,
+      allPlayers: true,
+      owners: 4,
+      total: 12,
+      small: 3,
+      medium: 4,
+      large: 5,
+      full: 2,
+      missingWater: 400000,
+    })
+    vi.mocked(fillBaseWater).mockResolvedValue({
+      ok: true,
+      message: 'Filled 12 base cisterns across 4 owners.',
+      result: { allPlayers: true, owners: 4, total: 12, small: 3, medium: 4, large: 5 },
+    })
+
+    render(<BaseWaterAdmin players={players} canWrite flash={flash} />)
+    await user.selectOptions(screen.getByRole('combobox', { name: /base owner/i }), 'all')
+    await user.click(screen.getByRole('button', { name: /fill all player-owned/i }))
+
+    await waitFor(() => expect(getBaseWaterSummary).toHaveBeenCalledWith(undefined, true))
+    expect(vi.mocked(prompt).mock.calls[0]?.[0]).toMatch(/12 cisterns across 4 owners/i)
+    expect(vi.mocked(prompt).mock.calls[0]?.[0]).toMatch(/orphaned\/unowned structures/i)
+    expect(fillBaseWater).toHaveBeenCalledWith(undefined, true)
+    expect(flash).toHaveBeenCalledWith('Filled 12 base cisterns across 4 owners.')
+  })
+
+  it('does not run all-player fill when typed confirmation does not match', async () => {
+    const user = userEvent.setup()
+    vi.mocked(prompt).mockReturnValue('fill all')
+    render(<BaseWaterAdmin players={players} canWrite flash={vi.fn()} />)
+    await user.selectOptions(screen.getByRole('combobox', { name: /base owner/i }), 'all')
+    await user.click(screen.getByRole('button', { name: /fill all player-owned/i }))
+    await waitFor(() => expect(getBaseWaterSummary).toHaveBeenCalled())
+    expect(fillBaseWater).not.toHaveBeenCalled()
   })
 
   it('disables writes when live data is unavailable', () => {


### PR DESCRIPTION
## Summary

- Add an explicit **All players — every owned base** option to Fill Base Water.
- Preview affected owner and cistern counts before any disruptive work.
- Require exact typed confirmation (`FILL ALL`) for server-wide scope while preserving the lighter selected-player confirmation.
- Fill every supported cistern attached to any rank-1-owned totem in one backup/stop/write/start cycle.
- Deduplicate by FGL entity ID and continue excluding orphaned/unowned structures, windtraps, and blood-water extractors.

## Safety boundary

The mutation remains one `UPDATE dune.fgl_entities` statement changing only `components.FWaterStorageComponent[1].m_WaterStored` for exact small, medium, and large cistern classes. Actor, placeable, ownership, inventory, and carried-water surfaces are unchanged.

## Validation

- Live read-only preview query: 114 supported cisterns across 2 rank-1 owners
- 813 Pester tests
- 132 Vitest tests
- Production WebUI build and changed-file ESLint
- Full installer build, including PowerShell 5.1 parsing and UTF-8 BOM checks
- Staged-patch gitleaks scan

Follow-up to #698. Kept in Unreleased for the next release; this PR publishes nothing.