### PR TITLE
Keep Bindu Sprint learnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ here cover everything those tags shipped.
   and PvP structure-damage fields that Funcom omits from its Solo Custom
   Settings interface. The underlying keys remain untouched for future
   reevaluation.
+- Enable All Skills now leaves Bindu Sprint and Voice Ignore untouched in both
+  Solo Mode and Self-Hosted Gameplay Admin. Keeping Bindu Sprint learnable
+  allows the Attitude of the Knife quest's learn-a-skill step to complete;
+  field testing confirmed its connected nodes can remain enabled.
 
 ## [13.8.3] - 2026-08-20
 

--- a/app/data/solo-ptc-v1.json
+++ b/app/data/solo-ptc-v1.json
@@ -124,7 +124,8 @@
     "point_buffer": 20,
     "intel_floor": 100,
     "exclude": [
-      "(TagName=\"Skills.Ability.VoiceStop\")"
+      "(TagName=\"Skills.Ability.VoiceStop\")",
+      "(TagName=\"Skills.Ability.Hypersprint\")"
     ]
   }
 }

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -1968,13 +1968,15 @@ function Invoke-DunePlayerMarkNpeCompleted {
 $script:DuneGrantAllSkillsLevelValue = 7
 $script:DuneGrantAllSkillsPointBuffer = 20
 $script:DuneGrantAllSkillsIntelFloor = 100
-# Ability tags Enable All Skills must NOT grant. "Ignore" — the Bene Gesserit
-# Voice ability that forces a target to act as if you are completely invisible —
-# is stored internally as Skills.Ability.VoiceStop (its in-game display name is
-# "Ignore"; identified by Coastal against the live skill tree). Per Coastal: keep
-# every other grant identical, just never grant this one. Exact-match against the
-# catalog key string so nothing else is affected.
-$script:DuneGrantAllSkillsExcludeKeys = @('(TagName="Skills.Ability.VoiceStop")')
+# Ability tags Enable All Skills must NOT grant:
+# - VoiceStop is the in-game Voice ability "Ignore".
+# - Hypersprint is Bindu Sprint, deliberately left learnable so the
+#   "Attitude of the Knife" quest can complete its learn-a-skill step.
+# Exact-match the catalog key strings; existing progress is never lowered.
+$script:DuneGrantAllSkillsExcludeKeys = @(
+    '(TagName="Skills.Ability.VoiceStop")'
+    '(TagName="Skills.Ability.Hypersprint")'
+)
 function Invoke-DunePlayerGrantAllSkills {
     param([string]$Ip, [long]$AccountId)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }

--- a/app/tools/DuneSoloDb/Program.cs
+++ b/app/tools/DuneSoloDb/Program.cs
@@ -892,7 +892,7 @@ internal static partial class Program
                     );
                     INSERT INTO fgl_entities (entity_id, components) VALUES (
                         1000,
-                        jsonb('{"FLevelComponent":[0,{"ModuleData":{"(TagName=\"Skills.Ability.VoiceStop\")":{"SkillPointsSpent":0},"(TagName=\"Skills.Attribute.Explorer6\")":{"SkillPointsSpent":2}},"TotalSkillPoints":2,"UnspentSkillPoints":0,"KeystoneBonusSkillPoints":0}],"FSpiceAddictionComponent":[0,{"SystemStatus":"AddictionDisabled","SpiceVisionEnabledStatus":"Disabled"}]}')
+                        jsonb('{"FLevelComponent":[0,{"ModuleData":{"(TagName=\"Skills.Ability.VoiceStop\")":{"SkillPointsSpent":0},"(TagName=\"Skills.Ability.Hypersprint\")":{"SkillPointsSpent":0},"(TagName=\"Skills.Attribute.Explorer6\")":{"SkillPointsSpent":2}},"TotalSkillPoints":2,"UnspentSkillPoints":0,"KeystoneBonusSkillPoints":0}],"FSpiceAddictionComponent":[0,{"SystemStatus":"AddictionDisabled","SpiceVisionEnabledStatus":"Disabled"}]}')
                     );
                     CREATE TABLE actor_fgl_entities (
                         actor_id INTEGER NOT NULL,
@@ -1360,7 +1360,10 @@ internal static partial class Program
                     "level_value":7,
                     "point_buffer":20,
                     "intel_floor":100,
-                    "exclude":["(TagName=\"Skills.Ability.VoiceStop\")"]
+                    "exclude":[
+                      "(TagName=\"Skills.Ability.VoiceStop\")",
+                      "(TagName=\"Skills.Ability.Hypersprint\")"
+                    ]
                   }
                 }
                 """.Replace("__SCHEMA_FINGERPRINT__", selfTestFingerprint));
@@ -1400,9 +1403,10 @@ internal static partial class Program
                 skillsPath,
                 """
                 {
-                  "count":3,
+                  "count":4,
                   "keys":[
                     "(TagName=\"Skills.Ability.VoiceStop\")",
+                    "(TagName=\"Skills.Ability.Hypersprint\")",
                     "(TagName=\"Skills.Ability.TestOne\")",
                     "(TagName=\"Skills.Attribute.TestTwo\")"
                   ]

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -59,6 +59,14 @@ Describe 'Get-DuneSqlAffected' -Tag 'Pure' {
     It 'returns 0 for $null' {
         Get-DuneSqlAffected $null | Should -Be 0
     }
+
+    Describe 'Enable All Skills exclusions' -Tag 'Pure' {
+        It 'leaves Bindu Sprint and Voice Ignore learnable' {
+            $script:DuneGrantAllSkillsExcludeKeys | Should -Contain '(TagName="Skills.Ability.Hypersprint")'
+            $script:DuneGrantAllSkillsExcludeKeys | Should -Contain '(TagName="Skills.Ability.VoiceStop")'
+            $script:DuneGrantAllSkillsExcludeKeys.Count | Should -Be 2
+        }
+    }
     It "returns 0 when result.ok is false" {
         Get-DuneSqlAffected @{ ok = $false; message = 'UPDATE 5' } | Should -Be 0
     }

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -1829,7 +1829,7 @@ export function SoloMode() {
             <ProgressionActionCard
               icon="Sparkles"
               title="Enable all skills"
-              description="Raise 144 approved skills to value 7, skip Voice Ignore, preserve unknown PTC keys, keep 20 unspent points, and raise Intel to 100."
+              description="Raise 143 approved skills to value 7, leave Bindu Sprint and Voice Ignore learnable, preserve unknown PTC keys, keep at least 20 unspent points, and raise Intel to 100."
               status={`${inspection?.progression.skillsAtSeven ?? 0}/144 enabled · ${inspection?.progression.unspentSkillPoints ?? 0} unspent · ${inspection?.progression.intel ?? 0} Intel`}
               busy={busy === 'progression:skills'}
               disabled={!canMutateActiveProfile || gameRunning}

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -682,8 +682,8 @@ const ACTIONS: ActionDef[] = [
     rowNote: 'Snapshot cosmetics, delete + recreate character in-game (same name), then restore. Offline to restore.',
     run: () => Promise.resolve({ message: '' }) },
   { id: 'grant-all-skills', group: 'Progression', label: 'Enable All Skills', icon: 'Sparkles', offlineOnly: true,
-    rowNote: 'Only do this AFTER applying "Unlock Trainers" above. Do NOT use this if you plan to level some skill trainer trees yourself. Enables every skill (multi-level left below max) + a ~20 skill-point buffer + 100 Intel. Offline.',
-    confirm: p => `Enable all skills for ${p.name}?\n\nOnly do this AFTER applying "Unlock Trainers". Do NOT use this if you plan to level some skill trainer trees yourself.\n\nUnlocks all 145 skills but leaves multi-level skills BELOW max on purpose so the tutorial step "Learn a new Ability from the Skills menu" stays completable (maxing everything soft-locks it). Also grants a small (~20) spendable skill-point buffer and tops Intel to 100 so nothing gates. Existing progress preserved. Player must be offline.`,
+    rowNote: 'Only do this AFTER applying "Unlock Trainers" above. Enables approved skills at 7 while leaving Bindu Sprint and Voice Ignore learnable, plus at least 20 skill points and 100 Intel. Offline.',
+    confirm: p => `Enable approved skills for ${p.name}?\n\nOnly do this AFTER applying "Unlock Trainers".\n\nRaises every approved skill to 7 except Bindu Sprint and Voice Ignore. Bindu Sprint stays learnable so "Attitude of the Knife" can complete normally; existing progress is never lowered. Also preserves at least 20 spendable skill points and raises Intel to 100. Player must be offline.`,
     run: p => grantAllSkills(p.account_id) },
   // Grant All Tech Recipes — DISABLED pending rework. The DB write marks every
   // recipe UnlockedState="Purchased", but in-game the items stay unclaimed/0-cost


### PR DESCRIPTION
## What changed

Both Solo Mode and Self-Hosted Gameplay Admin now leave Bindu Sprint (`Skills.Ability.Hypersprint`) and Voice Ignore untouched when running Enable All Skills. Every other approved skill is raised to value 7, existing progress is never lowered, and the existing unspent-point/Intel floors remain.

Keeping Bindu Sprint at zero lets the Attitude of the Knife learn-a-skill step complete normally, even when its connected nodes are already enabled.

## Validation

- Field-confirmed in PTC Solo: Bindu Sprint remained 0, connected Bindu nodes were 7, and Attitude of the Knife completed by learning Bindu Sprint.
- 63 focused Self-Hosted PlayersWrites tests passed.
- Solo helper self-test passed.
- WebUI production build passed.
- Release-diff secret scan passed.

This remains Unreleased for the next normal patch.