### PR TITLE
Deprecate legacy Cloudflare remote access

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -454,7 +454,7 @@ body:
         remote access fails, note:
 
         - What **Settings → Remote Device Access** shows: the remote-address badge
-          ("Tailscale Funnel" / "custom domain"), "No remote address yet", or
+          ("Tailscale Funnel" / "legacy custom domain"), "No remote address yet", or
           "Remote access bridge not running".
         - Whether the phone/tablet/PC can open the URL after scanning the QR.
         - Whether the affected account is Owner or Admin and which expected page

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -148,7 +148,7 @@ body:
         - Web portal — Settings — Server Browser Ping (datacenter id / IP fix — in-game server browser shows Ping 0 / empty bars)
         - Web portal — Settings — Database connection (Database port / Test connection — empty Players/Bases/Storage)
         - Web portal — Settings (Dune Server Tool self-updater — incl. Stable/Test channel toggle + pre-release picker)
-        - Web portal — Settings — Remote Device Access / Browser Portal accounts / QR / Tailscale Funnel / Cloudflare domain
+        - Web portal — Settings — Remote Device Access / Browser Portal accounts / QR / Tailscale Funnel / legacy Cloudflare domain
         - Web portal — Settings — Hyper-V over LAN (host IP / credential / Test / Route toggle / Remove credential)
         - Web portal — Settings — Server authorization token / 403002 recovery (regenerate + apply self-hosting token)
         - Web portal — Setup Wizard / first-run
@@ -449,9 +449,9 @@ body:
         Browser Portal remote access defaults to a **Tailscale Funnel**: DST is
         reached at a stable `https://<name>.ts.net` address that proxies to a
         local loopback **bridge** (127.0.0.1:47900), which forwards into DST.
-        (Bringing your **own Cloudflare domain** is an optional advanced path,
-        set up under **Settings → Remote Access**.) If pairing or remote access
-        fails, note:
+        Existing **Cloudflare custom-domain** configurations remain supported
+        during deprecation, but new setups use Tailscale Funnel. If pairing or
+        remote access fails, note:
 
         - What **Settings → Remote Device Access** shows: the remote-address badge
           ("Tailscale Funnel" / "custom domain"), "No remote address yet", or
@@ -462,9 +462,9 @@ body:
         - Whether Browser Portal account login is enabled, and whether the QR/link
           is the stable token-free URL or legacy `?key=` magic link. Never paste
           the key, password, cookie, account ID, hash, or salt.
-        - For Cloudflare Access, whether the team domain and application AUD are
-          configured. DST requires a valid signed Access JWT and does not trust
-          the raw email header.
+        - For a legacy Cloudflare setup, whether the team domain and application
+          AUD are configured. DST requires a valid signed Access JWT and does
+          not trust the raw email header.
         - On the host, the bridge health probe:
 
         ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Deprecated
+
+- Cloudflare named-tunnel/Access setup is now a legacy compatibility path and is
+  planned for removal. Existing configurations remain editable and operational
+  during deprecation; new remote-access setups are directed to Tailscale Funnel
+  plus Browser Portal Owner/Admin accounts.
+
 ## [14.0.0] - 2026-08-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ guarded controls in one native Windows app.
 - Manage one local VM or a separate Hyper-V host over LAN.
 - Use the responsive full Browser Portal from a phone, tablet, or PC with
   optional host-managed Owner and Admin accounts.
+- Use Tailscale Funnel for new remote setups. Existing Cloudflare custom-domain
+  configurations remain supported during deprecation but are planned for removal.
 
 ### Solo Mode
 

--- a/helper/README.md
+++ b/helper/README.md
@@ -6,6 +6,10 @@ on **his** PC to get into the host's full DST desktop portal running on
 DST surface — **zero changes to `app/`, `webui/`, `site/`, or
 `dune-server.ps1`.**
 
