### PR TITLE
Support fresh Solo progression schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ here cover everything those tags shipped.
   and PvP structure-damage fields that Funcom omits from its Solo Custom
   Settings interface. The underlying keys remain untouched for future
   reevaluation.
+- Solo progression actions now accept the fresh-character schema created by the
+  current PTC build. The additional fingerprint differs only in unrelated actor
+  spawner and map-marker definitions; all progression mutations remain
+  exact-schema gated and backup-first.
 
 ## [13.8.3] - 2026-08-20
 

--- a/app/data/solo-ptc-v1.json
+++ b/app/data/solo-ptc-v1.json
@@ -2,6 +2,9 @@
   "id": "ptc-wrapper-v1-2026-08",
   "wrapper_version": 1,
   "schema_fingerprint": "feede0b0d0629b1b8553e9ad9434e5009f4422b9d662ec6bbc44f6c3d3291518",
+  "compatible_schema_fingerprints": [
+    "abb4dd3b358668f5d79ef10215d38e7ebe3801a37347374d4c3d66a1557dc223"
+  ],
   "specializations": {
     "max_level": 100,
     "max_xp": 44182,

--- a/app/tools/DuneSoloDb/Program.cs
+++ b/app/tools/DuneSoloDb/Program.cs
@@ -1434,6 +1434,18 @@ internal static partial class Program
                     "Progression self-test did not reach verified target state.");
             }
 
+            var compatibleAdapterPath = Path.Combine(root, "compatible-adapter.json");
+            File.WriteAllText(
+                compatibleAdapterPath,
+                File.ReadAllText(adapterPath).Replace(
+                    $"\"schema_fingerprint\":\"{selfTestFingerprint}\"",
+                    $"\"schema_fingerprint\":\"{new string('1', 64)}\",\"compatible_schema_fingerprints\":[\"{selfTestFingerprint}\"]"));
+            EnableAllSkills(
+                target,
+                Path.Combine(root, "safety", "before-compatible-schema.db"),
+                compatibleAdapterPath,
+                skillsPath);
+
             var badAdapterPath = Path.Combine(root, "bad-adapter.json");
             File.WriteAllText(
                 badAdapterPath,
@@ -1526,6 +1538,7 @@ internal static partial class Program
                     "offline-specialization-max-with-rewards",
                     "offline-find-the-fremen-completion",
                     "offline-enable-all-skills-preserves-unknowns",
+                    "progression-compatible-schema-accepted",
                     "progression-schema-mismatch-fails-closed",
                     "invalid-restore-leaves-target-unchanged"
                 }

--- a/app/tools/DuneSoloDb/Progression.cs
+++ b/app/tools/DuneSoloDb/Progression.cs
@@ -480,13 +480,10 @@ internal static partial class Program
         PtcAdapter adapter)
     {
         var inspection = InspectPath(input);
-        if (!string.Equals(
-                inspection.SchemaFingerprint,
-                adapter.SchemaFingerprint,
-                StringComparison.OrdinalIgnoreCase))
+        if (!adapter.SchemaFingerprints.Contains(inspection.SchemaFingerprint))
         {
             throw new InvalidDataException(
-                $"PTC progression adapter schema mismatch: expected {adapter.SchemaFingerprint}, found {inspection.SchemaFingerprint}.");
+                $"PTC progression adapter schema mismatch: expected one of {string.Join(", ", adapter.SchemaFingerprints.Order())}, found {inspection.SchemaFingerprint}.");
         }
     }
 
@@ -900,9 +897,21 @@ internal static partial class Program
         }
         var fremen = root.GetProperty("find_the_fremen");
         var skills = root.GetProperty("enable_all_skills");
+        var schemaFingerprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            root.GetProperty("schema_fingerprint").GetString() ?? ""
+        };
+        if (root.TryGetProperty("compatible_schema_fingerprints", out var compatibleFingerprints))
+        {
+            foreach (var fingerprint in compatibleFingerprints.EnumerateArray())
+            {
+                var value = fingerprint.GetString();
+                if (!string.IsNullOrWhiteSpace(value)) { schemaFingerprints.Add(value); }
+            }
+        }
         return new PtcAdapter(
             Id: root.GetProperty("id").GetString() ?? "",
-            SchemaFingerprint: root.GetProperty("schema_fingerprint").GetString() ?? "",
+            SchemaFingerprints: schemaFingerprints,
             MaxLevel: specializations.GetProperty("max_level").GetInt32(),
             MaxXp: specializations.GetProperty("max_xp").GetInt32(),
             Tracks: tracks,
@@ -955,7 +964,7 @@ internal static partial class Program
 
     private sealed record PtcAdapter(
         string Id,
-        string SchemaFingerprint,
+        HashSet<string> SchemaFingerprints,
         int MaxLevel,
         int MaxXp,
         IReadOnlyDictionary<string, int> Tracks,


### PR DESCRIPTION
## What changed

Accept the exact fresh-character progression schema fingerprint produced by the current PTC build while preserving the existing proven fingerprint and unknown-schema fail-closed behavior.

The two schema shapes have the same 93 tables. Their only differences are unrelated actor-spawner and map-marker definitions; progression code references neither table.

## Validation

- Solo helper self-test, including accepted-compatible and rejected-unknown schema paths.
- All three progression actions passed against separate disposable copies of the fresh save, each with retained backup, SQLite integrity `ok`, and zero FK violations.
- Field-confirmed on the real fresh character using the local test installer.
- Full installer build and release-diff secret scan passed.

This remains Unreleased for the next normal patch.