### PR TITLE
Expand PTC Solo inventory, packages, settings, and backups

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,7 +76,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.7.0"
+      placeholder: "v13.8.0"
     validations:
       required: true
 
@@ -123,10 +123,10 @@ body:
         - Web portal — DD Seed Maps (Deep Desert per-seed POI maps)
         - Web portal — DD Seed Maps — wrong or missing POI / layout data for a seed
         - Web portal — Solo Mode — connection / wrapper or schema validation / process lock
-        - Web portal — Solo Mode — native settings (load / apply / retained INI backup)
-        - Web portal — Solo Mode — Give Item / Vehicle Kit / backpack or Developer Storage delivery
+        - Web portal — Solo Mode — native and Engine settings (load / apply / retained INI backup)
+        - Web portal — Solo Mode — Give Item / Vehicle Kit / Package / Cosmetics / backpack or built-storage delivery
         - Web portal — Solo Mode — Solari / Landsraad Scrip / Hajra Literjon fill
-        - Web portal — Solo Mode — save backup / restore / delete / safety backup
+        - Web portal — Solo Mode — save backup / restore / single or multi-select delete / safety backup
         - Web portal — Solo Mode — Progression — max specializations / Find the Fremen / Enable All Skills
         - Web portal — Database (Backup / Restore / Cross-VM or cross-BG migration / SQL Editor)
         - Web portal — Database (Backup Schedule / crontab)
@@ -158,8 +158,8 @@ body:
     id: menu_option
     attributes:
       label: Specific page / button / command
-      description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug? For in-game commands, include the exact `!command`, chat channel, monitoring interval, cooldown, whether any broadcast appeared, and whether it used the character name. For scheduled Funcom updates, include the scheduled time, whether Apply available Funcom server updates was enabled, installed/latest build IDs, and the last schedule result. For Specs > Apply level, include the track, before/after level, and before/after unspent skill points. For Reset Journey, include whether the post-NPE story restarted at Find the Fremen, which starter-class tree was reset, and how many skill points were refunded. For an Experimental Lab control, include its exact CVar or INI key, source/risk badge, file and section, and whether local Engine.ini management was enabled. For Solo Mode, include the adapter, wrapper/schema status, whether the game was fully closed, and the exact connection/settings/backup/restore step. For a database migration, name the failing step.
-      placeholder: "e.g. Solo Mode > Connect and validate, Solo Mode > Settings > Apply Solo settings, Solo Mode > Backups > Create backup / Restore, Server Health > Scheduled restarts > Save schedule, Settings > Public IP / DDNS > Apply public IP, Game Config > bottom bar > Apply INIs & restart, Gameplay Admin > Players > Specs > Apply level, DD Seed Maps > seed selector, Database > backup file > Restore, Help > Create GitHub Issue, or CLI -Cmd startup"
+      description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug? For in-game commands, include the exact `!command`, chat channel, monitoring interval, cooldown, whether any broadcast appeared, and whether it used the character name. For shared teleport destinations, include direct Save location vs Arm live capture, whether the player paused about five seconds, and whether they teleported on foot or from a vehicle seat. For scheduled Funcom updates, include the scheduled time, whether Apply available Funcom server updates was enabled, installed/latest build IDs, and the last schedule result. For Specs > Apply level, include the track, before/after level, and before/after unspent skill points. For Reset Journey, include whether the post-NPE story restarted at Find the Fremen, which starter-class tree was reset, and how many skill points were refunded. For an Experimental Lab control, include its exact CVar or INI key, source/risk badge, file and section, and whether local Engine.ini management was enabled. For Solo Mode, include the adapter, wrapper/schema status, whether the game was fully closed, and the exact connection/settings/inventory/package/cosmetic/backup/restore step. For a database migration, name the failing step.
+      placeholder: "e.g. Solo Mode > Inventory > Give Package, Solo Mode > Backups > Delete selected, Gameplay Admin > Overview > In-game commands > Save location, Server Health > Scheduled restarts > Save schedule, Settings > Public IP / DDNS > Apply public IP, Game Config > bottom bar > Apply INIs & restart, Gameplay Admin > Players > Specs > Apply level, DD Seed Maps > seed selector, Database > backup file > Restore, Help > Create GitHub Issue, or CLI -Cmd startup"
     validations:
       required: true
 
@@ -257,7 +257,7 @@ body:
   - type: textarea
     id: solo_diag
     attributes:
-      label: Solo Mode — local save, settings, backup, or restore details
+      label: Solo Mode — local save, settings, inventory, package, cosmetic, backup, or restore details
       description: |
         Only fill this in for the host-local **Solo Mode** page. Attach a fresh
         diagnostics ZIP; it includes `solo-mode.txt` with adapter, wrapper,
@@ -267,15 +267,18 @@ body:
 
         - PTC or retail/custom folder.
         - Exact step: Connect and validate, Apply Solo settings, Create backup,
-          Restore/Delete backup, Give Item, Give Vehicle Kit, Set currency
+          Restore/Delete one backup, Delete selected backups, Give Item, Give
+          Vehicle Kit, Give Package, Grant Cosmetic / Building Set, Set currency
           balances, Fill Hajra Literjon, Max specializations, Complete Find the
           Fremen, or Enable All Skills.
         - Whether Dune: Awakening was fully closed for a write.
         - The exact message DST showed.
         - For settings/currencies/fillables, the key or item and before/after value.
-        - For item grants, the item/template, quantity, quality, and selected
-          backpack or Developer Storage.
+        - For item/package/cosmetic grants, the selection, quantity/quality when
+          applicable, and selected backpack or built-storage destination.
         - For restore, whether the pre-restore safety backup was reported.
+        - For multi-delete, the selected backup count and exact deleted/retained
+          result. Do not paste backup paths.
 
         Do not paste your Steam/account folder name or full local save path.
         Leave blank if the bug is not about Solo Mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ here cover everything those tags shipped.
   preferring Developer Storage; users can still choose another supported
   destination.
 
+### Fixed
+
+- Fresh Solo backpacks can receive the Sandbike, Buggy, Treadwheel, and Light
+  Ornithopter kits again. Missing Welding Torch and Treadwheel Hull metadata no
+  longer injects a false 1000-volume charge that rejected those kits even when
+  their known parts fit the stock 175-volume backpack.
+
 ## [13.7.0] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.8.0] - 2026-08-18
+
 ### Added
 
 - Solo Mode can grant cosmetics and building sets through the existing
@@ -23,10 +25,11 @@ here cover everything those tags shipped.
   preferring Developer Storage; users can still choose another supported
   destination.
 - PTC Solo Settings can manage Sun Exposure, Maximum Vehicles Per Player, and
-  Shield Drops While Shooting in the observed `FLS_beta`
-  `Config\Windows\Engine.ini`. Writes are allowlisted, game-closed,
-  backup-first, atomic, and verified; all three controls are field-confirmed in
-  PTC Solo, and no retail path is assumed.
+  Shield Drops While Shooting in both observed `FLS_beta` Engine files:
+  `Config\Windows\Engine.ini` and `Config\WindowsClient\Engine.ini`. Writes are
+  allowlisted, game-closed, backup-first, atomic, and verified across both
+  files; all three controls are field-confirmed in PTC Solo, and no retail path
+  is assumed.
 - Solo Mode exposes the canonical DST package store directly, so Solo-only
   users can create, import, edit, delete, and grant reusable item packages
   without configuring Self-Hosted or relying on demo player data.
@@ -40,6 +43,13 @@ here cover everything those tags shipped.
 - Solo Backups supports selecting multiple retained backups and deleting them
   with one confirmation. DST validates the complete selection before staging
   any file and rolls staged files back if a later move fails.
+
+### Changed
+
+- Shared teleport guidance now explains the five-second direct-save settle time,
+  live-capture fallback after rapid travel, vehicle driver-seat limitation, and
+  why DST avoids speculative watchdogs around Funcom's undocumented developer
+  teleport command.
 
 ### Fixed
 
@@ -7711,7 +7721,8 @@ at the time. Also folds in the v3.0.1 / v3.1.2 patches.
   (`ssh`, `Gameplay Admin`, `setup-guide`, `report-issue`). _(originally
   3.1.2)_
 
