### PR TITLE
Correct v13.8.4 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
-## [13.8.4] - 2026-08-20
+## [13.8.4] - 2026-08-21
 
 ### Fixed
 


### PR DESCRIPTION
Publication crossed local midnight after the release PR was prepared. Correct the v13.8.4 changelog date from 2026-08-20 to the actual publication date, 2026-08-21. No product code or release scope changes.