### PR TITLE
Deploy Pages only for stable releases

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -42,6 +42,9 @@ permissions:
 
 jobs:
   build:
+    # Stable publication refreshes the site. Silent test-channel mirrors are
+    # prereleases and must not launch a redundant Pages deployment.
+    if: github.event_name != 'release' || !github.event.release.prerelease
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## What changed

Skip the Pages build/deploy jobs for prerelease publication events. Stable releases still refresh the site automatically; silent `-test1` mirrors no longer attempt a redundant deployment.

The `github-pages` environment now allows version-tag refs (`v*`) in addition to `main`, which resolved the stable v13.8.3 release deployment rejection.

## Validation

- Stable v13.8.3 release workflow rerun completed successfully after the environment policy correction.
- Workflow diff formatting and release-diff secret scan passed.