### PR TITLE
Release v13.8.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -80,7 +80,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v13.8.2"
+      placeholder: "v13.8.3"
     validations:
       required: true
 
@@ -164,7 +164,7 @@ body:
     attributes:
       label: Specific page / button / command
       description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug? For in-game commands, include the exact `!command`, chat channel, monitoring interval, cooldown, whether any broadcast appeared, and whether it used the character name. For shared teleport destinations, include direct Save location vs Arm live capture, whether the player paused about five seconds, and whether they teleported on foot or from a vehicle seat. For scheduled Funcom updates, include the scheduled time, whether Apply available Funcom server updates was enabled, installed/latest build IDs, and the last schedule result. For World Restart, include the failed progress step, whether rollback ran automatically, whether every player was offline, and whether the Roll back last restart button remains available. For Specs > Apply level, include the track, before/after level, and before/after unspent skill points. For Reset Journey, include whether the post-NPE story restarted at Find the Fremen, which starter-class tree was reset, and how many skill points were refunded. For DD Seed Maps, include the selected seed, POI type, displayed sector(s), and a current reference screenshot or link when possible. For an Experimental Lab control, include its exact CVar or INI key, source/risk badge, file and section, and whether local Engine.ini management was enabled. For Solo Mode, include the adapter, wrapper/schema status, whether the game was fully closed, and the exact connection/settings/inventory/package/cosmetic/backup/restore step. For a database migration, name the failing step.
-      placeholder: "e.g. Database > World Restart > Wait for fresh database, DD Seed Maps > seed 2 > Cave sectors, Solo Mode > Inventory > Give Package, Solo Mode > Backups > Delete selected, Gameplay Admin > Overview > In-game commands > Save location, Server Health > Scheduled restarts > Save schedule, Settings > Public IP / DDNS > Apply public IP, Game Config > bottom bar > Apply INIs & restart, Gameplay Admin > Players > Specs > Apply level, Database > backup file > Restore, Help > Create GitHub Issue, or CLI -Cmd startup"
+      placeholder: "e.g. Database > World Restart > Wait for fresh database, DD Seed Maps > seed 2 > Cave sectors, Solo Mode > Settings > Apply Solo settings notification, Solo Mode > Inventory > Give Package, Gameplay Admin > Overview > In-game commands > Save location, Server Health > Scheduled restarts > Save schedule, Settings > Public IP / DDNS > Apply public IP, Game Config > Save notification, Game Config > bottom bar > Apply INIs & restart, Gameplay Admin > Players > Specs > Apply level, Database > backup file > Restore, Help > Create GitHub Issue, or CLI -Cmd startup"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [13.8.3] - 2026-08-20
+
 ### Added
 
 - Game Config → Landsraad now exposes the current Landsraad timing controls:
