### PR TITLE
Keep inventory editors open until save succeeds; re-check updates on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ here cover everything those tags shipped.
   so existing server values stay visible and editable; DST never copies or
   deletes either set automatically.
 
+### Fixed
+
+- Inventory stack, durability and water editors now stay open until their save
+  actually succeeds. Previously they closed immediately, so a failed write
+  discarded the entered values and the error appeared without context.
+- The in-app update check now re-runs when the window regains focus, throttled
+  to once every five minutes, so a machine that was asleep or left in the
+  background no longer shows a stale result until the next hourly poll. (#349)
+
 ## [13.8.2] - 2026-08-20
 
 ### Added

--- a/webui/src/hooks/useUpdateCheck.ts
+++ b/webui/src/hooks/useUpdateCheck.ts
@@ -3,6 +3,7 @@ import type { UpdateCheck } from '../api/update'
 import { checkForUpdate } from '../api/update'
 
 const POLL_MS = 60 * 60 * 1000 // 1 hour
+const FOCUS_RECHECK_MS = 5 * 60 * 1000 // don't re-check on focus more than this often
 
 export interface UpdateState {
   data: UpdateCheck | null
@@ -18,8 +19,11 @@ export interface UpdateState {
 // Previously each call kept its own isolated useState, so a forced "Check now"
 // on the Settings page updated only that component's copy while the global
 // UpdateBanner kept its own stale result and stayed hidden until a full page
-// reload or the next 6-hour poll. With a shared store, any update found by any
+// reload or the next background poll. With a shared store, any update found by any
 // consumer (or pushed via publishUpdateCheck) surfaces in the banner instantly.
+// The background poll runs hourly, with an additional throttled re-check when
+// the window regains focus so a machine that was asleep or backgrounded doesn't
+// sit on a stale result.
 // ---------------------------------------------------------------------------
 
 interface Snapshot {
@@ -34,6 +38,7 @@ let inflight = false
 let started = false
 let pollId: number | null = null
 let mountCount = 0
+let lastCheckedAt = 0
 
 function emit() {
   for (const l of listeners) l()
@@ -50,6 +55,7 @@ async function run(force = false): Promise<void> {
   setState({ loading: true, error: null })
   try {
     const res = await checkForUpdate({ force })
+    lastCheckedAt = Date.now()
     setState({ data: res })
   } catch (e) {
     setState({ error: e instanceof Error ? e.message : String(e) })
@@ -57,6 +63,16 @@ async function run(force = false): Promise<void> {
     inflight = false
     setState({ loading: false })
   }
+}
+
+// The hourly poll only fires while the window is open and awake; a machine that
+// was asleep, or a window left in the background, can otherwise show a stale
+// result for up to an hour after a release. Re-check when the user comes back,
+// throttled so tabbing in and out doesn't spam the endpoint.
+function onWake(): void {
+  if (document.visibilityState === 'hidden') return
+  if (Date.now() - lastCheckedAt < FOCUS_RECHECK_MS) return
+  void run(false)
 }
 
 // Lets other components (e.g. the Settings update card, which runs its own
@@ -73,12 +89,16 @@ function subscribe(cb: () => void): () => void {
     started = true
     void run(false)
     pollId = window.setInterval(() => { void run(false) }, POLL_MS)
+    window.addEventListener('focus', onWake)
+    document.addEventListener('visibilitychange', onWake)
   }
   return () => {
     listeners.delete(cb)
     mountCount -= 1
     if (mountCount <= 0 && pollId !== null) {
       window.clearInterval(pollId)
+      window.removeEventListener('focus', onWake)
+      document.removeEventListener('visibilitychange', onWake)
       pollId = null
       started = false
       mountCount = 0

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -2478,15 +2478,19 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
     }
   }, [detail])
 
-  const run = async (fn: () => Promise<{ message: string }>, label: string) => {
+  // Returns true only when the write succeeded, so inline editors can stay open
+  // (with their entered values intact) when a save fails.
+  const run = async (fn: () => Promise<{ message: string }>, label: string): Promise<boolean> => {
     setBusy(true)
     try {
       const r = await fn()
       flash(r.message || `${label} done.`, 'ok')
       setTick(t => t + 1)
       onChanged()
+      return true
     } catch (e) {
       flash(e instanceof Error ? e.message : String(e), 'err')
+      return false
     } finally {
       setBusy(false)
     }
@@ -2515,7 +2519,7 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
 
 function ItemList({ title, icon, items, canWrite, busy, run, collapsed, extra, isOnline }: {
   title: string; icon: string; items: InventoryItem[]; canWrite: boolean; busy: boolean
-  run: (fn: () => Promise<{ message: string }>, label: string) => void | Promise<void>
+  run: (fn: () => Promise<{ message: string }>, label: string) => Promise<boolean>
   collapsed?: boolean
   extra?: React.ReactNode
   isOnline: boolean
@@ -2627,7 +2631,7 @@ function ItemList({ title, icon, items, canWrite, busy, run, collapsed, extra, i
 function StackEditor({ item, busy, run, isOnline, onClose }: {
   item: InventoryItem
   busy: boolean
-  run: (fn: () => Promise<{ message: string }>, label: string) => void | Promise<void>
+  run: (fn: () => Promise<{ message: string }>, label: string) => Promise<boolean>
   isOnline: boolean
   onClose: () => void
 }) {
@@ -2664,8 +2668,7 @@ function StackEditor({ item, busy, run, isOnline, onClose }: {
           disabled={busy || !valid}
           onClick={() => {
             if (!valid) return
-            void run(() => setItemStack(item.id, n), 'Save')
-            onClose()
+            void (async () => { if (await run(() => setItemStack(item.id, n), 'Save')) onClose() })()
           }}
         >
           <Icon name="Save" size={12} /> Save
@@ -2683,7 +2686,7 @@ function StackEditor({ item, busy, run, isOnline, onClose }: {
 function DurabilityEditor({ item, busy, run, isOnline, onClose }: {
   item: InventoryItem
   busy: boolean
-  run: (fn: () => Promise<{ message: string }>, label: string) => void | Promise<void>
+  run: (fn: () => Promise<{ message: string }>, label: string) => Promise<boolean>
   isOnline: boolean
   onClose: () => void
 }) {
@@ -2767,8 +2770,9 @@ function DurabilityEditor({ item, busy, run, isOnline, onClose }: {
           disabled={busy || !valid}
           onClick={() => {
             if (!valid) return
-            void run(() => setItemDurability(item.id, mN!, cN!, dN!), 'Save')
-            onClose()
+            void (async () => {
+              if (await run(() => setItemDurability(item.id, mN!, cN!, dN!), 'Save')) onClose()
+            })()
           }}
         >
           <Icon name="Save" size={12} /> Save
@@ -2788,7 +2792,7 @@ function DurabilityEditor({ item, busy, run, isOnline, onClose }: {
 function WaterEditor({ item, busy, run, onClose }: {
   item: InventoryItem
   busy: boolean
-  run: (fn: () => Promise<{ message: string }>, label: string) => void | Promise<void>
+  run: (fn: () => Promise<{ message: string }>, label: string) => Promise<boolean>
   onClose: () => void
 }) {
   const amt0 = parseFloat(item.water_amount)
@@ -2835,8 +2839,7 @@ function WaterEditor({ item, busy, run, onClose }: {
             disabled={busy || !valid}
             onClick={() => {
               if (!valid) return
-              void run(() => setItemWater(item.id, n), 'Save')
-              onClose()
+              void (async () => { if (await run(() => setItemWater(item.id, n), 'Save')) onClose() })()
             }}
           >
             <Icon name="Save" size={12} /> Save water


### PR DESCRIPTION
Two small UI fixes.

**Inventory editors closed before their save resolved**

The shared stack, durability and water editors called `run(...)` and then `onClose()` synchronously, so the row collapsed before the request finished. A failed write discarded whatever the admin had typed and surfaced an error with no visible context.

`run` now returns whether the write succeeded, and each editor closes only on success. Failures keep the editor open with the entered values intact. `ItemList` passes the result through. The Storage tab editor already behaved correctly and is unchanged.

**Update check could sit stale after sleep (#349)**

The background poll is hourly and only advances while the window is awake, so a machine that slept or a window left in the background could show an old result well after a release. Added a `focus` / `visibilitychange` re-check, throttled to once every five minutes, with listeners removed alongside the existing interval teardown. The issue text and a code comment both said "6 hours"; the poll has been 1 hour for some time, so those are corrected rather than the interval changed.

**Validation**

WebUI build and typecheck pass, 162 Vitest tests pass. The one lint error (`Database.tsx:234`, empty block) predates this branch and is untouched.