### PR TITLE
Fix Spice client sharing and default resets

### DIFF
--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -1623,6 +1623,12 @@ function Get-DuneIniEffective {
             }
         }
     }
+    $mapsKey = "$script:DuneGcSecSpice||m_PerMapSystemSettings"
+    $fallbackKey = "$script:DuneGcSecSpice||m_DefaultSystemSettings"
+    if ($eff.ContainsKey($mapsKey) -and $eff.ContainsKey($fallbackKey)) {
+        $eff[$mapsKey] = Complete-DuneSpicefieldBlobForClientShare `
+            -Blob $eff[$mapsKey] -FallbackBlob $eff[$fallbackKey]
+    }
     return $eff
 }
 
@@ -1829,6 +1835,51 @@ function Set-DuneSpicefieldLimitsInBlob {
             $mapBlob.Substring($settingsRange.end)
     }
     return $Blob.Substring(0, $mapRange.start) + $patchedMap + $Blob.Substring($mapRange.end + 1)
+}
+
+function Remove-DuneSpicefieldSizeFromBlob {
+    param([string]$Blob, [string]$MapId, [string]$FieldType)
+    $mapRange = Find-DuneSpicefieldMapRange -Blob $Blob -MapId $MapId
+    if (-not $mapRange) { return $Blob }
+    $mapBlob = $Blob.Substring($mapRange.start, $mapRange.length)
+    $sizeRange = Find-DuneSpicefieldSizeRange -MapBlob $mapBlob -FieldType $FieldType
+    if (-not $sizeRange) { return $Blob }
+
+    $removeStart = $sizeRange.start
+    $left = $removeStart - 1
+    while ($left -ge 0 -and [char]::IsWhiteSpace($mapBlob[$left])) { $left-- }
+    if ($left -ge 0 -and $mapBlob[$left] -eq ',') {
+        $removeStart = $left
+    }
+    $removeEnd = $sizeRange.end
+    if ($removeStart -eq $sizeRange.start) {
+        $right = $removeEnd + 1
+        while ($right -lt $mapBlob.Length -and [char]::IsWhiteSpace($mapBlob[$right])) { $right++ }
+        if ($right -lt $mapBlob.Length -and $mapBlob[$right] -eq ',') { $removeEnd = $right }
+    }
+    $patchedMap = $mapBlob.Remove($removeStart, $removeEnd - $removeStart + 1)
+    return $Blob.Substring(0, $mapRange.start) + $patchedMap + $Blob.Substring($mapRange.end + 1)
+}
+
+function Complete-DuneSpicefieldBlobForClientShare {
+    param([string]$Blob, [string]$FallbackBlob)
+    $seen = @{}
+    foreach ($field in @($script:DuneGameConfigSchema | Where-Object { $_.ContainsKey('SpiceMap') })) {
+        $id = "$($field.SpiceMap)|$($field.SpiceFieldType)"
+        if ($seen.ContainsKey($id)) { continue }
+        $seen[$id] = $true
+        $state = Get-DuneSpicefieldLimitsFromBlob -Blob $Blob `
+            -MapId "$($field.SpiceMap)" -FieldType "$($field.SpiceFieldType)"
+        if ($state.found) { continue }
+        $fallback = Get-DuneSpicefieldDefaultLimitsFromBlob -Blob $FallbackBlob `
+            -FieldType "$($field.SpiceFieldType)"
+        $mapRange = Find-DuneSpicefieldMapRange -Blob $Blob -MapId "$($field.SpiceMap)"
+        if (-not $fallback.found -or -not $mapRange) { continue }
+        $Blob = Set-DuneSpicefieldLimitsInBlob -Blob $Blob -MapId "$($field.SpiceMap)" `
+            -FieldType "$($field.SpiceFieldType)" -MaxActive ([int]$fallback.maxActive) `
+            -MaxPrimed ([int]$fallback.maxPrimed)
+    }
+    return $Blob
 }
 
 # Distinct (section, structKey) pairs that the schema declares as struct parents.
@@ -2294,25 +2345,32 @@ function Convert-DuneSpicefieldUpdates {
             $state = Get-DuneSpicefieldDefaultLimitsFromBlob -Blob $fallback `
                 -FieldType $field.fieldType
         }