@@ -33,6 +35,10 @@ here cover everything those tags shipped.
 - The in-app update check now re-runs when the window regains focus, throttled
   to once every five minutes, so a machine that was asleep or left in the
   background no longer shows a stale result until the next hourly poll. (#349)
+- Solo Mode and Self-Hosted Game Config save results now appear in a
+  viewport-fixed notification, so confirmation remains visible at any scroll
+  position. Successful notices clear after six seconds; warnings and errors
+  remain until dismissed.
 
 ## [13.8.2] - 2026-08-20
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '13.8.2'
+$script:DuneToolVersion = '13.8.3'
 
 # ---------- Restart-on-detach handoff -----------------------------------------
 # When a prior "Web Portal" detach left the server running headless, the

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '13.8.2',
+    [string]$Version = '13.8.3',
     [switch]$Quiet
 )
 

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>13.8.2</Version>
+    <Version>13.8.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "13.8.2"
+#define MyAppVersion "13.8.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "13.8.2"
+$script:ToolVersion = "13.8.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/components/ViewportNotice.tsx
+++ b/webui/src/components/ViewportNotice.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { Icon } from './Icon'
+
+export type ViewportNoticeKind = 'ok' | 'warn' | 'err'
+
+interface Props {
+  kind: ViewportNoticeKind
+  text: string
+  onDismiss: () => void
+  autoDismissMs?: number | null
+}
+
+export function ViewportNotice({
+  kind,
+  text,
+  onDismiss,
+  autoDismissMs = kind === 'ok' ? 6_000 : null,
+}: Props) {
+  const dismissRef = useRef(onDismiss)
+  dismissRef.current = onDismiss
+
+  useEffect(() => {
+    if (autoDismissMs === null || autoDismissMs <= 0) return
+    const timer = window.setTimeout(() => dismissRef.current(), autoDismissMs)
+    return () => window.clearTimeout(timer)
+  }, [autoDismissMs, kind, text])
+
+  return createPortal(
+    <div className="pointer-events-none fixed inset-x-4 bottom-4 z-[11000] flex justify-center sm:left-auto sm:right-4 sm:w-full sm:max-w-lg">
+      <div
+        role={kind === 'err' ? 'alert' : 'status'}
+        aria-live={kind === 'err' ? 'assertive' : 'polite'}
+        aria-atomic="true"
+        className={`card pointer-events-auto flex max-h-[min(50vh,24rem)] w-full items-start gap-2 overflow-y-auto p-3 text-sm shadow-lg ${
+          kind === 'ok'
+            ? 'border-success/40 bg-success/10 text-success'
+            : kind === 'warn'
+              ? 'border-warning/40 bg-warning/10 text-warning'
+              : 'border-danger/40 bg-danger/10 text-danger'
+        }`}
+      >
+        <Icon name={kind === 'ok' ? 'CheckCircle2' : kind === 'warn' ? 'ShieldAlert' : 'AlertCircle'} size={15} className="mt-0.5 shrink-0" />
+        <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">{text}</span>
+        <button
+          type="button"
+          className="shrink-0 rounded p-1 text-current/70 transition-colors hover:bg-white/10 hover:text-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current"
+          onClick={onDismiss}
+          aria-label="Dismiss notification"
+          title="Dismiss"
+        >
+          <Icon name="X" size={14} />
+        </button>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/webui/src/pages/GameConfig.tsx
+++ b/webui/src/pages/GameConfig.tsx
@@ -4,6 +4,7 @@ import { Icon } from '../components/Icon'
 import { CollapsibleCard, useCardCollapse } from '../components/CollapsibleCard'
 import { Link } from '../router'
 import { IniShareModal } from '../components/IniShareModal'
+import { ViewportNotice } from '../components/ViewportNotice'
 import { useStatus } from '../hooks/useStatus'
 import { api } from '../api/client'
 import { ServerNameCard } from './gameconfig/ServerNameCard'
@@ -1231,12 +1232,12 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
 
       }
       setSavedMsg(msg)
-      window.setTimeout(() => setSavedMsg(null), 8000)
       // Some settings (e.g. landclaim limits, building restrictions) are read by
       // BOTH server and client — remind the admin to mirror them on each client.
       const ca = out.clientApply
       setClientApply(ca && ca.items && ca.items.length > 0 ? ca : null)
     } catch (err) {
+      setSavedMsg(null)
       setSaveError(err instanceof Error ? err.message : String(err))
     } finally {
       setSaving(false)
@@ -1256,9 +1257,9 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
     try {
       const out = await reloadGameConfigPods()
       setSavedMsg(out.message)
-      window.setTimeout(() => setSavedMsg(null), 12000)
       await forceRefresh()
     } catch (err) {
+      setSavedMsg(null)
       setSaveError(err instanceof Error ? err.message : String(err))
     } finally {
       setReloadingPods(false)
@@ -1618,16 +1619,11 @@ export function GameConfig({ mode = 'standard' }: { mode?: 'standard' | 'experim
           </button>
         </div>
       )}
-      {saveError && (
-        <div className="card p-3 mb-4 border-danger/40 bg-danger/10 text-danger text-sm flex items-center gap-2">
-          <Icon name="AlertCircle" size={14} /> {saveError}
-        </div>
-      )}
-      {savedMsg && (
-        <div className="card p-3 mb-4 border-success/40 bg-success/10 text-success text-sm flex items-center gap-2">
-          <Icon name="CheckCircle2" size={14} /> {savedMsg}
-        </div>
-      )}
+      {saveError ? (
+        <ViewportNotice kind="err" text={saveError} onDismiss={() => setSaveError(null)} />
+      ) : savedMsg ? (
+        <ViewportNotice kind="ok" text={savedMsg} onDismiss={() => setSavedMsg(null)} />
+      ) : null}
       {mismatchMsg && (
         <div className="card p-3 mb-4 border-success/40 bg-success/10 text-success text-sm flex items-center gap-2">
           <Icon name="CheckCircle2" size={14} /> {mismatchMsg}

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -3,6 +3,7 @@ import { Icon } from '../components/Icon'
 import { PageHeader } from '../components/PageHeader'
 import { CollapsibleCard } from '../components/CollapsibleCard'
 import { ItemPicker } from '../components/ItemPicker'
+import { ViewportNotice } from '../components/ViewportNotice'
 import { GivePackageForm } from './gameplay/players/sections'
 import { useApi } from '../hooks/useApi'
 import {
@@ -1042,16 +1043,11 @@ export function SoloMode() {
       </div>
 
       {notice && (
-        <div role="alert" className={`card p-3 mb-4 text-sm flex items-start gap-2 ${
-          notice.kind === 'ok'
-            ? 'border-success/40 text-success'
-            : notice.kind === 'warn'
-              ? 'border-warning/40 text-warning'
-              : 'border-danger/40 text-danger'
-        }`}>
-          <Icon name={notice.kind === 'ok' ? 'CheckCircle2' : notice.kind === 'warn' ? 'ShieldAlert' : 'AlertCircle'} size={15} className="mt-0.5 shrink-0" />
-          <span className="whitespace-pre-wrap break-words">{notice.text}</span>
-        </div>
+        <ViewportNotice
+          kind={notice.kind}
+          text={notice.text}
+          onDismiss={() => setNotice(null)}
+        />
       )}
 
       {connected && !selectionMatchesActive && (

--- a/webui/tests/components/ViewportNotice.test.tsx
+++ b/webui/tests/components/ViewportNotice.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { ViewportNotice } from '../../src/components/ViewportNotice'
+
+describe('ViewportNotice', () => {
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('renders through the document body and can be dismissed', async () => {
+    const dismiss = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ViewportNotice kind="ok" text="Settings saved." onDismiss={dismiss} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Settings saved.')
+    await user.click(screen.getByRole('button', { name: 'Dismiss notification' }))
+    expect(dismiss).toHaveBeenCalledOnce()
+  })
+
+  it('automatically dismisses successful notices after six seconds', () => {
+    vi.useFakeTimers()
+    const dismiss = vi.fn()
+
+    render(<ViewportNotice kind="ok" text="Settings saved." onDismiss={dismiss} />)
+    vi.advanceTimersByTime(5_999)
+    expect(dismiss).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(dismiss).toHaveBeenCalledOnce()
+  })
+
+  it('keeps errors visible until explicitly dismissed', () => {
+    vi.useFakeTimers()
+    const dismiss = vi.fn()
+
+    render(<ViewportNotice kind="err" text="Save failed." onDismiss={dismiss} />)
+    vi.advanceTimersByTime(60_000)
+    expect(screen.getByRole('alert')).toHaveTextContent('Save failed.')
+    expect(dismiss).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What changed

- Expose current Landsraad timing controls while retaining legacy fields.
- Prevent the returning-player popup and prune stale startup templates.
- Keep inventory editors open until saves succeed and refresh update checks on window focus.
- Restore automatic Pages deployment on release publication.
- Keep Solo Mode and Self-Hosted Game Config results visible in viewport-fixed notices; success clears after six seconds, while warnings and errors remain dismissible.
- Include the merged dependency maintenance already on `main`.

## Validation

- 960 Pester tests
- Solo database helper self-test
- 165 WebUI tests
- Focused viewport-notice and Solo settings tests
- WebUI production build
- Full installer build and version/encoding/PowerShell 5.1 preflights
- Release-diff secret scan

Final installer: 80,576,776 bytes  
SHA-256: `ADC7C07114F824D2C03CE5AF8AF4F6D376CF64C4D03D3C40981AEAF27A2CA7D2`