+> Legacy scaffold: new remote-access setups should use DST's responsive Browser
+> Portal with Tailscale Funnel and host-managed Owner/Admin accounts. This helper
+> remains documented only for existing friend-helper deployments.
+
 ## Components
 
 ```
@@ -67,12 +71,10 @@ current DuneToken — which is rotated on every DST launch.
 
 ## Why this design
 
-- **Tailscale, not Cloudflare Tunnel.** The existing `/remote/*` SPA
-  already uses CF Tunnel + Access for a mobile-friendly subset. This
-  scaffold targets a *different* use case: a single trusted friend who
-  wants the **full** desktop portal (Database, Terminal, Setup Wizard,
-  everything the host sees). Tailscale gives identity-based access without
-  per-domain edge config, and friends don't need to set up an IdP.
+- **Tailscale, not Cloudflare Tunnel.** This scaffold predates Browser Portal
+  accounts and remains only for existing deployments. New trusted-user access
+  uses the full responsive Browser Portal, Tailscale Funnel, and Owner/Admin
+  roles without per-domain edge configuration.
 - **No DST code changes.** The bridge is a pure reverse proxy that reads
   the existing `last-url.txt` (DST already writes this for the desktop
   shell). DST stays on the **released** v11.0.3 surface — no risk of

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -107,9 +107,9 @@ const base = import.meta.env.BASE_URL;
           >Remote portal</a
         >
         — the responsive full Browser Portal on a phone, tablet, or PC, with
-        optional Owner/Admin accounts. Recommended setup is a free Tailscale
-        Funnel (no domain); a bring-your-own Cloudflare domain is supported as
-        an advanced option.
+        optional Owner/Admin accounts. New setups use a free Tailscale Funnel
+        with no domain. Existing Cloudflare custom-domain configurations remain
+        supported during deprecation but are planned for removal.
       </li>
     </ul>
 
@@ -207,11 +207,11 @@ const base = import.meta.env.BASE_URL;
       <p class="text-dune-muted leading-relaxed">
         Remote access is optional. v14 uses the same responsive Browser Portal
         as the desktop app, with host-created Owner/Admin accounts and
-        role-enforced navigation and APIs. The recommended path is a Tailscale
-        Funnel; a Cloudflare custom domain remains available for advanced
-        setups. Use the dedicated guide for account setup, role boundaries,
-        transport security, and revocation instead of exposing DST's local port
-        directly.
+        role-enforced navigation and APIs. New setups use Tailscale Funnel.
+        Existing Cloudflare custom domains should migrate before that legacy
+        path is removed. Use the dedicated guide for account setup, migration,
+        role boundaries, transport security, and revocation instead of exposing
+        DST's local port directly.
       </p>
       <a
         href={`${base}remote`}

--- a/site/src/pages/remote.astro
+++ b/site/src/pages/remote.astro
@@ -167,10 +167,12 @@ import PageHeader from "../components/PageHeader.astro";
         proven from an outside device.
       </p>
       <ol class="list-decimal list-inside space-y-2 text-dune-muted leading-relaxed text-sm">
-        <li>Enable Tailscale Funnel on <span class="font-mono">127.0.0.1:47900</span>.</li>
+        <li>Run <span class="font-mono">tailscale funnel --bg http://127.0.0.1:47900</span> in PowerShell.</li>
         <li>Confirm the <span class="font-mono">.ts.net</span> URL appears in Remote Device Access.</li>
-        <li>Create and locally verify a Browser Portal Owner account.</li>
-        <li>Test sign-in and the expected Owner/Admin page boundaries from outside the LAN.</li>
+        <li>Under Browser Portal accounts, create and locally verify an Owner.</li>
+        <li>Acknowledge native-app retirement, then enable account login.</li>
+        <li>Create any Browser Portal Admin account needed for role-boundary testing.</li>
+        <li>Test Owner sign-in and Admin restricted navigation from outside the LAN.</li>
         <li>Disable the legacy Cloudflare portal in Settings, then stop the Cloudflare tunnel.</li>
       </ol>
     </div>

--- a/site/src/pages/remote.astro
+++ b/site/src/pages/remote.astro
@@ -22,7 +22,7 @@ import PageHeader from "../components/PageHeader.astro";
         <li><a class="text-dune-text hover:underline" href="#funnel">Set up a Tailscale Funnel</a></li>
         <li><a class="text-dune-text hover:underline" href="#accounts">Create Browser Portal accounts</a></li>
         <li><a class="text-dune-text hover:underline" href="#device">Open and save the portal on a device</a></li>
-        <li><a class="text-dune-text hover:underline" href="#cloudflare">Optional Cloudflare custom domain</a></li>
+        <li><a class="text-dune-text hover:underline" href="#cloudflare">Migrate an existing Cloudflare domain</a></li>
         <li><a class="text-dune-text hover:underline" href="#trouble">Troubleshooting</a></li>
         <li><a class="text-dune-text hover:underline" href="#revoke">Disable or revoke access</a></li>
       </ol>
@@ -159,21 +159,20 @@ import PageHeader from "../components/PageHeader.astro";
     </div>
 
     <div id="cloudflare">
-      <h2 class="text-2xl font-semibold mb-4">6 · Optional: Cloudflare custom domain</h2>
+      <h2 class="text-2xl font-semibold mb-4">6 · Migrate an existing Cloudflare domain <span class="text-dune-muted text-base font-normal">— deprecated</span></h2>
       <p class="text-dune-muted leading-relaxed mb-3">
-        Tailscale Funnel is the simplest path. Hosts who want a custom hostname
-        can instead point a Cloudflare named tunnel at
-        <span class="font-mono">http://127.0.0.1:47900</span> and configure the
-        signed Access JWT issuer and audience in DST. Account-mode users still
-        sign in through the Browser Portal; no Cloudflare service token is
-        required for them.
+        Cloudflare named-tunnel/Access support remains operational for existing
+        users during deprecation, but it is planned for removal and should not be
+        used for new setups. Keep it running until the replacement Funnel path is
+        proven from an outside device.
       </p>
-      <p class="text-dune-muted text-sm leading-relaxed">
-        Cloudflare's documentation remains the source of truth for
-        <a class="underline text-dune-text" href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/" rel="noopener" target="_blank">named tunnels</a>
-        and
-        <a class="underline text-dune-text" href="https://developers.cloudflare.com/cloudflare-one/policies/access/" rel="noopener" target="_blank">Access policies</a>.
-      </p>
+      <ol class="list-decimal list-inside space-y-2 text-dune-muted leading-relaxed text-sm">
+        <li>Enable Tailscale Funnel on <span class="font-mono">127.0.0.1:47900</span>.</li>
+        <li>Confirm the <span class="font-mono">.ts.net</span> URL appears in Remote Device Access.</li>
+        <li>Create and locally verify a Browser Portal Owner account.</li>
+        <li>Test sign-in and the expected Owner/Admin page boundaries from outside the LAN.</li>
+        <li>Disable the legacy Cloudflare portal in Settings, then stop the Cloudflare tunnel.</li>
+      </ol>
     </div>
 
     <div id="trouble">
@@ -217,7 +216,7 @@ import PageHeader from "../components/PageHeader.astro";
         <li><strong class="text-dune-text">One device:</strong> sign out, or revoke that account's sessions from local Settings.</li>
         <li><strong class="text-dune-text">One account:</strong> disable, reset, demote, or delete it from Browser Portal account management.</li>
         <li><strong class="text-dune-text">All account sessions:</strong> use the local emergency Disable action. This restores legacy magic-link behavior.</li>
-        <li><strong class="text-dune-text">Public endpoint:</strong> turn off Funnel or stop the Cloudflare tunnel.</li>
+        <li><strong class="text-dune-text">Public endpoint:</strong> turn off Funnel. Existing Cloudflare users should stop that tunnel only after migration succeeds.</li>
         <li><strong class="text-dune-text">Background access:</strong> disable <strong>Help → Keep serving while DST is closed</strong>.</li>
       </ul>
     </div>

--- a/webui/src/pages/settings/MobileAppCard.tsx
+++ b/webui/src/pages/settings/MobileAppCard.tsx
@@ -104,16 +104,15 @@ export function MobileAppCard() {
       bodyClassName="card-body"
     >
 
-        {/* Secure remote access via Tailscale Funnel — the recommended, no-domain
-            path for the Browser Portal. (A Cloudflare custom domain
-            is the advanced alternative, configured under Settings → Remote Access;
-            pairing uses it automatically if set, so it isn't shown here.) */}
+        {/* Secure remote access via Tailscale Funnel — the supported path for new
+            Browser Portal setups. Existing Cloudflare custom-domain URLs remain
+            readable during their deprecation window. */}
         <div className="card p-3" style={{ marginBottom: '1rem' }}>
           <div className="flex items-center gap-2" style={{ fontWeight: 600 }}>
             <Icon name="Globe" size={16} /> Secure remote access
             {data && (
               data.url
-                ? <span className="badge safe" style={{ marginLeft: 'auto' }}>{data.source === 'funnel' ? 'Tailscale Funnel' : 'custom domain'}</span>
+                ? <span className="badge safe" style={{ marginLeft: 'auto' }}>{data.source === 'funnel' ? 'Tailscale Funnel' : 'legacy custom domain'}</span>
                 : <span className="badge" style={{ marginLeft: 'auto' }}>not set up</span>
             )}
           </div>
