### PR TITLE
Add live fallback for teleport bookmark capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ here cover everything those tags shipped.
   starts the battlegroup again. Orphaned structures, windtraps, and blood-water
   extractors are excluded.
 - In-game commands add admin-managed shared teleport destinations. An admin can
-  arm a name/player capture in DST, then that player types the one-time
-  `!tp save <code>` command at the
-  destination so DST records the exact live chat position; players can use
+  save an online player's database location directly in DST. For areas where
+  that transform remains at the map opening point, the admin can instead arm a
+  live capture and have that player type the one-time `!tp save <code>` command
+  at the destination. Players can use
   `!tp list` and `!tp <name>` to teleport themselves while on the same map,
   partition and dimension. Destinations stay local to that DST installation,
   the command is off by default, and each player has a configurable cooldown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ here cover everything those tags shipped.
   starts the battlegroup again. Orphaned structures, windtraps, and blood-water
   extractors are excluded.
 - In-game commands add admin-managed shared teleport destinations. An admin can
-  capture and name an online player's current location in DST; players can use
+  arm a name/player capture in DST, then that player types the one-time
+  `!tp save <code>` command at the
+  destination so DST records the exact live chat position; players can use
   `!tp list` and `!tp <name>` to teleport themselves while on the same map,
   partition and dimension. Destinations stay local to that DST installation,
   the command is off by default, and each player has a configurable cooldown.

--- a/app/server/lib/ChatCommands.ps1
+++ b/app/server/lib/ChatCommands.ps1
@@ -50,8 +50,10 @@ $script:DuneChatDrainMax     = 25
 
 $script:DuneChatStateFile = $null
 $script:DuneChatTeleportsFile = $null
+$script:DuneChatTeleportCaptureFile = $null
 $script:DuneChatTeleportMax = 20
 $script:DuneChatTeleportNameMax = 40