-        $pairFields = @($script:DuneGameConfigSchema | Where-Object {
-            $_.ContainsKey('SpiceMap') -and "$($_.SpiceMap)" -eq $field.mapId -and
-            "$($_.SpiceFieldType)" -eq $field.fieldType
-        })
-        $active = if ($state.found) { [int]$state.maxActive } else {
-            [int](($pairFields | Where-Object { "$($_.SpiceLimit)" -eq 'Active' } | Select-Object -First 1).Default)
-        }
-        $primed = if ($state.found) { [int]$state.maxPrimed } else {
-            [int](($pairFields | Where-Object { "$($_.SpiceLimit)" -eq 'Primed' } | Select-Object -First 1).Default)
-        }
-        $value = if ($update['remove']) { [int]$field.default } else {
+        if ($update['remove']) {
+            if ([string]::IsNullOrWhiteSpace($defaultBlob)) {
+                throw 'Funcom spicefield defaults are unavailable; refusing an inexact reset.'
+            }
+            $defaultState = Get-DuneSpicefieldLimitsFromBlob -Blob $defaultBlob `
+                -MapId $field.mapId -FieldType $field.fieldType
+            if ($defaultState.malformed) {
+                throw "Funcom spicefield default '$($field.mapId)/$($field.fieldType)' is malformed; refusing an inexact reset."
+            }
+            if (-not $defaultState.found) {
+                $blob = Remove-DuneSpicefieldSizeFromBlob -Blob $blob `
+                    -MapId $field.mapId -FieldType $field.fieldType
+                continue
+            }
+            $active = [int]$defaultState.maxActive
+            $primed = [int]$defaultState.maxPrimed
+        } else {
             $parsed = 0
             if (-not [int]::TryParse("$($update.value)", [ref]$parsed) -or $parsed -lt 0) {
                 throw "$key must be a whole number zero or greater."
             }
-            $parsed
+            $active = if ($state.found) { [int]$state.maxActive } else { [int]$field.default }
+            $primed = if ($state.found) { [int]$state.maxPrimed } else { [int]$field.default }
+            if ($field.limit -in @('Active', 'Both')) { $active = $parsed }
+            if ($field.limit -in @('Primed', 'Both')) { $primed = $parsed }
         }
