### PR TITLE
Remove fixed post-reboot settle delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ here cover everything those tags shipped.
   Previously, partial root completion could grant Karpov 38 research at zero
   Intel while leaving Wreck of the Alcyon active and unable to observe the
   research event.
+- **Reboot All** no longer waits a fixed 45 seconds before its post-reboot
+  on-demand-map repair. It now runs the same immediate conservative probe used
+  by normal start/restart flows; the VM boot hook and scheduled heal retain
+  coverage for slower Funcom operator reconciliation.
 
 ### Added
 

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -2384,12 +2384,11 @@ while ($true) {
         if ($estTotal) { Write-Host "  $estTotal" -ForegroundColor DarkGray }
         Write-Host "Pods may take another 1-2 min to all reach Healthy. Check with 'status'." -ForegroundColor DarkGray
 
-        # Auto-clear on-demand partitions so DD/Arrakeen/Harko spawn on demand
-        # post-reboot. 45s settling delay because (unlike startup) we did not
-        # already wait on overmap/survival Ready — the server-operator may
-        # still be reconciling on-demand ServerSets.
+        # Probe once immediately after reboot, matching the normal start/restart
+        # paths. The conservative heal leaves actively starting maps alone; the
+        # VM boot hook and 15-minute cron pass cover slower operator drift.
         if ($bgStartExit -eq 0) {
-            Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 45 -Phase 'post-reboot'
+            Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'post-reboot' -Fast
             Invoke-DuneBackupDumpPodPrune -Ip $ip -Phase 'post-reboot'
         } else {
             Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -1172,13 +1172,14 @@ function Show-DuneVmMemoryPressureWarning {
 }
 
 function Invoke-DuneRemotePartitionScript {
-    # Stages the bundled dune-clear-partitions.start to /tmp on the VM via an
-    # ssh exec + base64 stream (no scp/sftp dependency), runs it once with sudo,
-    # removes the staged copy. No persistent install, no boot script, no cron.
+    # Stages the bundled partition-heal installer via base64/SSH, refreshes its
+    # VM-side heal + boot hook + cron, runs one explicit safety mode, then removes
+    # the staged copy.
     # Returns @{ ok; rc; output }. Best-effort - never throws.
     param(
         [Parameter(Mandatory)][string]$Ip,
-        [int]$WaitAttempts = 60
+        [int]$WaitAttempts = 60,
+        [ValidateSet('boot', 'cron', 'manual')][string]$Mode = 'cron'
     )
     $local = Get-DuneRemotePartitionScriptPath
     if (-not $local) {
@@ -1207,7 +1208,7 @@ function Invoke-DuneRemotePartitionScript {
     }
     $output = & ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o LogLevel=QUIET `
                     -i "$sshKey" "$sshUser@$Ip" `
-                    "sudo -n DUNE_CLEAR_ATTEMPTS=$WaitAttempts sh $remoteTmp; rc=`$?; rm -f $remoteTmp; exit `$rc" 2>&1
+                    "sudo -n DUNE_CLEAR_ATTEMPTS=$WaitAttempts sh $remoteTmp $Mode; rc=`$?; rm -f $remoteTmp; exit `$rc" 2>&1
     $rc = $LASTEXITCODE
     return @{ ok = ($rc -eq 0); rc = $rc; output = @($output) }
 }
@@ -1226,6 +1227,7 @@ function Invoke-OnDemandPartitionClear {
         [Parameter(Mandatory)][string]$Ip,
         [int]$DelaySec = 30,
         [string]$Phase = 'post-start',
+        [ValidateSet('boot', 'cron', 'manual')][string]$Mode = 'cron',
         [switch]$Fast
     )
     Write-Host ""
@@ -1259,7 +1261,7 @@ function Invoke-OnDemandPartitionClear {
     }
 
     $waitAttempts = if ($Fast) { 1 } else { 60 }
-    $result = Invoke-DuneRemotePartitionScript -Ip $Ip -WaitAttempts $waitAttempts
+    $result = Invoke-DuneRemotePartitionScript -Ip $Ip -WaitAttempts $waitAttempts -Mode $Mode
     $runOut = $result.output
     $runRc  = $result.rc
 
@@ -2108,7 +2110,7 @@ while ($true) {
         # the next player without manual intervention. Skipped if `bg start`
         # itself failed (no point waiting on operator that never reconciled).
         if ($bgStartExit -eq 0) {
-            Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'post-startup' -Fast
+            Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'post-startup' -Mode cron -Fast
             Invoke-DuneBackupDumpPodPrune -Ip $ip -Phase 'post-startup'
         } else {
             Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
@@ -2388,7 +2390,7 @@ while ($true) {
         # paths. The conservative heal leaves actively starting maps alone; the
         # VM boot hook and 15-minute cron pass cover slower operator drift.
         if ($bgStartExit -eq 0) {
-            Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'post-reboot' -Fast
+            Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'post-reboot' -Mode cron -Fast
             Invoke-DuneBackupDumpPodPrune -Ip $ip -Phase 'post-reboot'
         } else {
             Write-Host "  Skipped on-demand partition auto-clear because battlegroup start exited $bgStartExit." -ForegroundColor DarkYellow
@@ -2848,7 +2850,7 @@ while ($true) {
         # if missing, then runs the partition-clear script with no settling
         # delay (operator has already had whatever time it needed by the time
         # the user invokes this).
-        Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'fix-on-demand-maps'
+        Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase 'fix-on-demand-maps' -Mode manual
         continue
     }
 
@@ -2897,7 +2899,7 @@ fi
         # Run in fast mode: no fixed settle delay and only one remote wait pass.
         # The persistent VM watchdog / manual Fix Partitions command covers
         # slower post-reconcile drift without making every start feel hung.
-        Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase "post-$cmdName" -Fast
+        Invoke-OnDemandPartitionClear -Ip $ip -DelaySec 0 -Phase "post-$cmdName" -Mode cron -Fast
     }
 
     # One-shot web/CLI commands are complete once the battlegroup command and

--- a/tests/CommandOrchestration.Tests.ps1
+++ b/tests/CommandOrchestration.Tests.ps1
@@ -52,4 +52,9 @@ Describe 'One-shot command orchestration' -Tag 'Commands' {
         $script:entry | Should -Match 'Interactive menu only: resolve Director port'
         $script:entry | Should -Match 'sudo kubectl get svc -A'
     }
+
+    It 'does not hold Reboot All on a fixed post-reboot operator settle' {
+        $script:entry | Should -Match "Invoke-OnDemandPartitionClear -Ip \`$ip -DelaySec 0 -Phase 'post-reboot' -Fast"
+        $script:entry | Should -Not -Match "Invoke-OnDemandPartitionClear -Ip \`$ip -DelaySec 45 -Phase 'post-reboot'"
+    }
 }

--- a/tests/CommandOrchestration.Tests.ps1
+++ b/tests/CommandOrchestration.Tests.ps1
@@ -54,7 +54,15 @@ Describe 'One-shot command orchestration' -Tag 'Commands' {
     }
 
     It 'does not hold Reboot All on a fixed post-reboot operator settle' {
-        $script:entry | Should -Match "Invoke-OnDemandPartitionClear -Ip \`$ip -DelaySec 0 -Phase 'post-reboot' -Fast"
+        $script:entry | Should -Match "Invoke-OnDemandPartitionClear -Ip \`$ip -DelaySec 0 -Phase 'post-reboot' -Mode cron -Fast"
         $script:entry | Should -Not -Match "Invoke-OnDemandPartitionClear -Ip \`$ip -DelaySec 45 -Phase 'post-reboot'"
+    }
+
+    It 'passes explicit conservative and manual partition-heal modes' {
+        $script:entry | Should -Match 'Invoke-DuneRemotePartitionScript -Ip \$Ip -WaitAttempts \$waitAttempts -Mode \$Mode'
+        $script:entry | Should -Match 'sh \$remoteTmp \$Mode'
+        $script:entry | Should -Match "-Phase 'post-startup' -Mode cron -Fast"
+        $script:entry | Should -Match '-Phase "post-\$cmdName" -Mode cron -Fast'
+        $script:entry | Should -Match "-Phase 'fix-on-demand-maps' -Mode manual"
     }
 }


### PR DESCRIPTION
## Summary
- remove Reboot All's unconditional 45-second post-reboot operator settle
- run the same immediate conservative one-pass pin probe used by normal start/restart flows
- retain delayed recovery through the VM boot hook and 15-minute cron heal

## Rationale
A VM reboot preserves k3s/etcd desired state, but the fixed sleep was only protecting the auxiliary on-demand-map cleanup from Funcom operator reconciliation. The cleanup script already leaves legitimately starting/Ready maps alone in conservative mode, and persistent VM-side recovery covers later drift. Reboot All therefore does not need to hold the console for 45 seconds before probing.

## Validation
- CommandOrchestration Pester: 6 passed
- PowerShell parse checks passed
- changed-file gitleaks scan passed

This is queued for the next normal release; no release is requested by this PR.