### PR TITLE
Harden shared teleports and chat monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ here cover everything those tags shipped.
 - Vehicle Durability Damage moved back to Experimental after field testing found
   that 0 does not disable ordinary use wear or permanent durability loss from
   welding/repair-station repairs. Its exact damage scope remains unconfirmed.
+- Shared `!tp` destinations now use the game's safe-surface teleport path instead
+  of forcing exact stored coordinates. Backed-up field testing confirmed safe
+  long-distance and elevated-location arrivals.
 
 ## [13.6.5] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ here cover everything those tags shipped.
   long-distance and elevated-location arrivals.
 - Chat-command broadcasts now address players by character name consistently
   instead of using the Funcom account-name portion for replies such as `!tp`.
+- Chat commands now offer an opt-in **Real-time (1 second)** monitoring interval
+  with its measured CPU cost shown; the lower-cost 3-second interval remains the
+  default.
 
 ## [13.6.5] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ here cover everything those tags shipped.
 - Shared `!tp` destinations now use the game's safe-surface teleport path instead
   of forcing exact stored coordinates. Backed-up field testing confirmed safe
   long-distance and elevated-location arrivals.
+- Chat-command broadcasts now address players by character name consistently
+  instead of using the Funcom account-name portion for replies such as `!tp`.
 
 ## [13.6.5] - 2026-08-12
 

--- a/app/server/lib/ChatCommands.ps1
+++ b/app/server/lib/ChatCommands.ps1
@@ -942,6 +942,31 @@ function Resolve-DuneChatFlsId {
     }
 }
 
