### PR TITLE
Simplify agent interaction instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,10 +26,11 @@ Apply this in **every session**, unless the maintainer explicitly asks otherwise
   `todos` table (and `todo_deps` for ordering) when that helps you keep track,
   but write the implementation yourself. There is no planner/builder split and
   no separate "executor" role — do not narrate one.
-- **Never spawn child sessions, worktrees, or sub-agents on your own
-  initiative.** The maintainer will ask when he wants one. When he does, it
-  inherits the current session's active model; never select a different model
-  for it.
+- Keep the parent session responsible for implementation, user communication,
+  and approval gates. Use a child or sub-agent only for bounded independent work
+  that genuinely benefits from separate context. It inherits the active model,
+  reports results and questions to the parent, and never asks the maintainer
+  directly.
 
 ## Repository layout
 

--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,8 +1,7 @@
 instructions: |-
-  read instructions to catch up
-  review the discord integrations
-  review recent releases to catch up
-  always popup a clickable box when requesting a response from the user
+  Load the repository instructions before acting.
+  For DST work, use the canonical sync routine to load current status.
+  Ask one question at a time in normal chat with numbered choices so Coastal can reply with the number only.
 automation:
   auto_issue_session: true
   remote_control: true


### PR DESCRIPTION
## Summary
- replace modal-first questions with numbered normal-chat choices
- route DST catch-up through the canonical sync routine
- align bounded helper sessions with parent-owned communication and approvals

## Scope
Instruction-only change. No product behavior or release required.