@@ -128,12 +127,19 @@ export function MobileAppCard() {
                 The address remains stable across DST restarts. Scan the current QR
                 whenever you need to open or save the Browser Portal on a device.
               </div>
+              {data.source !== 'funnel' && (
+                <div className="card p-2 border-warning/40 bg-warning/10 text-warning text-sm" style={{ marginTop: '0.75rem' }}>
+                  This Cloudflare custom-domain path is deprecated. Keep it running
+                  while you migrate to Tailscale Funnel, then test the Funnel URL
+                  before disabling Cloudflare.
+                </div>
+              )}
             </div>
           ) : (
             <div className="help-text" style={{ marginTop: '0.75rem' }}>
               No remote address yet. Install <a href="https://tailscale.com/download" target="_blank" rel="noreferrer">Tailscale</a> on this PC, then enable a Funnel on the bridge port for a free, no-domain public HTTPS address:
               <div style={{ marginTop: '0.5rem', fontSize: '12px', fontFamily: 'monospace', background: 'var(--surface-2, #1e293b)', padding: '0.5rem', borderRadius: '6px', wordBreak: 'break-all' }}>tailscale funnel --bg http://127.0.0.1:{bridgePort}</div>
-              <div style={{ marginTop: '0.5rem' }}>The address appears here automatically once the Funnel is active. (Prefer your own domain? Set up Cloudflare under <strong>Settings → Remote Access</strong> instead.)</div>
+              <div style={{ marginTop: '0.5rem' }}>The address appears here automatically once the Funnel is active.</div>
             </div>
           )}
         </div>
