### PR TITLE
Warn when VM capacity blocks map pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ here cover everything those tags shipped.
 
 ### Fixed
 
+- Server Health now identifies a Pending game-map pod that Kubernetes rejects
+  for `Insufficient memory`, shows the map request versus guest-visible RAM, and
+  explains that Hyper-V Dynamic Memory may require a full shutdown/start even
+  when startup/minimum settings were already raised.
 - Scheduled restart checkboxes keep the same visible size beside short and long
   labels.
 - Reset Journey recognizes legacy starter-class tags and stops safely before

--- a/app/resources/remote-scripts/dune-mem-pressure-probe.sh
+++ b/app/resources/remote-scripts/dune-mem-pressure-probe.sh
@@ -40,6 +40,7 @@
 #   dbop_total=<n>   dbop_open=<n>
 #   dbop=<name>~PH:<phase>~CT:<creationTimestamp>   (one per NON-Succeeded op)
 #   maplim=<map>~LIM:<memoryLimit>          (one per map in the BG spec)
+#   pending_map=<pod>~REQ:<request>~LIM:<limit>~RSN:<reason>~MSG:<scheduler message>
 #   img=<repo>~TAG:<tag>~SIZE:<human>       (one per retained seabass image)
 #   dnat_udp_rules=<n>   dnat_udp_ports=<space-separated ports>
 #   probe_done=1
@@ -178,6 +179,20 @@ if [ -n "$DBNS" ]; then
     while IFS= read -r lim; do
       [ -n "$lim" ] || continue
       echo "maplim=$lim"
+    done
+
+  # Pending game-map pods with the scheduler's own verdict. This catches the
+  # Dynamic Memory boot-capacity case where MemAvailable looks healthy but the
+  # node cannot admit a 16 GiB Hagga pod because kubelet registered less total
+  # capacity at boot.
+  PENDING_JPATH='{range .items[?(@.status.phase=="Pending")]}{.metadata.name}{"~REQ:"}{.spec.containers[0].resources.requests.memory}{"~LIM:"}{.spec.containers[0].resources.limits.memory}{"~RSN:"}{range .status.conditions[?(@.type=="PodScheduled")]}{.reason}{end}{"~MSG:"}{range .status.conditions[?(@.type=="PodScheduled")]}{.message}{end}{"\n"}{end}'
+  "$KUBECTL" -n "$DBNS" get pods -o jsonpath="$PENDING_JPATH" 2>/dev/null |
+    while IFS= read -r pending; do
+      [ -n "$pending" ] || continue
+      name=${pending%%~*}
+      case "$name" in
+        *-sg-*-pod-*) echo "pending_map=$pending" ;;
+      esac
     done
 fi
 

