### PR TITLE
Clean all deleted-character permission residue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ here cover everything those tags shipped.
   Previously, partial root completion could grant Karpov 38 research at zero
   Intel while leaving Wreck of the Alcyon active and unable to observe the
   research event.
+- **Full Delete** now removes every permission held by the deleted character's
+  current or historical actors and every remaining owner/co-owner/associate
+  from objects those characters owned. Previously, legacy actors and retained
+  co-owners could make abandoned bases appear ownerless while still blocking
+  **Claim Ownership**.
 
 ### Added
 

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -887,20 +887,15 @@ function Invoke-DunePlayerAwardIntel {
 
 # ----- Delete Account (DESTRUCTIVE) --------------------------------------
 # ----- Delete Account (matches Funcom's in-game delete + purge) -------------
-# After live-comparing against a real Funcom character-delete-and-purge
-# (2026-07-04), we know the game itself only does two things at purge time:
-#   1. UPDATE the old encrypted_player_state row's character_state = 'Deleted'.
-#      (Keeps the row so the pod doesn't crash on missing FKs; the view
-#      dune.player_state filters WHERE character_state = 'Active' so this
-#      hides the character from every game query that uses the view.)
-#   2. DELETE every permission held by an old character actor anywhere, plus
-#      every remaining rank on objects where that character held rank 1. Leaving
-#      a co-owner behind makes an owned object look ownerless while blocking
-#      Claim Ownership; leaving the deleted actor's rank 2/3 rows elsewhere
-#      preserves permissions for an actor that no longer exists.
-# The game does NOT delete physical totems, actors, buildings, encrypted_
-# accounts, or any per-player state tables. Those persist. This matches
-# behavior verified live against a fresh backup restore + real delete.
+# Live comparison with Funcom's character purge (2026-07-04) established its
+# base behavior: mark encrypted_player_state Deleted and remove the active
+# character's rank-1 ownership rows while preserving physical objects.
+#
+# DST Full Delete adds stricter permission cleanup. It removes every permission
+# held by current/historical actors on the account, plus every remaining rank on
+# objects where those actors held rank 1. This prevents deleted co-owner actors
+# and ownerless objects with retained co-owners from blocking Claim Ownership.
+# Physical totems, actors, buildings, accounts, and per-player state persist.
 function Invoke-DunePlayerDeleteAccount {
     param([string]$Ip, [long]$AccountId)
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -893,12 +893,11 @@ function Invoke-DunePlayerAwardIntel {
 #      (Keeps the row so the pod doesn't crash on missing FKs; the view
 #      dune.player_state filters WHERE character_state = 'Active' so this
 #      hides the character from every game query that uses the view.)
-#   2. DELETE every permission_actor_rank row where player_id is one of the
-#      old character's controllers AND rank = 1. This strips ownership on
-#      the character's solo-owned vehicles/bases/fiefs (they become abandoned
-#      and claimable by anyone). Co-owner rows (rank >= 2) that the character
-#      held on OTHER players' stuff are LEFT INTACT - Hawk keeps his own
-#      grants on Coastal's shared stuff, etc.
+#   2. DELETE every permission held by an old character actor anywhere, plus
+#      every remaining rank on objects where that character held rank 1. Leaving
+#      a co-owner behind makes an owned object look ownerless while blocking
+#      Claim Ownership; leaving the deleted actor's rank 2/3 rows elsewhere
+#      preserves permissions for an actor that no longer exists.
 # The game does NOT delete physical totems, actors, buildings, encrypted_
 # accounts, or any per-player state tables. Those persist. This matches
 # behavior verified live against a fresh backup restore + real delete.
@@ -911,17 +910,34 @@ DECLARE
     v_account_id bigint := $AccountId;
     v_wiped int := 0;
 BEGIN
-    -- Step 1: strip owner grants (rank = 1) held by any actor belonging to
-    -- the account's ACTIVE character(s). Vehicles/bases the character solely
-    -- owned become abandoned and claimable. Co-owner rows survive.
-    WITH deleted AS (
+    -- Step 1: identify every current or historical actor on the account and
+    -- each object they own. Including already-Deleted rows repairs permission
+    -- residue left by older Full Delete runs.
+    WITH deleted_character_actors AS (
+        SELECT DISTINCT actor_id
+        FROM dune.encrypted_player_state eps
+        CROSS JOIN LATERAL unnest(ARRAY[
+            eps.player_controller_id,
+            eps.player_pawn_id,
+            eps.player_state_id
+        ]) AS deleted_actor(actor_id)
+        WHERE eps.account_id = v_account_id
+    ),
+    owned_permission_actors AS (
+        SELECT DISTINCT par.permission_actor_id
+        FROM dune.permission_actor_rank par
+        JOIN deleted_character_actors deleted_actor
+          ON deleted_actor.actor_id = par.player_id
+        WHERE par.rank = 1
+    ),
+    deleted AS (
         DELETE FROM dune.permission_actor_rank par
-        USING dune.actors a, dune.encrypted_player_state eps
-        WHERE a.id = par.player_id
-          AND eps.account_id = v_account_id
-          AND eps.character_state = 'Active'::dune.characterstate
-          AND a.id IN (eps.player_controller_id, eps.player_pawn_id, eps.player_state_id)
-          AND par.rank = 1
+        WHERE par.player_id IN (
+                  SELECT actor_id FROM deleted_character_actors
+              )
+           OR par.permission_actor_id IN (
+                  SELECT permission_actor_id FROM owned_permission_actors
+              )
         RETURNING 1
     )
     SELECT COUNT(*) INTO v_wiped FROM deleted;
@@ -940,6 +956,6 @@ END
     if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
     return @{
         ok = $true
-        message = "Deleted account $AccountId's character - matches the game's own delete+purge: character marked Deleted, owner rank rows on their solo-owned vehicles/bases stripped (now claimable). Co-owner grants on other players' stuff left intact. Physical bases/totems/actors persist in the world."
+        message = "Deleted account $AccountId's character: active character marked Deleted, every permission held by all current/historical account actors removed, and every remaining rank cleared from objects they owned. Former vehicles/bases/fiefs are fully claimable; physical objects persist in the world."
     }
 }

--- a/tests/PlayersAdmin.Tests.ps1
+++ b/tests/PlayersAdmin.Tests.ps1
@@ -196,3 +196,44 @@ Describe 'Invoke-DunePlayerAwardCharXp offline actor targeting' -Tag 'PlayersAdm
         $script:writeCount | Should -Be 0
     }
 }
+
+Describe 'Invoke-DunePlayerDeleteAccount ownership cleanup' -Tag 'PlayersAdmin' {
+    BeforeEach {
+        $script:lastWriteSql = $null
+        $script:writeCount = 0
+    }
+
+    It 'deletes every permission rank from objects owned by the deleted character' {
+        $result = Invoke-DunePlayerDeleteAccount -Ip 'x' -AccountId 1
+
+        $result.ok | Should -BeTrue
+        $script:lastWriteSql | Should -Match 'WITH deleted_character_actors AS'
+        $script:lastWriteSql | Should -Match 'owned_permission_actors AS'
+        $script:lastWriteSql | Should -Match 'par\.rank = 1'
+        $script:lastWriteSql | Should -Match 'DELETE FROM dune\.permission_actor_rank par'
+        $script:lastWriteSql | Should -Match 'par\.permission_actor_id IN'
+        $script:lastWriteSql | Should -Match 'SELECT permission_actor_id FROM owned_permission_actors'
+    }
+
+    It 'also strips the deleted actors co-owner and associate rows elsewhere' {
+        Invoke-DunePlayerDeleteAccount -Ip 'x' -AccountId 1 | Out-Null
+
+        $script:lastWriteSql | Should -Match 'par\.player_id IN'
+        $script:lastWriteSql | Should -Match 'SELECT actor_id FROM deleted_character_actors'
+    }
+
+    It 'includes historical deleted actors while remaining scoped to the selected account' {
+        Invoke-DunePlayerDeleteAccount -Ip 'x' -AccountId 55 | Out-Null
+
+        $discovery = [regex]::Match(
+            $script:lastWriteSql,
+            '(?s)WITH deleted_character_actors AS \((.*?)\),\s*owned_permission_actors AS'
+        ).Groups[1].Value
+        $discovery | Should -Match 'eps\.account_id = v_account_id'
+        $discovery | Should -Not -Match 'character_state'
+        $discovery | Should -Match 'eps\.player_controller_id'
+        $discovery | Should -Match 'eps\.player_pawn_id'
+        $discovery | Should -Match 'eps\.player_state_id'
+        $script:lastWriteSql | Should -Match "SET character_state = 'Deleted'::dune\.characterstate"
+    }
+}


### PR DESCRIPTION
## Summary
- remove every permission held by all current/historical actors on a Full Deleted account
- remove every remaining owner/co-owner/associate from objects where those actors held rank 1
- preserve physical bases, vehicles, fiefs, actors, and unrelated permission sets

## Root cause
Full Delete removed only the deleted character's rank-1 row. A retained co-owner made an abandoned base appear ownerless while still blocking Claim Ownership, and earlier Deleted actors kept co-owner grants on other fiefs/vehicles.

## Live repair proof
- fresh full database backup and targeted permission snapshot retained
- removed exactly five stale rows across both historical Coastal deletions
- deleted-actor permission rows: 0
- abandoned base 266 permission rows: 0
- Hawk/current Coastal protected owner rows: 4/4 retained
- both players remained online; no database reset, battlegroup restart, or VM reboot was performed

## Validation
- PlayersAdmin Pester: 17 passed
- PowerShell parse checks passed
- changed-file gitleaks scan passed

Queued for the next normal release; this PR does not request a release.