### PR TITLE
Fix Hyper-V KVP daemon detection on Alpine

### DIFF
--- a/app/resources/remote-scripts/dune-hyperv-guest-recovery-install.sh
+++ b/app/resources/remote-scripts/dune-hyperv-guest-recovery-install.sh
@@ -45,20 +45,24 @@ online_memory() {
     done
 }
 
+kvp_running() {
+    "$PGREP" -f "(^|/)$KVP_PROCESS([[:space:]]|$)" >/dev/null 2>&1
+}
+
 ensure_kvp() {
     if [ "$FORCE_KVP_RESTART" = 1 ] ||
-       ! "$PGREP" -x "$KVP_PROCESS" >/dev/null 2>&1; then
+       ! kvp_running; then
         "$RC_SERVICE" "$KVP_SERVICE" restart >/dev/null 2>&1 ||
             fail "failed to restart $KVP_SERVICE"
     fi
     wait_count=0
-    while ! "$PGREP" -x "$KVP_PROCESS" >/dev/null 2>&1; do
+    while ! kvp_running; do
         wait_count=$((wait_count + 1))
         [ "$wait_count" -lt 6 ] ||
             fail "$KVP_PROCESS is still absent after service restart"
         sleep 1
     done
-    "$PGREP" -x "$KVP_PROCESS" >/dev/null 2>&1 ||
+    kvp_running ||
         fail "$KVP_PROCESS is still absent after service restart"
 }
 
@@ -82,7 +86,7 @@ if [ -w "$MEMORY_ROOT/auto_online_blocks" ]; then
     done
 fi
 
-if ! pgrep -x hv_kvp_daemon >/dev/null 2>&1; then
+if ! pgrep -f '(^|/)hv_kvp_daemon([[:space:]]|$)' >/dev/null 2>&1; then
     rc-service hv_kvp_daemon restart >/dev/null 2>&1 || true
 fi
 HOOKEOF

--- a/tests/HyperVGuestRecovery.Tests.ps1
+++ b/tests/HyperVGuestRecovery.Tests.ps1
@@ -146,6 +146,15 @@ Describe 'Hyper-V guest recovery backend' -Tag 'Pure' {
 }
 
 Describe 'Hyper-V guest recovery POSIX installer' {
+    It 'uses command-line KVP detection because Alpine pgrep exact-name misses the daemon' {
+        $source = Get-Content `
+            (Join-Path (Get-DstRepoRoot) 'app\resources\remote-scripts\dune-hyperv-guest-recovery-install.sh') -Raw
+
+        $source | Should -Match 'pgrep -f'
+        $source | Should -Not -Match 'pgrep -x'
+        $source | Should -Match '\(\^\|/\).*hv_kvp_daemon.*\(\[\[:space:\]\]\|\$\)'
+    }
+
     It 'onlines blocks, restarts stale KVP, and installs the boot hook' {
         $bash = Get-Command bash -ErrorAction SilentlyContinue
         if (-not $bash) { Set-ItResult -Skipped -Because 'bash is unavailable'; return }


### PR DESCRIPTION
## Summary
- detect `hv_kvp_daemon` by command line instead of exact process name
- reuse the same check during recovery retries and in the installed boot hook
- add regression coverage preventing the unsupported exact-name probe from returning

## Why
Alpine can report the daemon as running while `pgrep -x hv_kvp_daemon` returns no match. Recovery then restarts a healthy service repeatedly and falsely reports `DUNE_HYPERV_GUEST_RECOVERY_FAILED`.

## Validation
- focused Hyper-V guest recovery tests passed
- POSIX shell syntax passed
- full installer build passed
- field validation confirmed recovery reports OK and resolves the running KVP PID