### PR TITLE
Harden public PII safeguards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -369,7 +369,7 @@ body:
       placeholder: |
         Dashboard message: "SSH key is passphrase-protected, so background checks can't use it…"
         Setup "SSH key authorized on VM": "The VM rejected this key…"
-        SSH Key path (Settings): C:\Users\me\.ssh\dune_key
+        SSH Key path (Settings): C:\Users\<user>\.ssh\dune_key
       render: shell
     validations:
       required: false

--- a/.github/workflows/pii-guard.yml
+++ b/.github/workflows/pii-guard.yml
@@ -121,3 +121,85 @@ jobs:
             fi
           done
           exit "$fail"
+
+      - name: Scan full tree, PR text, and commit identities
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY:  ${{ github.event.pull_request.body }}
+        shell: python
+        run: |
+          import os
+          import pathlib
+          import re
+          import subprocess
+          import sys
+
+          first = "".join(("n", "e", "i", "l"))
+          last = "".join(("b", "r", "o", "o", "m", "e"))
+          email_lhs = "".join(("n", "b", "r", "o", "o", "m", "e"))
+          host_prefix = first + "pc"
+          identity_patterns = (
+              re.compile(rf"(?<![\w']){re.escape(first)}(?![\w'])", re.I),
+              re.compile(rf"(?<![\w']){re.escape(last)}(?![\w'])", re.I),
+              re.compile(re.escape(email_lhs) + r"@", re.I),
+              re.compile(re.escape(host_prefix), re.I),
+          )
+          allowed_user_segments = {
+              "user", "username", "yourname", "your-user", "user-with-apostrophe",
+              "example", "example-user", "anyone", "alice", "you", "name",
+              "&lt;you&gt;"
+          }
+
+          def reasons(text):
+              found = []
+              if any(pattern.search(text) for pattern in identity_patterns):
+                  found.append("banned identity")
+              if re.search(r"@desktop-[a-z0-9-]+", text, re.I):
+                  found.append("machine-name email")
+              if re.search(r"[a-z]:\\GH Projects\\", text, re.I):
+                  found.append("machine-local workspace path")
+              for match in re.finditer(r"[a-z]:\\Users\\([^\\\s\"']+)", text, re.I):
+                  segment = match.group(1).strip("<>").lower()
+                  if segment not in allowed_user_segments:
+                      found.append("unsanitized Windows user path")
+                      break
+              return sorted(set(found))
+
+          failures = []
+          pr_reasons = reasons(os.environ.get("PR_TITLE", "") + "\n" + os.environ.get("PR_BODY", ""))
+          if pr_reasons:
+              failures.append(("PR title/body", pr_reasons))
+
+          excluded = pathlib.PurePosixPath(".github/workflows/pii-guard.yml")
+          tracked = subprocess.check_output(("git", "ls-files", "-z")).decode().split("\0")
+          for name in tracked:
+              if not name or pathlib.PurePosixPath(name) == excluded:
+                  continue
+              path = pathlib.Path(name)
+              try:
+                  text = path.read_text(encoding="utf-8", errors="ignore")
+              except OSError:
+                  continue
+              file_reasons = reasons(text)
+              if file_reasons:
+                  failures.append((name, file_reasons))
+
+          base = os.environ["BASE_SHA"]
+          head = os.environ["HEAD_SHA"]
+          shas = subprocess.check_output(("git", "rev-list", f"{base}..{head}"), text=True).split()
+          for sha in shas:
+              metadata = subprocess.check_output(
+                  ("git", "show", "-s", "--format=%an%n%ae%n%cn%n%ce%n%B", sha),
+                  text=True,
+                  errors="ignore",
+              )
+              commit_reasons = reasons(metadata)
+              if commit_reasons:
+                  failures.append((f"commit {sha}", commit_reasons))
+
+          for subject, subject_reasons in failures:
+              print(f"::error::{subject}: {', '.join(subject_reasons)}")
+          if failures:
+              sys.exit(1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4709,7 +4709,7 @@ _Consolidated entry covering every release in the v10.x series (36 patches). Tag
 - **Apostrophe-in-username crash in the updater relauncher.** Paths embedded
   into the generated `DuneRelaunch-*.ps1` are now escaped (`'` → `''`)
   before being interpolated into single-quoted PowerShell literals, so usernames
-  like `C:\Users\O'Brien\AppData\...` no longer break the relauncher with a
+  like `C:\Users\<user-with-apostrophe>\AppData\...` no longer break the relauncher with a
   parse error on the first sleep.
 
 ### v10.2.6 - 2026-06-04

--- a/app/server/lib/Tailscale.ps1
+++ b/app/server/lib/Tailscale.ps1
@@ -9,8 +9,7 @@ function Get-DuneTailscalePath {
     foreach ($cand in @(
         (Join-Path $PSScriptRoot '..\..\tailscale\tailscale.exe'),   # installed: {app}\tailscale\tailscale.exe
         (Join-Path $PSScriptRoot '..\..\tailscale.exe'),             # installed: {app}\tailscale.exe
-        'C:\Program Files\Tailscale\tailscale.exe',
-        'X:\GH Projects\TailScale\tailscale.exe'                       # dev box
+        'C:\Program Files\Tailscale\tailscale.exe'
     )) {
         try { if ($cand -and (Test-Path -LiteralPath $cand)) { return (Resolve-Path -LiteralPath $cand).Path } } catch {}
     }

--- a/app/server/routes/Update.ps1
+++ b/app/server/routes/Update.ps1
@@ -569,7 +569,7 @@ Register-DuneRoute -Method POST -Path '/api/update/install' -Handler {
         $installArgs     = '/SP- /NORESTART'
         $logPath         = Join-Path $tmpDir ("relaunch-$safeTag.log")
         # Defensive escapes: %TEMP% / install path can contain an apostrophe
-        # (e.g. C:\Users\O'Brien\AppData\...) which would break the single-
+        # (e.g. C:\Users\<user-with-apostrophe>\AppData\...) which would break the single-
         # quoted literals embedded in the relauncher heredoc below.
         # PowerShell escapes ' as '' inside single-quoted strings.
         $destEsc         = $dest         -replace "'", "''"


### PR DESCRIPTION
## Summary
- remove a machine-local development fallback from tracked source
- standardize Windows user-path examples as explicit placeholders
- extend PII Guard across the full tracked tree, PR text, and introduced commit author/committer metadata
- reject unsanitized Windows user paths, local workspace paths, machine-name email domains, and banned maintainer identity patterns

Hosted issue, PR, comment, and release-note path redactions were applied separately through the GitHub API.

## Validation
- actionlint
- PowerShell parse check
- full tracked-tree PII scan
- hosted-content PII rescan
- staged gitleaks scan