### PR TITLE
Correct seed 2 cave locations for v13.8.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,7 +76,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.8.0"
+      placeholder: "v13.8.1"
     validations:
       required: true
 
@@ -121,7 +121,7 @@ body:
         - Web portal — Gameplay Admin — Storage
         - Web portal — Gameplay Admin — Blueprints (incl. Blueprint Designer link)
         - Web portal — DD Seed Maps (Deep Desert per-seed POI maps)
-        - Web portal — DD Seed Maps — wrong or missing POI / layout data for a seed
+        - Web portal — DD Seed Maps — wrong or missing POI / cave sector / layout data for a seed
         - Web portal — Solo Mode — connection / wrapper or schema validation / process lock
         - Web portal — Solo Mode — native and Engine settings (load / apply / retained INI backup)
         - Web portal — Solo Mode — Give Item / Vehicle Kit / Package / Cosmetics / backpack or built-storage delivery
@@ -158,8 +158,8 @@ body:
     id: menu_option
     attributes:
       label: Specific page / button / command
-      description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug? For in-game commands, include the exact `!command`, chat channel, monitoring interval, cooldown, whether any broadcast appeared, and whether it used the character name. For shared teleport destinations, include direct Save location vs Arm live capture, whether the player paused about five seconds, and whether they teleported on foot or from a vehicle seat. For scheduled Funcom updates, include the scheduled time, whether Apply available Funcom server updates was enabled, installed/latest build IDs, and the last schedule result. For Specs > Apply level, include the track, before/after level, and before/after unspent skill points. For Reset Journey, include whether the post-NPE story restarted at Find the Fremen, which starter-class tree was reset, and how many skill points were refunded. For an Experimental Lab control, include its exact CVar or INI key, source/risk badge, file and section, and whether local Engine.ini management was enabled. For Solo Mode, include the adapter, wrapper/schema status, whether the game was fully closed, and the exact connection/settings/inventory/package/cosmetic/backup/restore step. For a database migration, name the failing step.
-      placeholder: "e.g. Solo Mode > Inventory > Give Package, Solo Mode > Backups > Delete selected, Gameplay Admin > Overview > In-game commands > Save location, Server Health > Scheduled restarts > Save schedule, Settings > Public IP / DDNS > Apply public IP, Game Config > bottom bar > Apply INIs & restart, Gameplay Admin > Players > Specs > Apply level, DD Seed Maps > seed selector, Database > backup file > Restore, Help > Create GitHub Issue, or CLI -Cmd startup"
+      description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug? For in-game commands, include the exact `!command`, chat channel, monitoring interval, cooldown, whether any broadcast appeared, and whether it used the character name. For shared teleport destinations, include direct Save location vs Arm live capture, whether the player paused about five seconds, and whether they teleported on foot or from a vehicle seat. For scheduled Funcom updates, include the scheduled time, whether Apply available Funcom server updates was enabled, installed/latest build IDs, and the last schedule result. For Specs > Apply level, include the track, before/after level, and before/after unspent skill points. For Reset Journey, include whether the post-NPE story restarted at Find the Fremen, which starter-class tree was reset, and how many skill points were refunded. For DD Seed Maps, include the selected seed, POI type, displayed sector(s), and a current reference screenshot or link when possible. For an Experimental Lab control, include its exact CVar or INI key, source/risk badge, file and section, and whether local Engine.ini management was enabled. For Solo Mode, include the adapter, wrapper/schema status, whether the game was fully closed, and the exact connection/settings/inventory/package/cosmetic/backup/restore step. For a database migration, name the failing step.
+      placeholder: "e.g. DD Seed Maps > seed 2 > Cave sectors, Solo Mode > Inventory > Give Package, Solo Mode > Backups > Delete selected, Gameplay Admin > Overview > In-game commands > Save location, Server Health > Scheduled restarts > Save schedule, Settings > Public IP / DDNS > Apply public IP, Game Config > bottom bar > Apply INIs & restart, Gameplay Admin > Players > Specs > Apply level, Database > backup file > Restore, Help > Create GitHub Issue, or CLI -Cmd startup"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.8.1] - 2026-08-18
+
+### Fixed
+
+- Corrected the DD Seed Maps cave locations for seed 2 to match the current
+  live map: I1, H2, H5, G5 (two caves), and E9.
+
 ## [13.8.0] - 2026-08-18
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.8.0'
+$script:DuneToolVersion = '13.8.1'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.8.0',
+    [string]$Version = '13.8.1',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.8.0</Version>
+    <Version>13.8.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.8.0"
+#define MyAppVersion "13.8.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.8.0"
+$script:ToolVersion = "13.8.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/data/wickmaps.json
+++ b/webui/src/data/wickmaps.json
@@ -629,7 +629,7 @@
    "seed": 2,
    "confidence": "CONFIRMED",
    "reliability": "high",
-   "note": "Large spice set matches the reference table exactly.",
+   "note": "Live web map confirmed seed 2 and corrected caves to H2, H5, G5 x2, I1, and E9 on 2026-08-18.",
    "capturedUtc": "20250923015322",
    "image": "dd_seed_02.png",
    "imageSha256Short": null,
@@ -641,7 +641,7 @@
     "I5",
     "I9"
    ],
-   "poiCount": 41,
+   "poiCount": 43,
    "legend": [
     {
      "type": "wreck",
@@ -654,14 +654,14 @@
      "count": 10
     },
     {
-     "type": "large-spice-field",
-     "label": "Large Spice Field",
+     "type": "cave",
+     "label": "Cave",
      "count": 6
     },
     {
-     "type": "cave",
-     "label": "Cave",
-     "count": 4
+     "type": "large-spice-field",
+     "label": "Large Spice Field",
+     "count": 6
     },
     {
      "type": "taxi-service",
@@ -711,6 +711,18 @@
      "type": "large-spice-field"
     },
     {
+     "sector": "H2",
+     "subx": 3,
+     "suby": 2,
+     "type": "cave"
+    },
+    {
+     "sector": "H5",
+     "subx": 3,
+     "suby": 2,
+     "type": "cave"
+    },
+    {
      "sector": "H8",
      "subx": 3,
      "suby": 1,
@@ -729,13 +741,13 @@
      "type": "titanium"
     },
     {
-     "sector": "G6",
+     "sector": "G5",
      "subx": 3,
      "suby": 1,
      "type": "cave"
     },
     {
-     "sector": "G6",
+     "sector": "G5",
      "subx": 3,
      "suby": 2,
      "type": "cave"


### PR DESCRIPTION
## Summary

- Correct seed 2 cave sectors to I1, H2, H5, G5, G5, and E9 while preserving every other POI
- Bump all five version stamps and add the v13.8.1 changelog entry
- Refresh the bug-report template for DD Seed Maps cave reports

## Validation

- WebUI: 156 tests passed
- WebUI production build succeeded
- Full `DuneServerSetup.exe` build succeeded