### PR TITLE
Limit Hagga spice startup control to Small fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,11 +57,11 @@ here cover everything those tags shipped.
 
 ### Changed
 
-- Game Config → Spice adds simple Deep Desert and Hagga startup caps for Small,
-  Medium, and Large spice fields. Each cap writes both active and primed limits
-  through the normal server/client INI save path while preserving Funcom's
-  complete per-map settings structure; **Apply INIs & restart** adopts the new
-  defaults.
+- Game Config → Spice adds simple startup caps for Deep Desert Small, Medium,
+  and Large fields plus Hagga Small fields. Each cap writes both active and
+  primed limits through the normal server/client INI save path while preserving
+  Funcom's complete per-map settings structure; **Apply INIs & restart** adopts
+  the new defaults.
 - Hyper-V Dynamic Memory guests now persist automatic hot-added-memory onlining
   and recover a stale KVP integration daemon. DST remembers a verified guest IP
   and uses it only when SSH confirms that Hyper-V's IP signal is temporarily

--- a/app/server/lib/GameConfig.ps1
+++ b/app/server/lib/GameConfig.ps1
@@ -228,8 +228,6 @@ $script:DuneGameConfigSchema = @(
     @{ Section=$script:DuneGcSecSpice; Key='DST.SpiceStartup.DeepDesert.Medium.Max'; File='game'; Type='int'; Min=0; Default='12'; Label='Deep Desert Medium Fields at Startup'; Help='Caps both active and primed Medium fields after Apply INIs & restart. Guidance: 12 is Funcom''s normal high cap. This is a ceiling, not a forced count; if the current layout provides fewer fields, only those fields can appear.'; SpiceMap='DeepDesert_1'; SpiceFieldType='Medium'; SpiceLimit='Both'; ClientStructKey='m_PerMapSystemSettings'; ClientApply=$true; Category='Spice' }
     @{ Section=$script:DuneGcSecSpice; Key='DST.SpiceStartup.DeepDesert.Large.Max'; File='game'; Type='int'; Min=0; Default='1'; Label='Deep Desert Large Fields at Startup'; Help='Caps both active and primed Large fields after Apply INIs & restart. Guidance: use up to 6 to cover the largest known layouts. This is a ceiling, not a forced count: a max of 6 with only 4 fields in the seed still produces at most 4.'; SpiceMap='DeepDesert_1'; SpiceFieldType='Large'; SpiceLimit='Both'; ClientStructKey='m_PerMapSystemSettings'; ClientApply=$true; Category='Spice' }
     @{ Section=$script:DuneGcSecSpice; Key='DST.SpiceStartup.Hagga.Small.Max'; File='game'; Type='int'; Min=0; Default='5'; Label='Hagga Small Fields at Startup'; Help='Caps both active and primed Small fields after Apply INIs & restart. Guidance: 5 is Funcom''s normal active cap. This is a ceiling; it does not create fields beyond what Hagga can place.'; SpiceMap='Survival_1'; SpiceFieldType='Small'; SpiceLimit='Both'; ClientStructKey='m_PerMapSystemSettings'; ClientApply=$true; Category='Spice' }
-    @{ Section=$script:DuneGcSecSpice; Key='DST.SpiceStartup.Hagga.Medium.Max'; File='game'; Type='int'; Min=0; Default='5'; Label='Hagga Medium Fields at Startup'; Help='Caps both active and primed Medium fields after Apply INIs & restart. Guidance: 5 is Funcom''s normal active cap. This is a ceiling; it does not create fields beyond what Hagga can place.'; SpiceMap='Survival_1'; SpiceFieldType='Medium'; SpiceLimit='Both'; ClientStructKey='m_PerMapSystemSettings'; ClientApply=$true; Category='Spice' }
-    @{ Section=$script:DuneGcSecSpice; Key='DST.SpiceStartup.Hagga.Large.Max'; File='game'; Type='int'; Min=0; Default='3'; Label='Hagga Large Fields at Startup'; Help='Caps both active and primed Large fields after Apply INIs & restart. Guidance: 3 is Funcom''s normal active cap. This is a ceiling; it does not create fields beyond what Hagga can place.'; SpiceMap='Survival_1'; SpiceFieldType='Large'; SpiceLimit='Both'; ClientStructKey='m_PerMapSystemSettings'; ClientApply=$true; Category='Spice' }
 
     # --- Taxation ---
     @{ Section=$script:DuneGcSecTaxation; Key='m_bTaxationEnabled'; File='game'; Type='bool'; Default='False'; Label='Taxation Enabled'; Help='Whether the taxation system is active. Also needs client-side apply.'; ClientApply=$true; Category='Taxation' }
@@ -1623,12 +1621,6 @@ function Get-DuneIniEffective {
             }
         }
     }