@@ -186,7 +192,7 @@ export function MobileAppCard() {
               </div>
             ) : (
               <div className="text-secondary" style={{ width: 200, textAlign: 'center' }}>
-                Set up a Tailscale Funnel or a Cloudflare domain (Remote Access) to generate a QR code.
+                Set up a Tailscale Funnel to generate a QR code.
               </div>
             )}
 

--- a/webui/src/pages/settings/RemoteAccessCard.tsx
+++ b/webui/src/pages/settings/RemoteAccessCard.tsx
@@ -165,7 +165,7 @@ export function RemoteAccessCard() {
   }
 
   return (
-    <div className="card mb-4" data-section-nav-id="settings.remoteAccess" data-section-nav-label="Remote Access">
+    <div className="card mb-4" data-section-nav-id="settings.remoteAccess" data-section-nav-label="Legacy Cloudflare">
       <button
         type="button"
         onClick={() => setExpanded(v => !v)}
@@ -176,12 +176,11 @@ export function RemoteAccessCard() {
         <div className="flex items-center gap-3">
           <Icon name={expanded ? 'ChevronDown' : 'ChevronRight'} size={16} className="text-text-dim" />
           <Icon name="Shield" size={18} className="text-text-muted" />
-          <h2 className="text-lg font-semibold">Remote Access</h2>
+          <h2 className="text-lg font-semibold">Legacy Cloudflare custom domain</h2>
         </div>
         <div className="flex items-center gap-2">
-          {enabled
-            ? <span className="pill-success text-xs">enabled</span>
-            : <span className="pill-muted text-xs">advanced / optional</span>}
+          <span className="pill-warning text-xs">deprecated</span>
+          {enabled && <span className="pill-success text-xs">enabled</span>}
           {cf?.installed
             ? <span className="pill-info text-xs">cloudflared {cf.version || 'detected'}</span>
             : enabled
@@ -210,17 +209,17 @@ export function RemoteAccessCard() {
               <div className="text-xs text-text-muted bg-surface-2/60 border border-border rounded-lg px-3 py-2 flex items-start gap-2">
                 <Icon name="Info" size={14} className="mt-0.5 flex-none" />
                 <span>
-                  <strong>Advanced / optional — most hosts don&apos;t need this.</strong> For the
-                  Browser Portal, the recommended path is <strong>Tailscale Funnel</strong>
-                  (set up from <strong>Remote Device Access</strong>) — no domain or Cloudflare account.
-                  This card is only for bringing your <strong>own Cloudflare domain</strong> for a
-                  permanent, email-gated hostname.
+                  <strong>Deprecated — existing configurations only.</strong> Cloudflare
+                  named-tunnel/Access support is planned for removal. Existing
+                  configurations remain editable and operational during migration,
+                  but new setups should use <strong>Tailscale Funnel</strong> plus
+                  Browser Portal accounts under <strong>Remote Device Access</strong>.
                 </span>
               </div>
               <p className="text-sm text-text-muted">
-                Provides an optional custom-domain transport for the responsive
-                Browser Portal through a Cloudflare Tunnel + Access policy.
-                Browser Portal account roles remain enforced by DST. See the{' '}
+                This legacy card maintains the Cloudflare tunnel identity and email
+                ACL used by existing deployments. These fields do not create Browser
+                Portal accounts. See the{' '}
                 <a
                   href="https://coastal-ms.github.io/DST-DuneServerTool/remote"
                   target="_blank"
@@ -229,8 +228,22 @@ export function RemoteAccessCard() {
                 >
                   setup guide
                 </a>
-                {' '}for cloudflared install + tunnel + Access policy steps.
+                {' '}for the supported Funnel setup and migration sequence.
               </p>
+
+              <div className="rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm text-text-muted">
+                <div className="font-semibold text-warning mb-2">Migrate before Cloudflare removal</div>
+                <ol className="list-decimal pl-5 space-y-1">
+                  <li>Enable Tailscale Funnel from Remote Device Access.</li>
+                  <li>Create and locally verify a Browser Portal Owner account.</li>
+                  <li>Test the stable Funnel URL from an outside device.</li>
+                  <li>Create any Admin accounts and verify their restricted navigation.</li>
+                  <li>Only then disable this legacy portal and stop the Cloudflare tunnel.</li>
+                </ol>
+                <p className="mt-2 text-xs text-text-dim">
+                  Keep Cloudflare enabled until the replacement Funnel path is proven.
+                </p>
+              </div>
 
               <label className="flex items-center gap-3 cursor-pointer">
                 <input
@@ -240,7 +253,7 @@ export function RemoteAccessCard() {
                   className="h-4 w-4"
                 />
                 <span className="text-sm">
-                  <strong>Enable remote portal</strong>
+                  <strong>Enable legacy Cloudflare portal</strong>
                   <span className="block text-xs text-text-dim">
                     Clears the owner field on disable — every /remote/* request is
                     refused until re-enabled.
@@ -356,7 +369,7 @@ export function RemoteAccessCard() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-2">Admin allow-list</label>
+                <label className="block text-sm font-medium mb-2">Legacy Cloudflare email allow-list</label>
                 {acl.admins.length === 0 && (
                   <p className="text-xs text-text-dim mb-2">No admins yet — only the owner can sign in.</p>
                 )}
@@ -395,7 +408,7 @@ export function RemoteAccessCard() {
               <div className="flex items-center gap-3 pt-2 border-t border-border">
                 <button type="button" onClick={() => { void onSave() }} disabled={saving} className="btn-primary">
                   <Icon name={saving ? 'Loader2' : 'Save'} size={14} className={saving ? 'animate-spin' : ''} />
-                  {saving ? 'Saving…' : 'Save changes'}
+                  {saving ? 'Saving…' : 'Save legacy settings'}
                 </button>
                 {savedMsg && <span className="text-sm text-success">{savedMsg}</span>}
                 <div className="ml-auto">

--- a/webui/src/pages/settings/RemoteAccessCard.tsx
+++ b/webui/src/pages/settings/RemoteAccessCard.tsx
@@ -234,10 +234,14 @@ export function RemoteAccessCard() {
               <div className="rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm text-text-muted">
                 <div className="font-semibold text-warning mb-2">Migrate before Cloudflare removal</div>
                 <ol className="list-decimal pl-5 space-y-1">
-                  <li>Enable Tailscale Funnel from Remote Device Access.</li>
-                  <li>Create and locally verify a Browser Portal Owner account.</li>
-                  <li>Test the stable Funnel URL from an outside device.</li>
-                  <li>Create any Admin accounts and verify their restricted navigation.</li>
+                  <li>
+                    Run <code className="break-all font-mono text-xs">tailscale funnel --bg http://127.0.0.1:47900</code> in
+                    PowerShell, then confirm the Funnel URL in Remote Device Access.
+                  </li>
+                  <li>Under Remote Device Access → Browser Portal accounts, create and locally verify an Owner.</li>
+                  <li>Acknowledge native-app retirement, then enable account login.</li>
+                  <li>Create any Browser Portal Admin accounts needed for role-boundary testing.</li>
+                  <li>Test Owner sign-in and Admin restricted navigation from an outside device.</li>
                   <li>Only then disable this legacy portal and stop the Cloudflare tunnel.</li>
                 </ol>
                 <p className="mt-2 text-xs text-text-dim">


### PR DESCRIPTION
## What changed

- marks Cloudflare named-tunnel/Access support as deprecated and planned for removal
- directs new Browser Portal setups to Tailscale Funnel plus Owner/Admin accounts
- adds a backup-safe migration sequence while keeping existing Cloudflare configs editable and operational
- updates the site, Settings copy, README, diagnostics, helper docs, and Discord FAQs

## Boundary

No Cloudflare backend, routes, configuration, or existing-user behavior is removed. No release is included.

## Validation

- WebUI production build and 18 focused portal tests
- Astro production build and type check
- YAML, diff, changed-set gitleaks, and deprecation-copy readback