-[Unreleased]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.7.0...HEAD
+[Unreleased]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.8.0...HEAD
+[13.8.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.7.0...v13.8.0
 [13.7.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.6.5...v13.7.0
 [13.0.2]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.0.1...v13.0.2
 [13.0.1]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.0.0...v13.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ here cover everything those tags shipped.
   Ornithopter kits again. Missing Welding Torch and Treadwheel Hull metadata no
   longer injects a false 1000-volume charge that rejected those kits even when
   their known parts fit the stock 175-volume backpack.
+- Item and cosmetic catalog names now decode BOM-less UTF-8 explicitly, fixing
+  mojibake in names containing typographic apostrophes and other non-ASCII text.
 
 ## [13.7.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ here cover everything those tags shipped.
 - Solo Inventory keeps the selected delivery destination visible in a sticky
   card while scrolling, and blurs the selector on mouse-wheel input to prevent
   accidental destination changes.
+- Solo Backups supports selecting multiple retained backups and deleting them
+  with one confirmation. DST validates the complete selection before staging
+  any file and rolls staged files back if a later move fails.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ here cover everything those tags shipped.
 - Solo item delivery now selects the character backpack by default instead of
   preferring Developer Storage; users can still choose another supported
   destination.
+- PTC Solo Settings can manage Sun Exposure and Maximum Vehicles Per Player in
+  the observed `FLS_beta` `Config\Windows\Engine.ini`. Writes are allowlisted,
+  game-closed, backup-first, atomic, and verified; no retail path is assumed.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- Solo Mode can grant cosmetics and building sets through the existing
+  backup-safe offline item transaction. Unlock items are delivered to the Solo
+  backpack for processing on next login; grants remain local to that save and
+  do not create Funcom account entitlements.
+
 ## [13.7.0] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ here cover everything those tags shipped.
 - Solo Mode exposes the canonical DST package store directly, so Solo-only
   users can create, import, edit, delete, and grant reusable item packages
   without configuring Self-Hosted or relying on demo player data.
+- Solo inventory destinations include normal built storage boxes as well as
+  Developer Storage. Unfinished hologram containers are excluded using the
+  persisted `placeables.is_hologram` flag and rejected again at write time.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,10 @@ here cover everything those tags shipped.
 - Solo Mode exposes the canonical DST package store directly, so Solo-only
   users can create, import, edit, delete, and grant reusable item packages
   without configuring Self-Hosted or relying on demo player data.
-- Solo inventory destinations include normal built storage boxes as well as
-  Developer Storage. Unfinished hologram containers are excluded using the
-  persisted `placeables.is_hologram` flag and rejected again at write time.
+- Solo inventory destinations include built Chest, Small Storage Container,
+  Storage Container, Medium Storage Container, and Developer Storage
+  placeables. Unfinished hologram containers are excluded using the persisted
+  `placeables.is_hologram` flag and rejected again at write time.
 - Solo Inventory keeps the selected delivery destination visible in a sticky
   card while scrolling, and blurs the selector on mouse-wheel input to prevent
   accidental destination changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ here cover everything those tags shipped.
   backup-safe offline item transaction. Unlock items are delivered to the Solo
   backpack for processing on next login; grants remain local to that save and
   do not create Funcom account entitlements.
+- Solo item delivery now selects the character backpack by default instead of
+  preferring Developer Storage; users can still choose another supported
+  destination.
 
 ## [13.7.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ here cover everything those tags shipped.
   Shield Drops While Shooting in the observed `FLS_beta`
   `Config\Windows\Engine.ini`. Writes are allowlisted, game-closed,
   backup-first, atomic, and verified; no retail path is assumed.
+- Solo Mode exposes the canonical DST package store directly, so Solo-only
+  users can create, import, edit, delete, and grant reusable item packages
+  without configuring Self-Hosted or relying on demo player data.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ here cover everything those tags shipped.
 - PTC Solo Settings can manage Sun Exposure, Maximum Vehicles Per Player, and
   Shield Drops While Shooting in the observed `FLS_beta`
   `Config\Windows\Engine.ini`. Writes are allowlisted, game-closed,
-  backup-first, atomic, and verified; no retail path is assumed.
+  backup-first, atomic, and verified; all three controls are field-confirmed in
+  PTC Solo, and no retail path is assumed.
 - Solo Mode exposes the canonical DST package store directly, so Solo-only
   users can create, import, edit, delete, and grant reusable item packages
   without configuring Self-Hosted or relying on demo player data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ here cover everything those tags shipped.
 - Solo inventory destinations include normal built storage boxes as well as
   Developer Storage. Unfinished hologram containers are excluded using the
   persisted `placeables.is_hologram` flag and rejected again at write time.
+- Solo Inventory keeps the selected delivery destination visible in a sticky
+  card while scrolling, and blurs the selector on mouse-wheel input to prevent
+  accidental destination changes.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ here cover everything those tags shipped.
 - Solo item delivery now selects the character backpack by default instead of
   preferring Developer Storage; users can still choose another supported
   destination.
-- PTC Solo Settings can manage Sun Exposure and Maximum Vehicles Per Player in
-  the observed `FLS_beta` `Config\Windows\Engine.ini`. Writes are allowlisted,
-  game-closed, backup-first, atomic, and verified; no retail path is assumed.
+- PTC Solo Settings can manage Sun Exposure, Maximum Vehicles Per Player, and
+  Shield Drops While Shooting in the observed `FLS_beta`
+  `Config\Windows\Engine.ini`. Writes are allowlisted, game-closed,
+  backup-first, atomic, and verified; no retail path is assumed.
 
 ### Fixed
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.7.0'
+$script:DuneToolVersion = '13.8.0'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.7.0',
+    [string]$Version = '13.8.0',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.7.0</Version>
+    <Version>13.8.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.7.0"
+#define MyAppVersion "13.8.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/server/lib/Catalog.ps1
+++ b/app/server/lib/Catalog.ps1
@@ -31,7 +31,9 @@ function Load-DuneItemCatalog {
         return
     }
     try {
-        $json = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+        # item-catalog.json is UTF-8 without a BOM. Windows PowerShell 5.1
+        # otherwise decodes typographic punctuation through the ANSI code page.
+        $json = [IO.File]::ReadAllText($path, [Text.Encoding]::UTF8) | ConvertFrom-Json
         $list = [System.Collections.Generic.List[object]]::new()
         $cats = @{}
         foreach ($prop in $json.items.PSObject.Properties) {
@@ -85,7 +87,7 @@ function Load-DuneVehicleKitCatalog {
     }
     if (-not $path) { $script:DuneVehicleKitCatalog = $empty; return }
     try {
-        $json = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+        $json = [IO.File]::ReadAllText($path, [Text.Encoding]::UTF8) | ConvertFrom-Json
         $vehicles = @()
         foreach ($v in @($json.vehicles)) {
             $qty = [ordered]@{}

--- a/app/server/lib/Gameplay.ps1
+++ b/app/server/lib/Gameplay.ps1
@@ -47,7 +47,10 @@ function Initialize-DuneGameplayItemData {
         return
     }
     try {
-        $json = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+        # gameplay-item-data.json is UTF-8 without a BOM. Windows PowerShell 5.1
+        # otherwise decodes it through the active ANSI code page and turns names
+        # such as Smuggler's curly apostrophe into mojibake.
+        $json = [IO.File]::ReadAllText($path, [Text.Encoding]::UTF8) | ConvertFrom-Json
         if ($json.items) {
             foreach ($p in $json.items.PSObject.Properties) {
                 $v = $p.Value

--- a/app/server/lib/SoloMode.ps1
+++ b/app/server/lib/SoloMode.ps1
@@ -68,6 +68,14 @@ $script:DuneSoloConsoleSettings = @(
         label = 'Maximum Vehicles Per Player'
         help = 'Client-driven vehicle cap. 0 means unlimited.'
         status = 'Confirmed'
+    },
+    [ordered]@{
+        key = 'Dune.DisableShieldOnShooting'
+        type = 'bool01'
+        default = '1'
+        label = 'Shield Drops While Shooting'
+        help = 'PTC Solo field-confirmed. Disabled keeps the player shield raised while firing.'
+        status = 'Confirmed'
     }
 )
 

--- a/app/server/lib/SoloMode.ps1
+++ b/app/server/lib/SoloMode.ps1
@@ -1000,13 +1000,29 @@ function Set-DuneSoloConsoleSettings {
             [IO.File]::Replace($temp, $path, $replaceBackup, $true)
             $replaced = $true
         } else {
-            Move-Item -LiteralPath $temp -Destination $path
+            Move-Item -LiteralPath $temp -Destination $path -ErrorAction Stop
         }
         $verified = Read-DuneSoloConsoleSettings -Path $path
-        foreach ($entry in $verified.entries) {
-            if ($normalized.ContainsKey($entry.key) -and
-                [string]$normalized[$entry.key] -ne [string]$entry.value) {
-                throw "PTC Solo console setting verification failed for $($entry.key)."
+        foreach ($key in $normalized.Keys) {
+            $entry = @($verified.entries | Where-Object key -eq $key)
+            if ($entry.Count -ne 1 -or -not $entry[0].present -or
+                [string]$normalized[$key] -ne [string]$entry[0].value) {
+                throw "PTC Solo console setting verification failed for $key."
+            }
+            $occurrences = 0
+            $verifyInside = $false
+            foreach ($line in [IO.File]::ReadAllLines($path)) {
+                if ($line -match '^\s*\[(.+)\]\s*$') {
+                    $verifyInside = ($Matches[1] -eq $script:DuneSoloConsoleSection)
+                    continue
+                }
+                if ($verifyInside -and
+                    $line -match ('^\s*' + [regex]::Escape($key) + '\s*=')) {
+                    $occurrences++
+                }
+            }
+            if ($occurrences -ne 1) {
+                throw "PTC Solo console setting verification found $occurrences copies of $key."
             }
         }
         Remove-Item -LiteralPath $replaceBackup -Force -ErrorAction SilentlyContinue
@@ -1016,14 +1032,26 @@ function Set-DuneSoloConsoleSettings {
             backupPath = if (Test-Path -LiteralPath $backupPath) { $backupPath } else { '' }
         }
     } catch {
+        $writeError = $_
         if ($targetExisted -and $replaced -and (Test-Path -LiteralPath $replaceBackup -PathType Leaf)) {
-            [IO.File]::Replace($replaceBackup, $path, $null, $true)
+            $failedCopy = Join-Path $dir ".Engine.$([guid]::NewGuid().ToString('N')).failed"
+            try {
+                [IO.File]::Replace($replaceBackup, $path, $failedCopy, $true)
+                Remove-Item -LiteralPath $failedCopy -Force -ErrorAction SilentlyContinue
+            } catch {
+                throw "PTC Solo Engine.ini write failed ($($writeError.Exception.Message)); rollback also failed. Recovery file retained at $replaceBackup"
+            }
         } elseif (-not $targetExisted -and (Test-Path -LiteralPath $path -PathType Leaf)) {
-            Remove-Item -LiteralPath $path -Force
+            try {
+                Remove-Item -LiteralPath $path -Force -ErrorAction Stop
+            } catch {
+                throw "PTC Solo Engine.ini write failed ($($writeError.Exception.Message)); the newly created file could not be removed."
+            }
         }
-        throw
+        throw $writeError
     } finally {
-        Remove-Item -LiteralPath $temp, $replaceBackup -Force -ErrorAction SilentlyContinue
+        # A failed rollback must retain replaceBackup for manual recovery.
+        Remove-Item -LiteralPath $temp -Force -ErrorAction SilentlyContinue
     }
 }
 

--- a/app/server/lib/SoloMode.ps1
+++ b/app/server/lib/SoloMode.ps1
@@ -56,8 +56,8 @@ $script:DuneSoloConsoleSettings = @(
         type = 'bool01'
         default = '1'
         label = 'Sun Exposure Enabled'
-        help = 'PTC Solo candidate. 0 disables sun-exposure water drain; effect still needs Solo field confirmation.'
-        status = 'Unconfirmed'
+        help = 'PTC Solo field-confirmed. Disabled prevents sun exposure and its water drain.'
+        status = 'Confirmed'
     },
     [ordered]@{
         key = 'Vehicle.MaxVehiclesPerPlayer'

--- a/app/server/lib/SoloMode.ps1
+++ b/app/server/lib/SoloMode.ps1
@@ -1196,6 +1196,7 @@ function Get-DuneSoloBackups {
     return @(Get-ChildItem -LiteralPath $root -Filter '*.db' -File -Recurse -ErrorAction SilentlyContinue |
         Where-Object {
             try {
+                if ($_.FullName -like '*\.delete-staging\*') { return $false }
                 Assert-DuneSoloNoReparsePath -Path $_.FullName
                 $true
             } catch { $false }
@@ -1244,37 +1245,113 @@ function Remove-DuneSoloBackup {
         [Parameter(Mandatory)][string]$Confirm
     )
 
-    Assert-DuneSoloSupportedPlatform
     if ($Confirm -ne 'DELETE SOLO BACKUP') {
         throw 'Confirm the Solo backup deletion before continuing.'
     }
-    if (-not $RelativePath.Trim() -or [IO.Path]::IsPathRooted($RelativePath)) {
-        throw 'Choose a valid Solo backup.'
+    $result = Remove-DuneSoloBackups -RelativePaths @($RelativePath) `
+        -Confirm 'DELETE SOLO BACKUPS'
+    return @{
+        ok = $true
+        deleted = $RelativePath
+        deletedCount = $result.deletedCount
     }
-    if ([IO.Path]::GetExtension($RelativePath) -ne '.db') {
-        throw 'Only Solo .db backup files can be deleted.'
+}
+
+function Remove-DuneSoloBackups {
+    param(
+        [Parameter(Mandatory)][string[]]$RelativePaths,
+        [Parameter(Mandatory)][string]$Confirm
+    )
+
+    Assert-DuneSoloSupportedPlatform
+    if ($Confirm -ne 'DELETE SOLO BACKUPS') {
+        throw 'Confirm the selected Solo backup deletions before continuing.'
+    }
+    $requested = @($RelativePaths |
+        ForEach-Object { ([string]$_).Trim() } |
+        Where-Object { $_ } |
+        Select-Object -Unique)
+    if ($requested.Count -lt 1 -or $requested.Count -gt 100) {
+        throw 'Select between 1 and 100 Solo backups to delete.'
     }
     $profile = Get-DuneSoloProfile
     if (-not $profile.dbPath) { throw 'Connect a Solo profile before deleting backups.' }
     $root = Get-DuneSoloProfileBackupRoot -DbPath $profile.dbPath
-    $target = [IO.Path]::GetFullPath((Join-Path $root $RelativePath))
-    if (-not (Test-DuneSoloPathWithinRoot -Path $target -Root $root)) {
-        throw 'Backup path is outside the connected Solo profile backup directory.'
+    $listed = @{}
+    foreach ($entry in @(Get-DuneSoloBackups)) {
+        $listed[[string]$entry.relativePath] = $entry
     }
-    $entry = @(Get-DuneSoloBackups | Where-Object {
-        ([string]$_.relativePath).Equals($RelativePath, [StringComparison]::OrdinalIgnoreCase)
-    })
-    if ($entry.Count -ne 1 -or -not (Test-Path -LiteralPath $target -PathType Leaf)) {
-        throw 'Solo backup was not found in the connected profile backup list.'
+    $targets = New-Object System.Collections.Generic.List[object]
+    foreach ($relativePath in $requested) {
+        if ([IO.Path]::IsPathRooted($relativePath)) {
+            throw 'Choose valid relative Solo backup paths.'
+        }
+        if ([IO.Path]::GetExtension($relativePath) -ne '.db') {
+            throw 'Only Solo .db backup files can be deleted.'
+        }
+        $target = [IO.Path]::GetFullPath((Join-Path $root $relativePath))
+        if (-not (Test-DuneSoloPathWithinRoot -Path $target -Root $root)) {
+            throw 'Backup path is outside the connected Solo profile backup directory.'
+        }
+        $entry = @($listed.Keys | Where-Object {
+            $_.Equals($relativePath, [StringComparison]::OrdinalIgnoreCase)
+        })
+        if ($entry.Count -ne 1 -or -not (Test-Path -LiteralPath $target -PathType Leaf)) {
+            throw "Solo backup was not found in the connected profile backup list: $relativePath"
+        }
+        Assert-DuneSoloNoReparsePath -Path $target
+        [void]$targets.Add([pscustomobject]@{
+            relativePath = $relativePath
+            original = $target
+            staged = ''
+        })
     }
-    Assert-DuneSoloNoReparsePath -Path $target
-    Remove-Item -LiteralPath $target -Force -ErrorAction Stop
-    if (Test-Path -LiteralPath $target) {
-        throw 'Solo backup deletion could not be verified.'
+
+    $stageRoot = Join-Path $root ".delete-staging\$([guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $stageRoot -Force -ErrorAction Stop | Out-Null
+    $moved = New-Object System.Collections.Generic.List[object]
+    try {
+        for ($index = 0; $index -lt $targets.Count; $index++) {
+            $target = $targets[$index]
+            $staged = Join-Path $stageRoot ('{0:D3}-{1}' -f $index, [IO.Path]::GetFileName($target.original))
+            Move-Item -LiteralPath $target.original -Destination $staged -ErrorAction Stop
+            $target.staged = $staged
+            [void]$moved.Add($target)
+        }
+    } catch {
+        $moveError = $_
+        $rollbackErrors = New-Object System.Collections.Generic.List[string]
+        for ($index = $moved.Count - 1; $index -ge 0; $index--) {
+            $target = $moved[$index]
+            try {
+                if (Test-Path -LiteralPath $target.staged -PathType Leaf) {
+                    Move-Item -LiteralPath $target.staged -Destination $target.original -ErrorAction Stop
+                }
+            } catch {
+                [void]$rollbackErrors.Add("$($target.relativePath): $($_.Exception.Message)")
+            }
+        }
+        if ($rollbackErrors.Count -gt 0) {
+            throw "Solo backup staging failed ($($moveError.Exception.Message)); rollback failed: $($rollbackErrors -join '; '). Recovery directory: $stageRoot"
+        }
+        Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
+        throw $moveError
+    }
+
+    try {
+        Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction Stop
+    } catch {
+        throw "Selected backups were removed from the active list but staging cleanup failed. Recovery directory retained: $stageRoot"
+    }
+    foreach ($target in $targets) {
+        if (Test-Path -LiteralPath $target.original) {
+            throw "Solo backup deletion could not be verified: $($target.relativePath)"
+        }
     }
     return @{
         ok = $true
-        deleted = $RelativePath
+        deleted = @($targets | ForEach-Object { [string]$_.relativePath })
+        deletedCount = $targets.Count
     }
 }
 

--- a/app/server/lib/SoloMode.ps1
+++ b/app/server/lib/SoloMode.ps1
@@ -49,6 +49,27 @@ $script:DuneSoloSettingKeys = @(
     'LandsraadFactionStandingMultiplier',
     'bLandsraadDisableDecreeRerollLimit'
 )
+$script:DuneSoloConsoleSection = 'ConsoleVariables'
+$script:DuneSoloConsoleSettings = @(
+    [ordered]@{
+        key = 'Hydration.SunExposureEnabled'
+        type = 'bool01'
+        default = '1'
+        label = 'Sun Exposure Enabled'
+        help = 'PTC Solo candidate. 0 disables sun-exposure water drain; effect still needs Solo field confirmation.'
+        status = 'Unconfirmed'
+    },
+    [ordered]@{
+        key = 'Vehicle.MaxVehiclesPerPlayer'
+        type = 'int'
+        min = 0
+        max = 1000
+        default = '10'
+        label = 'Maximum Vehicles Per Player'
+        help = 'Client-driven vehicle cap. 0 means unlimited.'
+        status = 'Confirmed'
+    }
+)
 
 function Test-DuneSoloSupportedPlatform {
     $isWindowsVariable = Get-Variable -Name IsWindows -ErrorAction SilentlyContinue
@@ -801,6 +822,208 @@ function Set-DuneSoloSettings {
         throw
     } finally {
         Remove-Item -LiteralPath $temp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-DuneSoloPtcEnginePath {
+    param([Parameter(Mandatory)][hashtable]$Profile)
+    Assert-DuneSoloPtcAdapter -Profile $Profile
+    return (Join-Path ([string]$Profile.dataRoot) 'Config\Windows\Engine.ini')
+}
+
+function Read-DuneSoloConsoleSettings {
+    param([string]$Path = '')
+
+    Assert-DuneSoloSupportedPlatform
+    $profile = Get-DuneSoloProfile
+    $profileDir = if ($profile.dbPath) { Split-Path -Parent ([string]$profile.dbPath) } else { '' }
+    $channel = if ($profileDir) { [IO.Path]::GetFileName((Split-Path -Parent $profileDir)) } else { '' }
+    if ($channel -ne 'FLS_beta') {
+        return @{
+            ok = $true
+            supported = $false
+            adapter = $channel
+            path = ''
+            exists = $false
+            section = $script:DuneSoloConsoleSection
+            entries = @()
+        }
+    }
+    if (-not $Path) { $Path = Get-DuneSoloPtcEnginePath -Profile $profile }
+
+    $values = @{}
+    if (Test-Path -LiteralPath $Path -PathType Leaf) {
+        $inside = $false
+        foreach ($line in [IO.File]::ReadAllLines($Path)) {
+            if ($line -match '^\s*\[(.+)\]\s*$') {
+                $inside = ($Matches[1] -eq $script:DuneSoloConsoleSection)
+                continue
+            }
+            if ($inside -and $line -match '^\s*([^;#][^=]*?)\s*=(.*)$') {
+                $values[$Matches[1].Trim()] = $Matches[2].Trim()
+            }
+        }
+    }
+    $entries = foreach ($field in $script:DuneSoloConsoleSettings) {
+        $key = [string]$field.key
+        [pscustomobject]@{
+            key = $key
+            value = if ($values.ContainsKey($key)) { [string]$values[$key] } else { [string]$field.default }
+            present = $values.ContainsKey($key)
+            type = [string]$field.type
+            default = [string]$field.default
+            min = if ($field.Contains('min')) { [int]$field.min } else { $null }
+            max = if ($field.Contains('max')) { [int]$field.max } else { $null }
+            label = [string]$field.label
+            help = [string]$field.help
+            status = [string]$field.status
+        }
+    }
+    return @{
+        ok = $true
+        supported = $true
+        adapter = $channel
+        path = $Path
+        exists = (Test-Path -LiteralPath $Path -PathType Leaf)
+        section = $script:DuneSoloConsoleSection
+        entries = @($entries)
+    }
+}
+
+function Set-DuneSoloConsoleSettings {
+    param(
+        [Parameter(Mandatory)][hashtable]$Settings,
+        [Parameter(Mandatory)][string]$Confirm
+    )
+
+    Assert-DuneSoloSupportedPlatform
+    if ($Confirm -ne 'APPLY SOLO CONSOLE SETTINGS') {
+        throw 'Confirm the PTC Solo Engine.ini write before continuing.'
+    }
+    Assert-DuneSoloGameClosed
+    $profile = Get-DuneSoloProfile
+    if (-not $profile.dbPath) { throw 'Connect a Solo save before applying PTC console settings.' }
+    $path = Get-DuneSoloPtcEnginePath -Profile $profile
+
+    $schema = @{}
+    foreach ($field in $script:DuneSoloConsoleSettings) { $schema[[string]$field.key] = $field }
+    $normalized = @{}
+    foreach ($rawKey in $Settings.Keys) {
+        $key = [string]$rawKey
+        if (-not $schema.ContainsKey($key)) { throw "Unsupported PTC Solo console setting: $key" }
+        $value = ([string]$Settings[$rawKey]).Trim()
+        $field = $schema[$key]
+        if ($field.type -eq 'bool01') {
+            if ($value -notin @('0', '1')) { throw "$key must be 0 or 1." }
+        } elseif ($field.type -eq 'int') {
+            $number = 0
+            if (-not [int]::TryParse($value, [ref]$number) -or
+                $number -lt [int]$field.min -or $number -gt [int]$field.max) {
+                throw "$key must be between $($field.min) and $($field.max)."
+            }
+            $value = [string]$number
+        }
+        $normalized[$key] = $value
+    }
+    if ($normalized.Count -eq 0) { throw 'No PTC Solo console settings were provided.' }
+
+    $dir = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    $lines = if (Test-Path -LiteralPath $path -PathType Leaf) { [IO.File]::ReadAllLines($path) } else { @() }
+    $result = New-Object System.Collections.Generic.List[string]
+    $inside = $false
+    $foundSection = $false
+    $written = @{}
+    foreach ($line in $lines) {
+        if ($line -match '^\s*\[(.+)\]\s*$') {
+            if ($inside) {
+                foreach ($key in $normalized.Keys) {
+                    if (-not $written.ContainsKey($key)) {
+                        $result.Add("$key=$($normalized[$key])")
+                        $written[$key] = $true
+                    }
+                }
+            }
+            $inside = ($Matches[1] -eq $script:DuneSoloConsoleSection)
+            if ($inside) { $foundSection = $true }
+            $result.Add($line)
+            continue
+        }
+        if ($inside -and $line -match '^\s*([^;#][^=]*?)\s*=') {
+            $key = $Matches[1].Trim()
+            if ($normalized.ContainsKey($key)) {
+                if (-not $written.ContainsKey($key)) {
+                    $result.Add("$key=$($normalized[$key])")
+                    $written[$key] = $true
+                }
+                continue
+            }
+        }
+        $result.Add($line)
+    }
+    if ($inside) {
+        foreach ($key in $normalized.Keys) {
+            if (-not $written.ContainsKey($key)) {
+                $result.Add("$key=$($normalized[$key])")
+                $written[$key] = $true
+            }
+        }
+    }
+    if (-not $foundSection) {
+        if ($result.Count -gt 0 -and $result[$result.Count - 1] -ne '') { $result.Add('') }
+        $result.Add("[$script:DuneSoloConsoleSection]")
+        foreach ($key in $normalized.Keys) { $result.Add("$key=$($normalized[$key])") }
+    }
+
+    $backupRoot = Join-Path (Get-DuneSoloBackupRoot) 'settings'
+    New-Item -ItemType Directory -Path $backupRoot -Force | Out-Null
+    $stamp = (Get-Date).ToUniversalTime().ToString('yyyyMMdd-HHmmssfff')
+    $backupPath = Join-Path $backupRoot "Engine-$stamp.ini"
+    if (Test-Path -LiteralPath $path -PathType Leaf) {
+        Copy-Item -LiteralPath $path -Destination $backupPath -ErrorAction Stop
+    }
+
+    $temp = Join-Path $dir ".Engine.$([guid]::NewGuid().ToString('N')).tmp"
+    $replaceBackup = Join-Path $dir ".Engine.$([guid]::NewGuid().ToString('N')).previous"
+    $targetExisted = Test-Path -LiteralPath $path -PathType Leaf
+    $replaced = $false
+    try {
+        $hasBom = $false
+        if ($targetExisted) {
+            $bytes = [IO.File]::ReadAllBytes($path)
+            $hasBom = ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF)
+        }
+        [IO.File]::WriteAllLines($temp, $result.ToArray(), (New-Object Text.UTF8Encoding($hasBom)))
+        if ($targetExisted) {
+            [IO.File]::Replace($temp, $path, $replaceBackup, $true)
+            $replaced = $true
+        } else {
+            Move-Item -LiteralPath $temp -Destination $path
+        }
+        $verified = Read-DuneSoloConsoleSettings -Path $path
+        foreach ($entry in $verified.entries) {
+            if ($normalized.ContainsKey($entry.key) -and
+                [string]$normalized[$entry.key] -ne [string]$entry.value) {
+                throw "PTC Solo console setting verification failed for $($entry.key)."
+            }
+        }
+        Remove-Item -LiteralPath $replaceBackup -Force -ErrorAction SilentlyContinue
+        return @{
+            ok = $true
+            settings = $verified
+            backupPath = if (Test-Path -LiteralPath $backupPath) { $backupPath } else { '' }
+        }
+    } catch {
+        if ($targetExisted -and $replaced -and (Test-Path -LiteralPath $replaceBackup -PathType Leaf)) {
+            [IO.File]::Replace($replaceBackup, $path, $null, $true)
+        } elseif (-not $targetExisted -and (Test-Path -LiteralPath $path -PathType Leaf)) {
+            Remove-Item -LiteralPath $path -Force
+        }
+        throw
+    } finally {
+        Remove-Item -LiteralPath $temp, $replaceBackup -Force -ErrorAction SilentlyContinue
     }
 }
 

--- a/app/server/lib/SoloMode.ps1
+++ b/app/server/lib/SoloMode.ps1
@@ -1257,6 +1257,11 @@ function Remove-DuneSoloBackup {
     }
 }
 
+function Remove-DuneSoloBackupFile {
+    param([Parameter(Mandatory)][string]$Path)
+    Remove-Item -LiteralPath $Path -Force -ErrorAction Stop
+}
+
 function Remove-DuneSoloBackups {
     param(
         [Parameter(Mandatory)][string[]]$RelativePaths,
@@ -1307,8 +1312,13 @@ function Remove-DuneSoloBackups {
         })
     }
 
-    $stageRoot = Join-Path $root ".delete-staging\$([guid]::NewGuid().ToString('N'))"
+    $stageParent = Join-Path $root '.delete-staging'
+    if (Test-Path -LiteralPath $stageParent) {
+        Assert-DuneSoloNoReparsePath -Path $stageParent
+    }
+    $stageRoot = Join-Path $stageParent ([guid]::NewGuid().ToString('N'))
     New-Item -ItemType Directory -Path $stageRoot -Force -ErrorAction Stop | Out-Null
+    Assert-DuneSoloNoReparsePath -Path $stageRoot
     $moved = New-Object System.Collections.Generic.List[object]
     try {
         for ($index = 0; $index -lt $targets.Count; $index++) {
@@ -1338,10 +1348,23 @@ function Remove-DuneSoloBackups {
         throw $moveError
     }
 
-    try {
-        Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction Stop
-    } catch {
-        throw "Selected backups were removed from the active list but staging cleanup failed. Recovery directory retained: $stageRoot"
+    $deleted = New-Object System.Collections.Generic.List[string]
+    $retained = New-Object System.Collections.Generic.List[string]
+    foreach ($target in $targets) {
+        try {
+            Remove-DuneSoloBackupFile -Path $target.staged
+            [void]$deleted.Add([string]$target.relativePath)
+        } catch {
+            [void]$retained.Add([string]$target.relativePath)
+        }
+    }
+    if ($retained.Count -gt 0) {
+        throw "Solo backup deletion was partial. Permanently deleted: $($deleted -join ', '). Retained for recovery: $($retained -join ', '). Recovery directory: $stageRoot"
+    }
+    Remove-Item -LiteralPath $stageRoot -Force -ErrorAction SilentlyContinue
+    if ((Test-Path -LiteralPath $stageParent -PathType Container) -and
+        @(Get-ChildItem -LiteralPath $stageParent -Force -ErrorAction SilentlyContinue).Count -eq 0) {
+        Remove-Item -LiteralPath $stageParent -Force -ErrorAction SilentlyContinue
     }
     foreach ($target in $targets) {
         if (Test-Path -LiteralPath $target.original) {
@@ -1350,8 +1373,8 @@ function Remove-DuneSoloBackups {
     }
     return @{
         ok = $true
-        deleted = @($targets | ForEach-Object { [string]$_.relativePath })
-        deletedCount = $targets.Count
+        deleted = @($deleted)
+        deletedCount = $deleted.Count
     }
 }
 

--- a/app/server/lib/SoloMode.ps1
+++ b/app/server/lib/SoloMode.ps1
@@ -833,10 +833,22 @@ function Set-DuneSoloSettings {
     }
 }
 
-function Get-DuneSoloPtcEnginePath {
+function Get-DuneSoloPtcEnginePaths {
     param([Parameter(Mandatory)][hashtable]$Profile)
     Assert-DuneSoloPtcAdapter -Profile $Profile
-    return (Join-Path ([string]$Profile.dataRoot) 'Config\Windows\Engine.ini')
+    return @(
+        (Join-Path ([string]$Profile.dataRoot) 'Config\Windows\Engine.ini')
+        (Join-Path ([string]$Profile.dataRoot) 'Config\WindowsClient\Engine.ini')
+    )
+}
+
+function Invoke-DuneSoloFileReplace {
+    param(
+        [Parameter(Mandatory)][string]$Source,
+        [Parameter(Mandatory)][string]$Destination,
+        [Parameter(Mandatory)][string]$Backup
+    )
+    [IO.File]::Replace($Source, $Destination, $Backup, $true)
 }
 
 function Read-DuneSoloConsoleSettings {
@@ -857,7 +869,10 @@ function Read-DuneSoloConsoleSettings {
             entries = @()
         }
     }
-    if (-not $Path) { $Path = Get-DuneSoloPtcEnginePath -Profile $profile }
+    $paths = @(Get-DuneSoloPtcEnginePaths -Profile $profile)
+    # WindowsClient is the player-visible authority for these controls. Writes
+    # mirror both observed PTC files, while reads display the local-client value.
+    if (-not $Path) { $Path = $paths[-1] }
 
     $values = @{}
     if (Test-Path -LiteralPath $Path -PathType Leaf) {
@@ -892,6 +907,7 @@ function Read-DuneSoloConsoleSettings {
         supported = $true
         adapter = $channel
         path = $Path
+        paths = $paths
         exists = (Test-Path -LiteralPath $Path -PathType Leaf)
         section = $script:DuneSoloConsoleSection
         entries = @($entries)
@@ -901,7 +917,9 @@ function Read-DuneSoloConsoleSettings {
 function Set-DuneSoloConsoleSettings {
     param(
         [Parameter(Mandatory)][hashtable]$Settings,
-        [Parameter(Mandatory)][string]$Confirm
+        [Parameter(Mandatory)][string]$Confirm,
+        [string]$Path = '',
+        [switch]$SingleFile
     )
 
     Assert-DuneSoloSupportedPlatform
@@ -911,7 +929,7 @@ function Set-DuneSoloConsoleSettings {
     Assert-DuneSoloGameClosed
     $profile = Get-DuneSoloProfile
     if (-not $profile.dbPath) { throw 'Connect a Solo save before applying PTC console settings.' }
-    $path = Get-DuneSoloPtcEnginePath -Profile $profile
+    $paths = @(Get-DuneSoloPtcEnginePaths -Profile $profile)
 
     $schema = @{}
     foreach ($field in $script:DuneSoloConsoleSettings) { $schema[[string]$field.key] = $field }
@@ -934,6 +952,53 @@ function Set-DuneSoloConsoleSettings {
         $normalized[$key] = $value
     }
     if ($normalized.Count -eq 0) { throw 'No PTC Solo console settings were provided.' }
+
+    if (-not $SingleFile) {
+        $completed = New-Object System.Collections.Generic.List[object]
+        try {
+            foreach ($targetPath in $paths) {
+                $write = Set-DuneSoloConsoleSettings -Settings $normalized `
+                    -Confirm $Confirm -Path $targetPath -SingleFile
+                [void]$completed.Add($write)
+            }
+        } catch {
+            $writeError = $_
+            $rollbackErrors = New-Object System.Collections.Generic.List[string]
+            for ($index = $completed.Count - 1; $index -ge 0; $index--) {
+                $write = $completed[$index]
+                try {
+                    if ($write.targetExisted -and $write.backupPath) {
+                        $rollbackTemp = "$($write.path).$([guid]::NewGuid().ToString('N')).rollback"
+                        $failedCopy = "$($write.path).$([guid]::NewGuid().ToString('N')).failed"
+                        try {
+                            Copy-Item -LiteralPath $write.backupPath -Destination $rollbackTemp -ErrorAction Stop
+                            Invoke-DuneSoloFileReplace -Source $rollbackTemp `
+                                -Destination $write.path -Backup $failedCopy
+                        } finally {
+                            Remove-Item -LiteralPath $rollbackTemp, $failedCopy -Force -ErrorAction SilentlyContinue
+                        }
+                    } elseif (Test-Path -LiteralPath $write.path -PathType Leaf) {
+                        Remove-Item -LiteralPath $write.path -Force -ErrorAction Stop
+                    }
+                } catch {
+                    [void]$rollbackErrors.Add("$($write.path): $($_.Exception.Message)")
+                }
+            }
+            if ($rollbackErrors.Count -gt 0) {
+                throw "PTC Solo Engine.ini write failed ($($writeError.Exception.Message)); rollback failed: $($rollbackErrors -join '; ')"
+            }
+            throw $writeError
+        }
+        return @{
+            ok = $true
+            settings = Read-DuneSoloConsoleSettings
+            paths = $paths
+            backupPaths = @($completed | ForEach-Object { [string]$_.backupPath } | Where-Object { $_ })
+            backupPath = [string](@($completed | ForEach-Object { $_.backupPath } | Where-Object { $_ } | Select-Object -First 1)[0])
+        }
+    }
+    if (-not $Path) { throw 'PTC Solo Engine.ini target path is required.' }
+    $path = [IO.Path]::GetFullPath($Path)
 
     $dir = Split-Path -Parent $path
     if (-not (Test-Path -LiteralPath $dir)) {
@@ -988,7 +1053,8 @@ function Set-DuneSoloConsoleSettings {
     $backupRoot = Join-Path (Get-DuneSoloBackupRoot) 'settings'
     New-Item -ItemType Directory -Path $backupRoot -Force | Out-Null
     $stamp = (Get-Date).ToUniversalTime().ToString('yyyyMMdd-HHmmssfff')
-    $backupPath = Join-Path $backupRoot "Engine-$stamp.ini"
+    $targetFolder = [IO.Path]::GetFileName((Split-Path -Parent $path))
+    $backupPath = Join-Path $backupRoot "Engine-$targetFolder-$stamp-$([guid]::NewGuid().ToString('N')).ini"
     if (Test-Path -LiteralPath $path -PathType Leaf) {
         Copy-Item -LiteralPath $path -Destination $backupPath -ErrorAction Stop
     }
@@ -1005,7 +1071,7 @@ function Set-DuneSoloConsoleSettings {
         }
         [IO.File]::WriteAllLines($temp, $result.ToArray(), (New-Object Text.UTF8Encoding($hasBom)))
         if ($targetExisted) {
-            [IO.File]::Replace($temp, $path, $replaceBackup, $true)
+            Invoke-DuneSoloFileReplace -Source $temp -Destination $path -Backup $replaceBackup
             $replaced = $true
         } else {
             Move-Item -LiteralPath $temp -Destination $path -ErrorAction Stop
@@ -1037,6 +1103,8 @@ function Set-DuneSoloConsoleSettings {
         return @{
             ok = $true
             settings = $verified
+            path = $path
+            targetExisted = $targetExisted
             backupPath = if (Test-Path -LiteralPath $backupPath) { $backupPath } else { '' }
         }
     } catch {
@@ -1044,7 +1112,8 @@ function Set-DuneSoloConsoleSettings {
         if ($targetExisted -and $replaced -and (Test-Path -LiteralPath $replaceBackup -PathType Leaf)) {
             $failedCopy = Join-Path $dir ".Engine.$([guid]::NewGuid().ToString('N')).failed"
             try {
-                [IO.File]::Replace($replaceBackup, $path, $failedCopy, $true)
+                Invoke-DuneSoloFileReplace -Source $replaceBackup `
+                    -Destination $path -Backup $failedCopy
                 Remove-Item -LiteralPath $failedCopy -Force -ErrorAction SilentlyContinue
             } catch {
                 throw "PTC Solo Engine.ini write failed ($($writeError.Exception.Message)); rollback also failed. Recovery file retained at $replaceBackup"

--- a/app/server/routes/SoloMode.ps1
+++ b/app/server/routes/SoloMode.ps1
@@ -158,11 +158,17 @@ Register-DuneRoute -Method DELETE -Path '/api/solo/backups' -LocalOnly -Handler 
     param($req, $res, $routeParams, $body)
     try {
         $relativePath = [string](Get-DuneSoloBodyField -Body $body -Name 'relativePath' -Default '')
+        $rawRelativePaths = Get-DuneSoloBodyField -Body $body -Name 'relativePaths'
         $confirm = [string](Get-DuneSoloBodyField -Body $body -Name 'confirm' -Default '')
         $expectedProfileToken = [string](Get-DuneSoloBodyField -Body $body -Name 'expectedProfileToken' -Default '')
         $result = Invoke-WithDuneLock -Name 'solo-profile-data' -Script {
             Assert-DuneSoloExpectedProfile -ExpectedProfileToken $expectedProfileToken
-            Remove-DuneSoloBackup -RelativePath $relativePath -Confirm $confirm
+            if ($null -ne $rawRelativePaths) {
+                $relativePaths = @($rawRelativePaths | ForEach-Object { [string]$_ })
+                Remove-DuneSoloBackups -RelativePaths $relativePaths -Confirm $confirm
+            } else {
+                Remove-DuneSoloBackup -RelativePath $relativePath -Confirm $confirm
+            }
         }
         Write-DuneJson -Response $res -Body $result
     } catch {

--- a/app/server/routes/SoloMode.ps1
+++ b/app/server/routes/SoloMode.ps1
@@ -93,6 +93,44 @@ Register-DuneRoute -Method PUT -Path '/api/solo/settings' -LocalOnly -Handler {
     }
 }
 
+Register-DuneRoute -Method GET -Path '/api/solo/console-settings' -LocalOnly -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Write-DuneJson -Response $res -Body (Read-DuneSoloConsoleSettings)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+Register-DuneRoute -Method PUT -Path '/api/solo/console-settings' -LocalOnly -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $rawSettings = Get-DuneSoloBodyField -Body $body -Name 'settings'
+        $confirm = [string](Get-DuneSoloBodyField -Body $body -Name 'confirm' -Default '')
+        $expectedProfileToken = [string](Get-DuneSoloBodyField -Body $body -Name 'expectedProfileToken' -Default '')
+        if (-not $rawSettings) {
+            Write-DuneError -Response $res -Status 400 -Message 'Missing PTC Solo console settings.'
+            return
+        }
+        $settings = @{}
+        if ($rawSettings -is [hashtable]) {
+            foreach ($key in $rawSettings.Keys) { $settings[[string]$key] = [string]$rawSettings[$key] }
+        } else {
+            foreach ($property in $rawSettings.PSObject.Properties) {
+                $settings[$property.Name] = [string]$property.Value
+            }
+        }
+        $result = Invoke-WithDuneLock -Name 'solo-profile-data' -Script {
+            Assert-DuneSoloExpectedProfile -ExpectedProfileToken $expectedProfileToken
+            Set-DuneSoloConsoleSettings -Settings $settings -Confirm $confirm
+        }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        $status = if ($_.Exception.Message -like '*still running*') { 409 } else { 400 }
+        Write-DuneError -Response $res -Status $status -Message $_.Exception.Message
+    }
+}
+
 Register-DuneRoute -Method GET -Path '/api/solo/backups' -LocalOnly -Handler {
     param($req, $res, $routeParams, $body)
     try {

--- a/app/tools/DuneSoloDb/Program.cs
+++ b/app/tools/DuneSoloDb/Program.cs
@@ -29,6 +29,20 @@ internal static partial class Program
             ["AntiRadiationPill"] = 20
         };
 
+    // These templates are missing volume metadata from the extracted gameplay
+    // catalog. The torch and Treadwheel hull use adjacent-item values so the
+    // four vehicle kits known to fit the stock 175-volume backpack remain
+    // grantable. The two unverified Sandcrawler modules stay deliberately
+    // oversized so an uncertain large kit fails closed.
+    private static readonly IReadOnlyDictionary<string, double> KnownVolumeFallbacks =
+        new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["RepairTool5"] = 10d,
+            ["TreadwheelHull_6"] = 15d,
+            ["SandcrawlerSpiceContainer_Unique_Capacity_6"] = 1000d,
+            ["SandcrawlerSpiceHeader_6"] = 1000d
+        };
+
     public static int Main(string[] args)
     {
         try
@@ -898,7 +912,7 @@ internal static partial class Program
                         max_item_count INTEGER,
                         max_item_volume REAL
                     );
-                    INSERT INTO inventories VALUES (1, 10, 0, 60, 1000);
+                    INSERT INTO inventories VALUES (1, 10, 0, 60, 175);
                     INSERT INTO inventories VALUES (2, 20, 4, 1000, 50000);
                     CREATE TABLE items (
                         id INTEGER PRIMARY KEY,
@@ -1098,11 +1112,26 @@ internal static partial class Program
                   "names":{
                     "TestResource":"Test Resource",
                     "HeavyAmmo":"Heavy Darts",
-                    "AntiRadiationPill":"Iodine Pill"
+                    "AntiRadiationPill":"Iodine Pill",
+                    "BuggyKnownParts":"Buggy known parts",
+                    "RepairTool5":"Welding Torch Mk5",
+                    "TreadwheelHull_6":"Treadwheel Hull Mk6",
+                    "SandcrawlerSpiceHeader_6":"Sandcrawler Vacuum Mk6"
                   },
-                  "items":{"TestResource":{"stack_max":10,"volume":1.0}}
+                  "items":{
+                    "TestResource":{"stack_max":10,"volume":1.0},
+                    "BuggyKnownParts":{"stack_max":1,"volume":110.0}
+                  }
                 }
                 """);
+            var catalog = ReadCatalog(catalogPath);
+            if (catalog["RepairTool5"].Volume != 10d
+                || catalog["TreadwheelHull_6"].Volume != 15d
+                || catalog["SandcrawlerSpiceHeader_6"].Volume != 1000d)
+            {
+                throw new InvalidOperationException(
+                    "Vehicle-kit volume fallbacks were not applied correctly.");
+            }
             var grantSafety = Path.Combine(root, "safety", "before-grant.db");
             GrantItems(target, grantSafety, planPath, catalogPath);
             if (!File.Exists(grantSafety))
@@ -1151,6 +1180,51 @@ internal static partial class Program
                     throw new InvalidOperationException(
                         "Picker-only stack-limit fallbacks were not applied correctly.");
                 }
+            }
+
+            File.WriteAllText(
+                planPath,
+                """
+                {"destination":"inventory:1","items":[
+                  {"templateId":"BuggyKnownParts","quantity":1,"quality":0},
+                  {"templateId":"RepairTool5","quantity":1,"quality":0}
+                ]}
+                """);
+            var buggySafety = Path.Combine(root, "safety", "before-buggy-grant.db");
+            GrantItems(target, buggySafety, planPath, catalogPath);
+            if (!File.Exists(buggySafety))
+            {
+                throw new InvalidOperationException(
+                    "Stock-volume Buggy grant did not retain a safety backup.");
+            }
+
+            var beforeOversizedGrant = File.ReadAllBytes(target);
+            File.WriteAllText(
+                planPath,
+                """
+                {"destination":"inventory:1","items":[
+                  {"templateId":"SandcrawlerSpiceHeader_6","quantity":1,"quality":0}
+                ]}
+                """);
+            var oversizedRejected = false;
+            try
+            {
+                GrantItems(
+                    target,
+                    Path.Combine(root, "safety", "before-oversized-grant.db"),
+                    planPath,
+                    catalogPath);
+            }
+            catch (InvalidDataException ex)
+                when (ex.Message.Contains("volume capacity", StringComparison.OrdinalIgnoreCase))
+            {
+                oversizedRejected = true;
+            }
+            if (!oversizedRejected
+                || !File.ReadAllBytes(target).SequenceEqual(beforeOversizedGrant))
+            {
+                throw new InvalidOperationException(
+                    "Oversized unknown vehicle part did not fail closed.");
             }
 
             var currencySafety = Path.Combine(root, "safety", "before-currency.db");
@@ -1352,6 +1426,7 @@ internal static partial class Program
                     "unsupported-wrapper-rejected",
                     "offline-augment-max-with-safety-backup",
                     "offline-item-grant-with-capacity-and-safety-backup",
+                    "vehicle-kit-volume-fallbacks-preserve-stock-backpack-grants",
                     "offline-currency-write-with-safety-backup",
                     "offline-water-container-fills-with-safety-backups",
                     "offline-specialization-max-with-rewards",
@@ -1774,20 +1849,11 @@ internal static partial class Program
                 };
             }
         }
-        foreach (var templateId in new[]
-                 {
-                     "RepairTool5",
-                     "SandcrawlerSpiceContainer_Unique_Capacity_6",
-                     "SandcrawlerSpiceHeader_6",
-                     "TreadwheelHull_6"
-                 })
+        foreach (var (templateId, volume) in KnownVolumeFallbacks)
         {
             if (result.ContainsKey(templateId))
             {
-                // These four catalog gaps are part of vehicle-kit payloads already
-                // field-proven in PTC. 1000 volume each is intentionally far above
-                // their observed package footprint, so capacity checks fail safely.
-                result[templateId] = new CatalogRule(1, 1000d, true);
+                result[templateId] = new CatalogRule(1, volume, true);
             }
         }
         return result;

--- a/app/tools/DuneSoloDb/Program.cs
+++ b/app/tools/DuneSoloDb/Program.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using Microsoft.Data.Sqlite;
 
 namespace DuneSoloDb;
@@ -850,6 +851,25 @@ internal static partial class Program
                         '/Game/Dune/Environment/Props/Interactables/BP_Developer_StorageContainer.BP_Developer_StorageContainer_C',
                         jsonb('{}')
                     );
+                    INSERT INTO actors (id, class, properties) VALUES (
+                        21,
+                        '/Game/Dune/Environment/Props/Interactables/BP_Developer_StorageContainer.BP_Developer_StorageContainer_C',
+                        jsonb('{}')
+                    );
+                    INSERT INTO actors (id, class, properties) VALUES (
+                        22,
+                        '/Game/Dune/Systems/Building/Pieces/BP_StorageContainer.BP_StorageContainer_C',
+                        jsonb('{}')
+                    );
+                    CREATE TABLE placeables (
+                        id INTEGER PRIMARY KEY,
+                        owner_entity_id INTEGER,
+                        building_type TEXT,
+                        is_hologram INTEGER NOT NULL DEFAULT 0
+                    );
+                    INSERT INTO placeables VALUES (20, 1, 'Developer_StorageContainer_Placeable', 0);
+                    INSERT INTO placeables VALUES (21, 1, 'Developer_StorageContainer_Placeable', 1);
+                    INSERT INTO placeables VALUES (22, 1, 'StorageContainer_Placeable', 0);
                     CREATE TABLE fgl_entities (
                         entity_id INTEGER PRIMARY KEY,
                         components BLOB
@@ -914,6 +934,8 @@ internal static partial class Program
                     );
                     INSERT INTO inventories VALUES (1, 10, 0, 60, 175);
                     INSERT INTO inventories VALUES (2, 20, 4, 1000, 50000);
+                    INSERT INTO inventories VALUES (3, 21, 4, 15, 750);
+                    INSERT INTO inventories VALUES (4, 22, 4, 15, 750);
                     CREATE TABLE items (
                         id INTEGER PRIMARY KEY,
                         inventory_id INTEGER REFERENCES inventories(id),
@@ -1021,6 +1043,17 @@ internal static partial class Program
             {
                 throw new InvalidOperationException(
                     $"Map seed expected 2 from cycle index 14, found {inspection.MapSeed}.");
+            }
+            var starterStorage = inspection.Inventories.SingleOrDefault(
+                value => value.Key == "inventory:4");
+            if (inspection.Inventories.Any(value => value.Key == "inventory:3")
+                || inspection.Inventories.Count(value => value.Kind == "developer-storage") != 1
+                || starterStorage is null
+                || starterStorage.Kind != "storage"
+                || starterStorage.Label != "Storage Container #1")
+            {
+                throw new InvalidOperationException(
+                    "Built/hologram storage destination filtering is incorrect.");
             }
 
             var backup = Path.Combine(root, "backups", "game-test.db");
@@ -1132,6 +1165,43 @@ internal static partial class Program
                 throw new InvalidOperationException(
                     "Vehicle-kit volume fallbacks were not applied correctly.");
             }
+            File.WriteAllText(
+                planPath,
+                """
+                {"destination":"inventory:3","items":[
+                  {"templateId":"TestResource","quantity":1,"quality":0}
+                ]}
+                """);
+            var beforeHologramGrant = File.ReadAllBytes(target);
+            var hologramRejected = false;
+            try
+            {
+                GrantItems(
+                    target,
+                    Path.Combine(root, "safety", "before-hologram-grant.db"),
+                    planPath,
+                    catalogPath);
+            }
+            catch (InvalidDataException ex)
+                when (ex.Message.Contains("no longer exists", StringComparison.OrdinalIgnoreCase))
+            {
+                hologramRejected = true;
+            }
+            if (!hologramRejected
+                || !File.ReadAllBytes(target).SequenceEqual(beforeHologramGrant))
+            {
+                throw new InvalidOperationException(
+                    "Hologram Developer Storage grant did not fail closed.");
+            }
+            File.WriteAllText(
+                planPath,
+                """
+                {"destination":"inventory:2","items":[
+                  {"templateId":"TestResource","quantity":12,"quality":0},
+                  {"templateId":"HeavyAmmo","quantity":501,"quality":0},
+                  {"templateId":"AntiRadiationPill","quantity":21,"quality":0}
+                ]}
+                """);
             var grantSafety = Path.Combine(root, "safety", "before-grant.db");
             GrantItems(target, grantSafety, planPath, catalogPath);
             if (!File.Exists(grantSafety))
@@ -1740,25 +1810,42 @@ internal static partial class Program
 
         using var storage = connection.CreateCommand();
         storage.CommandText = """
-            SELECT inv.id, inv.max_item_count, inv.max_item_volume, COUNT(items.id)
+            SELECT inv.id,
+                   inv.max_item_count,
+                   inv.max_item_volume,
+                   COUNT(items.id),
+                   placeables.building_type
             FROM inventories AS inv
             JOIN actors ON actors.id = inv.actor_id
+            JOIN placeables ON placeables.id = actors.id
             LEFT JOIN items ON items.inventory_id = inv.id
             WHERE inv.inventory_type = 4
-              AND actors.class LIKE '%BP_Developer_StorageContainer%'
+              AND placeables.is_hologram = 0
+              AND placeables.owner_entity_id IS NOT NULL
+              AND placeables.owner_entity_id != 0
             GROUP BY inv.id
             ORDER BY inv.id;
             """;
         using (var reader = storage.ExecuteReader())
         {
-            var index = 1;
+            var labelCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             while (reader.Read())
             {
+                var baseLabel = FormatSoloStorageLabel(
+                    reader.IsDBNull(4) ? string.Empty : reader.GetString(4));
+                labelCounts.TryGetValue(baseLabel, out var priorCount);
+                var index = priorCount + 1;
+                labelCounts[baseLabel] = index;
                 results.Add(new InventoryDestination(
                     Id: reader.GetInt64(0),
                     Key: $"inventory:{reader.GetInt64(0)}",
-                    Label: $"Developer Storage #{index++}",
-                    Kind: "developer-storage",
+                    Label: $"{baseLabel} #{index}",
+                    Kind: string.Equals(
+                        baseLabel,
+                        "Developer Storage",
+                        StringComparison.OrdinalIgnoreCase)
+                        ? "developer-storage"
+                        : "storage",
                     ItemRows: reader.GetInt64(3),
                     MaxItemCount: reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
                     MaxItemVolume: reader.IsDBNull(2) ? 0 : reader.GetDouble(2),
@@ -1773,6 +1860,22 @@ internal static partial class Program
                 UsedVolume = GetUsedVolume(connection, result.Id, volumeRules)
             })
             .ToArray();
+    }
+
+    private static string FormatSoloStorageLabel(string buildingType)
+    {
+        var value = buildingType.Trim();
+        if (value.EndsWith("_Placeable", StringComparison.OrdinalIgnoreCase))
+        {
+            value = value[..^"_Placeable".Length];
+        }
+        if (value.Contains("Developer_StorageContainer", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Developer Storage";
+        }
+        value = value.Replace('_', ' ');
+        value = Regex.Replace(value, "([a-z0-9])([A-Z])", "$1 $2").Trim();
+        return string.IsNullOrWhiteSpace(value) ? "Storage" : value;
     }
 
     private static GrantPlan ReadGrantPlan(string path)
@@ -1870,7 +1973,7 @@ internal static partial class Program
                 StringComparison.OrdinalIgnoreCase));
         return destination
             ?? throw new InvalidDataException(
-                "The selected backpack or Developer Storage no longer exists.");
+                "The selected backpack or built storage inventory no longer exists.");
     }
 
     private static HashSet<int> ReadUsedPositions(

--- a/app/tools/DuneSoloDb/Program.cs
+++ b/app/tools/DuneSoloDb/Program.cs
@@ -4,7 +4,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Text.RegularExpressions;
 using Microsoft.Data.Sqlite;
 
 namespace DuneSoloDb;
@@ -42,6 +41,16 @@ internal static partial class Program
             ["TreadwheelHull_6"] = 15d,
             ["SandcrawlerSpiceContainer_Unique_Capacity_6"] = 1000d,
             ["SandcrawlerSpiceHeader_6"] = 1000d
+        };
+
+    private static readonly IReadOnlyDictionary<string, string> SoloStorageLabels =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["BasicContainer_Placeable"] = "Chest",
+            ["SpiceSilo_Placeable"] = "Small Storage Container",
+            ["StorageContainer_Placeable"] = "Storage Container",
+            ["MediumStorageContainer_Placeable"] = "Medium Storage Container",
+            ["Developer_StorageContainer_Placeable"] = "Developer Storage"
         };
 
     public static int Main(string[] args)
@@ -861,6 +870,10 @@ internal static partial class Program
                         '/Game/Dune/Systems/Building/Pieces/BP_StorageContainer.BP_StorageContainer_C',
                         jsonb('{}')
                     );
+                    INSERT INTO actors (id, class, properties) VALUES
+                        (23, 'BasicContainer', jsonb('{}')),
+                        (24, 'BP_SpiceSiloContainer', jsonb('{}')),
+                        (25, 'MediumStorageContainer', jsonb('{}'));
                     CREATE TABLE placeables (
                         id INTEGER PRIMARY KEY,
                         owner_entity_id INTEGER,
@@ -870,6 +883,9 @@ internal static partial class Program
                     INSERT INTO placeables VALUES (20, 1, 'Developer_StorageContainer_Placeable', 0);
                     INSERT INTO placeables VALUES (21, 1, 'Developer_StorageContainer_Placeable', 1);
                     INSERT INTO placeables VALUES (22, 1, 'StorageContainer_Placeable', 0);
+                    INSERT INTO placeables VALUES (23, 1, 'BasicContainer_Placeable', 0);
+                    INSERT INTO placeables VALUES (24, 1, 'SpiceSilo_Placeable', 0);
+                    INSERT INTO placeables VALUES (25, 1, 'MediumStorageContainer_Placeable', 0);
                     CREATE TABLE fgl_entities (
                         entity_id INTEGER PRIMARY KEY,
                         components BLOB
@@ -936,6 +952,9 @@ internal static partial class Program
                     INSERT INTO inventories VALUES (2, 20, 4, 1000, 50000);
                     INSERT INTO inventories VALUES (3, 21, 4, 15, 750);
                     INSERT INTO inventories VALUES (4, 22, 4, 15, 750);
+                    INSERT INTO inventories VALUES (5, 23, 4, 10, 250);
+                    INSERT INTO inventories VALUES (6, 24, 4, 10, 250);
+                    INSERT INTO inventories VALUES (7, 25, 4, 25, 1250);
                     CREATE TABLE items (
                         id INTEGER PRIMARY KEY,
                         inventory_id INTEGER REFERENCES inventories(id),
@@ -1044,13 +1063,18 @@ internal static partial class Program
                 throw new InvalidOperationException(
                     $"Map seed expected 2 from cycle index 14, found {inspection.MapSeed}.");
             }
-            var starterStorage = inspection.Inventories.SingleOrDefault(
-                value => value.Key == "inventory:4");
+            var expectedStorageLabels = new[]
+            {
+                "Chest #1",
+                "Small Storage Container #1",
+                "Storage Container #1",
+                "Medium Storage Container #1",
+                "Developer Storage #1"
+            };
             if (inspection.Inventories.Any(value => value.Key == "inventory:3")
                 || inspection.Inventories.Count(value => value.Kind == "developer-storage") != 1
-                || starterStorage is null
-                || starterStorage.Kind != "storage"
-                || starterStorage.Label != "Storage Container #1")
+                || expectedStorageLabels.Any(label =>
+                    inspection.Inventories.All(value => value.Label != label)))
             {
                 throw new InvalidOperationException(
                     "Built/hologram storage destination filtering is incorrect.");
@@ -1831,8 +1855,11 @@ internal static partial class Program
             var labelCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             while (reader.Read())
             {
-                var baseLabel = FormatSoloStorageLabel(
-                    reader.IsDBNull(4) ? string.Empty : reader.GetString(4));
+                var buildingType = reader.IsDBNull(4) ? string.Empty : reader.GetString(4);
+                if (!SoloStorageLabels.TryGetValue(buildingType, out var baseLabel))
+                {
+                    continue;
+                }
                 labelCounts.TryGetValue(baseLabel, out var priorCount);
                 var index = priorCount + 1;
                 labelCounts[baseLabel] = index;
@@ -1860,22 +1887,6 @@ internal static partial class Program
                 UsedVolume = GetUsedVolume(connection, result.Id, volumeRules)
             })
             .ToArray();
-    }
-
-    private static string FormatSoloStorageLabel(string buildingType)
-    {
-        var value = buildingType.Trim();
-        if (value.EndsWith("_Placeable", StringComparison.OrdinalIgnoreCase))
-        {
-            value = value[..^"_Placeable".Length];
-        }
-        if (value.Contains("Developer_StorageContainer", StringComparison.OrdinalIgnoreCase))
-        {
-            return "Developer Storage";
-        }
-        value = value.Replace('_', ' ');
-        value = Regex.Replace(value, "([a-z0-9])([A-Z])", "$1 $2").Trim();
-        return string.IsNullOrWhiteSpace(value) ? "Storage" : value;
     }
 
     private static GrantPlan ReadGrantPlan(string path)

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.7.0"
+$script:ToolVersion = "13.8.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/CosmeticsCatalog.Tests.ps1
+++ b/tests/CosmeticsCatalog.Tests.ps1
@@ -68,6 +68,12 @@ Describe 'Get-DuneCosmeticsCatalog includes the full building-set universe' -Tag
         @($script:cat.templates | Where-Object { $_.group -eq 'Armor & Suit Sets' }).Count | Should -BeGreaterThan 0
         @($script:cat.templates | Where-Object { $_.group -eq 'Swatches (Dyes)' }).Count   | Should -BeGreaterThan 0
     }
+    It 'decodes UTF-8 cosmetic names without mojibake under Windows PowerShell' {
+        $boots = $script:cat.templates |
+            Where-Object template -eq 'MTX_B1C3_Smug_LightArmor_SetVariant_Boots'
+        $boots.name | Should -Be ("Smuggler{0}s Agile Assault Boots" -f [char]0x2019)
+        $boots.name | Should -Not -Match ([char]0x00E2)
+    }
     It 'includes developer cosmetics and building unlocks' {
         $script:cat.templates.template | Should -Contain 'D_Choam_HeavyArmor_Swatch'
         $script:cat.templates.template | Should -Contain 'D_TestMeshVariant'

--- a/tests/DeveloperCatalog.Tests.ps1
+++ b/tests/DeveloperCatalog.Tests.ps1
@@ -48,6 +48,13 @@ Describe 'Developer template catalog coverage' -Tag 'Catalog' {
         $script:items.meta.total | Should -Be $script:items.items.Count
     }
 
+    It 'decodes UTF-8 Give Item names without mojibake under Windows PowerShell' {
+        $boots = $script:items.items |
+            Where-Object templateId -eq 'MTX_Stillsuit_Smuggler_Boots'
+        $boots.name | Should -Be ("Smuggler{0}s Stillsuit Boots" -f [char]0x2019)
+        $boots.name | Should -Not -Match ([char]0x00E2)
+    }
+
     It 'gives every entry a searchable display name' {
         @($script:items.items | Where-Object { -not $_.name }).Count | Should -Be 0
     }

--- a/tests/SoloMode.Tests.ps1
+++ b/tests/SoloMode.Tests.ps1
@@ -207,6 +207,34 @@ Describe 'Solo Mode write gates and settings backups' {
         } | Should -Throw '*still running*'
     }
 
+    It 'restores Engine.ini when verification reports a missing default-valued key' {
+        $layout = New-TestSoloLayout
+        $engine = Join-Path $layout.config 'Engine.ini'
+        $original = @(
+            '[ConsoleVariables]'
+            'Unknown.FutureKey=KeepMe'
+        ) -join [Environment]::NewLine
+        [IO.File]::WriteAllText($engine, $original)
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        Mock Get-DuneSoloGameProcesses { @() }
+        Mock Read-DuneSoloConsoleSettings {
+            @{
+                entries = @([pscustomobject]@{
+                    key = 'Hydration.SunExposureEnabled'
+                    value = '1'
+                    present = $false
+                })
+            }
+        }
+
+        {
+            Set-DuneSoloConsoleSettings -Settings @{
+                'Hydration.SunExposureEnabled' = '1'
+            } -Confirm 'APPLY SOLO CONSOLE SETTINGS'
+        } | Should -Throw '*verification failed*'
+        (Get-Content -LiteralPath $engine -Raw).Trim() | Should -Be $original.Trim()
+    }
+
     It 'rejects unsupported or out-of-range PTC console settings' {
         $layout = New-TestSoloLayout
         Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null

--- a/tests/SoloMode.Tests.ps1
+++ b/tests/SoloMode.Tests.ps1
@@ -164,6 +164,9 @@ Describe 'Solo Mode write gates and settings backups' {
     It 'reads and atomically writes allowlisted PTC Engine.ini settings' {
         $layout = New-TestSoloLayout
         $engine = Join-Path $layout.config 'Engine.ini'
+        $clientConfig = Join-Path $layout.root 'Config\WindowsClient'
+        New-Item -ItemType Directory -Path $clientConfig -Force | Out-Null
+        $clientEngine = Join-Path $clientConfig 'Engine.ini'
         @(
             '[Other.Section]'
             'KeepMe=Yes'
@@ -172,6 +175,12 @@ Describe 'Solo Mode write gates and settings backups' {
             'Hydration.SunExposureEnabled=1'
             'Unknown.FutureKey=KeepMe'
         ) | Set-Content -LiteralPath $engine -Encoding utf8
+        @(
+            '[ConsoleVariables]'
+            'Dune.DisableShieldOnShooting=1'
+            'Dune.DisableShieldOnShooting=1'
+            'Client.FutureKey=KeepMe'
+        ) | Set-Content -LiteralPath $clientEngine -Encoding utf8
         Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
         Mock Get-DuneSoloGameProcesses { @() }
 
@@ -188,13 +197,25 @@ Describe 'Solo Mode write gates and settings backups' {
 
         $result.ok | Should -BeTrue
         (Test-Path -LiteralPath $result.backupPath) | Should -BeTrue
+        @($result.backupPaths).Count | Should -Be 2
+        @($result.backupPaths | Select-Object -Unique).Count | Should -Be 2
+        (Get-Content -LiteralPath ($result.backupPaths | Where-Object { $_ -like '*Engine-Windows-*' }) -Raw) |
+            Should -Match 'Unknown\.FutureKey=KeepMe'
+        (Get-Content -LiteralPath ($result.backupPaths | Where-Object { $_ -like '*Engine-WindowsClient-*' }) -Raw) |
+            Should -Match 'Client\.FutureKey=KeepMe'
         $written = Get-Content -LiteralPath $engine -Raw
+        $clientWritten = Get-Content -LiteralPath $clientEngine -Raw
         $written | Should -Match '(?m)^KeepMe=Yes\r?$'
         $written | Should -Match '(?m)^Unknown\.FutureKey=KeepMe\r?$'
         @([regex]::Matches($written, '(?m)^Hydration\.SunExposureEnabled=0\r?$')).Count |
             Should -Be 1
         $written | Should -Match '(?m)^Vehicle\.MaxVehiclesPerPlayer=20\r?$'
         $written | Should -Match '(?m)^Dune\.DisableShieldOnShooting=0\r?$'
+        $clientWritten | Should -Match '(?m)^Client\.FutureKey=KeepMe\r?$'
+        $clientWritten | Should -Match '(?m)^Hydration\.SunExposureEnabled=0\r?$'
+        $clientWritten | Should -Match '(?m)^Vehicle\.MaxVehiclesPerPlayer=20\r?$'
+        @([regex]::Matches($clientWritten, '(?m)^Dune\.DisableShieldOnShooting=0\r?$')).Count |
+            Should -Be 1
     }
 
     It 'blocks PTC Engine.ini writes while the game is running' {
@@ -235,6 +256,35 @@ Describe 'Solo Mode write gates and settings backups' {
             } -Confirm 'APPLY SOLO CONSOLE SETTINGS'
         } | Should -Throw '*verification failed*'
         (Get-Content -LiteralPath $engine -Raw).Trim() | Should -Be $original.Trim()
+    }
+
+    It 'rolls back the host Engine.ini when the client-file commit fails' {
+        $layout = New-TestSoloLayout
+        $engine = Join-Path $layout.config 'Engine.ini'
+        $clientConfig = Join-Path $layout.root 'Config\WindowsClient'
+        New-Item -ItemType Directory -Path $clientConfig -Force | Out-Null
+        $clientEngine = Join-Path $clientConfig 'Engine.ini'
+        $hostOriginal = "[ConsoleVariables]`nHydration.SunExposureEnabled=1"
+        $clientOriginal = "[ConsoleVariables]`nHydration.SunExposureEnabled=1"
+        [IO.File]::WriteAllText($engine, $hostOriginal)
+        [IO.File]::WriteAllText($clientEngine, $clientOriginal)
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        Mock Get-DuneSoloGameProcesses { @() }
+        Mock Invoke-DuneSoloFileReplace {
+            param($Source, $Destination, $Backup)
+            if ($Destination -like '*WindowsClient\Engine.ini' -and $Source -like '*.tmp') {
+                throw 'simulated client commit failure'
+            }
+            [IO.File]::Replace($Source, $Destination, $Backup, $true)
+        }
+
+        {
+            Set-DuneSoloConsoleSettings -Settings @{
+                'Hydration.SunExposureEnabled' = '0'
+            } -Confirm 'APPLY SOLO CONSOLE SETTINGS'
+        } | Should -Throw '*simulated client commit failure*'
+        (Get-Content -LiteralPath $engine -Raw).Trim() | Should -Be $hostOriginal.Trim()
+        (Get-Content -LiteralPath $clientEngine -Raw).Trim() | Should -Be $clientOriginal.Trim()
     }
 
     It 'rejects unsupported or out-of-range PTC console settings' {

--- a/tests/SoloMode.Tests.ps1
+++ b/tests/SoloMode.Tests.ps1
@@ -183,6 +183,7 @@ Describe 'Solo Mode write gates and settings backups' {
         $result = Set-DuneSoloConsoleSettings -Settings @{
             'Hydration.SunExposureEnabled' = '0'
             'Vehicle.MaxVehiclesPerPlayer' = '20'
+            'Dune.DisableShieldOnShooting' = '0'
         } -Confirm 'APPLY SOLO CONSOLE SETTINGS'
 
         $result.ok | Should -BeTrue
@@ -193,6 +194,7 @@ Describe 'Solo Mode write gates and settings backups' {
         @([regex]::Matches($written, '(?m)^Hydration\.SunExposureEnabled=0\r?$')).Count |
             Should -Be 1
         $written | Should -Match '(?m)^Vehicle\.MaxVehiclesPerPlayer=20\r?$'
+        $written | Should -Match '(?m)^Dune\.DisableShieldOnShooting=0\r?$'
     }
 
     It 'blocks PTC Engine.ini writes while the game is running' {

--- a/tests/SoloMode.Tests.ps1
+++ b/tests/SoloMode.Tests.ps1
@@ -611,6 +611,51 @@ Describe 'Solo Mode backup profile isolation' {
         (Test-Path -LiteralPath $second) | Should -BeTrue
     }
 
+    It 'rejects a reparse point on the deletion staging directory' {
+        $layout = New-TestSoloLayout
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        $activeRoot = Get-DuneSoloProfileBackupRoot -DbPath $layout.db
+        $stageParent = Join-Path $activeRoot '.delete-staging'
+        $junctionTarget = Join-Path $script:SoloTestRoot 'staging-junction-target'
+        New-Item -ItemType Directory -Path $junctionTarget -Force | Out-Null
+        New-Item -ItemType Junction -Path $stageParent -Target $junctionTarget | Out-Null
+        $target = Join-Path $activeRoot 'keep.db'
+        [IO.File]::WriteAllBytes($target, [byte[]](1))
+
+        {
+            Remove-DuneSoloBackups -RelativePaths @('keep.db') `
+                -Confirm 'DELETE SOLO BACKUPS'
+        } | Should -Throw '*reparse point*'
+        (Test-Path -LiteralPath $target) | Should -BeTrue
+    }
+
+    It 'reports exact deleted and retained files when final cleanup is partial' {
+        $layout = New-TestSoloLayout
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        $activeRoot = Get-DuneSoloProfileBackupRoot -DbPath $layout.db
+        New-Item -ItemType Directory -Path $activeRoot -Force | Out-Null
+        $first = Join-Path $activeRoot 'first.db'
+        $second = Join-Path $activeRoot 'second.db'
+        [IO.File]::WriteAllBytes($first, [byte[]](1))
+        [IO.File]::WriteAllBytes($second, [byte[]](2))
+        Mock Remove-DuneSoloBackupFile {
+            param($Path)
+            if ($Path -like '*001-second.db') {
+                throw 'simulated final delete failure'
+            }
+            Remove-Item -LiteralPath $Path -Force -ErrorAction Stop
+        }
+
+        {
+            Remove-DuneSoloBackups -RelativePaths @('first.db', 'second.db') `
+                -Confirm 'DELETE SOLO BACKUPS'
+        } | Should -Throw '*Permanently deleted: first.db*Retained for recovery: second.db*'
+        (Test-Path -LiteralPath $first) | Should -BeFalse
+        (Test-Path -LiteralPath $second) | Should -BeFalse
+        @(Get-ChildItem -LiteralPath (Join-Path $activeRoot '.delete-staging') `
+            -Filter '*second.db' -File -Recurse).Count | Should -Be 1
+    }
+
     It 'rejects backup deletion traversal and non-db files' {
         $layout = New-TestSoloLayout
         Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null

--- a/tests/SoloMode.Tests.ps1
+++ b/tests/SoloMode.Tests.ps1
@@ -22,8 +22,9 @@ function global:Reset-TestSoloState {
 }
 
 function global:New-TestSoloLayout {
+    param([string]$Channel = 'FLS_beta')
     $root = Join-Path $env:LOCALAPPDATA 'DuneSandbox\Saved'
-    $profile = Join-Path $root 'Cloud\PlayerClientStorage\FLS_beta\123456789'
+    $profile = Join-Path $root "Cloud\PlayerClientStorage\$Channel\123456789"
     $config = Join-Path $root 'Config\Windows'
     New-Item -ItemType Directory -Path $profile, $config -Force | Out-Null
     $db = Join-Path $profile 'game.db'
@@ -158,6 +159,81 @@ Describe 'Solo Mode write gates and settings backups' {
         { Set-DuneSoloSettings -Settings @{ GatheringAmount = '2.500000' } -Confirm 'APPLY SOLO SETTINGS' } |
             Should -Throw '*verification failed*'
         (Get-Content -LiteralPath $ini -Raw).Trim() | Should -Be $original.Trim()
+    }
+
+    It 'reads and atomically writes allowlisted PTC Engine.ini settings' {
+        $layout = New-TestSoloLayout
+        $engine = Join-Path $layout.config 'Engine.ini'
+        @(
+            '[Other.Section]'
+            'KeepMe=Yes'
+            '[ConsoleVariables]'
+            'Hydration.SunExposureEnabled=1'
+            'Hydration.SunExposureEnabled=1'
+            'Unknown.FutureKey=KeepMe'
+        ) | Set-Content -LiteralPath $engine -Encoding utf8
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        Mock Get-DuneSoloGameProcesses { @() }
+
+        $before = Read-DuneSoloConsoleSettings
+        $before.supported | Should -BeTrue
+        ($before.entries | Where-Object key -eq 'Hydration.SunExposureEnabled').value |
+            Should -Be '1'
+
+        $result = Set-DuneSoloConsoleSettings -Settings @{
+            'Hydration.SunExposureEnabled' = '0'
+            'Vehicle.MaxVehiclesPerPlayer' = '20'
+        } -Confirm 'APPLY SOLO CONSOLE SETTINGS'
+
+        $result.ok | Should -BeTrue
+        (Test-Path -LiteralPath $result.backupPath) | Should -BeTrue
+        $written = Get-Content -LiteralPath $engine -Raw
+        $written | Should -Match '(?m)^KeepMe=Yes\r?$'
+        $written | Should -Match '(?m)^Unknown\.FutureKey=KeepMe\r?$'
+        @([regex]::Matches($written, '(?m)^Hydration\.SunExposureEnabled=0\r?$')).Count |
+            Should -Be 1
+        $written | Should -Match '(?m)^Vehicle\.MaxVehiclesPerPlayer=20\r?$'
+    }
+
+    It 'blocks PTC Engine.ini writes while the game is running' {
+        $layout = New-TestSoloLayout
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        Mock Get-DuneSoloGameProcesses { @([pscustomobject]@{ name = 'DuneSandbox'; pid = 42 }) }
+
+        {
+            Set-DuneSoloConsoleSettings -Settings @{
+                'Hydration.SunExposureEnabled' = '0'
+            } -Confirm 'APPLY SOLO CONSOLE SETTINGS'
+        } | Should -Throw '*still running*'
+    }
+
+    It 'rejects unsupported or out-of-range PTC console settings' {
+        $layout = New-TestSoloLayout
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        Mock Get-DuneSoloGameProcesses { @() }
+
+        {
+            Set-DuneSoloConsoleSettings -Settings @{ 'Unknown.Key' = '1' } `
+                -Confirm 'APPLY SOLO CONSOLE SETTINGS'
+        } | Should -Throw '*Unsupported PTC Solo console setting*'
+        {
+            Set-DuneSoloConsoleSettings -Settings @{
+                'Vehicle.MaxVehiclesPerPlayer' = '1001'
+            } -Confirm 'APPLY SOLO CONSOLE SETTINGS'
+        } | Should -Throw '*between 0 and 1000*'
+    }
+
+    It 'does not guess a retail Engine.ini folder' {
+        $layout = New-TestSoloLayout -Channel 'FLS_live'
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        Mock Get-DuneSoloGameProcesses { @() }
+
+        (Read-DuneSoloConsoleSettings).supported | Should -BeFalse
+        {
+            Set-DuneSoloConsoleSettings -Settings @{
+                'Hydration.SunExposureEnabled' = '0'
+            } -Confirm 'APPLY SOLO CONSOLE SETTINGS'
+        } | Should -Throw '*verified PTC FLS_beta adapter*'
     }
 
     It 'requires the exact item-grant confirmation phrase' {

--- a/tests/SoloMode.Tests.ps1
+++ b/tests/SoloMode.Tests.ps1
@@ -551,6 +551,66 @@ Describe 'Solo Mode backup profile isolation' {
         Assert-MockCalled Get-DuneSoloGameProcesses -Times 0
     }
 
+    It 'deletes multiple selected backups after validating the complete set' {
+        $layout = New-TestSoloLayout
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        $activeRoot = Get-DuneSoloProfileBackupRoot -DbPath $layout.db
+        New-Item -ItemType Directory -Path $activeRoot -Force | Out-Null
+        foreach ($name in @('first.db', 'second.db', 'keep.db')) {
+            [IO.File]::WriteAllBytes((Join-Path $activeRoot $name), [byte[]](1))
+        }
+
+        $result = Remove-DuneSoloBackups -RelativePaths @('first.db', 'second.db') `
+            -Confirm 'DELETE SOLO BACKUPS'
+
+        $result.deletedCount | Should -Be 2
+        @($result.deleted | Sort-Object) | Should -Be @('first.db', 'second.db')
+        (Test-Path -LiteralPath (Join-Path $activeRoot 'first.db')) | Should -BeFalse
+        (Test-Path -LiteralPath (Join-Path $activeRoot 'second.db')) | Should -BeFalse
+        (Test-Path -LiteralPath (Join-Path $activeRoot 'keep.db')) | Should -BeTrue
+    }
+
+    It 'validates every selected backup before deleting any' {
+        $layout = New-TestSoloLayout
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        $activeRoot = Get-DuneSoloProfileBackupRoot -DbPath $layout.db
+        New-Item -ItemType Directory -Path $activeRoot -Force | Out-Null
+        $valid = Join-Path $activeRoot 'valid.db'
+        [IO.File]::WriteAllBytes($valid, [byte[]](1))
+
+        {
+            Remove-DuneSoloBackups -RelativePaths @('valid.db', '..\foreign.db') `
+                -Confirm 'DELETE SOLO BACKUPS'
+        } | Should -Throw '*outside the connected Solo profile backup directory*'
+        (Test-Path -LiteralPath $valid) | Should -BeTrue
+    }
+
+    It 'rolls staged backups back when a later staging move fails' {
+        $layout = New-TestSoloLayout
+        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
+        $activeRoot = Get-DuneSoloProfileBackupRoot -DbPath $layout.db
+        New-Item -ItemType Directory -Path $activeRoot -Force | Out-Null
+        $first = Join-Path $activeRoot 'first.db'
+        $second = Join-Path $activeRoot 'second.db'
+        [IO.File]::WriteAllBytes($first, [byte[]](1))
+        [IO.File]::WriteAllBytes($second, [byte[]](2))
+        $script:moveCount = 0
+        Mock Move-Item {
+            param($LiteralPath, $Destination, $ErrorAction)
+            $script:moveCount++
+            if ($script:moveCount -eq 2) { throw 'simulated staging failure' }
+            Microsoft.PowerShell.Management\Move-Item -LiteralPath $LiteralPath `
+                -Destination $Destination -ErrorAction $ErrorAction
+        }
+
+        {
+            Remove-DuneSoloBackups -RelativePaths @('first.db', 'second.db') `
+                -Confirm 'DELETE SOLO BACKUPS'
+        } | Should -Throw '*simulated staging failure*'
+        (Test-Path -LiteralPath $first) | Should -BeTrue
+        (Test-Path -LiteralPath $second) | Should -BeTrue
+    }
+
     It 'rejects backup deletion traversal and non-db files' {
         $layout = New-TestSoloLayout
         Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null

--- a/tests/SoloModeRoutes.Tests.ps1
+++ b/tests/SoloModeRoutes.Tests.ps1
@@ -1,0 +1,27 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    $script:RouteFile = Join-Path (Get-DstRepoRoot) 'app\server\routes\SoloMode.ps1'
+}
+
+Describe 'Solo Mode route registration' {
+    It 'registers PTC console settings as local-only read and write routes' {
+        $routes = @(& {
+            function Register-DuneRoute {
+                param($Method, $Path, [switch]$LocalOnly, $Handler)
+                [pscustomobject]@{
+                    method = $Method
+                    path = $Path
+                    localOnly = [bool]$LocalOnly
+                }
+            }
+            . $script:RouteFile
+        })
+
+        $consoleRoutes = @($routes |
+            Where-Object path -eq '/api/solo/console-settings' |
+            Sort-Object method)
+        $consoleRoutes.Count | Should -Be 2
+        $consoleRoutes.method | Should -Be @('GET', 'PUT')
+        @($consoleRoutes | Where-Object { -not $_.localOnly }).Count | Should -Be 0
+    }
+}

--- a/webui/src/api/solo.ts
+++ b/webui/src/api/solo.ts
@@ -67,7 +67,7 @@ export interface SoloInventoryDestination {
   id: number
   key: string
   label: string
-  kind: 'backpack' | 'developer-storage'
+  kind: 'backpack' | 'developer-storage' | 'storage'
   itemRows: number
   maxItemCount: number
   maxItemVolume: number

--- a/webui/src/api/solo.ts
+++ b/webui/src/api/solo.ts
@@ -202,6 +202,8 @@ export function saveSoloConsoleSettings(
   ok: boolean
   settings: SoloConsoleSettingsResponse
   backupPath: string
+  backupPaths: string[]
+  paths: string[]
 }> {
   return api('/api/solo/console-settings', {
     method: 'PUT',

--- a/webui/src/api/solo.ts
+++ b/webui/src/api/solo.ts
@@ -124,6 +124,26 @@ export interface SoloSettingsResponse {
   entries: SoloSetting[]
 }
 
+export interface SoloConsoleSetting extends SoloSetting {
+  type: 'bool01' | 'int'
+  default: string
+  min: number | null
+  max: number | null
+  label: string
+  help: string
+  status: 'Confirmed' | 'Unconfirmed'
+}
+
+export interface SoloConsoleSettingsResponse {
+  ok: boolean
+  supported: boolean
+  adapter: string
+  path: string
+  exists: boolean
+  section: string
+  entries: SoloConsoleSetting[]
+}
+
 export interface SoloBackup {
   name: string
   relativePath: string
@@ -172,6 +192,24 @@ export function saveSoloSettings(settings: Record<string, string>, expectedProfi
   return api('/api/solo/settings', {
     method: 'PUT',
     body: JSON.stringify({ settings, expectedProfileToken, confirm: 'APPLY SOLO SETTINGS' }),
+  })
+}
+
+export function saveSoloConsoleSettings(
+  settings: Record<string, string>,
+  expectedProfileToken: string,
+): Promise<{
+  ok: boolean
+  settings: SoloConsoleSettingsResponse
+  backupPath: string
+}> {
+  return api('/api/solo/console-settings', {
+    method: 'PUT',
+    body: JSON.stringify({
+      settings,
+      expectedProfileToken,
+      confirm: 'APPLY SOLO CONSOLE SETTINGS',
+    }),
   })
 }
 

--- a/webui/src/api/solo.ts
+++ b/webui/src/api/solo.ts
@@ -238,6 +238,20 @@ export function deleteSoloBackup(
   })
 }
 
+export function deleteSoloBackups(
+  relativePaths: string[],
+  expectedProfileToken: string,
+): Promise<{ ok: boolean; deleted: string[]; deletedCount: number }> {
+  return api('/api/solo/backups', {
+    method: 'DELETE',
+    body: JSON.stringify({
+      relativePaths,
+      expectedProfileToken,
+      confirm: 'DELETE SOLO BACKUPS',
+    }),
+  })
+}
+
 export function restoreSoloBackup(relativePath: string, expectedProfileToken: string): Promise<{
   ok: boolean
   path: string

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -636,7 +636,7 @@ export function SoloMode() {
       return
     }
     if (!destination) {
-      setNotice({ kind: 'err', text: 'Choose a backpack or Developer Storage destination.' })
+      setNotice({ kind: 'err', text: 'Choose a backpack or built storage destination.' })
       return
     }
     if (!window.confirm(

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -9,6 +9,7 @@ import {
   connectSolo,
   createSoloBackup,
   deleteSoloBackup,
+  deleteSoloBackups,
   discoverSolo,
   fillSoloWaterContainer,
   completeSoloFindTheFremen,
@@ -338,6 +339,7 @@ export function SoloMode() {
   const [draft, setDraft] = useState<Record<string, string>>({})
   const [consoleDraft, setConsoleDraft] = useState<Record<string, string>>({})
   const [busy, setBusy] = useState<string | null>(null)
+  const [selectedBackupPaths, setSelectedBackupPaths] = useState<Set<string>>(new Set())
   const [notice, setNotice] = useState<{ kind: 'ok' | 'warn' | 'err'; text: string } | null>(null)
   const [itemTemplate, setItemTemplate] = useState('')
   const [itemDisplay, setItemDisplay] = useState<string | undefined>()
@@ -362,6 +364,15 @@ export function SoloMode() {
     if (!settingsState.data) return
     setDraft(Object.fromEntries(settingsState.data.entries.map(entry => [entry.key, entry.value])))
   }, [settingsState.data])
+
+  useEffect(() => {
+    const currentPaths = new Set(
+      (backupsState.data?.backups ?? []).map(backup => backup.relativePath),
+    )
+    setSelectedBackupPaths(current => new Set(
+      [...current].filter(path => currentPaths.has(path)),
+    ))
+  }, [backupsState.data?.backups])
 
   useEffect(() => {
     if (!consoleSettingsState.data) return
@@ -613,6 +624,39 @@ export function SoloMode() {
         statusState.data?.profileToken ?? '',
       )
       setNotice({ kind: 'ok', text: `Deleted Solo backup ${backup.name}.` })
+      await backupsState.refresh()
+    } catch (error) {
+      setNotice({ kind: 'err', text: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const deleteSelectedBackups = async () => {
+    if (!selectionMatchesActive) {
+      setNotice({ kind: 'err', text: 'Connect and validate the selected Solo profile before deleting backups.' })
+      return
+    }
+    const selected = (backupsState.data?.backups ?? [])
+      .filter(backup => selectedBackupPaths.has(backup.relativePath))
+    if (selected.length === 0) return
+    const preview = selected.slice(0, 5).map(backup => `- ${backup.name}`).join('\n')
+    const more = selected.length > 5 ? `\n- ...and ${selected.length - 5} more` : ''
+    if (!window.confirm(
+      `Permanently delete ${selected.length} selected Solo backup(s)?\n\n`
+      + `${preview}${more}\n\n`
+      + 'This does not change the live Solo save and cannot be undone.',
+    )) return
+
+    setBusy('delete-selected')
+    setNotice(null)
+    try {
+      const result = await deleteSoloBackups(
+        selected.map(backup => backup.relativePath),
+        statusState.data?.profileToken ?? '',
+      )
+      setSelectedBackupPaths(new Set())
+      setNotice({ kind: 'ok', text: `Deleted ${result.deletedCount} Solo backup(s).` })
       await backupsState.refresh()
     } catch (error) {
       setNotice({ kind: 'err', text: error instanceof Error ? error.message : String(error) })
@@ -1201,24 +1245,69 @@ export function SoloMode() {
                 Backups validate the wrapper, SQLite integrity, foreign keys, and one-character invariant. Restore always preserves the current save first.
               </p>
             </div>
-            <button className={`btn-primary shrink-0 ${SOLO_DISABLED_PRIMARY_CLASS}`} onClick={() => void createBackup()} disabled={!canMutateActiveProfile}>
-              <Icon name={busy === 'backup' ? 'LoaderCircle' : 'Archive'} size={14} className={busy === 'backup' ? 'animate-spin' : ''} />
-              Create backup
-            </button>
+            <div className="flex items-center gap-2 shrink-0">
+              <button
+                className="btn-secondary"
+                disabled={!canMutateActiveProfile || selectedBackupPaths.size === 0}
+                onClick={() => void deleteSelectedBackups()}
+              >
+                <Icon name={busy === 'delete-selected' ? 'LoaderCircle' : 'Trash2'} size={14} className={busy === 'delete-selected' ? 'animate-spin' : ''} />
+                Delete selected ({selectedBackupPaths.size})
+              </button>
+              <button className={`btn-primary ${SOLO_DISABLED_PRIMARY_CLASS}`} onClick={() => void createBackup()} disabled={!canMutateActiveProfile}>
+                <Icon name={busy === 'backup' ? 'LoaderCircle' : 'Archive'} size={14} className={busy === 'backup' ? 'animate-spin' : ''} />
+                Create backup
+              </button>
+            </div>
           </div>
           <div className="text-xs text-text-dim font-mono break-all mb-4">{backupsState.data?.root ?? status?.backupRoot}</div>
           {(backupsState.data?.backups.length ?? 0) === 0 ? (
             <p className="text-sm text-text-muted">No Solo backups created by DST yet.</p>
           ) : (
-            <div className="divide-y divide-border">
+            <div>
+              <div className="flex items-center gap-3 pb-3 border-b border-border text-xs text-text-muted">
+                <button
+                  className="btn-secondary py-1 px-2"
+                  disabled={!canMutateActiveProfile}
+                  onClick={() => setSelectedBackupPaths(new Set(
+                    backupsState.data!.backups.map(backup => backup.relativePath),
+                  ))}
+                >
+                  Select all
+                </button>
+                <button
+                  className="btn-secondary py-1 px-2"
+                  disabled={!canMutateActiveProfile || selectedBackupPaths.size === 0}
+                  onClick={() => setSelectedBackupPaths(new Set())}
+                >
+                  Clear
+                </button>
+                <span>{selectedBackupPaths.size} selected</span>
+              </div>
+              <div className="divide-y divide-border">
               {backupsState.data!.backups.map(backup => (
                 <div key={backup.relativePath} className="py-3 flex items-center justify-between gap-4">
-                  <div className="min-w-0">
+                  <div className="min-w-0 flex items-start gap-3">
+                    <input
+                      type="checkbox"
+                      className="mt-1 accent-ibad"
+                      aria-label={`Select ${backup.name}`}
+                      checked={selectedBackupPaths.has(backup.relativePath)}
+                      disabled={!canMutateActiveProfile}
+                      onChange={event => setSelectedBackupPaths(current => {
+                        const next = new Set(current)
+                        if (event.target.checked) next.add(backup.relativePath)
+                        else next.delete(backup.relativePath)
+                        return next
+                      })}
+                    />
+                    <div className="min-w-0">
                     <div className="font-medium text-sm truncate">{backup.name}</div>
                     <div className="text-xs text-text-muted">
                       {formatBytes(backup.bytes)} - {new Date(backup.modifiedAt).toLocaleString()}
                     </div>
                     <div className="text-[11px] text-text-dim font-mono truncate">{backup.relativePath}</div>
+                    </div>
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
                     <button
@@ -1240,6 +1329,7 @@ export function SoloMode() {
                   </div>
                 </div>
               ))}
+              </div>
             </div>
           )}
         </div>

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -195,6 +195,14 @@ export function getSoloCosmeticBackpackDestination(
   return inventories.find(inventory => inventory.kind === 'backpack')?.key ?? ''
 }
 
+export function getPreferredSoloInventoryDestination(
+  inventories: SoloInventoryDestination[],
+): string {
+  return inventories.find(inventory => inventory.kind === 'backpack')?.key
+    ?? inventories[0]?.key
+    ?? ''
+}
+
 export function buildSoloCosmeticGrant(
   templateId: string,
   inventories: SoloInventoryDestination[],
@@ -343,11 +351,7 @@ export function SoloMode() {
       return
     }
     if (!inventories.some(inventory => inventory.key === inventoryDestination)) {
-      const preferred = inventories
-        .filter(inventory => inventory.kind === 'developer-storage')
-        .sort((left, right) => left.itemRows - right.itemRows)[0]
-        ?? inventories[0]
-      setInventoryDestination(preferred?.key ?? '')
+      setInventoryDestination(getPreferredSoloInventoryDestination(inventories))
     }
   }, [statusState.data?.inspection?.inventories, inventoryDestination])
 

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -543,7 +543,7 @@ export function SoloMode() {
     if (Object.keys(changedConsoleSettings).length === 0) return
     if (!window.confirm(
       `Apply ${Object.keys(changedConsoleSettings).length} PTC Solo Engine.ini setting(s)?\n\n`
-      + 'PTC must be fully closed. DST will retain Engine.ini, write only the two allowlisted ConsoleVariables, and verify the result.',
+      + 'PTC must be fully closed. DST will retain both observed Engine.ini files, write only the three allowlisted ConsoleVariables, and verify both results.',
     )) return
 
     setBusy('console-settings')
@@ -555,7 +555,9 @@ export function SoloMode() {
       )
       setNotice({
         kind: 'ok',
-        text: `PTC Solo Engine.ini settings applied and verified. Previous file retained at ${result.backupPath}`,
+        text: result.backupPaths.length > 0
+          ? `PTC Solo Engine.ini settings applied and verified in both observed files. Previous files retained at ${result.backupPaths.join('; ')}`
+          : 'PTC Solo Engine.ini settings created and verified in both observed files.',
       })
       await Promise.all([consoleSettingsState.refresh(), runtimeState.refresh()])
     } catch (error) {
@@ -1137,7 +1139,10 @@ export function SoloMode() {
                 ) : (
                   <div className="space-y-4">
                     <div className="rounded border border-warning/30 bg-warning/5 p-3 text-xs text-text-muted">
-                      Writes only <span className="font-mono">Config\Windows\Engine.ini</span> under the connected PTC Solo root. Sun Exposure uses the observed PTC key but still needs Solo field confirmation.
+                      Writes only <span className="font-mono">Config\Windows\Engine.ini</span> and{' '}
+                      <span className="font-mono">Config\WindowsClient\Engine.ini</span> under the
+                      connected PTC Solo root. Sun Exposure, Maximum Vehicles Per Player and Shield
+                      Drops While Shooting are field-confirmed in PTC Solo.
                     </div>
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
                       {consoleSettingsState.data.entries.map(entry => (

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -15,11 +15,13 @@ import {
   grantSoloItems,
   maxSoloAugmentAttributes,
   restoreSoloBackup,
+  saveSoloConsoleSettings,
   saveSoloSettings,
   setSoloCurrencies,
   maxSoloSpecializations,
   type SoloBackup,
   type SoloBackupsResponse,
+  type SoloConsoleSettingsResponse,
   type SoloInventoryDestination,
   type SoloProfile,
   type SoloRuntime,
@@ -313,11 +315,16 @@ export function SoloMode() {
   const runtimeState = useApi<SoloRuntime>('/api/solo/runtime', { intervalMs: 3000 })
   const connected = statusState.data?.connected === true
   const settingsState = useApi<SoloSettingsResponse>('/api/solo/settings', { enabled: connected })
+  const consoleSettingsState = useApi<SoloConsoleSettingsResponse>(
+    '/api/solo/console-settings',
+    { enabled: connected },
+  )
   const backupsState = useApi<SoloBackupsResponse>('/api/solo/backups', { enabled: connected })
   const [dataRoot, setDataRoot] = useState('')
   const [selectedDb, setSelectedDb] = useState('')
   const [discoveredProfiles, setDiscoveredProfiles] = useState<SoloProfile[]>([])
   const [draft, setDraft] = useState<Record<string, string>>({})
+  const [consoleDraft, setConsoleDraft] = useState<Record<string, string>>({})
   const [busy, setBusy] = useState<string | null>(null)
   const [notice, setNotice] = useState<{ kind: 'ok' | 'warn' | 'err'; text: string } | null>(null)
   const [itemTemplate, setItemTemplate] = useState('')
@@ -343,6 +350,13 @@ export function SoloMode() {
     if (!settingsState.data) return
     setDraft(Object.fromEntries(settingsState.data.entries.map(entry => [entry.key, entry.value])))
   }, [settingsState.data])
+
+  useEffect(() => {
+    if (!consoleSettingsState.data) return
+    setConsoleDraft(Object.fromEntries(
+      consoleSettingsState.data.entries.map(entry => [entry.key, entry.value]),
+    ))
+  }, [consoleSettingsState.data])
 
   useEffect(() => {
     const inventories = statusState.data?.inspection?.inventories ?? []
@@ -382,6 +396,14 @@ export function SoloMode() {
     }
     return changed
   }, [draft, settingsState.data])
+  const changedConsoleSettings = useMemo(() => {
+    const changed: Record<string, string> = {}
+    for (const entry of consoleSettingsState.data?.entries ?? []) {
+      const next = consoleDraft[entry.key] ?? ''
+      if (next !== entry.value) changed[entry.key] = next
+    }
+    return changed
+  }, [consoleDraft, consoleSettingsState.data])
 
   const scanPath = async (path: string) => {
     const discovery = await discoverSolo(path)
@@ -433,6 +455,7 @@ export function SoloMode() {
       await statusState.refresh()
       await runtimeState.refresh()
       await settingsState.refresh()
+      await consoleSettingsState.refresh()
       await backupsState.refresh()
     } catch (error) {
       setNotice({ kind: 'err', text: error instanceof Error ? error.message : String(error) })
@@ -452,6 +475,7 @@ export function SoloMode() {
       setNotice({ kind: 'err', text: 'Connect and validate the selected Solo profile before applying settings.' })
       return
     }
+
     if (gameRunning) {
       setNotice({ kind: 'err', text: 'Close Dune: Awakening completely before applying Solo settings.' })
       return
@@ -473,6 +497,40 @@ export function SoloMode() {
       await settingsState.refresh()
       await statusState.refresh()
       await runtimeState.refresh()
+    } catch (error) {
+      setNotice({ kind: 'err', text: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const saveConsoleSettings = async () => {
+    if (!selectionMatchesActive) {
+      setNotice({ kind: 'err', text: 'Connect and validate the selected PTC Solo profile before applying Engine.ini settings.' })
+      return
+    }
+    if (gameRunning) {
+      setNotice({ kind: 'err', text: 'Close Dune: Awakening completely before applying PTC Engine.ini settings.' })
+      return
+    }
+    if (Object.keys(changedConsoleSettings).length === 0) return
+    if (!window.confirm(
+      `Apply ${Object.keys(changedConsoleSettings).length} PTC Solo Engine.ini setting(s)?\n\n`
+      + 'PTC must be fully closed. DST will retain Engine.ini, write only the two allowlisted ConsoleVariables, and verify the result.',
+    )) return
+
+    setBusy('console-settings')
+    setNotice(null)
+    try {
+      const result = await saveSoloConsoleSettings(
+        changedConsoleSettings,
+        statusState.data?.profileToken ?? '',
+      )
+      setNotice({
+        kind: 'ok',
+        text: `PTC Solo Engine.ini settings applied and verified. Previous file retained at ${result.backupPath}`,
+      })
+      await Promise.all([consoleSettingsState.refresh(), runtimeState.refresh()])
     } catch (error) {
       setNotice({ kind: 'err', text: error instanceof Error ? error.message : String(error) })
     } finally {
@@ -998,6 +1056,79 @@ export function SoloMode() {
             <div className="card p-5 text-sm text-text-muted">Loading Solo settings...</div>
           ) : (
             <>
+              <CollapsibleCard id="solo-settings-ptc-engine" title="PTC Engine settings" icon="Gauge">
+                {!consoleSettingsState.data ? (
+                  <div className="text-sm text-text-muted">Loading PTC Engine.ini settings...</div>
+                ) : !consoleSettingsState.data.supported ? (
+                  <div className="rounded border border-warning/30 bg-warning/5 p-3 text-sm text-text-muted">
+                    These controls are available only for the verified PTC <span className="font-mono">FLS_beta</span> profile. Retail folder structure is not assumed.
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    <div className="rounded border border-warning/30 bg-warning/5 p-3 text-xs text-text-muted">
+                      Writes only <span className="font-mono">Config\Windows\Engine.ini</span> under the connected PTC Solo root. Sun Exposure uses the observed PTC key but still needs Solo field confirmation.
+                    </div>
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                      {consoleSettingsState.data.entries.map(entry => (
+                        <label key={entry.key} className="block rounded border border-border bg-surface-2/40 p-3">
+                          <span className="flex items-center justify-between gap-2 text-xs text-text-muted">
+                            <span>{entry.label}</span>
+                            <span className={entry.status === 'Confirmed' ? 'text-success' : 'text-warning'}>
+                              {entry.status}
+                            </span>
+                          </span>
+                          {entry.type === 'bool01' ? (
+                            <select
+                              className={`${SOLO_INPUT_CLASS} mt-2`}
+                              style={{ colorScheme: 'dark' }}
+                              value={consoleDraft[entry.key] ?? entry.value}
+                              onChange={event => setConsoleDraft(current => ({
+                                ...current,
+                                [entry.key]: event.target.value,
+                              }))}
+                              disabled={!canMutateActiveProfile || gameRunning}
+                            >
+                              <option value="1">Enabled</option>
+                              <option value="0">Disabled</option>
+                            </select>
+                          ) : (
+                            <input
+                              type="number"
+                              min={entry.min ?? undefined}
+                              max={entry.max ?? undefined}
+                              className={`${SOLO_INPUT_CLASS} mt-2 font-mono`}
+                              value={consoleDraft[entry.key] ?? entry.value}
+                              onChange={event => setConsoleDraft(current => ({
+                                ...current,
+                                [entry.key]: event.target.value,
+                              }))}
+                              disabled={!canMutateActiveProfile || gameRunning}
+                            />
+                          )}
+                          <span className="block text-[11px] text-text-dim mt-2">{entry.help}</span>
+                          <span className="block text-[10px] font-mono text-text-dim mt-1">{entry.key}</span>
+                        </label>
+                      ))}
+                    </div>
+                    <button
+                      className={`btn-primary w-full justify-center ${SOLO_DISABLED_PRIMARY_CLASS}`}
+                      onClick={() => void saveConsoleSettings()}
+                      disabled={
+                        !canMutateActiveProfile
+                        || gameRunning
+                        || Object.keys(changedConsoleSettings).length === 0
+                      }
+                    >
+                      <Icon
+                        name={busy === 'console-settings' ? 'LoaderCircle' : 'Save'}
+                        size={14}
+                        className={busy === 'console-settings' ? 'animate-spin' : ''}
+                      />
+                      Apply PTC Engine settings
+                    </button>
+                  </div>
+                )}
+              </CollapsibleCard>
               {SETTING_GROUPS.map(group => (
                 <CollapsibleCard key={group.title} id={`solo-settings-${group.title.toLowerCase().replaceAll(' ', '-')}`} title={group.title} icon="SlidersHorizontal">
                   <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -375,6 +375,10 @@ export function SoloMode() {
   }, [backupsState.data?.backups])
 
   useEffect(() => {
+    setSelectedBackupPaths(new Set())
+  }, [statusState.data?.profileToken])
+
+  useEffect(() => {
     if (!consoleSettingsState.data) return
     setConsoleDraft(Object.fromEntries(
       consoleSettingsState.data.entries.map(entry => [entry.key, entry.value]),
@@ -657,10 +661,10 @@ export function SoloMode() {
       )
       setSelectedBackupPaths(new Set())
       setNotice({ kind: 'ok', text: `Deleted ${result.deletedCount} Solo backup(s).` })
-      await backupsState.refresh()
     } catch (error) {
       setNotice({ kind: 'err', text: error instanceof Error ? error.message : String(error) })
     } finally {
+      await backupsState.refresh()
       setBusy(null)
     }
   }

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -195,13 +195,28 @@ export function getSoloCosmeticBackpackDestination(
   return inventories.find(inventory => inventory.kind === 'backpack')?.key ?? ''
 }
 
-function SoloCosmeticGrantCard({
+export function buildSoloCosmeticGrant(
+  templateId: string,
+  inventories: SoloInventoryDestination[],
+): {
+  destination: string
+  items: Array<{ templateId: string; quantity: number; quality: number }>
+} {
+  return {
+    destination: getSoloCosmeticBackpackDestination(inventories),
+    items: [{ templateId, quantity: 1, quality: 0 }],
+  }
+}
+
+export function SoloCosmeticGrantCard({
   busy,
   disabled,
+  loadCatalog = getCosmeticsCatalog,
   onGrant,
 }: {
   busy: boolean
   disabled: boolean
+  loadCatalog?: () => Promise<CosmeticEntry[]>
   onGrant: (templateId: string, label: string) => Promise<void>
 }) {
   const [catalog, setCatalog] = useState<CosmeticEntry[] | null>(null)
@@ -211,7 +226,7 @@ function SoloCosmeticGrantCard({
 
   useEffect(() => {
     let active = true
-    getCosmeticsCatalog()
+    loadCatalog()
       .then(entries => {
         if (active) setCatalog(entries)
       })
@@ -219,11 +234,11 @@ function SoloCosmeticGrantCard({
         if (active) setCatalogError(error instanceof Error ? error.message : String(error))
       })
     return () => { active = false }
-  }, [])
+  }, [loadCatalog])
 
   const groups = useMemo(() => groupSoloCosmetics(catalog ?? [], query), [catalog, query])
   const matches = useMemo(() => groups.flatMap(([, entries]) => entries), [groups])
-  const chosen = catalog?.find(entry => entry.template === selected)
+  const chosen = matches.find(entry => entry.template === selected)
   const controlsDisabled = disabled || busy
 
   return (
@@ -1309,11 +1324,11 @@ export function SoloMode() {
                 || !inspection?.inventories.some(inventory => inventory.kind === 'backpack')
               }
               onGrant={async (templateId, label) => {
-                const backpack = getSoloCosmeticBackpackDestination(inspection?.inventories ?? [])
+                const grant = buildSoloCosmeticGrant(templateId, inspection?.inventories ?? [])
                 await giveSoloItems(
-                  [{ templateId, quantity: 1, quality: 0 }],
+                  grant.items,
                   label,
-                  backpack,
+                  grant.destination,
                   'Solo backpack',
                 )
               }}

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -20,14 +20,18 @@ import {
   maxSoloSpecializations,
   type SoloBackup,
   type SoloBackupsResponse,
+  type SoloInventoryDestination,
   type SoloProfile,
   type SoloRuntime,
   type SoloSettingsResponse,
   type SoloStatus,
 } from '../api/solo'
 import {
+  filterCosmeticsCatalog,
+  getCosmeticsCatalog,
   getVehicleKitCatalog,
   type CatalogItem,
+  type CosmeticEntry,
   type VehicleKitCatalog,
 } from '../api/gameplay'
 import { pickLocalFolder } from '../util/pathPicker'
@@ -166,6 +170,117 @@ function StatusPill({ ok, children }: { ok: boolean; children: React.ReactNode }
       <span className={`w-1.5 h-1.5 rounded-full ${ok ? 'bg-success' : 'bg-warning'}`} />
       {children}
     </span>
+  )
+}
+
+export const SOLO_COSMETIC_ENTITLEMENT_WARNING =
+  'Grants apply only to this Solo save. They do not create Funcom account ownership or unlock content on official servers.'
+
+export function groupSoloCosmetics(
+  catalog: CosmeticEntry[],
+  query: string,
+): Array<[string, CosmeticEntry[]]> {
+  const groups = new Map<string, CosmeticEntry[]>()
+  for (const entry of filterCosmeticsCatalog(catalog, query)) {
+    const current = groups.get(entry.group)
+    if (current) current.push(entry)
+    else groups.set(entry.group, [entry])
+  }
+  return Array.from(groups.entries()).sort(([left], [right]) => left.localeCompare(right))
+}
+
+export function getSoloCosmeticBackpackDestination(
+  inventories: SoloInventoryDestination[],
+): string {
+  return inventories.find(inventory => inventory.kind === 'backpack')?.key ?? ''
+}
+
+function SoloCosmeticGrantCard({
+  busy,
+  disabled,
+  onGrant,
+}: {
+  busy: boolean
+  disabled: boolean
+  onGrant: (templateId: string, label: string) => Promise<void>
+}) {
+  const [catalog, setCatalog] = useState<CosmeticEntry[] | null>(null)
+  const [catalogError, setCatalogError] = useState('')
+  const [query, setQuery] = useState('')
+  const [selected, setSelected] = useState('')
+
+  useEffect(() => {
+    let active = true
+    getCosmeticsCatalog()
+      .then(entries => {
+        if (active) setCatalog(entries)
+      })
+      .catch(error => {
+        if (active) setCatalogError(error instanceof Error ? error.message : String(error))
+      })
+    return () => { active = false }
+  }, [])
+
+  const groups = useMemo(() => groupSoloCosmetics(catalog ?? [], query), [catalog, query])
+  const matches = useMemo(() => groups.flatMap(([, entries]) => entries), [groups])
+  const chosen = catalog?.find(entry => entry.template === selected)
+  const controlsDisabled = disabled || busy
+
+  return (
+    <div className="card p-5 xl:col-span-2">
+      <h3 className="font-semibold mb-1">Grant Cosmetic / Building Set</h3>
+      <p className="text-xs text-text-muted mb-4">
+        Delivers one unlock item to the Solo backpack for processing on next login.
+      </p>
+      <div className="rounded border border-warning/30 bg-warning/5 p-3 mb-4 text-xs text-text-muted">
+        {SOLO_COSMETIC_ENTITLEMENT_WARNING} Some developer or entitlement entries may remain ordinary inventory items and do nothing. Owned-state detection is not available for Solo yet, so the full catalog is shown and duplicate grants are possible.
+      </div>
+      {catalogError ? (
+        <div className="text-xs text-danger">Cosmetics catalog failed to load: {catalogError}</div>
+      ) : !catalog ? (
+        <div className="text-xs text-text-dim flex items-center gap-2">
+          <Icon name="LoaderCircle" size={13} className="animate-spin" /> Loading cosmetics catalog...
+        </div>
+      ) : (
+        <>
+          <input
+            type="text"
+            value={query}
+            disabled={controlsDisabled}
+            placeholder="Search name, template id, or group"
+            onChange={event => setQuery(event.target.value)}
+            className={SOLO_INPUT_CLASS}
+          />
+          <select
+            value={selected}
+            disabled={controlsDisabled}
+            onChange={event => setSelected(event.target.value)}
+            className={`${SOLO_INPUT_CLASS} mt-3`}
+            style={{ colorScheme: 'dark' }}
+          >
+            <option value="">Choose a cosmetic or building set... ({matches.length})</option>
+            {groups.map(([group, entries]) => (
+              <optgroup key={group} label={`${group} (${entries.length})`}>
+                {entries.map(entry => (
+                  <option key={entry.template} value={entry.template}>{entry.name}</option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+          {chosen && <p className="text-[11px] font-mono text-text-dim truncate mt-2">{chosen.template}</p>}
+          <button
+            className={`btn-primary w-full mt-4 justify-center ${SOLO_DISABLED_PRIMARY_CLASS}`}
+            disabled={controlsDisabled || !chosen}
+            onClick={() => {
+              if (chosen) void onGrant(chosen.template, chosen.name)
+            }}
+          >
+            <Icon name={busy ? 'LoaderCircle' : 'Shirt'} size={14} className={busy ? 'animate-spin' : ''} />
+            Grant unlock
+          </button>
+        </>
+      )}
+    </div>
   )
 }
 
@@ -420,6 +535,8 @@ export function SoloMode() {
   const giveSoloItems = async (
     items: Array<{ templateId: string; quantity: number; quality: number }>,
     label: string,
+    destination = inventoryDestination,
+    targetLabel = 'selected Solo inventory',
   ) => {
     if (!selectionMatchesActive) {
       setNotice({ kind: 'err', text: 'Connect and validate the selected Solo profile before giving items.' })
@@ -429,12 +546,12 @@ export function SoloMode() {
       setNotice({ kind: 'err', text: 'Close Dune: Awakening completely before giving Solo items.' })
       return
     }
-    if (!inventoryDestination) {
+    if (!destination) {
       setNotice({ kind: 'err', text: 'Choose a backpack or Developer Storage destination.' })
       return
     }
     if (!window.confirm(
-      `Give ${label} to the selected Solo inventory?\n\n`
+      `Give ${label} to the ${targetLabel}?\n\n`
       + 'Dune: Awakening must be fully closed. DST will retain the current game.db, '
       + 'apply the item grant transactionally, run integrity and foreign-key checks, '
       + 'replace the save atomically, and verify the result.',
@@ -444,7 +561,7 @@ export function SoloMode() {
     setNotice(null)
     try {
       const result = await grantSoloItems(
-        inventoryDestination,
+        destination,
         items,
         statusState.data?.profileToken ?? '',
       )
@@ -1183,6 +1300,24 @@ export function SoloMode() {
                 Give vehicle kit
               </button>
             </div>
+
+            <SoloCosmeticGrantCard
+              busy={busy === 'give-items'}
+              disabled={
+                !canMutateActiveProfile
+                || gameRunning
+                || !inspection?.inventories.some(inventory => inventory.kind === 'backpack')
+              }
+              onGrant={async (templateId, label) => {
+                const backpack = getSoloCosmeticBackpackDestination(inspection?.inventories ?? [])
+                await giveSoloItems(
+                  [{ templateId, quantity: 1, quality: 0 }],
+                  label,
+                  backpack,
+                  'Solo backpack',
+                )
+              }}
+            />
 
             <div className="card p-5 xl:col-span-2">
               <h3 className="font-semibold mb-1">Max Augment Attributes</h3>

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -1057,7 +1057,18 @@ export function SoloMode() {
           ) : (
             <>
               <CollapsibleCard id="solo-settings-ptc-engine" title="PTC Engine settings" icon="Gauge">
-                {!consoleSettingsState.data ? (
+                {consoleSettingsState.error ? (
+                  <div className="rounded border border-danger/30 bg-danger/5 p-3 text-sm text-danger">
+                    <div>Could not load PTC Engine.ini settings: {consoleSettingsState.error}</div>
+                    <button
+                      className="btn-secondary mt-3"
+                      onClick={() => void consoleSettingsState.refresh()}
+                      disabled={consoleSettingsState.loading}
+                    >
+                      Retry
+                    </button>
+                  </div>
+                ) : !consoleSettingsState.data ? (
                   <div className="text-sm text-text-muted">Loading PTC Engine.ini settings...</div>
                 ) : !consoleSettingsState.data.supported ? (
                   <div className="rounded border border-warning/30 bg-warning/5 p-3 text-sm text-text-muted">

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -1342,7 +1342,7 @@ export function SoloMode() {
       )}
       {tab === 'inventory' && (
         <div className="space-y-4">
-          <div className="card p-5">
+          <div className="card p-5 sticky top-0 z-20 bg-surface/95 backdrop-blur-sm shadow-lg">
             <div className="flex items-start justify-between gap-4 mb-4">
               <div>
                 <h2 className="font-semibold flex items-center gap-2">
@@ -1369,6 +1369,7 @@ export function SoloMode() {
                   style={{ colorScheme: 'dark' }}
                   value={inventoryDestination}
                   onChange={event => setInventoryDestination(event.target.value)}
+                  onWheel={event => event.currentTarget.blur()}
                   disabled={busy !== null}
                 >
                   {inspection!.inventories.map(inventory => (

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -619,7 +619,6 @@ export function SoloMode() {
       setNotice({ kind: 'err', text: 'Choose a vehicle kit with deliverable parts.' })
       return
     }
-
     const templates = [...kit.kit, ...kit.unique, vehicleKits!.fuelTemplate, vehicleKits!.torchTemplate]
     const uniqueTemplates = [...new Set(templates)]
     await giveSoloItems(
@@ -1308,7 +1307,7 @@ export function SoloMode() {
                 </select>
               </label>
               <div className="rounded border border-border bg-surface-2/50 p-3 mt-4 text-xs text-text-muted">
-                Kit contents come from DST's versioned vehicle catalog. Large kits should go to Developer Storage rather than the backpack.
+                Kit contents come from DST's versioned vehicle catalog. Each non-stackable part needs a free slot; DST checks current contents before writing. If the package is not delivered, check the selected destination's free slots and volume.
               </div>
               <button
                 className={`btn-primary w-full mt-4 justify-center ${SOLO_DISABLED_PRIMARY_CLASS}`}

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -3,6 +3,7 @@ import { Icon } from '../components/Icon'
 import { PageHeader } from '../components/PageHeader'
 import { CollapsibleCard } from '../components/CollapsibleCard'
 import { ItemPicker } from '../components/ItemPicker'
+import { GivePackageForm } from './gameplay/players/sections'
 import { useApi } from '../hooks/useApi'
 import {
   connectSolo,
@@ -34,6 +35,7 @@ import {
   getVehicleKitCatalog,
   type CatalogItem,
   type CosmeticEntry,
+  type GiveItemEntry,
   type VehicleKitCatalog,
 } from '../api/gameplay'
 import { pickLocalFolder } from '../util/pathPicker'
@@ -216,6 +218,16 @@ export function buildSoloCosmeticGrant(
     destination: getSoloCosmeticBackpackDestination(inventories),
     items: [{ templateId, quantity: 1, quality: 0 }],
   }
+}
+
+export function buildSoloPackageGrant(
+  items: GiveItemEntry[],
+): Array<{ templateId: string; quantity: number; quality: number }> {
+  return items.map(item => ({
+    templateId: item.template,
+    quantity: item.qty,
+    quality: item.quality ?? 0,
+  }))
 }
 
 export function SoloCosmeticGrantCard({
@@ -1499,8 +1511,23 @@ export function SoloMode() {
             </div>
           </div>
 
-          <div className="rounded border border-border bg-surface-2/40 px-4 py-3 text-xs text-text-muted">
-            Saved multi-item packages are not enabled yet. They will use this same backup-safe transaction path before joining a future Solo preview build.
+          <div className="card p-5">
+            <h3 className="font-semibold mb-1">Give Package</h3>
+            <p className="text-xs text-text-muted mb-4">
+              Create, import, edit, delete, and grant the same saved packages used elsewhere in DST. Package management does not require Self-Hosted setup.
+            </p>
+            <GivePackageForm
+              busy={busy !== null}
+              giveDisabled={!canMutateActiveProfile || gameRunning}
+              targetLabel="selected Solo inventory"
+              showOverflow={false}
+              onGive={(items, packageName) => {
+                void giveSoloItems(
+                  buildSoloPackageGrant(items),
+                  `${packageName} package`,
+                )
+              }}
+            />
           </div>
         </div>
       )}

--- a/webui/src/pages/gameplay/ChatCommandsCard.tsx
+++ b/webui/src/pages/gameplay/ChatCommandsCard.tsx
@@ -427,12 +427,21 @@ export function ChatCommandsCard() {
                 <div className="mt-3 rounded border border-border bg-surface/50 p-3">
                   <div className="text-[11px] text-text-muted">
                     Shared destinations are stored only on this DST PC. Use
-                    <strong> Save location</strong> for normal areas. If that location returns
+                    <strong> Save location</strong> after standing still at the destination for
+                    about five seconds. If rapid travel leaves that location stale or returns
                     to a map opening point (observed in Hagga South), use
                     <strong> Arm live capture</strong>; the selected player then types the
                     one-time command at the destination. Teleports remain limited to the
                     same map, partition and dimension. Replies and <code>!tp list</code> are
                     public server broadcasts.
+                  </div>
+                  <div className="mt-2 text-[11px] text-warning">
+                    This uses Funcom&apos;s internal developer teleport command, not a normal
+                    player-travel system. Safe-surface replay is field-proven, but long-term
+                    engine behavior is not documented, so DST intentionally avoids speculative
+                    watchdogs around it. If vehicle arrival matters, save while mounted and
+                    teleport from the driver position; passenger, gunner and cutteray seats
+                    have failed back to the origin in testing.
                   </div>
                   <div className="mt-3 grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
                     <select

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -1533,8 +1533,9 @@ function OverflowToggle({ checked, disabled, onChange }: {
 // form owns two modes — a give/list view and an inline create/edit editor.
 interface PkgDraftRow { template: string; name: string; qty: string; quality: string }
 
-export function GivePackageForm({ busy, playerName, targetLabel, showOverflow = true, onGive }: {
+export function GivePackageForm({ busy, giveDisabled = false, playerName, targetLabel, showOverflow = true, onGive }: {
   busy: boolean
+  giveDisabled?: boolean
   playerName?: string
   targetLabel?: string
   showOverflow?: boolean
@@ -1779,7 +1780,7 @@ export function GivePackageForm({ busy, playerName, targetLabel, showOverflow = 
       {err && <div className="text-xs text-error">{err}</div>}
       {showOverflow && selected && <OverflowToggle checked={overflow} disabled={busy || saving} onChange={setOverflow} />}
       {selected && (
-        <button className="btn-primary w-full" disabled={busy || saving}
+        <button className="btn-primary w-full" disabled={busy || saving || giveDisabled}
           onClick={() => onGive(selected.items, selected.name, overflow)}>
           {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Check" size={13} />} Give to {giveLabel}
         </button>

--- a/webui/tests/components/SoloCosmeticGrantCard.test.tsx
+++ b/webui/tests/components/SoloCosmeticGrantCard.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  SoloCosmeticGrantCard,
+} from '../../src/pages/SoloMode'
+import type { CosmeticEntry } from '../../src/api/gameplay'
+
+const catalog: CosmeticEntry[] = [
+  { template: 'DesertSwatch', name: 'Desert Dye', group: 'Swatches (Dyes)' },
+  { template: 'ScoutSetVariant', name: 'Scout Set', group: 'Armor & Suit Sets' },
+]
+
+afterEach(cleanup)
+
+describe('SoloCosmeticGrantCard', () => {
+  it('grants the visible selection and disables a selection hidden by filtering', async () => {
+    const user = userEvent.setup()
+    const onGrant = vi.fn(async () => {})
+    render(
+      <SoloCosmeticGrantCard
+        busy={false}
+        disabled={false}
+        loadCatalog={async () => catalog}
+        onGrant={onGrant}
+      />,
+    )
+
+    const picker = await screen.findByRole('combobox')
+    const search = screen.getByRole('textbox')
+    const grant = screen.getByRole('button', { name: 'Grant unlock' })
+
+    await user.selectOptions(picker, 'ScoutSetVariant')
+    await user.click(grant)
+    expect(onGrant).toHaveBeenCalledWith('ScoutSetVariant', 'Scout Set')
+
+    await user.type(search, 'desert')
+    await waitFor(() => expect(grant).toBeDisabled())
+  })
+})

--- a/webui/tests/soloCosmetics.test.ts
+++ b/webui/tests/soloCosmetics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildSoloCosmeticGrant,
+  getPreferredSoloInventoryDestination,
   getSoloCosmeticBackpackDestination,
   groupSoloCosmetics,
   SOLO_COSMETIC_ENTITLEMENT_WARNING,
@@ -64,5 +65,6 @@ describe('Solo cosmetic grants', () => {
       destination: 'inventory:1',
       items: [{ templateId: 'ScoutSetVariant', quantity: 1, quality: 0 }],
     })
+    expect(getPreferredSoloInventoryDestination([...inventories])).toBe('inventory:1')
   })
 })

--- a/webui/tests/soloCosmetics.test.ts
+++ b/webui/tests/soloCosmetics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildSoloCosmeticGrant,
+  buildSoloPackageGrant,
   getPreferredSoloInventoryDestination,
   getSoloCosmeticBackpackDestination,
   groupSoloCosmetics,
@@ -66,5 +67,15 @@ describe('Solo cosmetic grants', () => {
       items: [{ templateId: 'ScoutSetVariant', quantity: 1, quality: 0 }],
     })
     expect(getPreferredSoloInventoryDestination([...inventories])).toBe('inventory:1')
+  })
+
+  it('maps canonical DST package rows into the Solo grant payload', () => {
+    expect(buildSoloPackageGrant([
+      { template: 'CopperBar', qty: 20, quality: 0 },
+      { template: 'RepairTool5', qty: 1, quality: 5 },
+    ])).toEqual([
+      { templateId: 'CopperBar', quantity: 20, quality: 0 },
+      { templateId: 'RepairTool5', quantity: 1, quality: 5 },
+    ])
   })
 })

--- a/webui/tests/soloCosmetics.test.ts
+++ b/webui/tests/soloCosmetics.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getSoloCosmeticBackpackDestination,
+  groupSoloCosmetics,
+  SOLO_COSMETIC_ENTITLEMENT_WARNING,
+} from '../src/pages/SoloMode'
+import type { CosmeticEntry } from '../src/api/gameplay'
+
+const catalog: CosmeticEntry[] = [
+  { template: 'DesertSwatch', name: 'Desert Dye', group: 'Swatches (Dyes)' },
+  { template: 'ScoutSetVariant', name: 'Scout Set', group: 'Armor & Suit Sets' },
+  { template: 'ObserverPatent', name: 'Observer Patent', group: 'Building Sets - Observer (Twitch)' },
+]
+
+describe('Solo cosmetic grants', () => {
+  it('filters and groups the shared cosmetics catalog', () => {
+    const groups = groupSoloCosmetics(catalog, 'scout')
+
+    expect(groups).toEqual([
+      ['Armor & Suit Sets', [catalog[1]]],
+    ])
+  })
+
+  it('sorts matching groups for a stable picker', () => {
+    expect(groupSoloCosmetics(catalog, '').map(([group]) => group)).toEqual([
+      'Armor & Suit Sets',
+      'Building Sets - Observer (Twitch)',
+      'Swatches (Dyes)',
+    ])
+  })
+
+  it('states that grants do not create account ownership', () => {
+    expect(SOLO_COSMETIC_ENTITLEMENT_WARNING).toContain('only to this Solo save')
+    expect(SOLO_COSMETIC_ENTITLEMENT_WARNING).toContain('do not create Funcom account ownership')
+  })
+
+  it('forces unlock delivery to the backpack instead of Developer Storage', () => {
+    expect(getSoloCosmeticBackpackDestination([
+      {
+        id: 2,
+        key: 'inventory:2',
+        label: 'Developer Storage',
+        kind: 'developer-storage',
+        itemRows: 0,
+        maxItemCount: 100,
+        maxItemVolume: 0,
+        usedVolume: 0,
+      },
+      {
+        id: 1,
+        key: 'inventory:1',
+        label: 'Backpack',
+        kind: 'backpack',
+        itemRows: 5,
+        maxItemCount: 35,
+        maxItemVolume: 1000,
+        usedVolume: 100,
+      },
+    ])).toBe('inventory:1')
+  })
+})

--- a/webui/tests/soloCosmetics.test.ts
+++ b/webui/tests/soloCosmetics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildSoloCosmeticGrant,
   getSoloCosmeticBackpackDestination,
   groupSoloCosmetics,
   SOLO_COSMETIC_ENTITLEMENT_WARNING,
@@ -35,7 +36,7 @@ describe('Solo cosmetic grants', () => {
   })
 
   it('forces unlock delivery to the backpack instead of Developer Storage', () => {
-    expect(getSoloCosmeticBackpackDestination([
+    const inventories = [
       {
         id: 2,
         key: 'inventory:2',
@@ -56,6 +57,12 @@ describe('Solo cosmetic grants', () => {
         maxItemVolume: 1000,
         usedVolume: 100,
       },
-    ])).toBe('inventory:1')
+    ] as const
+
+    expect(getSoloCosmeticBackpackDestination([...inventories])).toBe('inventory:1')
+    expect(buildSoloCosmeticGrant('ScoutSetVariant', [...inventories])).toEqual({
+      destination: 'inventory:1',
+      items: [{ templateId: 'ScoutSetVariant', quantity: 1, quality: 0 }],
+    })
   })
 })


### PR DESCRIPTION
## Summary
- prepare the branch for stable `v13.8.0`, including all five synchronized version stamps, changelog, and refreshed bug-report diagnostics
- add Solo cosmetic/building-set grants and canonical package CRUD/import/grant
- default delivery to backpack; support exact five built storage types; exclude holograms at discovery/write time
- keep destination selector sticky and protected from wheel changes
- fix vehicle-kit volume fallbacks and UTF-8 catalog decoding
- add three field-confirmed PTC controls mirrored to both observed Engine files: `Config\Windows\Engine.ini` and `Config\WindowsClient\Engine.ini`
- retain, atomically update, and verify both Engine files without guessing retail layout
- add multi-select Solo backup deletion with select-all/clear, one confirmation, complete pre-validation, staged rollback, reparse protection, and exact partial-cleanup reporting
- expand shared teleport guidance with five-second direct-save settling, live-capture fallback, vehicle driver-seat limits, and the boundary against speculative watchdogs around Funcom's undocumented developer command

## Validation
- DuneSoloDb self-test covers storage allowlist, hologram rejection, stock backpack vehicle grants, wrapper/integrity/FK semantics
- focused SoloMode + route Pester: 61 passed
- focused Solo Vitest: 19 passed
- WebUI production build passed
- full `v13.8.0` installer build passed: 76.81 MiB
- staged release-prep diff passed Gitleaks with no findings
- release diff review found no remaining blockers
- all GitHub checks passed on `5099495010638fd01535dcb673d787c9d54c58ee`

## Field-confirmed in PTC
- cosmetics and building-set grants
- package create, edit, import, delete, and grant
- backpack-first and built-storage delivery, with holograms excluded
- vehicle-kit delivery into a fresh backpack
- Sun Exposure
- Maximum Vehicles Per Player
- Shield Drops While Shooting
- multi-select backup deletion
- shared teleport direct-save, live-capture, and vehicle-seat behavior
- `v13.8.0` installer upgrade, launch, and version display

Some developer/entitlement cosmetic entries may remain inventory items and do nothing.