-    $mapsKey = "$script:DuneGcSecSpice||m_PerMapSystemSettings"
-    $fallbackKey = "$script:DuneGcSecSpice||m_DefaultSystemSettings"
-    if ($eff.ContainsKey($mapsKey) -and $eff.ContainsKey($fallbackKey)) {
-        $eff[$mapsKey] = Complete-DuneSpicefieldBlobForClientShare `
-            -Blob $eff[$mapsKey] -FallbackBlob $eff[$fallbackKey]
-    }
     return $eff
 }
 
@@ -1835,51 +1827,6 @@ function Set-DuneSpicefieldLimitsInBlob {
             $mapBlob.Substring($settingsRange.end)
     }
     return $Blob.Substring(0, $mapRange.start) + $patchedMap + $Blob.Substring($mapRange.end + 1)
-}
-
-function Remove-DuneSpicefieldSizeFromBlob {
-    param([string]$Blob, [string]$MapId, [string]$FieldType)
-    $mapRange = Find-DuneSpicefieldMapRange -Blob $Blob -MapId $MapId
-    if (-not $mapRange) { return $Blob }
-    $mapBlob = $Blob.Substring($mapRange.start, $mapRange.length)
-    $sizeRange = Find-DuneSpicefieldSizeRange -MapBlob $mapBlob -FieldType $FieldType
-    if (-not $sizeRange) { return $Blob }
-
-    $removeStart = $sizeRange.start
-    $left = $removeStart - 1
-    while ($left -ge 0 -and [char]::IsWhiteSpace($mapBlob[$left])) { $left-- }
-    if ($left -ge 0 -and $mapBlob[$left] -eq ',') {
-        $removeStart = $left
-    }
-    $removeEnd = $sizeRange.end
-    if ($removeStart -eq $sizeRange.start) {
-        $right = $removeEnd + 1
-        while ($right -lt $mapBlob.Length -and [char]::IsWhiteSpace($mapBlob[$right])) { $right++ }
-        if ($right -lt $mapBlob.Length -and $mapBlob[$right] -eq ',') { $removeEnd = $right }
-    }
-    $patchedMap = $mapBlob.Remove($removeStart, $removeEnd - $removeStart + 1)
-    return $Blob.Substring(0, $mapRange.start) + $patchedMap + $Blob.Substring($mapRange.end + 1)
-}
-
-function Complete-DuneSpicefieldBlobForClientShare {
-    param([string]$Blob, [string]$FallbackBlob)
-    $seen = @{}
-    foreach ($field in @($script:DuneGameConfigSchema | Where-Object { $_.ContainsKey('SpiceMap') })) {
-        $id = "$($field.SpiceMap)|$($field.SpiceFieldType)"
-        if ($seen.ContainsKey($id)) { continue }
-        $seen[$id] = $true
-        $state = Get-DuneSpicefieldLimitsFromBlob -Blob $Blob `
-            -MapId "$($field.SpiceMap)" -FieldType "$($field.SpiceFieldType)"
-        if ($state.found) { continue }
-        $fallback = Get-DuneSpicefieldDefaultLimitsFromBlob -Blob $FallbackBlob `
-            -FieldType "$($field.SpiceFieldType)"
-        $mapRange = Find-DuneSpicefieldMapRange -Blob $Blob -MapId "$($field.SpiceMap)"
-        if (-not $fallback.found -or -not $mapRange) { continue }
-        $Blob = Set-DuneSpicefieldLimitsInBlob -Blob $Blob -MapId "$($field.SpiceMap)" `
-            -FieldType "$($field.SpiceFieldType)" -MaxActive ([int]$fallback.maxActive) `
-            -MaxPrimed ([int]$fallback.maxPrimed)
-    }
-    return $Blob
 }
 
 # Distinct (section, structKey) pairs that the schema declares as struct parents.
@@ -2355,9 +2302,7 @@ function Convert-DuneSpicefieldUpdates {
                 throw "Funcom spicefield default '$($field.mapId)/$($field.fieldType)' is malformed; refusing an inexact reset."
             }
             if (-not $defaultState.found) {
-                $blob = Remove-DuneSpicefieldSizeFromBlob -Blob $blob `
-                    -MapId $field.mapId -FieldType $field.fieldType
-                continue
+                throw "Funcom spicefield default '$($field.mapId)/$($field.fieldType)' is absent; refusing an inexact reset."
             }
             $active = [int]$defaultState.maxActive
             $primed = [int]$defaultState.maxPrimed

