### PR TITLE
Hide unsupported Solo PvP settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ here cover everything those tags shipped.
 - The in-app updater now refreshes the selected GitHub release immediately
   before downloading, preventing a stale test-channel mirror cache from
   requesting an installer URL that was just retired during publication.
+- Solo Mode no longer displays the native player-vs-player, player-vs-vehicle,
+  and PvP structure-damage fields that Funcom omits from its Solo Custom
+  Settings interface. The underlying keys remain untouched for future
+  reevaluation.
 
 ## [13.8.3] - 2026-08-20
 

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -96,7 +96,16 @@ export const SOLO_ACTION_RULES = [
 const SOLO_INPUT_CLASS = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50 disabled:opacity-50 disabled:cursor-not-allowed'
 const SOLO_DISABLED_PRIMARY_CLASS = 'disabled:bg-surface-2 disabled:text-text-dim disabled:border disabled:border-border disabled:opacity-100'
 export const SOLO_READ_ONLY_SETTINGS = new Set(['DifficultyLevel'])
-export const SOLO_HIDDEN_SETTINGS = new Set(['PVPMode'])
+export const SOLO_HIDDEN_SETTINGS = new Set([
+  'PVPMode',
+  'PlayerDamageToPlayer',
+  'PlayerDamageToVehicle',
+  'PVPDamageStructures',
+])
+
+export function isSoloSettingVisible(key: string): boolean {
+  return !SOLO_HIDDEN_SETTINGS.has(key)
+}
 
 type SoloSettingOption = { value: string; label: string }
 export type SoloSettingControl =
@@ -1322,7 +1331,7 @@ export function SoloMode() {
               {SETTING_GROUPS.map(group => (
                 <CollapsibleCard key={group.title} id={`solo-settings-${group.title.toLowerCase().replaceAll(' ', '-')}`} title={group.title} icon="SlidersHorizontal">
                   <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-                    {group.keys.map(key => {
+                    {group.keys.filter(isSoloSettingVisible).map(key => {
                       const value = draft[key] ?? ''
                       const control = getSoloSettingControl(key)
                       const disabled = SOLO_READ_ONLY_SETTINGS.has(key)

--- a/webui/tests/soloSettingsControls.test.ts
+++ b/webui/tests/soloSettingsControls.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getSoloSettingControl, validateSoloSettingChanges } from '../src/pages/SoloMode'
+import {
+  getSoloSettingControl,
+  isSoloSettingVisible,
+  validateSoloSettingChanges,
+} from '../src/pages/SoloMode'
 
 describe('Solo Mode setting controls', () => {
   it('uses buttons for boolean settings', () => {
@@ -34,6 +38,14 @@ describe('Solo Mode setting controls', () => {
 
   it('keeps game-controlled fields as text', () => {
     expect(getSoloSettingControl('DifficultyLevel')).toEqual({ type: 'text' })
+  })
+
+  it('hides native PvP-only settings that Funcom omits from Solo controls', () => {
+    expect(isSoloSettingVisible('PVPMode')).toBe(false)
+    expect(isSoloSettingVisible('PlayerDamageToPlayer')).toBe(false)
+    expect(isSoloSettingVisible('PlayerDamageToVehicle')).toBe(false)
+    expect(isSoloSettingVisible('PVPDamageStructures')).toBe(false)
+    expect(isSoloSettingVisible('PlayerDamageToNPC')).toBe(true)
   })
 
   it('rejects decimal values for integer settings', () => {


### PR DESCRIPTION
## What changed

Hide `PlayerDamageToPlayer`, `PlayerDamageToVehicle`, and `PVPDamageStructures` alongside `PVPMode` in Solo Mode. Funcom's PTC Solo Custom Settings interface omits those native keys while exposing the separate player-to-enemy and enemy damage controls.

The backend continues to preserve the underlying native settings for future evidence-based reevaluation. This remains Unreleased for the next normal patch.

## Validation

- 7 focused Solo settings control tests passed.
- WebUI production build passed.
- Release-diff secret scan passed.