+$script:DuneChatTeleportCaptureTtlSeconds = 120
 
 function Get-DuneChatCommandsStatePath {
     if ($script:DuneChatStateFile) { return $script:DuneChatStateFile }
@@ -71,12 +73,33 @@ function Get-DuneChatTeleportsPath {
     return (Join-Path $dir 'teleport-bookmarks.json')
 }
 
+function Get-DuneChatTeleportCapturePath {
+    if ($script:DuneChatTeleportCaptureFile) { return $script:DuneChatTeleportCaptureFile }
+    return (Join-Path (Split-Path -Parent (Get-DuneChatTeleportsPath)) 'teleport-capture.json')
+}
+
+function Invoke-DuneChatTeleportFileLock {
+    param([Parameter(Mandatory)][scriptblock]$Script, [int]$TimeoutSeconds = 10)
+    $mutex = [Threading.Mutex]::new($false, 'Local\DuneServerTool.ChatTeleportBookmarks')
+    $acquired = $false
+    try {
+        try { $acquired = $mutex.WaitOne($TimeoutSeconds * 1000) }
+        catch [Threading.AbandonedMutexException] { $acquired = $true }
+        if (-not $acquired) { throw 'Teleport bookmarks are busy. Try again.' }
+        return (& $Script)
+    } finally {
+        if ($acquired) { try { $mutex.ReleaseMutex() } catch {} }
+        $mutex.Dispose()
+    }
+}
+
 function ConvertTo-DuneChatTeleportName {
     param([string]$Name)
     $value = ([string]$Name).Trim() -replace '\s+', ' '
     if (-not $value -or $value.Length -gt $script:DuneChatTeleportNameMax) { return '' }
     if ($value -notmatch "^[A-Za-z0-9][A-Za-z0-9 _'-]*$") { return '' }
-    if ($value -ieq 'list' -or $value -ieq 'chat-teleport-bookmarks') { return '' }
+    if ($value -ieq 'chat-teleport-bookmarks' -or
+        $value -match '^(?i:(?:list|save))(?:\s|$)') { return '' }
     return $value
 }
 
@@ -99,12 +122,44 @@ function Read-DuneChatTeleports {
 
     $items = @()
     $keys = @{}
+    $reservedKeys = @{}
+    foreach ($entry in @($parsed)) {
+        $rawName = ([string]$entry.name).Trim()
+        if ($rawName -ieq 'chat-teleport-bookmarks' -or
+            $rawName -match '^(?i:(?:list|save))(?:\s|$)') { continue }
+        $reservedName = ConvertTo-DuneChatTeleportName -Name $rawName
+        if (-not $reservedName) { throw 'Teleport bookmarks contain an invalid or reserved name.' }
+        $reservedKey = $reservedName.ToLowerInvariant()
+        if ($reservedKeys.ContainsKey($reservedKey)) {
+            throw "Teleport bookmarks contain duplicate name '$reservedName'."
+        }
+        $reservedKeys[$reservedKey] = $true
+    }
     foreach ($entry in @($parsed)) {
         # Preview 4's first field build accidentally saved the named-lock value
         # instead of the requested bookmark name. Ignore that exact internal
         # sentinel so the next real save replaces the broken one cleanly.
         if ([string]$entry.name -ieq 'chat-teleport-bookmarks') { continue }
-        $name = ConvertTo-DuneChatTeleportName -Name ([string]$entry.name)
+        $rawName = ([string]$entry.name).Trim()
+        $legacyCommandName = $rawName -match '^(?i:(?:list|save))(?:\s|$)'
+        if ($legacyCommandName) {
+            $base = "legacy-$rawName"
+            if ($base.Length -gt $script:DuneChatTeleportNameMax) {
+                $base = $base.Substring(0, $script:DuneChatTeleportNameMax).Trim()
+            }
+            $name = ConvertTo-DuneChatTeleportName -Name $base
+            $suffix = 2
+            while ($name -and (
+                    $reservedKeys.ContainsKey($name.ToLowerInvariant()) -or
+                    $keys.ContainsKey($name.ToLowerInvariant()))) {
+                $tail = "-$suffix"
+                $stemLength = $script:DuneChatTeleportNameMax - $tail.Length
+                $name = ConvertTo-DuneChatTeleportName -Name ($base.Substring(0, [math]::Min($base.Length, $stemLength)).Trim() + $tail)
+                $suffix++
+            }
+        } else {
+            $name = ConvertTo-DuneChatTeleportName -Name $rawName
+        }
         if (-not $name) { throw 'Teleport bookmarks contain an invalid or reserved name.' }
         $key = $name.ToLowerInvariant()
         if ($keys.ContainsKey($key)) { throw "Teleport bookmarks contain duplicate name '$name'." }
@@ -169,7 +224,105 @@ function Save-DuneChatTeleports {
     }
 }
 
-function Save-DuneChatTeleportFromPawn {
+function Read-DuneChatTeleportCapture {
+    param([switch]$IncludeConsumed)
+    $path = Get-DuneChatTeleportCapturePath
+    if (-not (Test-Path -LiteralPath $path)) { return $null }
+    try {
+        $entry = Get-Content -LiteralPath $path -Raw -ErrorAction Stop |
+            ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        throw "Could not read pending teleport capture: $($_.Exception.Message)"
+    }
+    $expires = [datetime]::MinValue
+    if (-not [datetime]::TryParse(
+            [string]$entry.expiresAt, [cultureinfo]::InvariantCulture,
+            [Globalization.DateTimeStyles]::RoundtripKind, [ref]$expires)) {
+        throw 'Pending teleport capture has an invalid expiry.'
+    }
+    if ($expires.ToUniversalTime() -le [datetime]::UtcNow) { return $null }
+    $consumedAt = [string]$entry.consumedAt
+    if ($consumedAt -and -not $IncludeConsumed) { return $null }
+    return [ordered]@{
+        name = [string]$entry.name
+        key = [string]$entry.key
+        pawnId = [int64]$entry.pawnId
+        funcomId = [string]$entry.funcomId
+        playerName = [string]$entry.playerName
+        token = [string]$entry.token
+        map = [string]$entry.map
+        partition = [int64]$entry.partition
+        dimension = [int]$entry.dimension
+        armedAt = [string]$entry.armedAt
+        expiresAt = [string]$entry.expiresAt
+        consumedAt = $consumedAt
+    }
+}
+
+function Save-DuneChatTeleportCapture {
+    param([System.Collections.IDictionary]$Capture)
+    $path = Get-DuneChatTeleportCapturePath
+    $temp = "$path.$([guid]::NewGuid().ToString('N')).tmp"
+    try {
+        $json = ConvertTo-Json -InputObject $Capture -Depth 4
+        [IO.File]::WriteAllText($temp, $json, (New-Object Text.UTF8Encoding($false)))
+        Move-Item -LiteralPath $temp -Destination $path -Force
+    } catch {
+        throw "Could not save pending teleport capture: $($_.Exception.Message)"
+    } finally {
+        Remove-Item -LiteralPath $temp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Remove-DuneChatTeleportCapture {
+    $path = Get-DuneChatTeleportCapturePath
+    if (-not (Test-Path -LiteralPath $path)) { return }
+    Remove-Item -LiteralPath $path -Force -ErrorAction Stop
+    if (Test-Path -LiteralPath $path) {
+        throw 'Pending teleport capture could not be removed.'
+    }
+}
+
+function Cancel-DuneChatTeleportCapture {
+    param([string]$Token)
+    if ([string]::IsNullOrWhiteSpace($Token)) {
+        return @{ ok = $false; status = 400; error = 'Capture token is required.' }
+    }
+    $pending = Read-DuneChatTeleportCapture -IncludeConsumed
+    if (-not $pending) {
+        return @{ ok = $false; status = 404; error = 'No pending teleport capture exists.' }
+    }
+    if ([string]$pending.token -ine $Token.Trim()) {
+        return @{ ok = $false; status = 409; error = 'A newer teleport capture replaced the one shown. Refresh DST before cancelling.' }
+    }
+    Remove-DuneChatTeleportCapture
+    return @{ ok = $true }
+}
+
+function Set-DuneChatTeleportBookmark {
+    param([hashtable]$Bookmark)
+    $current = @(Read-DuneChatTeleports)
+    $next = @()
+    $replaced = $false
+    foreach ($item in $current) {
+        if ([string]$item.key -eq [string]$Bookmark.key) {
+            $next += $Bookmark
+            $replaced = $true
+        } else {
+            $next += $item
+        }
+    }
+    if (-not $replaced) {
+        if ($next.Count -ge $script:DuneChatTeleportMax) {
+            return @{ ok = $false; status = 409; error = "Teleport bookmark limit reached ($($script:DuneChatTeleportMax))." }
+        }
+        $next += $Bookmark
+    }
+    [void](Save-DuneChatTeleports -Bookmarks $next)
+    return @{ ok = $true; bookmark = $Bookmark; replaced = $replaced; teleports = @($next) }
+}
+
+function Set-DuneChatTeleportCaptureForPawn {
     param([string]$Ip, [string]$Name, [long]$PawnId)
     $nameValue = ConvertTo-DuneChatTeleportName -Name $Name
     if (-not $nameValue) {
@@ -180,14 +333,13 @@ function Save-DuneChatTeleportFromPawn {
     $sql = @"
 SELECT COALESCE(ps.character_name, '') AS player_name,
        COALESCE(ps.online_status::text, 'Offline') AS status,
+       COALESCE(account.funcom_id, '') AS funcom_id,
        COALESCE(a.map, '') AS map,
        COALESCE(a.partition_id, 0)::text AS partition,
-       COALESCE(a.dimension_index, 0)::text AS dimension,
-       (a.transform).location.x AS x,
-       (a.transform).location.y AS y,
-       (a.transform).location.z AS z
+       COALESCE(a.dimension_index, 0)::text AS dimension
 FROM dune.player_state ps
 JOIN dune.actors a ON a.id = ps.player_pawn_id
+JOIN dune.accounts account ON account.id = ps.account_id
 WHERE ps.player_pawn_id = $PawnId::bigint
 LIMIT 1;
 "@
@@ -201,52 +353,93 @@ LIMIT 1;
         return @{ ok = $false; status = 409; error = 'The selected player must be online and standing at the destination.' }
     }
 
+    $funcomId = ([string]$row['funcom_id']).Trim()
+    if (-not $funcomId) {
+        return @{ ok = $false; status = 409; error = 'The selected player has no chat identity to arm.' }
+    }
     $map = ([string]$row['map']).Trim()
     $partition = [int64](ConvertTo-DuneInt $row['partition'])
     $dimension = [int](ConvertTo-DuneInt $row['dimension'])
     if (-not $map -or $partition -le 0) {
-        return @{ ok = $false; status = 409; error = 'The selected player has no current map/partition to capture.' }
+        return @{ ok = $false; status = 409; error = 'The selected player current map/partition is unavailable.' }
     }
-    try {
-        $x = [Convert]::ToDouble($row['x'], [cultureinfo]::InvariantCulture)
-        $y = [Convert]::ToDouble($row['y'], [cultureinfo]::InvariantCulture)
-        $z = [Convert]::ToDouble($row['z'], [cultureinfo]::InvariantCulture)
-    } catch {
-        return @{ ok = $false; status = 409; error = 'The selected player has no current coordinates to capture.' }
-    }
-
-    $bookmark = [ordered]@{
+    $now = [datetime]::UtcNow
+    $token = [guid]::NewGuid().ToString('N').Substring(0, 6).ToUpperInvariant()
+    $capture = [ordered]@{
         name = $nameValue
         key = $nameValue.ToLowerInvariant()
+        pawnId = $PawnId
+        funcomId = $funcomId
+        playerName = [string]$row['player_name']
+        token = $token
         map = $map
         partition = $partition
         dimension = $dimension
+        armedAt = $now.ToString('o')
+        expiresAt = $now.AddSeconds($script:DuneChatTeleportCaptureTtlSeconds).ToString('o')
+    }
+    Save-DuneChatTeleportCapture -Capture $capture
+    return @{ ok = $true; pending = $capture }
+}
+
+function Complete-DuneChatTeleportCapture {
+    param([string]$Ip, [string]$FuncomId, [string]$Token, [hashtable]$Location)
+    $pending = Read-DuneChatTeleportCapture -IncludeConsumed
+    if (-not $pending) {
+        return @{ ok = $false; status = 404; error = 'No admin-armed teleport capture is waiting. Arm one in DST first.' }
+    }
+    if ($pending.consumedAt) {
+        return @{ ok = $false; status = 409; error = 'That capture code was already consumed. Arm a new capture in DST.' }
+    }
+    if ([string]$pending.funcomId -ine [string]$FuncomId) {
+        return @{ ok = $false; status = 403; error = "The pending capture is waiting for $($pending.playerName), not this player." }
+    }
+    if (-not $Token -or [string]$pending.token -ine $Token.Trim()) {
+        return @{ ok = $false; status = 403; error = "Use the exact capture command shown in DST: !tp save $($pending.token)" }
+    }
+    if (-not $Location) {
+        return @{ ok = $false; status = 409; error = 'The game chat message did not include a live location.' }
+    }
+    try {
+        $x = [Convert]::ToDouble($Location.x, [cultureinfo]::InvariantCulture)
+        $y = [Convert]::ToDouble($Location.y, [cultureinfo]::InvariantCulture)
+        $z = [Convert]::ToDouble($Location.z, [cultureinfo]::InvariantCulture)
+    } catch {
+        return @{ ok = $false; status = 409; error = 'The game chat message contained invalid live coordinates.' }
+    }
+    $current = Get-DuneChatPlayerLocation -Ip $Ip -FuncomId $FuncomId
+    if (-not $current.ok -or [string]$current.status -match '^(?i:offline)$') {
+        return @{ ok = $false; status = 409; error = 'Could not resolve the player current map for capture.' }
+    }
+    if (-not $current.map -or [int64]$current.partition -le 0) {
+        return @{ ok = $false; status = 409; error = 'The player current map/partition is unavailable.' }
+    }
+    if ([string]$current.map -ine [string]$pending.map -or
+        [int64]$current.partition -ne [int64]$pending.partition -or
+        [int]$current.dimension -ne [int]$pending.dimension) {
+        return @{ ok = $false; status = 409; error = 'The player changed map, partition, or dimension after capture was armed. Arm it again at the destination.' }
+    }
+
+    $bookmark = [ordered]@{
+        name = [string]$pending.name
+        key = [string]$pending.key
+        map = [string]$pending.map
+        partition = [int64]$pending.partition
+        dimension = [int]$pending.dimension
         x = $x
         y = $y
         z = $z
-        capturedFrom = [string]$row['player_name']
+        capturedFrom = [string]$pending.playerName
         capturedAt = ([datetime]::UtcNow).ToString('o')
     }
-
-    $current = @(Read-DuneChatTeleports)
-    $next = @()
-    $replaced = $false
-    foreach ($item in $current) {
-        if ([string]$item.key -eq [string]$bookmark.key) {
-            $next += $bookmark
-            $replaced = $true
-        } else {
-            $next += $item
-        }
+    $pending.consumedAt = ([datetime]::UtcNow).ToString('o')
+    Save-DuneChatTeleportCapture -Capture $pending
+    $result = Set-DuneChatTeleportBookmark -Bookmark $bookmark
+    if ($result.ok) {
+        try { Remove-DuneChatTeleportCapture }
+        catch { $result['cleanupWarning'] = $_.Exception.Message }
     }
-    if (-not $replaced) {
-        if ($next.Count -ge $script:DuneChatTeleportMax) {
-            return @{ ok = $false; status = 409; error = "Teleport bookmark limit reached ($($script:DuneChatTeleportMax))." }
-        }
-        $next += $bookmark
-    }
-    [void](Save-DuneChatTeleports -Bookmarks $next)
-    return @{ ok = $true; bookmark = $bookmark; replaced = $replaced; teleports = @($next) }
+    return $result
 }
 
 function Remove-DuneChatTeleport {
@@ -529,7 +722,9 @@ function Resolve-DuneChatCommandAction {
     }
 
     $key = Get-DuneChatCooldownKey -FromId $Message.fromId -Verb $cmd.verb
-    if ($cmd.verb -eq 'tp' -and ((@($cmd.args) -join ' ').Trim() -ieq 'list')) {
+    $tpAction = if (@($cmd.args).Count -gt 0) { [string]$cmd.args[0] } else { '' }
+    $isListAction = ($tpAction -eq 'list' -and @($cmd.args).Count -eq 1)
+    if ($cmd.verb -eq 'tp' -and ($isListAction -or $tpAction -eq 'save')) {
         return @{ action = 'run'; verb = $cmd.verb; args = @($cmd.args); key = $key; from = $Message.fromId }
     }
     $cool = Test-DuneChatCooldown -Cooldowns $State.cooldowns -Key $key `
@@ -1060,8 +1255,23 @@ function Invoke-DuneChatCommandItem {
 }
 
 function Invoke-DuneChatCommandTeleport {
-    param([string]$Ip, [string]$FuncomId, [string[]]$CommandArgs)
+    param([string]$Ip, [string]$FuncomId, [string[]]$CommandArgs, [hashtable]$Message)
     $wanted = (@($CommandArgs) -join ' ').Trim()
+    $argv = @($CommandArgs)
+    if ($argv.Count -gt 0 -and [string]$argv[0] -ieq 'save') {
+        $token = if ($argv.Count -gt 1) { (@($argv[1..($argv.Count - 1)]) -join ' ').Trim() } else { '' }
+        try {
+            $result = Invoke-DuneChatTeleportFileLock -Script {
+                Complete-DuneChatTeleportCapture -Ip $Ip -FuncomId $FuncomId -Token $token -Location $Message.location
+            }
+        } catch {
+            return @{ ok = $false; applyCooldown = $false; reply = 'Could not save the armed teleport destination - check DST.' }
+        }
+        if (-not $result.ok) {
+            return @{ ok = $false; applyCooldown = $false; reply = [string]$result.error }
+        }
+        return @{ ok = $true; applyCooldown = $false; reply = "Saved $($result.bookmark.name) at your live location." }
+    }
     $bookmarks = @()
     try { $bookmarks = @(Read-DuneChatTeleports) } catch {
         return @{ ok = $false; reply = 'Teleport destinations are unavailable - check DST.' }
@@ -1116,12 +1326,12 @@ function Invoke-DuneChatCommandTeleport {
 }
 
 function Invoke-DuneChatCommandExecutor {
-    param([string]$Ip, [hashtable]$State, [string]$Verb, [string]$FuncomId, [string[]]$CommandArgs)
+    param([string]$Ip, [hashtable]$State, [string]$Verb, [string]$FuncomId, [string[]]$CommandArgs, [hashtable]$Message)
     switch ("$Verb".ToLowerInvariant()) {
         'kit'     { return Invoke-DuneChatCommandKit -Ip $Ip -State $State -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
         'item'    { return Invoke-DuneChatCommandItem -Ip $Ip -State $State -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
         'water'   { return Invoke-DuneChatCommandWater -Ip $Ip -FuncomId $FuncomId }
-        'tp'      { return Invoke-DuneChatCommandTeleport -Ip $Ip -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
+        'tp'      { return Invoke-DuneChatCommandTeleport -Ip $Ip -FuncomId $FuncomId -CommandArgs @($CommandArgs) -Message $Message }
         'vehicle' { return Invoke-DuneChatCommandVehicle -Ip $Ip -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
         'small'   { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Small' }
         'medium'  { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Medium' }
@@ -1174,7 +1384,7 @@ function Invoke-DuneChatCommandTick {
                 }
                 'run' {
                     $res = Invoke-DuneChatCommandExecutor -Ip $ip -State $state -Verb $act.verb `
-                              -FuncomId $msg.fromId -CommandArgs @($act.args)
+                              -FuncomId $msg.fromId -CommandArgs @($act.args) -Message $msg
                     if ($res.reply) {
                         [void](Send-DuneChatReply -Ip $ip -State $state -ToFuncomId $msg.fromId -Message $res.reply)
                     }

--- a/app/server/lib/ChatCommands.ps1
+++ b/app/server/lib/ChatCommands.ps1
@@ -322,11 +322,78 @@ function Set-DuneChatTeleportBookmark {
     return @{ ok = $true; bookmark = $Bookmark; replaced = $replaced; teleports = @($next) }
 }
 
+function Save-DuneChatTeleportFromPawn {
+    param([string]$Ip, [string]$Name, [long]$PawnId)
+    $nameValue = ConvertTo-DuneChatTeleportName -Name $Name
+    if (-not $nameValue) {
+        return @{ ok = $false; status = 400; error = "Name must be 1-$($script:DuneChatTeleportNameMax) characters, use letters/numbers/spaces/_/-/', and cannot start with 'list' or 'save'." }
+    }
+    if ($PawnId -le 0) { return @{ ok = $false; status = 400; error = 'pawn_id is required.' } }
+
+    $sql = @"
+SELECT COALESCE(ps.character_name, '') AS player_name,
+       COALESCE(ps.online_status::text, 'Offline') AS status,
+       COALESCE(a.map, '') AS map,
+       COALESCE(a.partition_id, 0)::text AS partition,
+       COALESCE(a.dimension_index, 0)::text AS dimension,
+       (a.transform).location.x AS x,
+       (a.transform).location.y AS y,
+       (a.transform).location.z AS z
+FROM dune.player_state ps
+JOIN dune.actors a ON a.id = ps.player_pawn_id
+WHERE ps.player_pawn_id = $PawnId::bigint
+LIMIT 1;
+"@
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $res.ok) { return @{ ok = $false; status = 500; error = "capture player location: $($res.error)" } }
+    $rows = ConvertTo-DuneRowMaps -Result $res
+    if ($rows.Count -eq 0) { return @{ ok = $false; status = 404; error = "Player pawn $PawnId was not found." } }
+    $row = $rows[0]
+    if ([string]$row['status'] -match '^(?i:offline)$') {
+        return @{ ok = $false; status = 409; error = 'The selected player must be online and standing at the destination.' }
+    }
+
+    $map = ([string]$row['map']).Trim()
+    $partition = [int64](ConvertTo-DuneInt $row['partition'])
+    $dimension = [int](ConvertTo-DuneInt $row['dimension'])
+    if (-not $map -or $partition -le 0) {
+        return @{ ok = $false; status = 409; error = 'The selected player has no current map/partition to capture.' }
+    }
+    if ($null -eq $row['x'] -or $null -eq $row['y'] -or $null -eq $row['z']) {
+        return @{ ok = $false; status = 409; error = 'The selected player has no current coordinates to capture.' }
+    }
+    try {
+        $x = [Convert]::ToDouble($row['x'], [cultureinfo]::InvariantCulture)
+        $y = [Convert]::ToDouble($row['y'], [cultureinfo]::InvariantCulture)
+        $z = [Convert]::ToDouble($row['z'], [cultureinfo]::InvariantCulture)
+    } catch {
+        return @{ ok = $false; status = 409; error = 'The selected player has no current coordinates to capture.' }
+    }
+    if ([double]::IsNaN($x) -or [double]::IsInfinity($x) -or
+        [double]::IsNaN($y) -or [double]::IsInfinity($y) -or
+        [double]::IsNaN($z) -or [double]::IsInfinity($z)) {
+        return @{ ok = $false; status = 409; error = 'The selected player has invalid coordinates to capture.' }
+    }
+    $bookmark = [ordered]@{
+        name = $nameValue
+        key = $nameValue.ToLowerInvariant()
+        map = $map
+        partition = $partition
+        dimension = $dimension
+        x = $x
+        y = $y
+        z = $z
+        capturedFrom = [string]$row['player_name']
+        capturedAt = ([datetime]::UtcNow).ToString('o')
+    }
+    return Set-DuneChatTeleportBookmark -Bookmark $bookmark
+}
+
 function Set-DuneChatTeleportCaptureForPawn {
     param([string]$Ip, [string]$Name, [long]$PawnId)
     $nameValue = ConvertTo-DuneChatTeleportName -Name $Name
     if (-not $nameValue) {
-        return @{ ok = $false; status = 400; error = "Name must be 1-$($script:DuneChatTeleportNameMax) characters, use letters/numbers/spaces/_/-/', and cannot be 'list'." }
+        return @{ ok = $false; status = 400; error = "Name must be 1-$($script:DuneChatTeleportNameMax) characters, use letters/numbers/spaces/_/-/', and cannot start with 'list' or 'save'." }
     }
     if ($PawnId -le 0) { return @{ ok = $false; status = 400; error = 'pawn_id is required.' } }
 
@@ -400,12 +467,22 @@ function Complete-DuneChatTeleportCapture {
     if (-not $Location) {
         return @{ ok = $false; status = 409; error = 'The game chat message did not include a live location.' }
     }
+    if (-not $Location.ContainsKey('x') -or -not $Location.ContainsKey('y') -or
+        -not $Location.ContainsKey('z') -or
+        $null -eq $Location.x -or $null -eq $Location.y -or $null -eq $Location.z) {
+        return @{ ok = $false; status = 409; error = 'The game chat message did not include complete live coordinates.' }
+    }
     try {
         $x = [Convert]::ToDouble($Location.x, [cultureinfo]::InvariantCulture)
         $y = [Convert]::ToDouble($Location.y, [cultureinfo]::InvariantCulture)
         $z = [Convert]::ToDouble($Location.z, [cultureinfo]::InvariantCulture)
     } catch {
         return @{ ok = $false; status = 409; error = 'The game chat message contained invalid live coordinates.' }
+    }
+    if ([double]::IsNaN($x) -or [double]::IsInfinity($x) -or
+        [double]::IsNaN($y) -or [double]::IsInfinity($y) -or
+        [double]::IsNaN($z) -or [double]::IsInfinity($z)) {
+        return @{ ok = $false; status = 409; error = 'The game chat message contained non-finite live coordinates.' }
     }
     $current = Get-DuneChatPlayerLocation -Ip $Ip -FuncomId $FuncomId
     if (-not $current.ok -or [string]$current.status -match '^(?i:offline)$') {
@@ -620,7 +697,9 @@ function ConvertFrom-DuneChatMessage {
         text      = $body
         timestamp = [string]$inner.m_Timestamp
         location  = if ($inner.m_OriginLocation) {
-            @{ x = [double]$inner.m_OriginLocation.X; y = [double]$inner.m_OriginLocation.Y; z = [double]$inner.m_OriginLocation.Z }
+            # Preserve raw values here. Capture completion owns validation so a
+            # missing/malformed field cannot become 0 or throw out of the parser.
+            @{ x = $inner.m_OriginLocation.X; y = $inner.m_OriginLocation.Y; z = $inner.m_OriginLocation.Z }
         } else { $null }
     }
 }

--- a/app/server/routes/ChatCommands.ps1
+++ b/app/server/routes/ChatCommands.ps1
@@ -39,6 +39,7 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/chat-commands' -Handler {
             commands   = $commands
             packages   = $packages
             teleports  = @(Read-DuneChatTeleports)
+            pendingTeleportCapture = (Read-DuneChatTeleportCapture)
             pollSeconds = [int](Get-DuneChatCommandPollSeconds -State $state)
             pollChoices = @($script:DuneChatPollChoices)
             ready      = [bool]$ready.ready
@@ -58,9 +59,6 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/chat-commands/teleports' -H
             Write-DuneError -Response $res -Status 400 -Message 'Body must be a JSON object.'
             return
         }
-        # Keep this name distinct from Invoke-WithDuneLock's own $Name parameter.
-        # PowerShell scriptblocks use dynamic scope, so reusing $name here caused
-        # every bookmark to be saved as the lock name instead of the admin's name.
         $bookmarkName = [string]$body['name']
         $pawnId = 0L
         if (-not [int64]::TryParse([string]$body['pawn_id'], [ref]$pawnId)) {
@@ -72,8 +70,13 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/chat-commands/teleports' -H
             Write-DuneError -Response $res -Status 503 -Message $ctx.message
             return
         }
-        $result = Invoke-WithDuneLock -Name 'chat-teleport-bookmarks' -Script {
-            Save-DuneChatTeleportFromPawn -Ip $ctx.ip -Name $bookmarkName -PawnId $pawnId
+        $state = Read-DuneChatCommandsState
+        if (-not $state.enabled -or -not $state.commands['tp'].enabled) {
+            Write-DuneError -Response $res -Status 409 -Message 'Turn on in-game command listening and !tp before arming a capture.'
+            return
+        }
+        $result = Invoke-DuneChatTeleportFileLock -Script {
+            Set-DuneChatTeleportCaptureForPawn -Ip $ctx.ip -Name $bookmarkName -PawnId $pawnId
         }
         if (-not $result.ok) {
             Write-DuneError -Response $res -Status ([int]$result.status) -Message $result.error
@@ -93,7 +96,7 @@ Register-DuneRoute -Method DELETE -Path '/api/gameplay/chat-commands/teleports' 
             return
         }
         $bookmarkName = [string]$body['name']
-        $result = Invoke-WithDuneLock -Name 'chat-teleport-bookmarks' -Script {
+        $result = Invoke-DuneChatTeleportFileLock -Script {
             Remove-DuneChatTeleport -Name $bookmarkName
         }
         if (-not $result.ok) {
@@ -103,6 +106,27 @@ Register-DuneRoute -Method DELETE -Path '/api/gameplay/chat-commands/teleports' 
         Write-DuneJson -Response $res -Body $result
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Teleport bookmark delete failed: $($_.Exception.Message)"
+    }
+}
+
+Register-DuneRoute -Method DELETE -Path '/api/gameplay/chat-commands/teleports/capture' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        if (-not ($body -is [hashtable])) {
+            Write-DuneError -Response $res -Status 400 -Message 'Body must be a JSON object.'
+            return
+        }
+        $captureToken = [string]$body['token']
+        $result = Invoke-DuneChatTeleportFileLock -Script {
+            Cancel-DuneChatTeleportCapture -Token $captureToken
+        }
+        if (-not $result.ok) {
+            Write-DuneError -Response $res -Status ([int]$result.status) -Message $result.error
+            return
+        }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Pending teleport capture cancel failed: $($_.Exception.Message)"
     }
 }
 

--- a/app/server/routes/ChatCommands.ps1
+++ b/app/server/routes/ChatCommands.ps1
@@ -70,9 +70,40 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/chat-commands/teleports' -H
             Write-DuneError -Response $res -Status 503 -Message $ctx.message
             return
         }
+        $result = Invoke-DuneChatTeleportFileLock -Script {
+            Save-DuneChatTeleportFromPawn -Ip $ctx.ip -Name $bookmarkName -PawnId $pawnId
+        }
+        if (-not $result.ok) {
+            Write-DuneError -Response $res -Status ([int]$result.status) -Message $result.error
+            return
+        }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Teleport bookmark save failed: $($_.Exception.Message)"
+    }
+}
+
+Register-DuneRoute -Method POST -Path '/api/gameplay/chat-commands/teleports/capture' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        if (-not ($body -is [hashtable])) {
+            Write-DuneError -Response $res -Status 400 -Message 'Body must be a JSON object.'
+            return
+        }
+        $bookmarkName = [string]$body['name']
+        $pawnId = 0L
+        if (-not [int64]::TryParse([string]$body['pawn_id'], [ref]$pawnId)) {
+            Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'
+            return
+        }
         $state = Read-DuneChatCommandsState
         if (-not $state.enabled -or -not $state.commands['tp'].enabled) {
-            Write-DuneError -Response $res -Status 409 -Message 'Turn on in-game command listening and !tp before arming a capture.'
+            Write-DuneError -Response $res -Status 409 -Message 'Turn on in-game command listening and !tp before arming a live capture.'
+            return
+        }
+        $ctx = Get-DuneDbContext
+        if (-not $ctx.ok) {
+            Write-DuneError -Response $res -Status 503 -Message $ctx.message
             return
         }
         $result = Invoke-DuneChatTeleportFileLock -Script {
@@ -84,7 +115,7 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/chat-commands/teleports' -H
         }
         Write-DuneJson -Response $res -Body $result
     } catch {
-        Write-DuneError -Response $res -Status 500 -Message "Teleport bookmark save failed: $($_.Exception.Message)"
+        Write-DuneError -Response $res -Status 500 -Message "Live teleport capture arm failed: $($_.Exception.Message)"
     }
 }
 

--- a/tests/ChatCommands.Tests.ps1
+++ b/tests/ChatCommands.Tests.ps1
@@ -198,6 +198,22 @@ Describe 'Resolve-DuneChatCommandAction' {
         $r.verb | Should -Be 'tp'
     }
 
+    It 'allows !tp save during a teleport cooldown' {
+        $st = New-DstChatState
+        $st.cooldowns[(Get-DuneChatCooldownKey -FromId 'A#1' -Verb 'tp')] =
+            ([datetime]::UtcNow).ToString('o')
+        $m = @{ type = 'TextChat'; channel = 'Proximity'; fromId = 'A#1'; text = '!tp save' }
+        (Resolve-DuneChatCommandAction -Message $m -State $st).action | Should -Be 'run'
+    }
+
+    It 'does not treat list-prefixed destination text as the list action' {
+        $st = New-DstChatState
+        $st.cooldowns[(Get-DuneChatCooldownKey -FromId 'A#1' -Verb 'tp')] =
+            ([datetime]::UtcNow).ToString('o')
+        $m = @{ type = 'TextChat'; channel = 'Proximity'; fromId = 'A#1'; text = '!tp list camp' }
+        (Resolve-DuneChatCommandAction -Message $m -State $st).action | Should -Be 'cooldown'
+    }
+
     It 'never runs on a non-TextChat envelope' {
         $st = New-DstChatState
         $m = @{ type = 'SystemMessage'; channel = 'Proximity'; fromId = 'A#1'; text = '!large' }
@@ -332,15 +348,22 @@ Describe 'teleport bookmarks' {
 
     BeforeEach {
         $script:DuneChatTeleportsFile = Join-Path $TestDrive 'teleport-bookmarks.json'
+        $script:DuneChatTeleportCaptureFile = Join-Path $TestDrive 'teleport-capture.json'
+        Remove-Item -LiteralPath $script:DuneChatTeleportsFile -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $script:DuneChatTeleportCaptureFile -Force -ErrorAction SilentlyContinue
     }
 
     AfterEach {
         $script:DuneChatTeleportsFile = $null
+        $script:DuneChatTeleportCaptureFile = $null
     }
 
     It 'accepts friendly names while rejecting reserved or unsafe names' {
         ConvertTo-DuneChatTeleportName -Name '  Base   Camp  ' | Should -Be 'Base Camp'
         ConvertTo-DuneChatTeleportName -Name 'list' | Should -BeNullOrEmpty
+        ConvertTo-DuneChatTeleportName -Name 'List Camp' | Should -BeNullOrEmpty
+        ConvertTo-DuneChatTeleportName -Name 'save' | Should -BeNullOrEmpty
+        ConvertTo-DuneChatTeleportName -Name 'Save Camp' | Should -BeNullOrEmpty
         ConvertTo-DuneChatTeleportName -Name 'chat-teleport-bookmarks' | Should -BeNullOrEmpty
         ConvertTo-DuneChatTeleportName -Name '../outside' | Should -BeNullOrEmpty
     }
@@ -353,37 +376,163 @@ Describe 'teleport bookmarks' {
         @(Read-DuneChatTeleports).Count | Should -Be 0
     }
 
-    It 'captures an online player location and replaces a matching name' {
+    It 'migrates a legacy save-prefixed bookmark to a reachable name' {
+        [IO.File]::WriteAllText(
+            $script:DuneChatTeleportsFile,
+            '[{"name":"Save Camp","key":"save camp","map":"HaggaBasin","partition":1,"dimension":0,"x":1,"y":2,"z":3}]',
+            (New-Object Text.UTF8Encoding($false)))
+        $items = @(Read-DuneChatTeleports)
+        $items.Count | Should -Be 1
+        $items[0].name | Should -Be 'legacy-Save Camp'
+        $items[0].key | Should -Be 'legacy-save camp'
+    }
+
+    It 'migrates command-prefixed names without colliding with existing bookmarks' {
+        [IO.File]::WriteAllText(
+            $script:DuneChatTeleportsFile,
+            '[{"name":"Save Camp","key":"save camp","map":"HaggaBasin","partition":1,"dimension":0,"x":1,"y":2,"z":3},{"name":"legacy-Save Camp","key":"legacy-save camp","map":"HaggaBasin","partition":1,"dimension":0,"x":4,"y":5,"z":6}]',
+            (New-Object Text.UTF8Encoding($false)))
+        $items = @(Read-DuneChatTeleports)
+        $items.Count | Should -Be 2
+        @($items.name | Sort-Object) | Should -Be @('legacy-Save Camp', 'legacy-Save Camp-2')
+    }
+
+    It 'arms an online player without reading stale actor coordinates' {
         Mock Invoke-DuneSqlQuery {
             @{
                 ok = $true
-                columns = @('player_name', 'status', 'map', 'partition', 'dimension', 'x', 'y', 'z')
-                rows = ,@('Coastal', 'Online', 'HaggaBasin', '1', '0', '100.5', '200.25', '300')
+                columns = @('player_name', 'status', 'funcom_id', 'map', 'partition', 'dimension')
+                rows = ,@('Coastal', 'Online', 'Coastal#1', 'HaggaBasin', '1', '0')
             }
         }
 
-        $first = Save-DuneChatTeleportFromPawn -Ip 'vm' -Name 'Base Camp' -PawnId 42
-        $first.ok | Should -BeTrue
-        $first.replaced | Should -BeFalse
-        @(Read-DuneChatTeleports).Count | Should -Be 1
-
-        $second = Save-DuneChatTeleportFromPawn -Ip 'vm' -Name 'base camp' -PawnId 42
-        $second.ok | Should -BeTrue
-        $second.replaced | Should -BeTrue
-        @(Read-DuneChatTeleports).Count | Should -Be 1
+        $result = Set-DuneChatTeleportCaptureForPawn -Ip 'vm' -Name 'Base Camp' -PawnId 42
+        $result.ok | Should -BeTrue
+        $result.pending.funcomId | Should -Be 'Coastal#1'
+        $result.pending.token | Should -Match '^[A-F0-9]{6}$'
+        $result.pending.map | Should -Be 'HaggaBasin'
+        @(Read-DuneChatTeleports).Count | Should -Be 0
+        (Read-DuneChatTeleportCapture).name | Should -Be 'Base Camp'
     }
 
     It 'refuses to capture an offline player' {
         Mock Invoke-DuneSqlQuery {
             @{
                 ok = $true
-                columns = @('player_name', 'status', 'map', 'partition', 'dimension', 'x', 'y', 'z')
-                rows = ,@('Coastal', 'Offline', 'HaggaBasin', '1', '0', 1, 2, 3)
+                columns = @('player_name', 'status', 'funcom_id', 'map', 'partition', 'dimension')
+                rows = ,@('Coastal', 'Offline', 'Coastal#1', 'HaggaBasin', '1', '0')
             }
         }
-        $r = Save-DuneChatTeleportFromPawn -Ip 'vm' -Name 'Base' -PawnId 42
+        $r = Set-DuneChatTeleportCaptureForPawn -Ip 'vm' -Name 'Base' -PawnId 42
         $r.ok | Should -BeFalse
         $r.error | Should -BeLike '*must be online*'
+    }
+
+    It 'completes an armed capture from the exact live chat origin' {
+        $now = [datetime]::UtcNow
+        Save-DuneChatTeleportCapture -Capture @{
+            name = 'South Camp'
+            key = 'south camp'
+            pawnId = 42
+            funcomId = 'Coastal#1'
+            playerName = 'Coastal'
+            token = 'ABC123'
+            map = 'HaggaBasin'
+            partition = 1
+            dimension = 0
+            armedAt = $now.ToString('o')
+            expiresAt = $now.AddMinutes(2).ToString('o')
+        }
+        Mock Get-DuneChatPlayerLocation {
+            @{ ok = $true; status = 'Online'; map = 'HaggaBasin'; partition = 1; dimension = 0 }
+        }
+
+        $message = @{ location = @{ x = 111.25; y = -222.5; z = 333.75 } }
+        $r = Invoke-DuneChatCommandExecutor -Ip 'vm' -State (New-DstChatState) -Verb 'tp' `
+            -FuncomId 'Coastal#1' -CommandArgs @('save', 'ABC123') -Message $message
+        $r.ok | Should -BeTrue
+        $r.applyCooldown | Should -BeFalse
+        $r.reply | Should -Be 'Saved South Camp at your live location.'
+        $saved = @(Read-DuneChatTeleports)
+        $saved.Count | Should -Be 1
+        $saved[0].x | Should -Be 111.25
+        $saved[0].y | Should -Be -222.5
+        Read-DuneChatTeleportCapture | Should -BeNullOrEmpty
+    }
+
+    It 'rejects a stale or incorrect one-time capture code' {
+        $now = [datetime]::UtcNow
+        Save-DuneChatTeleportCapture -Capture @{
+            name = 'South Camp'; key = 'south camp'; pawnId = 42
+            funcomId = 'Coastal#1'; playerName = 'Coastal'; token = 'ABC123'
+            map = 'HaggaBasin'; partition = 1; dimension = 0
+            armedAt = $now.ToString('o'); expiresAt = $now.AddMinutes(2).ToString('o')
+        }
+        $message = @{ location = @{ x = 1; y = 2; z = 3 } }
+        $r = Invoke-DuneChatCommandExecutor -Ip 'vm' -State (New-DstChatState) -Verb 'tp' `
+            -FuncomId 'Coastal#1' -CommandArgs @('save', 'OLD999') -Message $message
+        $r.ok | Should -BeFalse
+        $r.reply | Should -BeLike '*!tp save ABC123*'
+        @(Read-DuneChatTeleports).Count | Should -Be 0
+    }
+
+    It 'rejects capture when the player changed maps after arming' {
+        $now = [datetime]::UtcNow
+        Save-DuneChatTeleportCapture -Capture @{
+            name = 'South Camp'; key = 'south camp'; pawnId = 42
+            funcomId = 'Coastal#1'; playerName = 'Coastal'; token = 'ABC123'
+            map = 'HaggaBasin'; partition = 1; dimension = 0
+            armedAt = $now.ToString('o'); expiresAt = $now.AddMinutes(2).ToString('o')
+        }
+        Mock Get-DuneChatPlayerLocation {
+            @{ ok = $true; status = 'Online'; map = 'DeepDesert'; partition = 8; dimension = 0 }
+        }
+        $message = @{ location = @{ x = 1; y = 2; z = 3 } }
+        $r = Invoke-DuneChatCommandExecutor -Ip 'vm' -State (New-DstChatState) -Verb 'tp' `
+            -FuncomId 'Coastal#1' -CommandArgs @('save', 'ABC123') -Message $message
+        $r.ok | Should -BeFalse
+        $r.reply | Should -BeLike '*changed map*'
+        @(Read-DuneChatTeleports).Count | Should -Be 0
+    }
+
+    It 'consumes the one-time code before commit and never reuses it after cleanup failure' {
+        $now = [datetime]::UtcNow
+        Save-DuneChatTeleportCapture -Capture @{
+            name = 'South Camp'; key = 'south camp'; pawnId = 42
+            funcomId = 'Coastal#1'; playerName = 'Coastal'; token = 'ABC123'
+            map = 'HaggaBasin'; partition = 1; dimension = 0
+            armedAt = $now.ToString('o'); expiresAt = $now.AddMinutes(2).ToString('o')
+        }
+        Mock Get-DuneChatPlayerLocation {
+            @{ ok = $true; status = 'Online'; map = 'HaggaBasin'; partition = 1; dimension = 0 }
+        }
+        Mock Remove-DuneChatTeleportCapture { throw 'simulated cleanup failure' }
+        $message = @{ location = @{ x = 1; y = 2; z = 3 } }
+
+        $first = Complete-DuneChatTeleportCapture -Ip 'vm' -FuncomId 'Coastal#1' `
+            -Token 'ABC123' -Location $message.location
+        $first.ok | Should -BeTrue
+        $first.cleanupWarning | Should -BeLike '*simulated cleanup failure*'
+        Read-DuneChatTeleportCapture | Should -BeNullOrEmpty
+
+        $second = Complete-DuneChatTeleportCapture -Ip 'vm' -FuncomId 'Coastal#1' `
+            -Token 'ABC123' -Location $message.location
+        $second.ok | Should -BeFalse
+        $second.error | Should -BeLike '*already consumed*'
+    }
+
+    It 'refuses a stale cancellation token without removing the newer capture' {
+        $now = [datetime]::UtcNow
+        Save-DuneChatTeleportCapture -Capture @{
+            name = 'New Camp'; key = 'new camp'; pawnId = 42
+            funcomId = 'Coastal#1'; playerName = 'Coastal'; token = 'NEW123'
+            map = 'HaggaBasin'; partition = 1; dimension = 0
+            armedAt = $now.ToString('o'); expiresAt = $now.AddMinutes(2).ToString('o')
+        }
+        $result = Cancel-DuneChatTeleportCapture -Token 'OLD999'
+        $result.ok | Should -BeFalse
+        $result.status | Should -Be 409
+        (Read-DuneChatTeleportCapture).token | Should -Be 'NEW123'
     }
 
     It 'lists destinations without consuming the teleport cooldown' {

--- a/tests/ChatCommands.Tests.ps1
+++ b/tests/ChatCommands.Tests.ps1
@@ -48,6 +48,15 @@ Describe 'ConvertFrom-DuneChatMessage' {
         [math]::Round($m.location.z, 2) | Should -Be 22060.14
     }
 
+    It 'does not coerce or throw on a malformed origin coordinate' {
+        $bad = $script:RealEnvelope.Replace(
+            '\"X\":-44405.412464',
+            '\"X\":\"not-a-coordinate\"')
+        $m = ConvertFrom-DuneChatMessage -Text $bad
+        $m | Should -Not -BeNullOrEmpty
+        $m.location.x | Should -Be 'not-a-coordinate'
+    }
+
     It 'finds the envelope even when wrapped in a larger term dump' {
         # basic_get hands back an Erlang term, so the envelope arrives embedded
         # in surrounding noise rather than as a clean JSON document.
@@ -415,6 +424,33 @@ Describe 'teleport bookmarks' {
         (Read-DuneChatTeleportCapture).name | Should -Be 'Base Camp'
     }
 
+    It 'still saves a normal online actor transform directly' {
+        Mock Invoke-DuneSqlQuery {
+            @{
+                ok = $true
+                columns = @('player_name', 'status', 'map', 'partition', 'dimension', 'x', 'y', 'z')
+                rows = ,@('Coastal', 'Online', 'HaggaBasin', '1', '0', '100.5', '200.25', '300')
+            }
+        }
+        $result = Save-DuneChatTeleportFromPawn -Ip 'vm' -Name 'CHome' -PawnId 42
+        $result.ok | Should -BeTrue
+        $result.bookmark.name | Should -Be 'CHome'
+        $result.bookmark.x | Should -Be 100.5
+        @(Read-DuneChatTeleports).Count | Should -Be 1
+    }
+
+    It 'rejects missing or non-finite direct coordinates' {
+        Mock Invoke-DuneSqlQuery {
+            @{
+                ok = $true
+                columns = @('player_name', 'status', 'map', 'partition', 'dimension', 'x', 'y', 'z')
+                rows = ,@('Coastal', 'Online', 'HaggaBasin', '1', '0', $null, 'NaN', 'Infinity')
+            }
+        }
+        (Save-DuneChatTeleportFromPawn -Ip 'vm' -Name 'Bad' -PawnId 42).ok | Should -BeFalse
+        @(Read-DuneChatTeleports).Count | Should -Be 0
+    }
+
     It 'refuses to capture an offline player' {
         Mock Invoke-DuneSqlQuery {
             @{
@@ -473,6 +509,24 @@ Describe 'teleport bookmarks' {
             -FuncomId 'Coastal#1' -CommandArgs @('save', 'OLD999') -Message $message
         $r.ok | Should -BeFalse
         $r.reply | Should -BeLike '*!tp save ABC123*'
+        @(Read-DuneChatTeleports).Count | Should -Be 0
+    }
+
+    It 'rejects incomplete or non-finite live coordinates' {
+        $now = [datetime]::UtcNow
+        Save-DuneChatTeleportCapture -Capture @{
+            name = 'South Camp'; key = 'south camp'; pawnId = 42
+            funcomId = 'Coastal#1'; playerName = 'Coastal'; token = 'ABC123'
+            map = 'HaggaBasin'; partition = 1; dimension = 0
+            armedAt = $now.ToString('o'); expiresAt = $now.AddMinutes(2).ToString('o')
+        }
+        $missing = Complete-DuneChatTeleportCapture -Ip 'vm' -FuncomId 'Coastal#1' `
+            -Token 'ABC123' -Location @{ x = $null; y = 2; z = 3 }
+        $missing.ok | Should -BeFalse
+
+        $nonFinite = Complete-DuneChatTeleportCapture -Ip 'vm' -FuncomId 'Coastal#1' `
+            -Token 'ABC123' -Location @{ x = [double]::NaN; y = 2; z = 3 }
+        $nonFinite.ok | Should -BeFalse
         @(Read-DuneChatTeleports).Count | Should -Be 0
     }
 

--- a/tests/ChatCommandsRoutes.Tests.ps1
+++ b/tests/ChatCommandsRoutes.Tests.ps1
@@ -19,11 +19,12 @@ Describe 'Chat command route registration' {
                 'DELETE /api/gameplay/chat-commands/teleports/capture'
                 'GET /api/gameplay/chat-commands'
                 'POST /api/gameplay/chat-commands/teleports'
+                'POST /api/gameplay/chat-commands/teleports/capture'
                 'PUT /api/gameplay/chat-commands'
             )
     }
 
-    It 'passes the requested bookmark name into the armed capture' {
+    It 'passes the requested bookmark name into direct save' {
         $routes = @(& {
             function Register-DuneRoute {
                 param($Method, $Path, $Handler)
@@ -33,6 +34,36 @@ Describe 'Chat command route registration' {
         })
         $post = $routes | Where-Object {
             $_.method -eq 'POST' -and $_.path -eq '/api/gameplay/chat-commands/teleports'
+        } | Select-Object -First 1
+
+        $script:CapturedBookmarkName = ''
+        function Get-DuneDbContext { @{ ok = $true; ip = 'vm' } }
+        function Invoke-DuneChatTeleportFileLock {
+            param([scriptblock]$Script)
+            & $Script
+        }
+        function Save-DuneChatTeleportFromPawn {
+            param($Ip, [string]$Name, $PawnId)
+            $script:CapturedBookmarkName = $Name
+            @{ ok = $true; status = 200; teleports = @() }
+        }
+        function Write-DuneJson { param($Response, $Body) }
+        function Write-DuneError { param($Response, $Status, $Message); throw $Message }
+
+        & $post.handler $null $null $null @{ name = 'CHome'; pawn_id = 42 }
+        $script:CapturedBookmarkName | Should -Be 'CHome'
+    }
+
+    It 'passes the requested name into an armed live capture' {
+        $routes = @(& {
+            function Register-DuneRoute {
+                param($Method, $Path, $Handler)
+                [pscustomobject]@{ method = $Method; path = $Path; handler = $Handler }
+            }
+            . $script:RouteFile
+        })
+        $post = $routes | Where-Object {
+            $_.method -eq 'POST' -and $_.path -eq '/api/gameplay/chat-commands/teleports/capture'
         } | Select-Object -First 1
 
         $script:CapturedBookmarkName = ''
@@ -52,7 +83,7 @@ Describe 'Chat command route registration' {
         function Write-DuneJson { param($Response, $Body) }
         function Write-DuneError { param($Response, $Status, $Message); throw $Message }
 
-        & $post.handler $null $null $null @{ name = 'CHome'; pawn_id = 42 }
-        $script:CapturedBookmarkName | Should -Be 'CHome'
+        & $post.handler $null $null $null @{ name = 'Hagga South'; pawn_id = 42 }
+        $script:CapturedBookmarkName | Should -Be 'Hagga South'
     }
 }

--- a/tests/ChatCommandsRoutes.Tests.ps1
+++ b/tests/ChatCommandsRoutes.Tests.ps1
@@ -16,13 +16,14 @@ Describe 'Chat command route registration' {
         @($routes | ForEach-Object { "$($_.method) $($_.path)" } | Sort-Object) |
             Should -Be @(
                 'DELETE /api/gameplay/chat-commands/teleports'
+                'DELETE /api/gameplay/chat-commands/teleports/capture'
                 'GET /api/gameplay/chat-commands'
                 'POST /api/gameplay/chat-commands/teleports'
                 'PUT /api/gameplay/chat-commands'
             )
     }
 
-    It 'passes the requested bookmark name through the named lock' {
+    It 'passes the requested bookmark name into the armed capture' {
         $routes = @(& {
             function Register-DuneRoute {
                 param($Method, $Path, $Handler)
@@ -36,14 +37,17 @@ Describe 'Chat command route registration' {
 
         $script:CapturedBookmarkName = ''
         function Get-DuneDbContext { @{ ok = $true; ip = 'vm' } }
-        function Invoke-WithDuneLock {
-            param([string]$Name, [scriptblock]$Script)
+        function Read-DuneChatCommandsState {
+            @{ enabled = $true; commands = @{ tp = @{ enabled = $true } } }
+        }
+        function Invoke-DuneChatTeleportFileLock {
+            param([scriptblock]$Script)
             & $Script
         }
-        function Save-DuneChatTeleportFromPawn {
+        function Set-DuneChatTeleportCaptureForPawn {
             param($Ip, [string]$Name, $PawnId)
             $script:CapturedBookmarkName = $Name
-            @{ ok = $true; status = 200; teleports = @() }
+            @{ ok = $true; status = 200; pending = @{ name = $Name; token = 'ABC123' } }
         }
         function Write-DuneJson { param($Response, $Body) }
         function Write-DuneError { param($Response, $Status, $Message); throw $Message }

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -2215,6 +2215,13 @@ export function saveChatCommands(patch: {
 
 export function armChatTeleport(name: string, pawnId: number) {
   return api<{ ok: boolean; pending: ChatCommandsState['pendingTeleportCapture'] }>(
+    '/api/gameplay/chat-commands/teleports/capture',
+    { method: 'POST', body: JSON.stringify({ name, pawn_id: pawnId }) },
+  )
+}
+
+export function saveChatTeleport(name: string, pawnId: number) {
+  return api<{ ok: boolean; replaced: boolean; teleports: ChatCommandsState['teleports'] }>(
     '/api/gameplay/chat-commands/teleports',
     { method: 'POST', body: JSON.stringify({ name, pawn_id: pawnId }) },
   )

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -2213,11 +2213,18 @@ export function saveChatCommands(patch: {
   })
 }
 
-export function saveChatTeleport(name: string, pawnId: number) {
-  return api<{ ok: boolean; replaced: boolean; teleports: ChatCommandsState['teleports'] }>(
+export function armChatTeleport(name: string, pawnId: number) {
+  return api<{ ok: boolean; pending: ChatCommandsState['pendingTeleportCapture'] }>(
     '/api/gameplay/chat-commands/teleports',
     { method: 'POST', body: JSON.stringify({ name, pawn_id: pawnId }) },
   )
+}
+
+export function cancelChatTeleportCapture(token: string) {
+  return api<{ ok: boolean }>('/api/gameplay/chat-commands/teleports/capture', {
+    method: 'DELETE',
+    body: JSON.stringify({ token }),
+  })
 }
 
 export function deleteChatTeleport(name: string) {

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -480,6 +480,20 @@ export type ChatTeleportBookmark = {
   capturedAt: string
 }
 
+export type PendingChatTeleportCapture = {
+  name: string
+  key: string
+  pawnId: number
+  funcomId: string
+  playerName: string
+  token: string
+  map: string
+  partition: number
+  dimension: number
+  armedAt: string
+  expiresAt: string
+}
+
 export type ChatCommandsState = {
   ok: boolean
   enabled: boolean
@@ -488,6 +502,7 @@ export type ChatCommandsState = {
   commands: Record<string, ChatCommandSetting>
   packages?: string[]      // kit names available to !kit, from the package store
   teleports?: ChatTeleportBookmark[]
+  pendingTeleportCapture?: PendingChatTeleportCapture | null
   pollSeconds?: number
   pollChoices?: number[]
   ready?: boolean

--- a/webui/src/pages/gameplay/ChatCommandsCard.tsx
+++ b/webui/src/pages/gameplay/ChatCommandsCard.tsx
@@ -8,6 +8,7 @@ import {
   getChatCommands,
   getPlayers,
   saveChatCommands,
+  saveChatTeleport,
 } from '../../api/gameplay'
 import { getSpicefields, saveSpicefield } from '../../api/gameconfig'
 import type { ChatCommandsState, SpicefieldType } from '../../api/types'
@@ -161,6 +162,7 @@ export function ChatCommandsCard() {
   const [deletingTeleport, setDeletingTeleport] = useState<string | null>(null)
   const [showTeleports, setShowTeleports] = useState(true)
   const [expandedTeleport, setExpandedTeleport] = useState<string | null>(null)
+  const [copiedCapture, setCopiedCapture] = useState(false)
 
   const load = useCallback(async () => {
     setLoading(true); setErr(null)
@@ -238,6 +240,25 @@ export function ChatCommandsCard() {
     }
   }
 
+  async function saveTeleportDirect() {
+    const name = captureName.trim()
+    if (!name || capturePawn <= 0) {
+      setErr('Choose an online player and enter a destination name.')
+      return
+    }
+    setSaving(true); setErr(null); setOk(null)
+    try {
+      const res = await saveChatTeleport(name, capturePawn)
+      setState(prev => (prev ? { ...prev, teleports: res.teleports ?? [] } : prev))
+      setCaptureName('')
+      setOk(res.replaced ? `Updated "${name}".` : `Saved "${name}".`)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
   async function cancelTeleportCapture(token: string) {
     setSaving(true); setErr(null); setOk(null)
     try {
@@ -249,6 +270,16 @@ export function ChatCommandsCard() {
     } finally {
       setSaving(false)
     }
+  }
+
+  function copyCaptureCommand(token: string) {
+    const command = `!tp save ${token}`
+    void navigator.clipboard?.writeText(command).then(() => {
+      setCopiedCapture(true)
+      setTimeout(() => setCopiedCapture(false), 1500)
+    }).catch(() => {
+      setErr(`Could not copy automatically. Type: ${command}`)
+    })
   }
 
   async function removeTeleport(name: string) {
@@ -395,12 +426,13 @@ export function ChatCommandsCard() {
               {verb === 'tp' && (
                 <div className="mt-3 rounded border border-border bg-surface/50 p-3">
                   <div className="text-[11px] text-text-muted">
-                    Shared destinations are stored only on this DST PC. Arm a name and
-                    player here, then that player types <code>!tp save</code> while standing
-                    at the destination. This captures the live game-chat position instead
-                    of a potentially stale database transform. Teleports remain limited to
-                    the same map, partition and dimension. Replies and <code>!tp list</code>{' '}
-                    are public server broadcasts.
+                    Shared destinations are stored only on this DST PC. Use
+                    <strong> Save location</strong> for normal areas. If that location returns
+                    to a map opening point (observed in Hagga South), use
+                    <strong> Arm live capture</strong>; the selected player then types the
+                    one-time command at the destination. Teleports remain limited to the
+                    same map, partition and dimension. Replies and <code>!tp list</code> are
+                    public server broadcasts.
                   </div>
                   <div className="mt-3 grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
                     <select
@@ -422,20 +454,31 @@ export function ChatCommandsCard() {
                       maxLength={40}
                       disabled={saving || loading}
                       onChange={e => setCaptureName(e.target.value)}
-                      onKeyDown={e => { if (e.key === 'Enter') void armTeleportCapture() }}
+                      onKeyDown={e => { if (e.key === 'Enter') void saveTeleportDirect() }}
                       placeholder="Destination name"
                       className="px-2 py-1.5 rounded bg-surface border border-border text-text text-xs"
                     />
-                    <button
-                      type="button"
-                      className="btn-secondary"
-                      disabled={saving || loading || !canArmTeleport || capturePawn <= 0 || !captureName.trim()}
-                      onClick={() => void armTeleportCapture()}
-                    >
-                      <Icon name={saving ? 'Loader2' : 'MapPin'} size={13}
-                            className={saving ? 'animate-spin' : ''} />
-                      Arm capture
-                    </button>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="btn-secondary"
+                        disabled={saving || loading || capturePawn <= 0 || !captureName.trim()}
+                        onClick={() => void saveTeleportDirect()}
+                      >
+                        <Icon name={saving ? 'Loader2' : 'MapPin'} size={13}
+                              className={saving ? 'animate-spin' : ''} />
+                        Save location
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-secondary"
+                        disabled={saving || loading || !canArmTeleport || capturePawn <= 0 || !captureName.trim()}
+                        onClick={() => void armTeleportCapture()}
+                      >
+                        <Icon name="Radio" size={13} />
+                        Arm live capture
+                      </button>
+                    </div>
                   </div>
                   {pendingCapture && (
                     <div className="mt-3 rounded border border-warning/40 bg-warning/10 p-2 text-[11px]">
@@ -447,7 +490,14 @@ export function ChatCommandsCard() {
                         </span>
                         <button
                           type="button"
-                          className="ml-auto text-text-dim hover:text-danger"
+                          className="ml-auto text-text-dim hover:text-text"
+                          onClick={() => copyCaptureCommand(pendingCapture.token)}
+                        >
+                          {copiedCapture ? 'Copied' : 'Copy command'}
+                        </button>
+                        <button
+                          type="button"
+                          className="text-text-dim hover:text-danger"
                           disabled={saving || loading}
                           onClick={() => void cancelTeleportCapture(pendingCapture.token)}
                         >
@@ -463,7 +513,7 @@ export function ChatCommandsCard() {
                   )}
                   {!canArmTeleport && (
                     <div className="mt-2 text-[11px] text-warning">
-                      Turn on chat listening and <code>!tp</code> before arming a capture.
+                      Turn on chat listening and <code>!tp</code> before using live capture.
                     </div>
                   )}
                   {teleports.length === 0 ? (

--- a/webui/src/pages/gameplay/ChatCommandsCard.tsx
+++ b/webui/src/pages/gameplay/ChatCommandsCard.tsx
@@ -2,11 +2,12 @@ import { useCallback, useEffect, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import { CollapsibleCard } from '../../components/CollapsibleCard'
 import {
+  armChatTeleport,
+  cancelChatTeleportCapture,
   deleteChatTeleport,
   getChatCommands,
   getPlayers,
   saveChatCommands,
-  saveChatTeleport,
 } from '../../api/gameplay'
 import { getSpicefields, saveSpicefield } from '../../api/gameconfig'
 import type { ChatCommandsState, SpicefieldType } from '../../api/types'
@@ -218,7 +219,7 @@ export function ChatCommandsCard() {
     })
   }
 
-  async function captureTeleport() {
+  async function armTeleportCapture() {
     const name = captureName.trim()
     if (!name || capturePawn <= 0) {
       setErr('Choose an online player and enter a destination name.')
@@ -226,10 +227,23 @@ export function ChatCommandsCard() {
     }
     setSaving(true); setErr(null); setOk(null)
     try {
-      const res = await saveChatTeleport(name, capturePawn)
-      setState(prev => (prev ? { ...prev, teleports: res.teleports ?? [] } : prev))
+      const res = await armChatTeleport(name, capturePawn)
+      setState(prev => (prev ? { ...prev, pendingTeleportCapture: res.pending ?? null } : prev))
       setCaptureName('')
-      setOk(res.replaced ? `Updated "${name}".` : `Saved "${name}".`)
+      setOk(`Capture armed for "${name}". The selected player must type !tp save in game.`)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function cancelTeleportCapture(token: string) {
+    setSaving(true); setErr(null); setOk(null)
+    try {
+      await cancelChatTeleportCapture(token)
+      setState(prev => (prev ? { ...prev, pendingTeleportCapture: null } : prev))
+      setOk('Pending teleport capture cancelled.')
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e))
     } finally {
@@ -261,6 +275,8 @@ export function ChatCommandsCard() {
   const packages = state?.packages ?? []
   const kitOn = commands['kit']?.enabled === true
   const teleports = state?.teleports ?? []
+  const pendingCapture = state?.pendingTeleportCapture ?? null
+  const canArmTeleport = enabled && commands['tp']?.enabled === true
 
   return (
     <CollapsibleCard
@@ -379,8 +395,10 @@ export function ChatCommandsCard() {
               {verb === 'tp' && (
                 <div className="mt-3 rounded border border-border bg-surface/50 p-3">
                   <div className="text-[11px] text-text-muted">
-                    Shared destinations are stored only on this DST PC. Capture an online
-                    player standing at the destination. Players can teleport only while on
+                    Shared destinations are stored only on this DST PC. Arm a name and
+                    player here, then that player types <code>!tp save</code> while standing
+                    at the destination. This captures the live game-chat position instead
+                    of a potentially stale database transform. Teleports remain limited to
                     the same map, partition and dimension. Replies and <code>!tp list</code>{' '}
                     are public server broadcasts.
                   </div>
@@ -404,21 +422,50 @@ export function ChatCommandsCard() {
                       maxLength={40}
                       disabled={saving || loading}
                       onChange={e => setCaptureName(e.target.value)}
-                      onKeyDown={e => { if (e.key === 'Enter') void captureTeleport() }}
+                      onKeyDown={e => { if (e.key === 'Enter') void armTeleportCapture() }}
                       placeholder="Destination name"
                       className="px-2 py-1.5 rounded bg-surface border border-border text-text text-xs"
                     />
                     <button
                       type="button"
                       className="btn-secondary"
-                      disabled={saving || loading || capturePawn <= 0 || !captureName.trim()}
-                      onClick={() => void captureTeleport()}
+                      disabled={saving || loading || !canArmTeleport || capturePawn <= 0 || !captureName.trim()}
+                      onClick={() => void armTeleportCapture()}
                     >
                       <Icon name={saving ? 'Loader2' : 'MapPin'} size={13}
                             className={saving ? 'animate-spin' : ''} />
-                      Save location
+                      Arm capture
                     </button>
                   </div>
+                  {pendingCapture && (
+                    <div className="mt-3 rounded border border-warning/40 bg-warning/10 p-2 text-[11px]">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-warning">
+                          Waiting for {pendingCapture.playerName} to type{' '}
+                          <code>!tp save {pendingCapture.token}</code>{' '}
+                          for <strong>{pendingCapture.name}</strong>.
+                        </span>
+                        <button
+                          type="button"
+                          className="ml-auto text-text-dim hover:text-danger"
+                          disabled={saving || loading}
+                          onClick={() => void cancelTeleportCapture(pendingCapture.token)}
+                        >
+                          Cancel capture
+                        </button>
+                      </div>
+                      <div className="mt-1 text-text-dim">
+                        Armed on {pendingCapture.map}, partition {pendingCapture.partition}.
+                        Expires {new Date(pendingCapture.expiresAt).toLocaleTimeString()}.
+                        Click Refresh after the player receives the saved confirmation.
+                      </div>
+                    </div>
+                  )}
+                  {!canArmTeleport && (
+                    <div className="mt-2 text-[11px] text-warning">
+                      Turn on chat listening and <code>!tp</code> before arming a capture.
+                    </div>
+                  )}
                   {teleports.length === 0 ? (
                     <div className="mt-3 text-[11px] text-text-dim">
                       No destinations saved. <code>!tp list</code> will report an empty list.

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -478,11 +478,18 @@ Spice Melange:
   })
 
   describe('in-game teleport bookmark API', () => {
-    it('captures the selected online player location', async () => {
-      await gp.saveChatTeleport('Base Camp', 42)
+    it('arms the selected online player location capture', async () => {
+      await gp.armChatTeleport('Base Camp', 42)
       expect(last().url).toBe('/api/gameplay/chat-commands/teleports')
       expect(last().method).toBe('POST')
       expect(last().body).toEqual({ name: 'Base Camp', pawn_id: 42 })
+    })
+
+    it('cancels a pending location capture', async () => {
+      await gp.cancelChatTeleportCapture('ABC123')
+      expect(last().url).toBe('/api/gameplay/chat-commands/teleports/capture')
+      expect(last().method).toBe('DELETE')
+      expect(last().body).toEqual({ token: 'ABC123' })
     })
 
     it('deletes a bookmark by name', async () => {

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -480,6 +480,13 @@ Spice Melange:
   describe('in-game teleport bookmark API', () => {
     it('arms the selected online player location capture', async () => {
       await gp.armChatTeleport('Base Camp', 42)
+      expect(last().url).toBe('/api/gameplay/chat-commands/teleports/capture')
+      expect(last().method).toBe('POST')
+      expect(last().body).toEqual({ name: 'Base Camp', pawn_id: 42 })
+    })
+
+    it('saves the selected player database location directly', async () => {
+      await gp.saveChatTeleport('Base Camp', 42)
       expect(last().url).toBe('/api/gameplay/chat-commands/teleports')
       expect(last().method).toBe('POST')
       expect(last().body).toEqual({ name: 'Base Camp', pawn_id: 42 })


### PR DESCRIPTION
## Summary
- keep direct **Save location** as the default for normal areas
- add optional admin-armed live capture for areas where the online database transform remains at map entry
- require the selected player to type a one-time `!tp save <code>` command at the destination
- add a **Copy command** button for the generated capture command
- preserve shared bookmark list/details, cooldowns, same-map teleport, and local-only persistence

## Root cause
Online `actors.transform` works for locations such as ordinary Hagga bookmarks, but can remain at the opening location in Hagga South. Game chat carries the pawn's exact live `m_OriginLocation`, so the optional fallback captures that authoritative value without removing the simple direct-save path.

## Safety
- only an admin can arm a live capture
- selected player, one-time token, expiry, map, partition, and dimension must match
- tokens are consumed before bookmark commit and cannot be reused
- stale browser cancellation cannot remove a newer capture
- map transitions fail closed
- non-finite or incomplete coordinates are rejected
- bookmark/capture mutations use a cross-runspace named mutex
- legacy command-conflicting names migrate without data loss

## Validation
- 886 Pester tests pass
- 16 Solo database helper self-tests pass
- 149 Vitest tests pass
- WebUI production build/typecheck passes
- PowerShell parse and BOM checks pass
- staged secret scan passes
- focused read-only reviews report no remaining high-confidence defects