--- a/tests/GameConfig.Tests.ps1
+++ b/tests/GameConfig.Tests.ps1
@@ -2012,16 +2012,16 @@ Describe 'GameConfig: spicefield startup defaults' -Tag 'GameConfig' {
             'm_DefaultSystemSettings=(m_SpiceFieldTypeSettings=(((Name="Small"), (MaxGloballyPrimed=6,MaxGloballyActive=3)),((Name="Medium"), (MaxGloballyPrimed=10,MaxGloballyActive=5)),((Name="Large"), (MaxGloballyPrimed=5,MaxGloballyActive=3))))' + "`n"
     }
 
-    It 'exposes six client-and-server startup caps in the normal Spice card' {
+    It 'exposes Deep Desert sizes and Hagga Small in the normal Spice card' {
         $fields = @($script:DuneGameConfigSchema | Where-Object { $_.ContainsKey('SpiceMap') })
 
-        $fields.Count | Should -Be 6
+        $fields.Count | Should -Be 4
         $fields.Key | Should -Contain 'DST.SpiceStartup.DeepDesert.Small.Max'
         $fields.Key | Should -Contain 'DST.SpiceStartup.DeepDesert.Medium.Max'
         $fields.Key | Should -Contain 'DST.SpiceStartup.DeepDesert.Large.Max'
         $fields.Key | Should -Contain 'DST.SpiceStartup.Hagga.Small.Max'
-        $fields.Key | Should -Contain 'DST.SpiceStartup.Hagga.Medium.Max'
-        $fields.Key | Should -Contain 'DST.SpiceStartup.Hagga.Large.Max'
+        $fields.Key | Should -Not -Contain 'DST.SpiceStartup.Hagga.Medium.Max'
+        $fields.Key | Should -Not -Contain 'DST.SpiceStartup.Hagga.Large.Max'
         @($fields | Where-Object { -not $_.ClientApply }).Count | Should -Be 0
         @($fields | Where-Object { $_.Category -ne 'Spice' }).Count | Should -Be 0
         @($fields | Where-Object { $_.SpiceLimit -ne 'Both' }).Count | Should -Be 0
@@ -2032,8 +2032,6 @@ Describe 'GameConfig: spicefield startup defaults' -Tag 'GameConfig' {
         ($fields | Where-Object Key -eq 'DST.SpiceStartup.DeepDesert.Medium.Max').Default | Should -Be '12'
         ($fields | Where-Object Key -eq 'DST.SpiceStartup.DeepDesert.Large.Max').Default | Should -Be '1'
         ($fields | Where-Object Key -eq 'DST.SpiceStartup.Hagga.Small.Max').Default | Should -Be '5'
-        ($fields | Where-Object Key -eq 'DST.SpiceStartup.Hagga.Medium.Max').Default | Should -Be '5'
-        ($fields | Where-Object Key -eq 'DST.SpiceStartup.Hagga.Large.Max').Default | Should -Be '3'
     }
 
     It 'surfaces the active cap from the complete existing override' {
@@ -2043,8 +2041,6 @@ Describe 'GameConfig: spicefield startup defaults' -Tag 'GameConfig' {
         $values['DST.SpiceStartup.DeepDesert.Medium.Max'] | Should -Be '12'
         $values['DST.SpiceStartup.DeepDesert.Large.Max'] | Should -Be '6'
         $values['DST.SpiceStartup.Hagga.Small.Max'] | Should -Be '10'
-        $values['DST.SpiceStartup.Hagga.Medium.Max'] | Should -Be '10'
-        $values['DST.SpiceStartup.Hagga.Large.Max'] | Should -Be '6'
     }
 
     It 'shares the complete parent struct instead of invalid pseudo keys' {
@@ -2054,18 +2050,6 @@ Describe 'GameConfig: spicefield startup defaults' -Tag 'GameConfig' {
 
         @($notice.items).Count | Should -Be 1
         $notice.items[0].structKey | Should -Be 'm_PerMapSystemSettings'
-    }
-
-    It 'materializes Hagga fallback sizes into the complete client-share parent' {
-        $effective = Get-DuneIniEffective -Raw $script:SpiceUserRaw
-        $shared = $effective["$script:SpiceSection||m_PerMapSystemSettings"]
-        $medium = Get-DuneSpicefieldLimitsFromBlob -Blob $shared -MapId 'Survival_1' -FieldType 'Medium'
-        $large = Get-DuneSpicefieldLimitsFromBlob -Blob $shared -MapId 'Survival_1' -FieldType 'Large'
-
-        $medium.maxActive | Should -Be 10
-        $medium.maxPrimed | Should -Be 2
-        $large.maxActive | Should -Be 6
-        $large.maxPrimed | Should -Be 2
     }
 
     It 'loads live defaults before applying spice startup fields to a fresh client file' {
@@ -2142,23 +2126,6 @@ Describe 'GameConfig: spicefield startup defaults' -Tag 'GameConfig' {
                     @{ file='game'; section=$script:SpiceSection; key='DST.SpiceStartup.DeepDesert.Large.Max'; value='1'; remove=$true }
                 )
         } | Should -Throw '*malformed*'
-    }
-
-    It 'resets an inserted Hagga size by removing its override and restoring fallback behavior' {
-        $customFold = @(Convert-DuneSpicefieldUpdates -Raw $script:SpiceUserRaw -DefaultsRaw $script:SpiceDefaultsRaw -Updates @(
-            @{ file='game'; section=$script:SpiceSection; key='DST.SpiceStartup.Hagga.Medium.Max'; value='7'; remove=$false }
-        ))
-        $customRaw = ConvertTo-DuneIniManaged -Raw $script:SpiceUserRaw -Updates $customFold -QuotedKeys @{}
-        (Get-DuneIniEffectiveByKey -Raw $customRaw)['DST.SpiceStartup.Hagga.Medium.Max'] | Should -Be '7'
-
-        $resetFold = @(Convert-DuneSpicefieldUpdates -Raw $customRaw -DefaultsRaw $script:SpiceDefaultsRaw -Updates @(
-            @{ file='game'; section=$script:SpiceSection; key='DST.SpiceStartup.Hagga.Medium.Max'; value='5'; remove=$true }
-        ))
-        $resetRaw = ConvertTo-DuneIniManaged -Raw $customRaw -Updates $resetFold -QuotedKeys @{}
-        $resetBlob = Get-DuneIniSectionScalarValue -Raw $resetRaw -Section $script:SpiceSection -Key 'm_PerMapSystemSettings'
-
-        (Get-DuneSpicefieldLimitsFromBlob -Blob $resetBlob -MapId 'Survival_1' -FieldType 'Medium').found | Should -BeFalse
-        (Get-DuneIniEffectiveByKey -Raw $resetRaw)['DST.SpiceStartup.Hagga.Medium.Max'] | Should -Be '10'
     }
 
     It 'fails closed for malformed targets' {


### PR DESCRIPTION
## Summary
- remove nonexistent Hagga Medium and Large startup controls
- keep Hagga Small plus Deep Desert Small/Medium/Large
- remove fallback materialization/reset logic that was only needed for nonexistent Hagga sizes
- fail closed if any exposed Funcom per-map default is absent or malformed
- correct changelog scope

## Validation
- 121 Game Config Pester tests passed
- 9 player-config sharing Vitest tests passed
- WebUI production build passed
- PowerShell parse checks passed
- staged gitleaks scan found no leaks