### PR TITLE
Scan pull request merge result for PII

### DIFF
--- a/.github/workflows/pii-guard.yml
+++ b/.github/workflows/pii-guard.yml
@@ -26,11 +26,10 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR head with full history
+      - name: Checkout PR merge result with full history
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build banned pattern
         id: build


### PR DESCRIPTION
## Summary
- scan GitHub's synthetic pull-request merge result instead of the stale head branch tree
- keep explicit base/head SHAs for diff and introduced-commit checks
- avoid false PII failures on dependency branches that predate sanitized base-branch placeholders

## Validation
- actionlint
- staged gitleaks scan
- diff check