--- a/app/server/lib/VmMemoryPressure.ps1
+++ b/app/server/lib/VmMemoryPressure.ps1
@@ -199,8 +199,9 @@ function ConvertFrom-DuneImageSize {
 # ConvertFrom-DuneMemPressureProbe : parse the probe's stdout into a structured
 # finding. PURE - no SSH, no I/O - so the wiring is unit-testable from a fixture.
 #
-# Returns @{ ok; mem; operators; db; node; disk; bg; dbOps; mapLimits; images;
-#            dnat; signals; pressure; severity; headline; warnings; raw }.
+# Returns @{ ok; mem; operators; db; node; disk; bg; dbOps; mapLimits;
+#            pendingMaps; images; dnat; signals; pressure; capacityBlocked;
+#            severity; headline; warnings; raw }.
 #
 # NOTE: this returns OBSERVATIONS, not verdicts. Everything except the memory
 # signals is reported as-is for the operator to read and act on (or not) - see
@@ -228,12 +229,14 @@ function ConvertFrom-DuneMemPressureProbe {
         bg        = @{ name=''; databasePhase='' }
         dbOps     = @{ total=0; open=0; stuck=@(); active=@(); failed=@(); activeCount=0; failedCount=0; known=$false }
         mapLimits = @{ entries=@(); known=$false }
+        pendingMaps = @()
         images    = @{ entries=@(); builds=@(); buildCount=0; totalBytes=0; known=$false }
         dnat      = @{ udpRules=$null; ports=@(); missing=$false }
         faults    = @()
         gamePodsRunning = $null
-        signals   = @{ oomKills=0; highRestartPods=0; maxRestarts=0; lowMemory=$false; churnPods=0; memoryCorroborated=$false }
+        signals   = @{ oomKills=0; highRestartPods=0; maxRestarts=0; lowMemory=$false; churnPods=0; memoryCorroborated=$false; schedulerMemoryBlocks=0 }
         pressure  = $false
+        capacityBlocked = $false
         severity  = 'none'
         headline  = ''
         warnings  = @()
@@ -253,6 +256,7 @@ function ConvertFrom-DuneMemPressureProbe {
     $dbRecords = New-Object System.Collections.Generic.List[string]
     $dbOpRecords = New-Object System.Collections.Generic.List[string]
     $mapLimRecords = New-Object System.Collections.Generic.List[string]
+    $pendingMapRecords = New-Object System.Collections.Generic.List[string]
     $imgRecords = New-Object System.Collections.Generic.List[string]
     foreach ($line in $lines) {
         if ($line -eq '__FREE_H_BEGIN__') { $inFreeH = $true;  continue }
@@ -289,6 +293,7 @@ function ConvertFrom-DuneMemPressureProbe {
             'dbop_total'         { [int]$tmpi = 0; if ([int]::TryParse($v, [ref]$tmpi)) { $result.dbOps.total = $tmpi; $result.dbOps.known = $true } }
             'dbop_open'          { [int]$tmpi = 0; if ([int]::TryParse($v, [ref]$tmpi)) { $result.dbOps.open  = $tmpi; $result.dbOps.known = $true } }
             'maplim'             { $mapLimRecords.Add($v); $result.mapLimits.known = $true }
+            'pending_map'        { $pendingMapRecords.Add($v) }
             'img'                { $imgRecords.Add($v); $result.images.known = $true }
             'dnat_udp_rules'     { [int]$tmpi = 0; if ([int]::TryParse($v, [ref]$tmpi)) { $result.dnat.udpRules = $tmpi } }
             'dnat_udp_ports'     { $result.dnat.ports = @($v -split '\s+' | Where-Object { $_ -match '^\d+$' }) }
@@ -355,6 +360,12 @@ function ConvertFrom-DuneMemPressureProbe {
 
     # --- per-map memory limits --------------------------------------------
     $result.mapLimits.entries = @(foreach ($r in $mapLimRecords) { _ConvertFrom-DuneMapLimitRecord -Record $r })
+    $result.pendingMaps = @(foreach ($r in $pendingMapRecords) { _ConvertFrom-DunePendingMapRecord -Record $r })
+    $memoryBlockedMaps = @($result.pendingMaps | Where-Object {
+        $_.reason -eq 'Unschedulable' -and $_.message -match '(?i)\bInsufficient memory\b'
+    })
+    $result.signals.schedulerMemoryBlocks = $memoryBlockedMaps.Count
+    $result.capacityBlocked = ($memoryBlockedMaps.Count -gt 0)
 
     # --- retained container images ----------------------------------------
     $builds = New-Object System.Collections.Generic.List[string]
@@ -448,6 +459,16 @@ function ConvertFrom-DuneMemPressureProbe {
             $warn.Add("Fix: raise the VM's RAM in Hyper-V, or lower per-map memory limits (Hagga/Deep Desert). See vm-memory-pressure.txt in the diagnostics bundle.")
         }
     }
+    if ($result.capacityBlocked) {
+        $blocked = $memoryBlockedMaps[0]
+        $request = if ($blocked.request) { $blocked.request } elseif ($blocked.limit) { $blocked.limit } else { '?' }
+        $mapLabel = if ($blocked.map -eq 'Survival_1') { 'Hagga' } elseif ($blocked.map -eq 'DeepDesert_1') { 'Deep Desert' } else { $blocked.map }
+        $result.severity = 'critical'
+        $result.headline = "$mapLabel cannot start - Kubernetes reports Insufficient memory"
+        $warn.Add(("{0} is Pending and requests {1}; the VM guest reports {2} total. This is scheduler capacity, not low MemAvailable pressure." -f `
+            $blocked.map, $request, (Format-DuneMemKiB $result.mem.totalK)))
+        $warn.Add('Fix: check Hyper-V Dynamic Memory startup/minimum. If those settings were already raised, fully shut down and start the VM so the guest and kubelet register the new capacity; a normal restart may retain the old boot capacity.')
+    }
 
     $result.warnings = @($warn)
     $result.faults   = @(_Get-DuneVmFaults -Finding $result)
@@ -518,7 +539,55 @@ function _Get-DuneVmFaults {
         })
     }
 
+    # 4) Kubernetes explicitly refuses a game-map pod for Insufficient memory.
+    # This differs from runtime MemoryPressure: plenty of RAM can be free while
+    # the pod request exceeds node capacity registered from a low-memory boot.
+    $blocked = @($Finding.pendingMaps | Where-Object {
+        $_.reason -eq 'Unschedulable' -and $_.message -match '(?i)\bInsufficient memory\b'
+    })
+    foreach ($pod in $blocked) {
+        $request = if ($pod.request) { $pod.request } elseif ($pod.limit) { $pod.limit } else { '?' }
+        $mapLabel = if ($pod.map -eq 'Survival_1') { 'Hagga' } elseif ($pod.map -eq 'DeepDesert_1') { 'Deep Desert' } else { $pod.map }
+        $out.Add(@{
+            id       = "map-capacity-$($pod.name)"
+            headline = "$mapLabel cannot start because Kubernetes reports Insufficient memory"
+            detail   = ("The pod requests {0}, while the VM guest reports {1} total. MemAvailable can still look healthy because the scheduler checks registered node capacity before the container starts." -f `
+                        $request, (Format-DuneMemKiB $Finding.mem.totalK))
+            action   = 'Check Hyper-V Dynamic Memory startup/minimum. If already raised, fully shut down and start the VM so the guest and kubelet register the new capacity; then start the battlegroup. Do not lower the map limit.'
+        })
+    }
+
     return $out.ToArray()
+}
+
+# Parse ONE pending game-map pod record:
+# <pod>~REQ:<request>~LIM:<limit>~RSN:<reason>~MSG:<scheduler message>
+function _ConvertFrom-DunePendingMapRecord {
+    param([string]$Record)
+    $entry = @{ name=''; map=''; request=''; limit=''; reason=''; message='' }
+    if ([string]::IsNullOrWhiteSpace($Record)) { return $entry }
+    $parts = $Record -split '~'
+    $entry.name = $parts[0].Trim()
+    if ($entry.name -match '-sg-(.+?)-pod-\d+$') {
+        switch ($Matches[1]) {
+            'survival-1'   { $entry.map = 'Survival_1' }
+            'deepdesert-1' { $entry.map = 'DeepDesert_1' }
+            default        { $entry.map = ($Matches[1] -replace '-', '_') }
+        }
+    }
+    foreach ($segment in ($parts | Select-Object -Skip 1)) {
+        $colon = $segment.IndexOf(':')
+        if ($colon -lt 1) { continue }
+        $tag = $segment.Substring(0, $colon)
+        $value = $segment.Substring($colon + 1).Trim()
+        switch ($tag) {
+            'REQ' { $entry.request = $value }
+            'LIM' { $entry.limit = $value }
+            'RSN' { $entry.reason = $value }
+            'MSG' { $entry.message = $value }
+        }
+    }
+    return $entry
 }
 
 # Parse ONE DatabaseOperation record: <name>~PH:<phase>~CT:<creationTimestamp>

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -603,13 +603,16 @@ done
             $memLines = [System.Collections.Generic.List[string]]::new()
             $memLines.Add('# VM memory-pressure probe')
             $memLines.Add("# Generated $(Get-Date -Format 'o')")
-            $memLines.Add('# Detects OOMKilled/exit-137 Funcom operators + Postgres and low MemAvailable with Swap:0.')
+            $memLines.Add('# Detects runtime memory pressure and game-map pods blocked by scheduler capacity.')
             $memLines.Add('')
             if (-not $memFinding.ok) {
                 $memLines.Add("Probe unavailable: $($memFinding.message)")
                 $warnings.Add("VM memory-pressure probe skipped: $($memFinding.message)")
             } else {
-                if ($memFinding.pressure) {
+                if ($memFinding.capacityBlocked) {
+                    $memLines.Add("RESULT: MAP START BLOCKED BY VM CAPACITY (severity: $($memFinding.severity))")
+                    $memLines.Add(">> $($memFinding.headline)")
+                } elseif ($memFinding.pressure) {
                     $memLines.Add("RESULT: MEMORY PRESSURE DETECTED (severity: $($memFinding.severity))")
                     $memLines.Add(">> $($memFinding.headline)")
                 } else {
@@ -659,6 +662,16 @@ done
                     $memLines.Add('difference here is information, not a fault):')
                     foreach ($e in @($memFinding.mapLimits.entries)) {
                         $memLines.Add(("  {0,-40} {1,-8} reference {2}" -f $e.map, $e.limit, $(if ($e.reference) { $e.reference } else { '(not in snapshot)' })))
+                    }
+                    $memLines.Add('')
+                }
+                if (@($memFinding.pendingMaps).Count -gt 0) {
+                    $memLines.Add('Pending game-map pods:')
+                    foreach ($pod in @($memFinding.pendingMaps)) {
+                        $memLines.Add(("  {0} map={1} request={2} limit={3} reason={4}" -f `
+                            $pod.name, $pod.map, $(if ($pod.request) { $pod.request } else { '?' }),
+                            $(if ($pod.limit) { $pod.limit } else { '?' }), $pod.reason))
+                        if ($pod.message) { $memLines.Add("    scheduler: $($pod.message)") }
                     }
                     $memLines.Add('')
                 }
@@ -907,13 +920,18 @@ Register-DuneRoute -Method GET -Path '/api/diagnostics/vm-memory' -Handler {
     param($req, $res, $routeParams, $body)
     try {
         if (-not (Get-Command Get-DuneVmMemoryPressure -ErrorAction SilentlyContinue)) {
-            Write-DuneJson -Response $res -Body @{ ok=$false; pressure=$false; message='memory-pressure helper not loaded' }
+            Write-DuneJson -Response $res -Body @{
+                ok=$false; pressure=$false; capacityBlocked=$false
+                pendingMaps=@(); message='memory-pressure helper not loaded'
+            }
             return
         }
         $f = Get-DuneVmMemoryPressure
         $body = @{
             ok       = [bool]$f.ok
             pressure = [bool]$f.pressure
+            capacityBlocked = [bool]$f.capacityBlocked
+            pendingMaps = @($f.pendingMaps)
             severity = [string]($f.severity)
             headline = [string]($f.headline)
             warnings = @($f.warnings)

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1111,9 +1111,10 @@ function Show-DuneVmMemoryPressureWarning {
     # Run the read-only VM health probe over SSH and print red warnings for
     # anything the operator has to act on: a stuck DatabaseOperation holding the
     # server down, DiskPressure / a filling root volume, a missing game-UDP
-    # bridge, per-map memory limits crushed by Funcom's experimental swap
-    # preset, and genuine memory pressure (OOM-killed operators, evicted
-    # Postgres, or a tiny MemAvailable with Swap: 0).
+    # bridge, a Pending map rejected by the scheduler for Insufficient memory,
+    # per-map limits crushed by Funcom's experimental swap preset, and genuine
+    # runtime pressure (OOM-killed operators, evicted Postgres, or tiny
+    # MemAvailable with Swap: 0).
     #
     # 2026-07-26: elevated restart counts NO LONGER declare memory pressure on
     # their own. Funcom's operators restart in lockstep by design (exit 255 /
@@ -1158,7 +1159,7 @@ function Show-DuneVmMemoryPressureWarning {
         $finding = ConvertFrom-DuneMemPressureProbe -Raw (($out | Out-String)) -PublicIpConfigured $publicIpConfigured
         if (-not $finding.ok) { return }
 
-        if ($finding.pressure) {
+        if ($finding.pressure -or $finding.capacityBlocked) {
             Write-Host ""
             Write-Host "  WARNING: $($finding.headline)" -ForegroundColor Red
             foreach ($w in @($finding.warnings)) {

--- a/tests/VmHealthProbe.Tests.ps1
+++ b/tests/VmHealthProbe.Tests.ps1
@@ -9,6 +9,7 @@
 #     not Ready
 #   * Kubernetes' own DiskPressure node condition
 #   * a public IP configured, game pods running, and zero game UDP rules
+#   * Kubernetes reports a Pending game-map pod Unschedulable for Insufficient memory
 #
 # Everything else the probe reads - disk usage, retained build images, per-map
 # memory limits - is information with no verdict attached. The most important
@@ -115,7 +116,7 @@ probe_done=1
         ($r.mapLimits.entries | Where-Object { $_.map -eq 'Survival_1' }).reference | Should -Be '12Gi'
     }
 
-    # ---- the three fault signatures ---------------------------------------
+    # ---- system-declared fault signatures ---------------------------------
     It 'reports a database operation only when the battlegroup also says DATABASE is not Ready' {
         $r = ConvertFrom-DuneMemPressureProbe -Raw $outageFixture
         $f = @($r.faults | Where-Object { $_.id -eq 'db-operation-stuck' })

--- a/tests/VmMemoryPressure.Tests.ps1
+++ b/tests/VmMemoryPressure.Tests.ps1
@@ -19,6 +19,26 @@ Describe 'Format-DuneMemKiB' -Tag 'Pure' {
     }
 }
 
+Describe 'VM memory probe script' -Tag 'Pure' {
+    It 'captures pending map scheduler reasons and remains POSIX-shell valid' {
+        $path = Join-Path (Get-DstRepoRoot) 'app\resources\remote-scripts\dune-mem-pressure-probe.sh'
+        $source = Get-Content $path -Raw
+        $source | Should -Match 'pending_map='
+        $source | Should -Match 'Insufficient memory|PodScheduled'
+
+        $bash = Get-Command bash -ErrorAction SilentlyContinue
+        if (-not $bash) { Set-ItResult -Skipped -Because 'bash is unavailable'; return }
+        & $bash.Source -n $path
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It 'serializes scheduler-capacity fields through the dashboard API route' {
+        $route = Get-Content (Join-Path (Get-DstRepoRoot) 'app\server\routes\Diagnostics.ps1') -Raw
+        $route | Should -Match 'capacityBlocked\s*=\s*\[bool\]\$f\.capacityBlocked'
+        $route | Should -Match 'pendingMaps\s*=\s*@\(\$f\.pendingMaps\)'
+    }
+}
+
 Describe 'ConvertFrom-DuneMemPressureProbe' -Tag 'Pure' {
 
     # Mirrors Pat's case (2026-07-07): 23.5 GiB VM, 69 MiB available, Swap: 0,
@@ -80,6 +100,42 @@ probe_done=1
         $r.pressure           | Should -BeFalse
         $r.severity           | Should -Be 'none'
         @($r.warnings).Count  | Should -Be 0
+    }
+
+    It 'detects a map pod blocked by scheduler capacity even with ample MemAvailable' {
+        $blocked = @'
+mem_total_k=15309209
+mem_avail_k=11324620
+swap_total_k=0
+node_cond=MemoryPressure=False
+node_cond=Ready=True
+maplim=Survival_1~LIM:16Gi
+pending_map=sh-abc-def-sg-survival-1-pod-1~REQ:16Gi~LIM:16Gi~RSN:Unschedulable~MSG:0/1 nodes are available: 1 Insufficient memory.
+probe_done=1
+'@
+        $r = ConvertFrom-DuneMemPressureProbe -Raw $blocked
+
+        $r.pressure | Should -BeFalse
+        $r.capacityBlocked | Should -BeTrue
+        $r.severity | Should -Be 'critical'
+        $r.headline | Should -Match 'Hagga cannot start'
+        $r.pendingMaps[0].map | Should -Be 'Survival_1'
+        $r.pendingMaps[0].request | Should -Be '16Gi'
+        (@($r.warnings) -join ' ') | Should -Match 'full.*shut down.*start'
+        (@($r.faults | Where-Object { $_.id -like 'map-capacity-*' })).Count | Should -Be 1
+    }
+
+    It 'does not infer a capacity fault from a Pending pod without the scheduler verdict' {
+        $pending = @'
+mem_total_k=15309209
+mem_avail_k=11324620
+pending_map=sh-abc-def-sg-survival-1-pod-1~REQ:16Gi~LIM:16Gi~RSN:~MSG:
+probe_done=1
+'@
+        $r = ConvertFrom-DuneMemPressureProbe -Raw $pending
+
+        $r.capacityBlocked | Should -BeFalse
+        @($r.faults | Where-Object { $_.id -like 'map-capacity-*' }).Count | Should -Be 0
     }
 
     It 'does NOT flag low available when swap provides a cushion' {

--- a/webui/src/api/diagnostics.ts
+++ b/webui/src/api/diagnostics.ts
@@ -24,9 +24,18 @@ export function buildDiagnosticBundle() {
 export interface VmMemoryPressure {
   ok: boolean
   pressure: boolean
+  capacityBlocked: boolean
   severity: 'none' | 'warn' | 'critical'
   headline: string
   warnings: string[]
+  pendingMaps: {
+    name: string
+    map: string
+    request: string
+    limit: string
+    reason: string
+    message: string
+  }[]
   message?: string
   maxRestarts?: number
   oomKills?: number

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -110,7 +110,8 @@ export function Dashboard() {
   const bg = BG_STYLES[bgState]
   const bgInfo = status?.bg?.info ?? null
   const gameServers = status?.bg?.gameServers ?? []
-  const survivalPhase = findSurvivalServer(gameServers)?.phase?.trim() || ''
+  const survivalServer = findSurvivalServer(gameServers)
+  const survivalPhase = survivalServer?.phase?.trim() || ''
   const ports = status?.ports
   const portResults = Array.isArray(ports?.results) ? ports.results : []
   const tcp = portResults.filter(r => r.protocol === 'TCP')

--- a/webui/src/pages/dashboard/VmMemoryPressureBanner.tsx
+++ b/webui/src/pages/dashboard/VmMemoryPressureBanner.tsx
@@ -1,15 +1,10 @@
-// VmMemoryPressureBanner — red Server Health banner that fires when the VM is
-// low on memory: Funcom operators OOM-killed (exit 137 / high restart counts),
-// Postgres evicted, or a tiny MemAvailable with Swap: 0. This is the root cause
-// of the "battlegroup restarted outside its schedule" / "ping surge under load"
-// class of report (murm, Hagga per-map sizing, Pat 2026-07-07), and until now
-// could only be found by exporting logs and hand-reading them.
+// VmMemoryPressureBanner — Server Health banner for runtime pressure and the
+// separate scheduler-capacity fault where a map pod cannot fit on the VM node.
 //
 // Backed by GET /api/diagnostics/vm-memory, which is read-only and cached 60s
 // server-side, so polling here is cheap. OPT-IN: hidden by default, shown only
-// when the operator enables it under Settings → Dashboard warnings. When off we
-// don't even poll the probe. Renders nothing unless enabled AND the probe
-// succeeded AND detected pressure.
+// Runtime pressure remains opt-in. Scheduler Insufficient-memory is a concrete
+// broken state, so it is polled/shown regardless of that preference.
 import { useCallback, useEffect, useState } from 'react'
 import { Icon } from '../../components/Icon'
 import { getVmMemoryPressure, type VmMemoryPressure } from '../../api/diagnostics'
@@ -23,8 +18,7 @@ export function VmMemoryPressureBanner({ vmRunning }: Props) {
   const [finding, setFinding] = useState<VmMemoryPressure | null>(null)
   const [show, setShow] = useVmMemPressureEnabled()
 
-  // Only active when the operator opted in AND the VM is running.
-  const active = show && vmRunning
+  const active = vmRunning
 
   const load = useCallback(async () => {
     if (!active) return
@@ -45,9 +39,11 @@ export function VmMemoryPressureBanner({ vmRunning }: Props) {
     return () => window.clearInterval(id)
   }, [active, load])
 
-  if (!active || !finding || !finding.ok || !finding.pressure) return null
+  if (!active || !finding || !finding.ok) return null
+  const capacityBlocked = finding.capacityBlocked === true
+  if (!capacityBlocked && (!show || !finding.pressure)) return null
 
-  const critical = finding.severity === 'critical'
+  const critical = capacityBlocked || finding.severity === 'critical'
   const tone = critical
     ? 'border-danger/50 bg-danger/10 text-danger'
     : 'border-warning/50 bg-warning/10 text-warning'
@@ -68,15 +64,17 @@ export function VmMemoryPressureBanner({ vmRunning }: Props) {
             </ul>
           )}
         </div>
-        <button
-          type="button"
-          onClick={() => setShow(false)}
-          className="shrink-0 -mt-0.5 -mr-1 p-1 rounded hover:bg-current/10 text-current/70 hover:text-current transition-colors"
-          title="Hide this warning. Turn it back on under Settings → Dashboard warnings."
-          aria-label="Hide VM memory-pressure warning"
-        >
-          <Icon name="X" size={16} />
-        </button>
+        {!capacityBlocked && (
+          <button
+            type="button"
+            onClick={() => setShow(false)}
+            className="shrink-0 -mt-0.5 -mr-1 p-1 rounded hover:bg-current/10 text-current/70 hover:text-current transition-colors"
+            title="Hide this warning. Turn it back on under Settings → Dashboard warnings."
+            aria-label="Hide VM memory-pressure warning"
+          >
+            <Icon name="X" size={16} />
+          </button>
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- detect game-map pods Kubernetes marks `Pending / Unschedulable / Insufficient memory`
- report scheduler capacity separately from runtime memory pressure
- show a non-dismissible Server Health warning with map, request, and guest-visible RAM
- explain Dynamic Memory settings may already be raised and require a full VM shutdown/start before guest/kubelet capacity changes
- print the same finding in CLI Start/Reboot and diagnostics bundles
- keep runtime memory-pressure warnings opt-in while concrete scheduler faults always show

## Field evidence
A live Hagga pod requested 16 GiB while the VM guest exposed 14.6 GiB. MemAvailable remained healthy, but Kubernetes could not assign the pod. Dynamic Memory was already configured; raising minimum from 16 GB to 30 GB and performing a full shutdown/start restored Hagga, and DD-to-Hagga transfer succeeded.

## Validation
- 37 focused Pester tests passed
- WebUI production build passed
- remote probe passed `bash -n`
- exact probe ran read-only against a healthy VM with exit 0, `probe_done=1`, no pending-map findings, and no errors
- PowerShell parse checks passed
- staged gitleaks scan found no leaks