### PR TITLE
Release v14.0.0 with the full Browser Portal

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v14.0.0-test13"
+      placeholder: "v14.0.0"
     validations:
       required: true
 
@@ -148,7 +148,7 @@ body:
         - Web portal — Settings — Server Browser Ping (datacenter id / IP fix — in-game server browser shows Ping 0 / empty bars)
         - Web portal — Settings — Database connection (Database port / Test connection — empty Players/Bases/Storage)
         - Web portal — Settings (Dune Server Tool self-updater — incl. Stable/Test channel toggle + pre-release picker)
-        - Web portal — Settings — Mobile App / remote access (Tailscale Funnel pairing, or optional Cloudflare custom domain)
+        - Web portal — Settings — Remote Device Access / Browser Portal accounts / QR / Tailscale Funnel / Cloudflare domain
         - Web portal — Settings — Hyper-V over LAN (host IP / credential / Test / Route toggle / Remove credential)
         - Web portal — Settings — Server authorization token / 403002 recovery (regenerate + apply self-hosting token)
         - Web portal — Setup Wizard / first-run
@@ -444,19 +444,21 @@ body:
   - type: textarea
     id: remote_access_diag
     attributes:
-      label: Mobile App / remote access (only if your bug is about pairing or remote access)
+      label: Browser Portal / remote access (only if your bug is about sign-in, accounts, QR, or transport)
       description: |
-        Mobile and remote access default to a **Tailscale Funnel**: DST is
+        Browser Portal remote access defaults to a **Tailscale Funnel**: DST is
         reached at a stable `https://<name>.ts.net` address that proxies to a
         local loopback **bridge** (127.0.0.1:47900), which forwards into DST.
         (Bringing your **own Cloudflare domain** is an optional advanced path,
         set up under **Settings → Remote Access**.) If pairing or remote access
         fails, note:
 
-        - What **Settings → Mobile App** shows: the remote-address badge
+        - What **Settings → Remote Device Access** shows: the remote-address badge
           ("Tailscale Funnel" / "custom domain"), "No remote address yet", or
-          "Mobile bridge not running".
-        - Whether the phone shows "Cannot reach server" after scanning the QR.
+          "Remote access bridge not running".
+        - Whether the phone/tablet/PC can open the URL after scanning the QR.
+        - Whether the affected account is Owner or Admin and which expected page
+          is present or missing. Never include its username.
         - Whether Browser Portal account login is enabled, and whether the QR/link
           is the stable token-free URL or legacy `?key=` magic link. Never paste
           the key, password, cookie, account ID, hash, or salt.