-        if ($field.limit -in @('Active', 'Both')) { $active = $value }
-        if ($field.limit -in @('Primed', 'Both')) { $primed = $value }
         $blob = Set-DuneSpicefieldLimitsInBlob -Blob $blob -MapId $field.mapId `
             -FieldType $field.fieldType -MaxActive $active -MaxPrimed $primed `
             -DefaultsBlob $defaultBlob

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -2028,6 +2028,12 @@ Describe 'GameConfig: spicefield startup defaults' -Tag 'GameConfig' {
         @($fields | Where-Object { $_.ClientStructKey -ne 'm_PerMapSystemSettings' }).Count | Should -Be 0
         ($fields | Where-Object Key -eq 'DST.SpiceStartup.DeepDesert.Large.Max').Help |
             Should -Match 'ceiling.*max of 6.*only 4'
+        ($fields | Where-Object Key -eq 'DST.SpiceStartup.DeepDesert.Small.Max').Default | Should -Be '60'
+        ($fields | Where-Object Key -eq 'DST.SpiceStartup.DeepDesert.Medium.Max').Default | Should -Be '12'
+        ($fields | Where-Object Key -eq 'DST.SpiceStartup.DeepDesert.Large.Max').Default | Should -Be '1'
+        ($fields | Where-Object Key -eq 'DST.SpiceStartup.Hagga.Small.Max').Default | Should -Be '5'
+        ($fields | Where-Object Key -eq 'DST.SpiceStartup.Hagga.Medium.Max').Default | Should -Be '5'
+        ($fields | Where-Object Key -eq 'DST.SpiceStartup.Hagga.Large.Max').Default | Should -Be '3'
     }
 
     It 'surfaces the active cap from the complete existing override' {
@@ -2048,6 +2054,23 @@ Describe 'GameConfig: spicefield startup defaults' -Tag 'GameConfig' {
 
         @($notice.items).Count | Should -Be 1
         $notice.items[0].structKey | Should -Be 'm_PerMapSystemSettings'
+    }
+
+    It 'materializes Hagga fallback sizes into the complete client-share parent' {
+        $effective = Get-DuneIniEffective -Raw $script:SpiceUserRaw
+        $shared = $effective["$script:SpiceSection||m_PerMapSystemSettings"]
+        $medium = Get-DuneSpicefieldLimitsFromBlob -Blob $shared -MapId 'Survival_1' -FieldType 'Medium'
+        $large = Get-DuneSpicefieldLimitsFromBlob -Blob $shared -MapId 'Survival_1' -FieldType 'Large'
+
+        $medium.maxActive | Should -Be 10
+        $medium.maxPrimed | Should -Be 2
+        $large.maxActive | Should -Be 6
+        $large.maxPrimed | Should -Be 2
+    }
+
+    It 'loads live defaults before applying spice startup fields to a fresh client file' {
+        $route = Get-Content (Join-Path (Get-DstRepoRoot) 'app\server\routes\GameConfig.ps1') -Raw
+        $route | Should -Match 'Test-DuneUpdatesHaveStructMember[\s\S]+?-or[\s\S]+?Test-DuneUpdatesHaveSpicefieldMember'
     }
 
     It 'patches only the selected map and size' {
@@ -2088,6 +2111,54 @@ Describe 'GameConfig: spicefield startup defaults' -Tag 'GameConfig' {
         $state.maxActive | Should -Be 6
         $state.maxPrimed | Should -Be 6
         (Get-DuneSpicefieldLimitsFromBlob -Blob $folded[0].value -MapId 'Survival_1' -FieldType 'Small').maxActive | Should -Be 5
+    }
+
+    It 'resets a Funcom per-map size to its exact active and primed defaults' {
+        $folded = @(Convert-DuneSpicefieldUpdates -Raw $script:SpiceUserRaw -DefaultsRaw $script:SpiceDefaultsRaw -Updates @(
+            @{ file='game'; section=$script:SpiceSection; key='DST.SpiceStartup.DeepDesert.Large.Max'; value='1'; remove=$true }
+        ))
+        $state = Get-DuneSpicefieldLimitsFromBlob -Blob $folded[0].value -MapId 'DeepDesert_1' -FieldType 'Large'
+
+        $state.maxActive | Should -Be 1
+        $state.maxPrimed | Should -Be 1
+    }
+
+    It 'refuses an inexact reset when Funcom defaults are unavailable' {
+        {
+            Convert-DuneSpicefieldUpdates -Raw $script:SpiceUserRaw -DefaultsRaw '' -Updates @(
+                @{ file='game'; section=$script:SpiceSection; key='DST.SpiceStartup.DeepDesert.Large.Max'; value='1'; remove=$true }
+            )
+        } | Should -Throw '*defaults are unavailable*'
+    }
+
+    It 'refuses an inexact reset when the Funcom default subnode is malformed' {
+        $malformedDefaults = $script:SpiceDefaultsRaw.Replace(
+            'MaxGloballyPrimed=1,MaxGloballyActive=1',
+            'MaxGloballyPrimed=1'
+        )
+        {
+            Convert-DuneSpicefieldUpdates -Raw $script:SpiceUserRaw `
+                -DefaultsRaw $malformedDefaults -Updates @(
+                    @{ file='game'; section=$script:SpiceSection; key='DST.SpiceStartup.DeepDesert.Large.Max'; value='1'; remove=$true }
+                )
+        } | Should -Throw '*malformed*'
+    }
+
+    It 'resets an inserted Hagga size by removing its override and restoring fallback behavior' {
+        $customFold = @(Convert-DuneSpicefieldUpdates -Raw $script:SpiceUserRaw -DefaultsRaw $script:SpiceDefaultsRaw -Updates @(
+            @{ file='game'; section=$script:SpiceSection; key='DST.SpiceStartup.Hagga.Medium.Max'; value='7'; remove=$false }
+        ))
+        $customRaw = ConvertTo-DuneIniManaged -Raw $script:SpiceUserRaw -Updates $customFold -QuotedKeys @{}
+        (Get-DuneIniEffectiveByKey -Raw $customRaw)['DST.SpiceStartup.Hagga.Medium.Max'] | Should -Be '7'
+
+        $resetFold = @(Convert-DuneSpicefieldUpdates -Raw $customRaw -DefaultsRaw $script:SpiceDefaultsRaw -Updates @(
+            @{ file='game'; section=$script:SpiceSection; key='DST.SpiceStartup.Hagga.Medium.Max'; value='5'; remove=$true }
+        ))
+        $resetRaw = ConvertTo-DuneIniManaged -Raw $customRaw -Updates $resetFold -QuotedKeys @{}
+        $resetBlob = Get-DuneIniSectionScalarValue -Raw $resetRaw -Section $script:SpiceSection -Key 'm_PerMapSystemSettings'
+
+        (Get-DuneSpicefieldLimitsFromBlob -Blob $resetBlob -MapId 'Survival_1' -FieldType 'Medium').found | Should -BeFalse
+        (Get-DuneIniEffectiveByKey -Raw $resetRaw)['DST.SpiceStartup.Hagga.Medium.Max'] | Should -Be '10'
     }
 
     It 'fails closed for malformed targets' {

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -229,37 +229,30 @@ function isExperimentalCategory(category: string): boolean {
 
 const EXPERIMENTAL_PAGE_SIZE = 25
 
-// Build file-aware client blocks for a category's customised scalar fields.
-function buildCategoryClientBlocks(
+// Build file-aware client blocks for a category's customised fields. Struct-backed
+// controls emit their complete parent line once, never pseudo member keys.
+export function buildCategoryClientBlocks(
   cat: GameConfigCategory,
   cfg: GameConfigResponse | null,
 ): { entries: ClientShareEntry[]; count: number; hasClientFields: boolean } {
-  const clientFields = (cat.fields ?? []).filter(f => f && f.key && f.clientApply && !f.structKey)
+  const clientFields = (cat.fields ?? []).filter(f => f && f.key && f.clientApply)
   const hasClientFields = clientFields.length > 0
-  const byFile = new Map<'game' | 'engine', Map<string, string[]>>()
+  const items: ClientShareValue[] = []
   let count = 0
   for (const f of clientFields) {
     if (!isCustomized(cfg, f)) continue
     const v = liveValue(cfg, f)
     if (v === '') continue
-    const bySection = byFile.get(f.file) ?? new Map<string, string[]>()
-    const arr = bySection.get(f.section) ?? []
-    arr.push(`${f.key}=${v}`)
-    bySection.set(f.section, arr)
-    byFile.set(f.file, bySection)
+    items.push({
+      file: f.file,
+      section: f.section,
+      key: f.key,
+      value: v,
+      structKey: f.structKey,
+    })
     count++
   }
-  const entries: ClientShareEntry[] = []
-  for (const [file, bySection] of byFile) {
-    const parts: string[] = []
-    for (const [section, lines] of bySection) parts.push(`[${section}]`, ...lines, '')
-    entries.push({
-      file,
-      path: CLIENT_INI_PATHS[file],
-      block: parts.join('\r\n').replace(/\s+$/, '') + '\r\n',
-    })
-  }
-  return { entries, count, hasClientFields }
+  return { entries: buildClientShareEntries(items, cfg), count, hasClientFields }
 }
 
 // The value an input should hold: the live override when present, otherwise the default.

--- a/webui/tests/api/playerConfigBlocks.test.ts
+++ b/webui/tests/api/playerConfigBlocks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildAllClientBlocks, buildClientShareEntries } from '../../src/pages/GameConfig'
+import { buildAllClientBlocks, buildCategoryClientBlocks, buildClientShareEntries } from '../../src/pages/GameConfig'
 import type { GameConfigCategory, GameConfigResponse } from '../../src/api/types'
 
 // The "Player config" button promises one thing: exactly the lines a player must
@@ -158,5 +158,30 @@ describe('buildAllClientBlocks', () => {
 
     expect(out[0].block).toContain(`Data=${data}`)
     expect(out[0].block).not.toMatch(/^m_LandsraadContractsPerVotingBlock=/m)
+  })
+
+  it('shows Give players this for struct-backed Spice card settings', () => {
+    const section = '/Script/DuneSandbox.SpiceHarvestingSystem'
+    const struct = '(("DeepDesert_1", (m_SpiceFieldTypeSettings=(((Name="Large"), (MaxGloballyPrimed=6,MaxGloballyActive=6))))))'
+    const spice = {
+      category: 'Spice',
+      fields: [
+        {
+          section, key: 'DST.SpiceStartup.DeepDesert.Large.Max',
+          structKey: 'm_PerMapSystemSettings', file: 'game', type: 'int',
+          label: 'Deep Desert Large Fields at Startup', default: '1', clientApply: true,
+        },
+      ],
+    } as unknown as GameConfigCategory
+    const out = buildCategoryClientBlocks(spice, cfg({
+      [`${section}||m_PerMapSystemSettings`]: struct,
+      [`${section}||DST.SpiceStartup.DeepDesert.Large.Max`]: '6',
+    }, {}))
+
+    expect(out.hasClientFields).toBe(true)
+    expect(out.count).toBe(1)
+    expect(out.entries).toHaveLength(1)
+    expect(out.entries[0].block).toContain(`m_PerMapSystemSettings=${struct}`)
+    expect(out.entries[0].block).not.toContain('DST.SpiceStartup')
   })
 })


### PR DESCRIPTION
## Summary
- restore the Spice card's **Give players this** action for struct-backed startup caps
- emit one complete `m_PerMapSystemSettings` line instead of invalid pseudo keys
- materialize Hagga fallback size values into the share-only parent so copied config reproduces displayed values
- reset Deep Desert entries to exact Funcom per-map defaults
- reset inserted Hagga Medium/Large entries by removing their override and restoring `m_DefaultSystemSettings` fallback
- fail closed when defaults are unavailable or malformed

## Validation
- 123 Game Config Pester tests passed
- 9 player-config sharing Vitest tests passed
- WebUI production build passed
- PowerShell parse checks passed
- staged gitleaks scan found no leaks