### PR TITLE
Refresh updater release before download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- The in-app updater now refreshes the selected GitHub release immediately
+  before downloading, preventing a stale test-channel mirror cache from
+  requesting an installer URL that was just retired during publication.
+
 ## [13.8.3] - 2026-08-20
 
 ### Added

--- a/app/server/routes/Update.ps1
+++ b/app/server/routes/Update.ps1
@@ -453,7 +453,10 @@ Register-DuneRoute -Method POST -Path '/api/update/install' -Handler {
             }
             return
         }
-        $rel = Get-DuneSelectedRelease
+        # Mirror releases are replaced atomically during stable publication.
+        # Never install from the one-hour release-list cache: it may still point
+        # at the deleted prior mirror even after a forced check sees the new tag.
+        $rel = Get-DuneSelectedRelease -Force
         if (-not $rel -or -not $rel.assetUrl) {
             Write-DuneError -Response $res -Status 503 -Message 'No installer asset available on the selected release.'
             return

--- a/tests/UpdateChannel.Tests.ps1
+++ b/tests/UpdateChannel.Tests.ps1
@@ -77,6 +77,16 @@ Describe 'Get-DuneSelectedRelease channel resolution' {
         function global:Get-DuneUpdatePreReleaseTag { '' }
     }
 
+    Describe 'Update install route cache safety' {
+        It 'force-refreshes the selected release before downloading' {
+            $routePath = Join-Path (Split-Path $PSScriptRoot -Parent) 'app\server\routes\Update.ps1'
+            $source = Get-Content -LiteralPath $routePath -Raw
+            $installRoute = $source.Substring($source.IndexOf('# POST /api/update/install'))
+
+            $installRoute | Should -Match '\$rel\s*=\s*Get-DuneSelectedRelease\s+-Force'
+        }
+    }
+
     It 'stable channel returns the stable latest, not a prerelease' {
         function global:Get-DuneUpdateChannel { 'stable' }
         $r = Get-DuneSelectedRelease


### PR DESCRIPTION
## What changed

Force-refresh the selected GitHub release immediately before the in-app updater downloads its installer. This prevents a Test-channel worker from using the retired prior `-test1` mirror URL after stable publication replaces that mirror.

The fix remains Unreleased for the next normal patch. Restarting DST or switching to Stable remains the immediate workaround for v13.8.3 and earlier.

## Validation

- 27 focused updater tests passed.
- PowerShell parse check passed.
- Release-diff secret scan passed.