### PR TITLE
Fix signed release workflow parameter splatting

### DIFF
--- a/.github/workflows/release-signed.yml
+++ b/.github/workflows/release-signed.yml
@@ -111,10 +111,10 @@ jobs:
         env:
           BUILD_TAG: ${{ inputs.attach_to_release_tag }}
         run: |
-          $biArgs = @('-SkipInstaller')
-          if ('${{ inputs.skip_version_check }}' -eq 'true') { $biArgs += '-SkipVersionCheck' }
-          if ('${{ inputs.prerelease_build }}' -eq 'true') { $biArgs += '-Prerelease' }
-          if ($env:BUILD_TAG) { $biArgs += @('-BuildTag',$env:BUILD_TAG) }
+          $biArgs = @{ SkipInstaller = $true }
+          if ('${{ inputs.skip_version_check }}' -eq 'true') { $biArgs.SkipVersionCheck = $true }
+          if ('${{ inputs.prerelease_build }}' -eq 'true') { $biArgs.Prerelease = $true }
+          if ($env:BUILD_TAG) { $biArgs.BuildTag = $env:BUILD_TAG }
           & '${{ github.workspace }}\app\installer\Build-Installer.ps1' @biArgs
 
       # ── Sign the two inner exes IN PLACE (only if SignPath is configured). ──
@@ -190,10 +190,15 @@ jobs:
         env:
           BUILD_TAG: ${{ inputs.attach_to_release_tag }}
         run: |
-          $biArgs = @('-SkipWebBuild','-SkipExeBuild','-SkipShellBuild','-SkipSoloBuild')
-          if ('${{ inputs.skip_version_check }}' -eq 'true') { $biArgs += '-SkipVersionCheck' }
-          if ('${{ inputs.prerelease_build }}' -eq 'true') { $biArgs += '-Prerelease' }
-          if ($env:BUILD_TAG) { $biArgs += @('-BuildTag',$env:BUILD_TAG) }
+          $biArgs = @{
+            SkipWebBuild = $true
+            SkipExeBuild = $true
+            SkipShellBuild = $true
+            SkipSoloBuild = $true
+          }
+          if ('${{ inputs.skip_version_check }}' -eq 'true') { $biArgs.SkipVersionCheck = $true }
+          if ('${{ inputs.prerelease_build }}' -eq 'true') { $biArgs.Prerelease = $true }
+          if ($env:BUILD_TAG) { $biArgs.BuildTag = $env:BUILD_TAG }
           & '${{ github.workspace }}\app\installer\Build-Installer.ps1' @biArgs
 
       # ── Sign the installer itself. ──

--- a/tests/BuildMetadata.Tests.ps1
+++ b/tests/BuildMetadata.Tests.ps1
@@ -59,6 +59,10 @@ Describe 'Build artifact metadata' {
         $workflow | Should -Match 'inputs\.attach_to_release_tag.*github\.ref'
         $workflow | Should -Match 'fetch-depth:\s*0'
         $workflow | Should -Not -Match 'github\.ref.*Prerelease'
+        $workflow | Should -Match '\$biArgs\s*=\s*@\{'
+        $workflow | Should -Match '\$biArgs\.BuildTag\s*='
+        $workflow | Should -Not -Match '\$biArgs\s*=\s*@\('
+        $workflow | Should -Not -Match '\$biArgs\s*\+='
     }
 
     It 'publishes through replacement so an installed hardlink is not overwritten' {


### PR DESCRIPTION
## Summary
- replace positional array splatting with named hashtable splatting in both release build phases
- pass switch and tag inputs to `Build-Installer.ps1` with their intended parameter names
- add a regression guard that rejects array-based workflow argument construction

## Root cause
The test11 exact-tag workflow passed `@('-SkipInstaller', '-Prerelease', '-BuildTag', ...)` through array splatting. PowerShell treated those entries as positional values, so `Build-Installer.ps1` rejected `-BuildTag` before building.

## Validation
- targeted BuildMetadata Pester suite: 6 passed
- actionlint passed
- changed-file gitleaks scan passed