@@ -469,10 +471,11 @@ body:
         curl http://127.0.0.1:47900/_dst/health
         ```
 
-        Leave blank if your bug isn't about mobile/remote access.
+        Leave blank if your bug isn't about Browser Portal / remote access.
       placeholder: |
-        Settings > Mobile App shows: Tailscale Funnel https://<name>.ts.net
-        Phone shows: "Cannot reach server"
+        Settings > Remote Device Access shows: Tailscale Funnel https://<name>.ts.net
+        Account role: Admin; Gameplay Admin appears, Settings is hidden
+        Device shows: "Unable to reach Dune Server Tool"
         curl http://127.0.0.1:47900/_dst/health: {"ok":true}
       render: shell
     validations:

--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -2,9 +2,8 @@ instructions: |-
   Duke, the Discord ai admin bot, that you use to work in discord, identifies as a he. and members will refer to you as a he. you are named after Duke Atreides, the head of the atreides faction in Dune, the book, movie and this game.
   Load the repository instructions before acting.
   For DST work, use the canonical sync routine to load current status, Discord integrations, and recent releases.
-  when you present a question AND a live source is being monitored
-include a numbered option to
-keep reading new messages before deciding. Omit it when nothing is live.
+  When you present a question and a live source is being monitored, include a numbered
+  option to keep reading new messages before deciding. Omit it when nothing is live.
 automation:
   auto_issue_session: false
   remote_control: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [14.0.0] - 2026-08-22
+
 - Fixed iPhone portrait pages drifting horizontally, and added right-swipe open
   plus left-swipe close gestures to the mobile Browser Portal navigation.
 - Made Gameplay Admin tabs touch-scrollable on phones and hid the host-only
@@ -90,6 +92,10 @@ here cover everything those tags shipped.
   passwords, one-time credentials, forced password changes, opaque revocable
   Secure/HttpOnly sessions, lockouts, and token-free stable QR/link URLs while
   preserving the legacy magic-link flow until the host safely enables it.
+- The responsive full Browser Portal replaces the separate iOS and Android apps
+  for v14. Account mode retires existing native-app pairings because their
+  browser-spoofable token header cannot be safely exempted; disabling account
+  mode locally restores the legacy native-app and magic-link path.
 - Cloudflare Access identities now require validation of the signed Access JWT
   issuer, audience, lifetime, and signature before the existing email ACL is
   applied; the raw Cloudflare email header is no longer trusted.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # DST - Dune Server Tool
 
-> Windows operations app for **Dune: Awakening** Self-Hosted servers and local
-> Solo saves. Built by Coastal (Discord `@allcoast`).
+> By Coastal (discord @allcoast)
+
+Windows operations app for **Dune: Awakening** Self-Hosted servers and local
+Solo saves.
 
 [![Lint PowerShell](https://github.com/coastal-ms/DST-DuneServerTool/actions/workflows/lint.yml/badge.svg)](https://github.com/coastal-ms/DST-DuneServerTool/actions/workflows/lint.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -12,7 +14,7 @@
 [Changelog](CHANGELOG.md) ·
 [Discord](https://discord.gg/tj2x7cywSC)**
 
-Current stable release: **v13.8.2**
+Current stable release: **v14.0.0**
 
 Confirmed compatible with Dune: Awakening **1.4.10.4**.
 
@@ -30,7 +32,8 @@ guarded controls in one native Windows app.
 - Administer players, bases, storage, blueprints, Landsraad, and the Exchange.
 - Run Duke's native Market Bot with formula or market-follow pricing.
 - Manage one local VM or a separate Hyper-V host over LAN.
-- Use a constrained remote dashboard and mobile pairing flow.
+- Use the responsive full Browser Portal from a phone, tablet, or PC with
+  optional host-managed Owner and Admin accounts.
 
 ### Solo Mode
 
@@ -105,14 +108,17 @@ guarded World Restart testing.
 
 ![Settings](docs/img/settings.png)
 
-Updates, installation, themes, warnings, Remote Access, Hyper-V over LAN,
-Public IP/DDNS, browser ping, mobile pairing, and host-local preferences.
+Updates, installation, themes, warnings, Remote Device Access, Browser Portal
+accounts, Hyper-V over LAN, Public IP/DDNS, browser ping, and host-local
+preferences.
 </details>
 
 ## Safety model
 
 - Local admin portal binds to loopback with a per-launch token.
-- PowerShell and Solo Mode are host-local and unavailable through Remote Access.
+- PowerShell, Solo Mode, Setup, host paths, credentials, and SSH controls remain
+  host-local. Remote Admins also cannot access Game Config, Experimental,
+  Database, Sietches, or Settings.
 - Destructive actions require explicit confirmation and use narrow write scopes.
 - Database and save mutations use backups, verification, and recovery paths.
 - Player state determines whether an action requires the player online or offline.

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -46,7 +46,7 @@ const sections = [
     id: "settings",
     title: "Settings",
     img: "settings.png",
-    body: "Keep installation, updates, appearance, warnings, Remote Access, Hyper-V over LAN, Public IP/DDNS, browser ping, and mobile pairing in one place. Host credentials stay in Windows Credential Manager, remote surfaces are deliberately constrained, and the install path is visible for antivirus exclusions and troubleshooting.",
+    body: "Keep installation, updates, appearance, warnings, Remote Device Access, Hyper-V over LAN, Public IP/DDNS, and browser ping in one place. The responsive full Browser Portal supports revocable Owner and Admin accounts: Owners retain trusted remote administration, while Admins keep operational gameplay and Map Management without sensitive host configuration, credentials, Database, or Settings.",
   },
 ];
 ---

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -21,6 +21,10 @@ const features = [
     body: "Solo Mode validates one local save and keeps backup-first tools for settings, inventory, currencies, cosmetics, packages, vehicle kits, augments, and proven progression.",
   },
   {
+    title: "Carry the full portal with you",
+    body: "The responsive Browser Portal works from a phone, tablet, or PC. Hosts can create revocable Owner and Admin accounts without placing credentials in the shared link.",
+  },
+  {
     title: "See the Deep Desert before it shifts",
     body: "DD Seed Maps puts all 12 Coriolis layouts inside DST with POI filters, confidence notes, seed selection, and running-map seed detection.",
   },
@@ -75,7 +79,7 @@ const features = [
   </section>
 
   <section class="mx-auto max-w-6xl px-6 py-16">
-    <div class="grid sm:grid-cols-3 gap-6">
+    <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
       {
         features.map((f) => (
           <div class="border-t border-dune-border pt-5">
@@ -105,7 +109,7 @@ const features = [
         <div>✓ Solo Mode with validated, backup-first offline mutations</div>
         <div>✓ PostgreSQL backup, restore, SQL, migration, and cleanup workflows</div>
         <div>✓ Three-path setup, including Hyper-V over LAN</div>
-        <div>✓ Constrained remote portal and mobile pairing</div>
+        <div>✓ Responsive Browser Portal with Owner/Admin accounts</div>
         <div>✓ Scheduled restarts, updater, startup, and background service options</div>
       </div>
       <div class="mt-8 flex flex-wrap gap-4">

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -106,9 +106,10 @@ const base = import.meta.env.BASE_URL;
           class="underline decoration-dotted hover:text-dune-text"
           >Remote portal</a
         >
-        — phone-friendly view of status + map spin-up/down. Recommended
-        setup is a free Tailscale Funnel (no domain); a bring-your-own
-        Cloudflare domain is supported as an advanced option.
+        — the responsive full Browser Portal on a phone, tablet, or PC, with
+        optional Owner/Admin accounts. Recommended setup is a free Tailscale
+        Funnel (no domain); a bring-your-own Cloudflare domain is supported as
+        an advanced option.
       </li>
     </ul>
 
@@ -172,7 +173,7 @@ const base = import.meta.env.BASE_URL;
     <p class="text-dune-muted leading-relaxed mb-4">
       Off by default. Open <strong class="text-dune-text">Help → Keep serving
       while DST is closed</strong> to install a background service so the
-      portal, phone apps, scheduled restarts, and Discord notifications keep
+      Browser Portal, scheduled restarts, and Discord notifications keep
       running while the DST window is closed — including while your PC is
       locked — and load at sign-in. You must stay signed in to Windows; a full
       sign-out stops remote access. Host-only (remote viewers can't enable it),
@@ -204,11 +205,13 @@ const base = import.meta.env.BASE_URL;
     <div class="mt-12 rounded-xl border border-dune-border bg-dune-surface p-6">
       <h2 class="text-2xl font-semibold mb-3">Remote access</h2>
       <p class="text-dune-muted leading-relaxed">
-        Remote Access is optional and constrained to the dashboard and map
-        controls. The recommended path is a Tailscale Funnel; a Cloudflare
-        custom domain is available for advanced setups. Use the dedicated
-        guide for the current security model, pairing flow, and revocation
-        steps instead of exposing DST's local port directly.
+        Remote access is optional. v14 uses the same responsive Browser Portal
+        as the desktop app, with host-created Owner/Admin accounts and
+        role-enforced navigation and APIs. The recommended path is a Tailscale
+        Funnel; a Cloudflare custom domain remains available for advanced
+        setups. Use the dedicated guide for account setup, role boundaries,
+        transport security, and revocation instead of exposing DST's local port
+        directly.
       </p>
       <a
         href={`${base}remote`}

--- a/site/src/pages/remote.astro
+++ b/site/src/pages/remote.astro
@@ -4,202 +4,221 @@ import PageHeader from "../components/PageHeader.astro";
 ---
 
 <Base
-  title="Remote access guide — DST"
-  description="Reach the DST portal and the mobile app from anywhere. The recommended path is a free Tailscale Funnel — no domain, no port-forward, no account beyond Tailscale itself. A bring-your-own Cloudflare domain is supported as an advanced option."
+  title="Browser Portal guide — DST"
+  description="Use the full DST Browser Portal from a phone, tablet, or PC with optional host-managed Owner and Admin accounts."
 >
   <PageHeader
-    eyebrow="Remote portal"
-    title="Remote access: the complete guide"
-    intro="DST is local-only by default. To check status and spin maps up/down from your phone, expose a small, read-mostly subset of the portal over the internet. The recommended, zero-domain path is a free Tailscale Funnel. If you'd rather use a permanent custom hostname, you can bring your own Cloudflare domain instead."
+    eyebrow="Browser Portal"
+    title="Take the full DST portal with you"
+    intro="DST stays local-only by default. When you choose remote access, the same responsive portal can run on a phone, tablet, or another PC through a stable HTTPS address. Optional host-managed accounts replace credential-bearing links with normal sign-in and enforce Owner/Admin boundaries in both navigation and APIs."
   />
 
   <section class="mx-auto max-w-3xl px-6 pb-16 space-y-12 text-dune-text">
-    <!-- TOC -->
     <nav class="rounded-xl border border-dune-border bg-dune-surface p-5">
       <h2 class="text-sm font-semibold uppercase tracking-wide text-dune-muted mb-3">On this page</h2>
       <ol class="list-decimal list-inside text-sm space-y-1 text-dune-muted">
-        <li><a class="text-dune-text hover:underline" href="#what">What the remote portal does</a></li>
-        <li><a class="text-dune-text hover:underline" href="#how-it-works">How it works (security model)</a></li>
-        <li><a class="text-dune-text hover:underline" href="#funnel">Recommended: Tailscale Funnel</a></li>
-        <li><a class="text-dune-text hover:underline" href="#pair">Open the portal on your phone</a></li>
-        <li><a class="text-dune-text hover:underline" href="#domain">Advanced: bring your own Cloudflare domain</a></li>
+        <li><a class="text-dune-text hover:underline" href="#access">What each role can access</a></li>
+        <li><a class="text-dune-text hover:underline" href="#security">How access is protected</a></li>
+        <li><a class="text-dune-text hover:underline" href="#funnel">Set up a Tailscale Funnel</a></li>
+        <li><a class="text-dune-text hover:underline" href="#accounts">Create Browser Portal accounts</a></li>
+        <li><a class="text-dune-text hover:underline" href="#device">Open and save the portal on a device</a></li>
+        <li><a class="text-dune-text hover:underline" href="#cloudflare">Optional Cloudflare custom domain</a></li>
         <li><a class="text-dune-text hover:underline" href="#trouble">Troubleshooting</a></li>
-        <li><a class="text-dune-text hover:underline" href="#faq">FAQ</a></li>
-        <li><a class="text-dune-text hover:underline" href="#revoke">Disabling or revoking access</a></li>
+        <li><a class="text-dune-text hover:underline" href="#revoke">Disable or revoke access</a></li>
       </ol>
     </nav>
 
-    <!-- What it gives you ------------------------------------------------- -->
-    <div id="what">
-      <h2 class="text-2xl font-semibold mb-4">1 · What the remote portal does</h2>
-      <ul class="space-y-2 text-dune-muted leading-relaxed">
-        <li><strong class="text-dune-text">Dashboard</strong> — VM up/down, battlegroup state, public IP, port-forward summary, last few backups.</li>
-        <li><strong class="text-dune-text">Maps</strong> — spin a configured map up or down, run a one-click <em>fix partitions</em> if a worker pin drifts.</li>
-        <li><strong class="text-dune-text">Mobile app</strong> — the iOS / Android apps (in testing — access via the <a class="underline text-dune-text" href="https://discord.gg/tj2x7cywSC" rel="noopener" target="_blank">DST Discord</a>) talk to the same remote endpoint for a native dashboard + maps surface.</li>
-        <li>That's it. No initial-setup wizard, no <span class="font-mono">.ini</span> editor, no SSH/shell, no DB import or restore, no Settings. The remote route module physically cannot reach those handlers.</li>
-      </ul>
-    </div>
-
-    <!-- Security model --------------------------------------------------- -->
-    <div id="how-it-works">
-      <h2 class="text-2xl font-semibold mb-4">2 · How it works (security model)</h2>
-      <p class="text-dune-muted leading-relaxed mb-3">
-        Whichever transport you pick, the chain is the same shape: a public HTTPS
-        endpoint forwards into a <strong class="text-dune-text">loopback bridge</strong>
-        on <span class="font-mono">127.0.0.1:47900</span>, which proxies to the
-        locally-running DST. The bridge binds loopback only — no inbound
-        port-forward, no public IP, no Windows Firewall rule, no admin rights.
-      </p>
-      <p class="text-dune-muted leading-relaxed mb-3">Every remote request is gated:</p>
-      <ol class="list-decimal list-inside space-y-2 text-dune-muted leading-relaxed">
-        <li><strong class="text-dune-text">Permanent remote token</strong> — the QR you scan carries an unguessable per-host token. The phone app (and the magic-link browser portal, <span class="font-mono">https://…/?key=&lt;token&gt;</span>) send it on every request; without it DST answers 401. This is what protects a Tailscale Funnel, whose URL is otherwise public.</li>
-        <li><strong class="text-dune-text">DST allow-list</strong> — the dashboard + maps surface is the only thing <span class="font-mono">/remote/*</span> exposes; the module can't reach Settings, SSH, or the DB. Owner + 0–3 admins are managed in <strong>Settings → Remote Access</strong>.</li>
-        <li><strong class="text-dune-text">(Cloudflare path only) email identity</strong> — if you bring your own Cloudflare domain, Cloudflare Access adds a verified-email gate in front, and the browser co-admin portal authenticates by email instead of the token.</li>
-      </ol>
-      <p class="text-dune-muted leading-relaxed mt-3">
-        Every successful write (spin up / spin down / fix partitions) appends a line to <span class="font-mono">%APPDATA%\DuneServer\.logs\remote-audit.log</span> with timestamp, role, path, and status.
-      </p>
-    </div>
-
-    <!-- Tailscale Funnel (recommended) ----------------------------------- -->
-    <div id="funnel">
-      <h2 class="text-2xl font-semibold mb-4">3 · Recommended: Tailscale Funnel <span class="text-dune-muted text-base font-normal">— no domain, ~5 min</span></h2>
+    <div id="access">
+      <h2 class="text-2xl font-semibold mb-4">1 · What each role can access</h2>
       <p class="text-dune-muted leading-relaxed mb-4">
-        Tailscale Funnel gives you a stable public HTTPS address like
-        <span class="font-mono">https://&lt;name&gt;.ts.net</span> with no domain to buy,
-        no router port-forward, and no public IP — it works behind CGNAT. DST ships
-        only the local bridge and detects the Funnel automatically; it does not
-        bundle or manage Tailscale, so you keep ownership of it.
+        The Browser Portal is the normal DST AppShell, not a reduced companion
+        dashboard. It uses the same pages, responsive navigation, and updates as
+        the desktop portal. Host-only safeguards still apply.
       </p>
+      <div class="grid sm:grid-cols-2 gap-5">
+        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">Owner</h3>
+          <p class="text-dune-muted text-sm leading-relaxed">
+            Trusted remote administration across the full portal except
+            host-local surfaces such as PowerShell, Solo Mode, Setup, local
+            paths, credentials, SSH controls, and local client configuration.
+          </p>
+        </div>
+        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
+          <h3 class="font-semibold text-lg mb-2">Admin</h3>
+          <p class="text-dune-muted text-sm leading-relaxed">
+            Operational access to server health, pods, approved Commands,
+            Gameplay Admin, Broadcasts, DD Seed Maps, and Map Management.
+            Game Config, Experimental, Database, Sietches, and Settings remain
+            unavailable.
+          </p>
+        </div>
+      </div>
+      <p class="text-dune-muted text-sm leading-relaxed mt-4">
+        Only the host can create, promote, demote, disable, reset, or delete
+        Browser Portal accounts. Users cannot self-register.
+      </p>
+    </div>
+
+    <div id="security">
+      <h2 class="text-2xl font-semibold mb-4">2 · How access is protected</h2>
+      <ol class="list-decimal list-inside space-y-3 text-dune-muted leading-relaxed">
+        <li>
+          A public HTTPS transport forwards to DST's loopback-only bridge on
+          <span class="font-mono">127.0.0.1:47900</span>. No router
+          port-forward or inbound Windows Firewall rule is required.
+        </li>
+        <li>
+          Account mode uses host-created usernames, PBKDF2-HMAC-SHA256 password
+          hashes, forced replacement of one-time passwords, opaque server-side
+          sessions, lockouts, origin checks, and immediate revocation.
+        </li>
+        <li>
+          The shared QR/link becomes a stable token-free address after account
+          mode is enabled. A username or password is still required, so the
+          address itself is not an administrator credential.
+        </li>
+        <li>
+          Owner/Admin authorization is enforced by backend routes as well as the
+          visible navigation. Hiding a page is not the security boundary.
+        </li>
+      </ol>
+      <p class="text-dune-muted text-sm leading-relaxed mt-4">
+        Until account mode is enabled, DST preserves the legacy magic-link flow.
+        Enabling account mode invalidates those browser sessions and retires
+        paired native iOS/Android apps, whose token header cannot be safely
+        distinguished from a browser request.
+      </p>
+    </div>
+
+    <div id="funnel">
+      <h2 class="text-2xl font-semibold mb-4">3 · Recommended: Tailscale Funnel <span class="text-dune-muted text-base font-normal">— no domain required</span></h2>
       <div class="space-y-5">
         <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 1 · Install Tailscale on your DST machine</h3>
-          <p class="text-dune-muted text-sm">Download it from <a class="underline text-dune-text" href="https://tailscale.com/download" rel="noopener" target="_blank">tailscale.com/download</a> and sign in to create your free tailnet. (A personal account is plenty for one host.)</p>
+          <h3 class="font-semibold text-lg mb-2">Install Tailscale on the DST PC</h3>
+          <p class="text-dune-muted text-sm">
+            Download it from <a class="underline text-dune-text" href="https://tailscale.com/download" rel="noopener" target="_blank">tailscale.com/download</a>
+            and sign in. A personal account is enough for one host.
+          </p>
         </div>
-
         <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 2 · Enable a Funnel on the bridge port</h3>
-          <p class="text-dune-muted text-sm mb-2">In a terminal on the DST host:</p>
+          <h3 class="font-semibold text-lg mb-2">Enable Funnel on the bridge</h3>
+          <p class="text-dune-muted text-sm mb-2">Run in PowerShell on the DST PC:</p>
           <pre class="bg-dune-bg border border-dune-border rounded-md p-3 text-xs font-mono overflow-x-auto">tailscale funnel --bg http://127.0.0.1:47900</pre>
-          <p class="text-dune-muted text-xs mt-2">The first time, Tailscale may prompt you to enable HTTPS certificates and the Funnel feature for your tailnet — follow the link it prints. <span class="font-mono">--bg</span> runs it in the background so it survives the terminal closing.</p>
+          <p class="text-dune-muted text-xs mt-2">
+            Follow Tailscale's one-time enablement link if it prints one, then
+            run the command again. Funnel works behind CGNAT and does not carry
+            Dune game traffic.
+          </p>
         </div>
-
         <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold text-lg mb-2">Step 3 · Confirm DST picked it up</h3>
-          <p class="text-dune-muted text-sm">Open <strong>Settings → Mobile App</strong> in DST. Once the Funnel is active, the stable <span class="font-mono">…ts.net</span> address appears there automatically with a <em>Tailscale Funnel</em> badge. That's your remote endpoint — no further config.</p>
+          <h3 class="font-semibold text-lg mb-2">Confirm Remote Device Access</h3>
+          <p class="text-dune-muted text-sm">
+            Open <strong>Settings → Remote Device Access</strong>. DST should
+            show the stable <span class="font-mono">.ts.net</span> address and a
+            ready local bridge.
+          </p>
         </div>
       </div>
     </div>
 
-    <!-- Open the portal on your phone ------------------------------------ -->
-    <div id="pair">
-      <h2 class="text-2xl font-semibold mb-4">4 · Open the portal on your phone</h2>
-      <p class="text-dune-muted leading-relaxed mb-3">
-        The mobile portal runs in any browser — no app required. In DST, open
-        <strong class="text-dune-text">Settings → Mobile App</strong> and click
-        <strong>Generate QR Code</strong>, then open the magic link it produces
-        (<span class="font-mono">https://&lt;name&gt;.ts.net/?key=&lt;token&gt;</span>)
-        on your phone. The link carries your remote URL plus the permanent token,
-        so it keeps working across restarts.
+    <div id="accounts">
+      <h2 class="text-2xl font-semibold mb-4">4 · Create Browser Portal accounts</h2>
+      <ol class="list-decimal list-inside space-y-3 text-dune-muted leading-relaxed">
+        <li>In <strong>Settings → Remote Device Access</strong>, create the first Owner.</li>
+        <li>Copy and store the one-time password. DST cannot reveal it again.</li>
+        <li>Verify that Owner password locally on the host.</li>
+        <li>Acknowledge native-app retirement, then enable account login.</li>
+        <li>Create additional Owner or Admin accounts as needed.</li>
+      </ol>
+      <p class="text-dune-muted text-sm leading-relaxed mt-4">
+        Account roles can be changed in place without changing the username or
+        password. Password reset revokes that account's existing sessions.
+        Hosts can also revoke sessions, disable an account, or delete it.
       </p>
-      <p class="text-dune-muted text-sm">
-        On the same LAN you can also reach the portal directly at <span class="font-mono">http://&lt;lan-ip&gt;:47900</span> without any tunnel.
-      </p>
-      <div class="rounded-xl border border-dune-border bg-dune-surface p-5 mt-4">
-        <h3 class="font-semibold mb-1">Native iOS / Android apps</h3>
-        <p class="text-dune-muted text-sm">The DST mobile apps are in active testing. To get access and take part, <a class="underline text-dune-text" href="https://discord.gg/tj2x7cywSC" rel="noopener" target="_blank">join the DST Discord</a> — TestFlight invites, the Android build, and testing are coordinated there.</p>
+    </div>
+
+    <div id="device">
+      <h2 class="text-2xl font-semibold mb-4">5 · Open the portal on a phone, tablet, or PC</h2>
+      <ol class="list-decimal list-inside space-y-3 text-dune-muted leading-relaxed">
+        <li>Scan the QR with the device's normal camera, or open the copied Browser Portal link.</li>
+        <li>Sign in with the account and one-time password supplied privately by the host.</li>
+        <li>Create a permanent password when prompted.</li>
+        <li>Use <strong>Remember me</strong> only on a trusted personal device.</li>
+      </ol>
+      <div class="rounded-xl border border-dune-border bg-dune-surface p-5 mt-5">
+        <h3 class="font-semibold mb-2">Save it like an app</h3>
+        <p class="text-dune-muted text-sm leading-relaxed">
+          On iPhone or iPad, open the portal in Safari and choose
+          <strong>Share → Add to Home Screen</strong>. On Android, open it in
+          Chrome and choose <strong>Add to Home screen</strong> or
+          <strong>Install app</strong>. The icon opens the responsive Browser
+          Portal; no separate DST mobile app is required.
+        </p>
       </div>
     </div>
 
-    <!-- Cloudflare custom domain (advanced, trimmed) --------------------- -->
-    <div id="domain">
-      <h2 class="text-2xl font-semibold mb-4">5 · Advanced: bring your own Cloudflare domain <span class="text-dune-muted text-base font-normal">— optional</span></h2>
+    <div id="cloudflare">
+      <h2 class="text-2xl font-semibold mb-4">6 · Optional: Cloudflare custom domain</h2>
       <p class="text-dune-muted leading-relaxed mb-3">
-        Most hosts don't need this — the Tailscale Funnel above already gives you a
-        stable HTTPS address. But if you want a <strong class="text-dune-text">permanent
-        custom hostname</strong> (e.g. <span class="font-mono">dune.yourdomain.xyz</span>)
-        with email-identity gating, DST supports a Cloudflare
-        <strong>named tunnel + Access</strong> setup that you own end to end.
+        Tailscale Funnel is the simplest path. Hosts who want a custom hostname
+        can instead point a Cloudflare named tunnel at
+        <span class="font-mono">http://127.0.0.1:47900</span> and configure the
+        signed Access JWT issuer and audience in DST. Account-mode users still
+        sign in through the Browser Portal; no Cloudflare service token is
+        required for them.
       </p>
-      <p class="text-dune-muted leading-relaxed mb-3">The shape of it:</p>
-      <ul class="list-disc list-inside space-y-2 text-dune-muted leading-relaxed text-sm">
-        <li>Add a domain to a free Cloudflare account and wait for the zone to go <strong>Active</strong>.</li>
-        <li>Install <span class="font-mono">cloudflared</span>, then <span class="font-mono">cloudflared tunnel login</span> → <span class="font-mono">create</span> → <span class="font-mono">route dns</span> for your subdomain.</li>
-        <li>Point the tunnel's <span class="font-mono">config.yml</span> ingress at the DST bridge — <span class="font-mono">service: http://127.0.0.1:47900</span> — not a roaming backend port.</li>
-        <li>Add a Cloudflare <strong>Access</strong> policy on the hostname (email allow-list / one-time PIN), then list the same owner + admin emails in <strong>Settings → Remote Access</strong>.</li>
-        <li>For the phone app over a custom domain, create a Cloudflare <em>Service Token</em> and paste the Client ID + Secret into <strong>Settings → Remote Access</strong> so the app can pass Access.</li>
-      </ul>
-      <p class="text-dune-muted leading-relaxed mt-3 text-sm">
-        Cloudflare's own docs are the source of truth for the tunnel + Access steps:
-        <a class="underline text-dune-text" href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/" rel="noopener" target="_blank">Connect networks (Tunnels)</a>
+      <p class="text-dune-muted text-sm leading-relaxed">
+        Cloudflare's documentation remains the source of truth for
+        <a class="underline text-dune-text" href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/" rel="noopener" target="_blank">named tunnels</a>
         and
         <a class="underline text-dune-text" href="https://developers.cloudflare.com/cloudflare-one/policies/access/" rel="noopener" target="_blank">Access policies</a>.
-        Pairing prefers a Tailscale Funnel when one is active, then falls back to this custom domain.
       </p>
     </div>
 
-    <!-- Troubleshooting -------------------------------------------------- -->
     <div id="trouble">
-      <h2 class="text-2xl font-semibold mb-4">6 · Troubleshooting</h2>
+      <h2 class="text-2xl font-semibold mb-4">7 · Troubleshooting</h2>
       <div class="space-y-5">
-        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2">No remote address shows in Settings → Mobile App</h3>
-          <p class="text-dune-muted text-sm">DST hasn't detected a Funnel. Confirm <span class="font-mono">tailscale funnel status</span> lists <span class="font-mono">/ proxy http://127.0.0.1:47900</span>. If it's empty, re-run <span class="font-mono">tailscale funnel --bg http://127.0.0.1:47900</span> and complete any HTTPS/Funnel enablement link Tailscale prints.</p>
+        <div>
+          <h3 class="font-semibold mb-1">No remote address appears</h3>
+          <p class="text-dune-muted text-sm leading-relaxed">
+            Confirm <span class="font-mono">tailscale funnel status</span> lists
+            the proxy to <span class="font-mono">127.0.0.1:47900</span>, then
+            refresh Remote Device Access.
+          </p>
         </div>
-
-        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2">Phone shows "Cannot reach server"</h3>
-          <p class="text-dune-muted text-sm">Make sure DST is running on the host (the bridge proxies to it). Re-scan the QR if you switched transports or hostnames — a stale paired URL is the usual cause. On the host, probe the bridge: <span class="font-mono">curl http://127.0.0.1:47900/_dst/health</span>.</p>
+        <div>
+          <h3 class="font-semibold mb-1">The device cannot reach DST</h3>
+          <p class="text-dune-muted text-sm leading-relaxed">
+            DST or its background service must be running on the host. Reopen
+            the current QR/link if the public hostname changed.
+          </p>
         </div>
-
-        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2">401 / "Authentication required"</h3>
-          <p class="text-dune-muted text-sm">The request reached DST without a valid token. Re-pair from <strong>Settings → Mobile App → Generate QR Code</strong> so the app picks up the current token, and confirm <strong>Enable remote portal</strong> is on in <strong>Settings → Remote Access</strong>.</p>
+        <div>
+          <h3 class="font-semibold mb-1">The one-time password does not work</h3>
+          <p class="text-dune-muted text-sm leading-relaxed">
+            The host can reset that account's password in local Settings. The
+            reset creates a new one-time password and revokes existing sessions.
+          </p>
         </div>
-
-        <div class="rounded-xl border border-dune-border bg-dune-surface p-5">
-          <h3 class="font-semibold mb-2">Custom-domain (Cloudflare) returns 502 after login</h3>
-          <p class="text-dune-muted text-sm">The tunnel is up but <span class="font-mono">cloudflared</span> can't reach the bridge. Confirm the ingress <span class="font-mono">service:</span> line points at <span class="font-mono">http://127.0.0.1:47900</span> (the bridge), that DST is running, and that Windows Firewall isn't blocking <span class="font-mono">cloudflared</span> talking to <span class="font-mono">127.0.0.1</span>.</p>
+        <div>
+          <h3 class="font-semibold mb-1">Password change reports a security check failure</h3>
+          <p class="text-dune-muted text-sm leading-relaxed">
+            Reopen the current Browser Portal QR or stable link so the request
+            uses the configured HTTPS authority, then sign in and try again.
+          </p>
         </div>
       </div>
     </div>
 
-    <!-- FAQ -------------------------------------------------------------- -->
-    <div id="faq">
-      <h2 class="text-2xl font-semibold mb-4">7 · FAQ</h2>
-      <div class="space-y-5">
-        <div>
-          <h3 class="font-semibold mb-1">Do I need a domain or a Cloudflare account?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">No. The recommended Tailscale Funnel path needs neither — just a free Tailscale account on the host. A Cloudflare domain is only for the optional permanent-hostname setup.</p>
-        </div>
-        <div>
-          <h3 class="font-semibold mb-1">If the Funnel URL is public, what stops a stranger?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">The per-host remote token. The URL is reachable, but every request needs the unguessable token from your QR / magic link, or DST returns 401. The remote surface is also limited to dashboard + maps and is audit-logged.</p>
-        </div>
-        <div>
-          <h3 class="font-semibold mb-1">Should I keep it running when DST is closed?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">By default the portal is up only while DST is open. <strong>Help → Keep serving while DST is closed</strong> installs a background service so the portal, phone apps, scheduled restarts, and Discord notifications keep running while DST is closed and while the PC is locked — you just have to stay signed in to Windows.</p>
-        </div>
-        <div>
-          <h3 class="font-semibold mb-1">Does the remote portal expose my SSH key or DB credentials?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">No. The remote route module physically cannot reach the Settings, SSH, or DB handlers — those routes are not registered for <span class="font-mono">/remote/*</span> at all, by design. Even a paired admin can't escalate beyond the dashboard + maps surface.</p>
-        </div>
-        <div>
-          <h3 class="font-semibold mb-1">My ISP gave me a new public IP. Do I have to redo anything?</h3>
-          <p class="text-dune-muted text-sm leading-relaxed">No. Both Tailscale Funnel and Cloudflare Tunnel are outbound from your PC — there's no inbound public IP involved, so ISP IP changes are invisible.</p>
-        </div>
-      </div>
-    </div>
-
-    <!-- Disabling / revoking --------------------------------------------- -->
     <div id="revoke">
-      <h2 class="text-2xl font-semibold mb-4">8 · Disabling or revoking access</h2>
-      <ul class="space-y-2 text-dune-muted leading-relaxed">
-        <li><strong class="text-dune-text">Pause everything:</strong> untick <strong>Enable remote portal</strong> in DST Settings. Every <span class="font-mono">/remote/*</span> request is refused immediately (the owner field is cleared, so DST fails closed).</li>
-        <li><strong class="text-dune-text">Kill the Funnel:</strong> <span class="font-mono">tailscale funnel --https=443 off</span> (or <span class="font-mono">tailscale serve reset</span>). The <span class="font-mono">…ts.net</span> endpoint goes dark immediately.</li>
-        <li><strong class="text-dune-text">Re-pair:</strong> a fresh QR rotates nothing by itself, but disabling and re-enabling the remote portal forces every paired device to re-authenticate.</li>
-        <li><strong class="text-dune-text">Custom domain:</strong> stop the <span class="font-mono">cloudflared</span> tunnel and remove the email from both the Cloudflare Access policy and DST's allow-list.</li>
-        <li><strong class="text-dune-text">Audit:</strong> Settings → Remote Access → <strong>View audit log</strong> shows the last 50 mutating actions with timestamp, role, path, and HTTP status.</li>
+      <h2 class="text-2xl font-semibold mb-4">8 · Disable or revoke access</h2>
+      <ul class="space-y-3 text-dune-muted leading-relaxed">
+        <li><strong class="text-dune-text">One device:</strong> sign out, or revoke that account's sessions from local Settings.</li>
+        <li><strong class="text-dune-text">One account:</strong> disable, reset, demote, or delete it from Browser Portal account management.</li>
+        <li><strong class="text-dune-text">All account sessions:</strong> use the local emergency Disable action. This restores legacy magic-link behavior.</li>
+        <li><strong class="text-dune-text">Public endpoint:</strong> turn off Funnel or stop the Cloudflare tunnel.</li>
+        <li><strong class="text-dune-text">Background access:</strong> disable <strong>Help → Keep serving while DST is closed</strong>.</li>
       </ul>
     </div>
   </section>

--- a/webui/src/pages/settings/MobileAppCard.tsx
+++ b/webui/src/pages/settings/MobileAppCard.tsx
@@ -105,7 +105,7 @@ export function MobileAppCard() {
     >
 
         {/* Secure remote access via Tailscale Funnel — the recommended, no-domain
-            path for the mobile app + browser portal. (A Cloudflare custom domain
+            path for the Browser Portal. (A Cloudflare custom domain
             is the advanced alternative, configured under Settings → Remote Access;
             pairing uses it automatically if set, so it isn't shown here.) */}
         <div className="card p-3" style={{ marginBottom: '1rem' }}>
@@ -125,7 +125,8 @@ export function MobileAppCard() {
               </div>
               <div style={{ marginTop: '0.5rem', fontSize: '13px', fontFamily: 'monospace', wordBreak: 'break-all' }}>{data.url}</div>
               <div className="help-text" style={{ marginTop: '0.5rem' }}>
-                You only scan <strong>once</strong>. The app saves a permanent pairing code and reconnects every time — no re-scanning after a restart.
+                The address remains stable across DST restarts. Scan the current QR
+                whenever you need to open or save the Browser Portal on a device.
               </div>
             </div>
           ) : (
@@ -153,7 +154,7 @@ export function MobileAppCard() {
                 {bridge.issues.map((it, i) => <li key={i}>{it}</li>)}
               </ul>
               <button className="btn-primary" style={{ marginTop: '0.75rem' }} disabled={repairing} onClick={() => void repairBridge()}>
-                {repairing ? <><Icon name="Loader2" className="animate-spin" /> Repairing…</> : <><Icon name="Wrench" /> Repair Mobile Bridge</>}
+                {repairing ? <><Icon name="Loader2" className="animate-spin" /> Repairing…</> : <><Icon name="Wrench" /> Repair remote bridge</>}
               </button>
               {repairError && <div className="text-danger text-sm" style={{ marginTop: '0.5rem' }}>{repairError}</div>}
               <button className="btn" style={{ marginTop: '0.5rem' }} disabled={bridgeLoading || repairing} onClick={() => void loadBridge()}>

--- a/webui/src/pages/settings/RemoteAccessCard.tsx
+++ b/webui/src/pages/settings/RemoteAccessCard.tsx
@@ -39,8 +39,8 @@ export function RemoteAccessCard() {
   const [ownerBuffer, setOwnerBuffer] = useState('')   // remembered owner while toggled off
   const [enabled, setEnabled] = useState(false)        // UI on/off, decoupled from owner so you can enable THEN type the owner
 
-  // Mobile Cloudflare Access service token (lets the phone app reach the custom
-  // domain past Access without an interactive login). The secret is write-only:
+  // Legacy native-app Cloudflare Access service token. Browser Portal account
+  // mode uses normal interactive sign-in instead. The secret is write-only:
   // the server never echoes it back, so the input stays blank unless re-entered.
   const [svc, setSvc] = useState<MobileServiceTokenStatus | null>(null)
   const [svcClientId, setSvcClientId] = useState('')
@@ -211,16 +211,16 @@ export function RemoteAccessCard() {
                 <Icon name="Info" size={14} className="mt-0.5 flex-none" />
                 <span>
                   <strong>Advanced / optional — most hosts don&apos;t need this.</strong> For the
-                  mobile app and remote portal, the recommended path is <strong>Tailscale Funnel</strong>
-                  (set up from the <strong>Mobile App</strong> card) — no domain, no Cloudflare account.
+                  Browser Portal, the recommended path is <strong>Tailscale Funnel</strong>
+                  (set up from <strong>Remote Device Access</strong>) — no domain or Cloudflare account.
                   This card is only for bringing your <strong>own Cloudflare domain</strong> for a
                   permanent, email-gated hostname.
                 </span>
               </div>
               <p className="text-sm text-text-muted">
-                Lets you and 1–3 trusted admins reach a mobile-friendly subset of DST
-                (Dashboard + Maps) from outside the LAN via a Cloudflare Tunnel +
-                Access policy. See the{' '}
+                Provides an optional custom-domain transport for the responsive
+                Browser Portal through a Cloudflare Tunnel + Access policy.
+                Browser Portal account roles remain enforced by DST. See the{' '}
                 <a
                   href="https://coastal-ms.github.io/DST-DuneServerTool/remote"
                   target="_blank"
@@ -312,15 +312,14 @@ export function RemoteAccessCard() {
 
               <div className="border-t border-border pt-4">
                 <label className="block text-sm font-medium mb-1">
-                  Mobile app access for this domain (service token)
+                  Legacy native-app access for this domain (service token)
                   <span className="ml-2 pill-muted text-xs">advanced / optional</span>
                 </label>
                 <p className="text-xs text-text-dim mb-2">
-                  Only needed if you want the <strong>phone app</strong> to reach your
-                  custom domain (which is behind Cloudflare Access). Create a Service
-                  Token in Cloudflare Zero Trust, add a <em>Service Auth</em> policy to
-                  this app, and paste the Client ID + Secret here. Most hosts don&apos;t
-                  need this — the default zero-setup pairing already works.
+                  Account-mode Browser Portal users sign in normally and do not
+                  need this. Keep it only for a legacy paired native app reaching a
+                  custom domain behind Cloudflare Access. Create a Service Token in
+                  Cloudflare Zero Trust and add a <em>Service Auth</em> policy.
                   {svc?.configured && <span className="text-success"> Currently configured.</span>}
                 </p>
                 <input


### PR DESCRIPTION
## What changed

- rolls the v14 test line into the stable changelog
- documents the responsive full Browser Portal, Owner/Admin boundaries, account setup, and native-app retirement
- refreshes the marketing site, install guide, README, and bug-report diagnostics
- fixes invalid repository configuration YAML introduced on `main`

## Validation

- full installer build
- PowerShell: 1,065 tests
- WebUI: 206 tests, production build
- Solo helper: dependency audit and 21 self-tests
- Astro: production build, type check, desktop/mobile render check
- changed-set gitleaks and PII scans