+function Resolve-DuneChatCharacterName {
+    param([string]$Ip, [string]$FuncomId)
+    if ([string]::IsNullOrWhiteSpace($FuncomId)) { return @{ ok = $false; message = 'no funcom id' } }
+    $safe = $FuncomId -replace "'", "''"
+    $sql = @"
+SELECT COALESCE(ps.character_name, '') AS character_name
+FROM dune.accounts account
+JOIN dune.player_state ps ON ps.account_id = account.id
+WHERE account.funcom_id = '$safe'
+ORDER BY ps.last_avatar_activity DESC NULLS LAST
+LIMIT 1;
+"@
+    try {
+        $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+        if (-not $res.ok) { return @{ ok = $false; message = [string]$res.error } }
+        $rows = ConvertTo-DuneRowMaps -Result $res
+        if ($rows.Count -eq 0) { return @{ ok = $false; message = "no active character for $FuncomId" } }
+        $name = ([string]$rows[0]['character_name']).Trim()
+        if (-not $name) { return @{ ok = $false; message = "empty character name for $FuncomId" } }
+        return @{ ok = $true; characterName = $name }
+    } catch {
+        return @{ ok = $false; message = $_.Exception.Message }
+    }
+}
+
 function Get-DuneChatPlayerLocation {
     param([string]$Ip, [string]$FuncomId)
     if ([string]::IsNullOrWhiteSpace($FuncomId)) {
@@ -1000,9 +1025,11 @@ function Send-DuneChatReply {
     if (-not (Get-Command Send-V6GenericBroadcast -ErrorAction SilentlyContinue)) {
         return @{ ok = $false; message = 'Broadcast helper unavailable (Broadcast.ps1 not loaded).' }
     }
-    # Name the player so a broadcast reply is obviously aimed at whoever typed
-    # the command, since everyone can see it.
-    $who = ($ToFuncomId -split '#')[0]
+    # Name the character so broadcasts match the identity players see in-game.
+    # Fall back to the Funcom display id only when the active character cannot
+    # be resolved; a reply is still better than silently dropping the result.
+    $identity = Resolve-DuneChatCharacterName -Ip $Ip -FuncomId $ToFuncomId
+    $who = if ($identity.ok) { [string]$identity.characterName } else { ($ToFuncomId -split '#')[0] }
     $body = if ($who) { "$who - $Message" } else { $Message }
     $title = if ($State -and $State.replyTitle) { [string]$State.replyTitle } else { 'Server' }
     try {

--- a/app/server/lib/ChatCommands.ps1
+++ b/app/server/lib/ChatCommands.ps1
@@ -628,7 +628,7 @@ function Read-DuneChatCommandsState {
 # node every time (~1.5 core-seconds, measured 2026-08-04 on an 8-core VM). So
 # the sustained cost is roughly 1.5 / interval cores, for as long as the feature
 # is enabled, whether or not anyone is chatting.
-$script:DuneChatPollChoices = @(3, 5, 10, 15, 30)
+$script:DuneChatPollChoices = @(1, 3, 5, 10, 15, 30)
 $script:DuneChatPollDefault = 3
 
 # What the scheduler actually sleeps between drains. Clamped here rather than

--- a/app/server/lib/ChatCommands.ps1
+++ b/app/server/lib/ChatCommands.ps1
@@ -1398,7 +1398,9 @@ function Invoke-DuneChatCommandTeleport {
 
     $fls = Resolve-DuneChatFlsId -Ip $Ip -FuncomId $FuncomId
     if (-not $fls.ok) { return @{ ok = $false; reply = 'Could not resolve your player id for teleport.' } }
-    $res = Invoke-DuneRmqTeleportToExact -FlsId $fls.flsId `
+    # Let the game resolve a safe landing surface. TeleportToExact can force a
+    # distant stored Z before destination terrain finishes streaming.
+    $res = Invoke-DuneRmqTeleportTo -FlsId $fls.flsId `
         -X ([double]$bookmark.x) -Y ([double]$bookmark.y) -Z ([double]$bookmark.z)
     if (-not $res.ok) { return @{ ok = $false; reply = "Teleport to '$($bookmark.name)' failed." } }
     return @{ ok = $true; reply = "Teleported to $($bookmark.name)." }

--- a/tests/ChatCommands.Tests.ps1
+++ b/tests/ChatCommands.Tests.ps1
@@ -303,6 +303,50 @@ Describe 'defaults' {
     }
 }
 
+Describe 'chat command broadcasts' {
+    BeforeAll {
+        if (-not (Get-Command Invoke-DuneSqlQuery -ErrorAction SilentlyContinue)) {
+            function global:Invoke-DuneSqlQuery { param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec) }
+        }
+        if (-not (Get-Command Send-V6GenericBroadcast -ErrorAction SilentlyContinue)) {
+            function global:Send-V6GenericBroadcast { param($Title, $Body, $DurationSec) }
+        }
+    }
+
+    It 'addresses every command reply by active character name' {
+        Mock Invoke-DuneSqlQuery {
+            @{
+                ok = $true
+                columns = @('character_name')
+                rows = ,@('Riftwalker')
+            }
+        }
+        Mock Send-V6GenericBroadcast { @{ ok = $true } }
+
+        $result = Send-DuneChatReply -Ip 'vm' -State (New-DstChatState) `
+            -ToFuncomId 'AccountName#1234' -Message 'Teleported to Riftwatch.'
+
+        $result.ok | Should -BeTrue
+        Should -Invoke Send-V6GenericBroadcast -Times 1 -Exactly -ParameterFilter {
+            $Title -eq 'Server' -and
+            $Body -eq 'Riftwalker - Teleported to Riftwatch.' -and
+            $DurationSec -eq 12
+        }
+    }
+
+    It 'falls back to account display name when character lookup fails' {
+        Mock Invoke-DuneSqlQuery { @{ ok = $false; error = 'offline' } }
+        Mock Send-V6GenericBroadcast { @{ ok = $true } }
+
+        [void](Send-DuneChatReply -Ip 'vm' -State (New-DstChatState) `
+            -ToFuncomId 'AccountName#1234' -Message 'Try again.')
+
+        Should -Invoke Send-V6GenericBroadcast -Times 1 -Exactly -ParameterFilter {
+            $Body -eq 'AccountName - Try again.'
+        }
+    }
+}
+
 Describe 'self-only commands' {
     # !kit, !item, !vehicle and !water resolve the target from the chat message's
     # sender and take no player argument, so a player can never aim them at

--- a/tests/ChatCommands.Tests.ps1
+++ b/tests/ChatCommands.Tests.ps1
@@ -295,6 +295,7 @@ Describe 'defaults' {
         # This value sets a permanent CPU load on someone's game server, so it is
         # clamped in the reader rather than trusted from the state file.
         (New-DuneChatCommandsDefault).pollSeconds | Should -Be 3
+        $script:DuneChatPollChoices | Should -Contain 1
         Get-DuneChatCommandPollSeconds -State @{ pollSeconds = 10 }    | Should -Be 10
         Get-DuneChatCommandPollSeconds -State @{ pollSeconds = 0 }     | Should -Be 3
         Get-DuneChatCommandPollSeconds -State @{ pollSeconds = -5 }    | Should -Be 1

--- a/tests/ChatCommands.Tests.ps1
+++ b/tests/ChatCommands.Tests.ps1
@@ -350,6 +350,9 @@ Describe 'teleport bookmarks' {
         if (-not (Get-Command Invoke-DuneSqlQuery -ErrorAction SilentlyContinue)) {
             function global:Invoke-DuneSqlQuery { param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec) }
         }
+        if (-not (Get-Command Invoke-DuneRmqTeleportTo -ErrorAction SilentlyContinue)) {
+            function global:Invoke-DuneRmqTeleportTo { param($FlsId, $X, $Y, $Z) }
+        }
         if (-not (Get-Command Invoke-DuneRmqTeleportToExact -ErrorAction SilentlyContinue)) {
             function global:Invoke-DuneRmqTeleportToExact { param($FlsId, $X, $Y, $Z) }
         }
@@ -608,18 +611,22 @@ Describe 'teleport bookmarks' {
         $r.reply | Should -BeLike "*Available: Base*"
     }
 
-    It 'teleports only within the current map, partition and dimension' {
+    It 'uses the non-exact teleport path within the current map, partition and dimension' {
         Save-DuneChatTeleports -Bookmarks @(
             [ordered]@{ name = 'Base'; key = 'base'; map = 'HaggaBasin'; partition = 1; dimension = 0; x = 1; y = 2; z = 3; capturedFrom = 'Coastal'; capturedAt = '2026-08-16T00:00:00Z' }
         ) | Should -BeTrue
         Mock Get-DuneChatPlayerLocation { @{ ok = $true; status = 'Online'; map = 'HaggaBasin'; partition = 1; dimension = 0 } }
         Mock Resolve-DuneChatFlsId { @{ ok = $true; flsId = 'FLS1' } }
+        Mock Invoke-DuneRmqTeleportTo { @{ ok = $true } }
         Mock Invoke-DuneRmqTeleportToExact { @{ ok = $true } }
 
         $r = Invoke-DuneChatCommandExecutor -Ip 'vm' -State (New-DstChatState) -Verb 'tp' -FuncomId 'A#1' -CommandArgs @('Base')
         $r.ok | Should -BeTrue
         $r.reply | Should -Be 'Teleported to Base.'
-        Should -Invoke Invoke-DuneRmqTeleportToExact -Times 1 -Exactly
+        Should -Invoke Invoke-DuneRmqTeleportTo -Times 1 -Exactly -ParameterFilter {
+            $FlsId -eq 'FLS1' -and $X -eq 1 -and $Y -eq 2 -and $Z -eq 3
+        }
+        Should -Invoke Invoke-DuneRmqTeleportToExact -Times 0 -Exactly
     }
 
     It 'blocks a destination on another map before sending RMQ' {
@@ -627,11 +634,13 @@ Describe 'teleport bookmarks' {
             [ordered]@{ name = 'Base'; key = 'base'; map = 'HaggaBasin'; partition = 1; dimension = 0; x = 1; y = 2; z = 3; capturedFrom = 'Coastal'; capturedAt = '2026-08-16T00:00:00Z' }
         ) | Should -BeTrue
         Mock Get-DuneChatPlayerLocation { @{ ok = $true; status = 'Online'; map = 'DeepDesert'; partition = 8; dimension = 0 } }
+        Mock Invoke-DuneRmqTeleportTo { @{ ok = $true } }
         Mock Invoke-DuneRmqTeleportToExact { @{ ok = $true } }
 
         $r = Invoke-DuneChatCommandExecutor -Ip 'vm' -State (New-DstChatState) -Verb 'tp' -FuncomId 'A#1' -CommandArgs @('Base')
         $r.ok | Should -BeFalse
         $r.reply | Should -BeLike '*Travel to that map first*'
+        Should -Invoke Invoke-DuneRmqTeleportTo -Times 0 -Exactly
         Should -Invoke Invoke-DuneRmqTeleportToExact -Times 0 -Exactly
     }
 }

--- a/webui/src/pages/gameplay/ChatCommandsCard.tsx
+++ b/webui/src/pages/gameplay/ChatCommandsCard.tsx
@@ -45,7 +45,7 @@ const SPICE_VERBS = new Set(['small', 'medium', 'large'])
 // 15.41% at a 3s poll, so ~1.5 core-seconds per check. Shown in the picker so
 // the trade is made with the numbers visible rather than blind.
 const POLL_COST: Record<number, string> = {
-  3: '0.50', 5: '0.30', 10: '0.15', 15: '0.10', 30: '0.05',
+  1: '1.50', 3: '0.50', 5: '0.30', 10: '0.15', 15: '0.10', 30: '0.05',
 }
 
 // The cap a spice command works within is not part of this feature - it is the
@@ -655,13 +655,16 @@ export function ChatCommandsCard() {
           onChange={e => {
             const n = Number(e.target.value)
             setState(prev => (prev ? { ...prev, pollSeconds: n } : prev))
-            void patch({ pollSeconds: n }, `Now checking every ${n} seconds.`)
+            void patch(
+              { pollSeconds: n },
+              n === 1 ? 'Real-time monitoring enabled.' : `Now checking every ${n} seconds.`,
+            )
           }}
           className="px-2 py-1 rounded bg-surface border border-border text-text text-xs"
         >
-          {(state?.pollChoices ?? [3, 5, 10, 15, 30]).map(n => (
+          {(state?.pollChoices ?? [1, 3, 5, 10, 15, 30]).map(n => (
             <option key={n} value={n}>
-              {n} seconds — about {POLL_COST[n] ?? (1.5 / n).toFixed(2)} of a processor core
+              {n === 1 ? 'Real-time (1 second)' : `${n} seconds`} — about {POLL_COST[n] ?? (1.5 / n).toFixed(2)} of a processor core
             </option>
           ))}
         </select>


### PR DESCRIPTION
## Summary
- replay shared `!tp` destinations through the game's safe-surface teleport path
- preserve existing map, partition, and dimension guards
- address all chat-command broadcasts by active character name instead of Funcom account name
- add opt-in **Real-time (1 second)** monitoring with measured ~1.50-core cost; default remains 3 seconds

## Field validation
- Fargen tested `solo-6`: long-distance replay to Riftwatch landed correctly without the prior under-mesh failure
- the same test exposed inconsistent account-name broadcast labeling and intermittent pickup under 3-second polling
- `solo-7` will field-test character-name replies and opt-in real-time monitoring

## Validation
- ChatCommands + route suites: 66 passed
- WebUI build passed
- PowerShell parse check passed
- gitleaks: no leaks found