### PR TITLE
Release v14.0.1 hotfix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v14.0.0"
+      placeholder: "v14.0.1"
     validations:
       required: true
 
@@ -89,7 +89,7 @@ body:
     id: surface
     attributes:
       label: Where did the bug happen?
-      description: Which part of the tool was affected? Pick the closest match. (Nav groups are Server Health, PowerShell, Game Data, Database, System, plus a Help dropdown on the right.)
+      description: Which part of the tool was affected? Pick the closest match. (Nav groups are Server Health, Commands, Game Data, Database, System, plus a Help dropdown on the right.)
       options:
         - Web portal — Server Health (Dashboard)
         - Web portal — Database — VM info card (disk / swap / active and failed database operations / failed-operation cleanup / retained build images / old-image cleanup / per-map memory limits)
@@ -98,7 +98,7 @@ body:
         - Web portal — Battlegroup shows "Unknown" / tool can't connect to the VM (SSH)
         - Web portal — Commands
         - Web portal — Browser Portal sign-in / forced password change / Settings account management / QR or portal link
-        - Web portal — PowerShell (embedded xterm.js terminal)
+        - Web portal — Commands — Open PowerShell (embedded xterm.js terminal, local only)
         - Web portal — Game Config — VM INI (UserGame.ini / UserEngine.ini / Apply INIs to pods / Spicefield Types / Crafting / Land Claim Timer)
         - Web portal — Experimental Lab (recovered Dune / Unreal Engine CVars, remaining DefaultGame.ini / DefaultEngine.ini settings, source/risk filters)
         - Web portal — Commands — Apply INIs & Restart
@@ -169,7 +169,7 @@ body:
     attributes:
       label: Specific page / button / command
       description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug? For Browser Portal authentication, include login vs forced change vs local Settings administration, whether account mode was enabled, transport (Funnel or Cloudflare), and HTTP status only—never include usernames, passwords, cookies, tokens, account IDs, hashes, or salts. For the DST updater, include Update Banner vs Settings, the visible TEST number before/after, and the exact verification message; attach fresh diagnostics so the sanitized relaunch, Inno, and installed-identity logs are included. For in-game commands, include the exact `!command`, chat channel, monitoring interval, cooldown, whether any broadcast appeared, and whether it used the character name. For shared teleport destinations, include direct Save location vs Arm live capture, whether the player paused about five seconds, and whether they teleported on foot or from a vehicle seat. For scheduled Funcom updates, include the scheduled time, whether Apply available Funcom server updates was enabled, installed/latest build IDs, and the last schedule result. For Reboot All, include the visible phase and whether an on-demand-map repair ran. For World Restart, include the failed progress step, whether rollback ran automatically, whether every player was offline, and whether the Roll back last restart button remains available. For Specs > Apply level, include the track, before/after level, and before/after unspent skill points. For Apply Quick Preset, include the exact preset and the first journey research/crafting objective still active afterward. For Full Delete, include whether the deleted character owned or co-owned the affected object and whether Claim Ownership appears—never include account, actor, or permission IDs. For Reset Journey, include whether the post-NPE story restarted at Find the Fremen, which starter-class tree was reset, and how many skill points were refunded. For DD Seed Maps, include the selected seed, POI type, displayed sector(s), and a current reference screenshot or link when possible. For an Experimental Lab control, include its exact CVar or INI key, source/risk badge, file and section, and whether local Engine.ini management was enabled. For Solo Mode, include the adapter, wrapper/schema status, whether the game was fully closed, and the exact action. PTC Import Base Blueprint is intentionally disabled before save access; report only if the UI/backend allows the action or changes a save. After deleting/recreating a character, state whether PTC was fully restarted before creation. For Enable All Skills, state whether Bindu Sprint remained learnable. For a database migration, name the failing step.
-      placeholder: "e.g. Browser Portal > Sign in, Settings > Remote Device Access > Verify owner login, Settings > Desktop shell > Save and restart shell, Database > World Restart > Wait for fresh database, or Gameplay Admin > Players > Specs > Apply level"
+      placeholder: "e.g. Commands > Open PowerShell, Browser Portal > Sign in, Settings > Remote Device Access > Verify owner login, Settings > Desktop shell > Save and restart shell, Database > World Restart > Wait for fresh database, or Gameplay Admin > Players > Specs > Apply level"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ here cover everything those tags shipped.
   **Open PowerShell** action on the Commands page instead of occupying a
   permanent desktop-sidebar entry. Remote Browser Portal viewers still cannot
   see or access the terminal.
-- The **Buy Me a Coffee** support link is visible again in both expanded and
-  collapsed desktop sidebars.
+- Framework modification.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [14.0.1] - 2026-08-22
+
+### Changed
+
+- The local embedded PowerShell terminal now opens from a dedicated
+  **Open PowerShell** action on the Commands page instead of occupying a
+  permanent desktop-sidebar entry. Remote Browser Portal viewers still cannot
+  see or access the terminal.
+- The **Buy Me a Coffee** support link is visible again in both expanded and
+  collapsed desktop sidebars.
+
 ### Deprecated
 
 - Cloudflare named-tunnel/Access setup is now a legacy compatibility path and is

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Solo saves.
 [Changelog](CHANGELOG.md) ·
 [Discord](https://discord.gg/tj2x7cywSC)**
 
-Current stable release: **v14.0.0**
+Current stable release: **v14.0.1**
 
 Confirmed compatible with Dune: Awakening **1.4.10.4**.
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '14.0.0'
+$script:DuneToolVersion = '14.0.1'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '14.0.0',
+    [string]$Version = '14.0.1',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>14.0.0</Version>
+    <Version>14.0.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "14.0.0"
+#define MyAppVersion "14.0.1"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "14.0.0"
+$script:ToolVersion = "14.0.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -138,6 +138,7 @@ export function Sidebar({ collapsed }: Props) {
     key: g,
     items: NAV_ITEMS
       .filter(i => i.group === g)
+      .filter(i => !i.sidebarHidden)
       .filter(i => !i.localOnly || isLocalViewer())
       .filter(i => !i.ownerOnly || canAccessOwnerSurfaces)
       .filter(i => !i.windowsOnly || isWindowsViewer()),
@@ -263,8 +264,8 @@ export function Sidebar({ collapsed }: Props) {
           title="Support development — Buy Me a Coffee"
           className={
             collapsed
-              ? 'hidden w-full items-center justify-center h-8 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors'
-              : 'hidden w-full items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors uppercase tracking-widest font-semibold'
+              ? 'flex w-full items-center justify-center h-8 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors'
+              : 'flex w-full items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-warning/50 text-warning hover:bg-warning/15 hover:border-warning/70 transition-colors uppercase tracking-widest font-semibold'
           }
         >
           <Icon name="Coffee" size={collapsed ? 14 : 11} />

--- a/webui/src/nav.ts
+++ b/webui/src/nav.ts
@@ -14,6 +14,9 @@ export type NavItem = {
   // MUST also enforce loopback-only on the server — the client filter is
   // just a UX hide, not a security boundary.
   localOnly?: boolean
+  // Hide this item from the desktop sidebar while retaining it in other
+  // navigation surfaces such as the classic top menu.
+  sidebarHidden?: boolean
   // Owner-only items stay available on the host and to remote Owner accounts,
   // but are hidden from delegated remote Admin accounts. The API must enforce
   // the same boundary; this is only the navigation half.
@@ -25,7 +28,7 @@ export const NAV_ITEMS: NavItem[] = [
   { to: '/',            label: 'Server Health', icon: 'LayoutDashboard', group: 'overview' },
   { to: '/pods',        label: 'Pods',          icon: 'Boxes',           group: 'overview' },
   { to: '/commands',    label: 'Commands',     icon: 'Zap',             group: 'terminal' },
-  { to: '/terminal',    label: 'PowerShell',   icon: 'SquareTerminal',  group: 'terminal', localOnly: true },
+  { to: '/terminal',    label: 'PowerShell',   icon: 'SquareTerminal',  group: 'terminal', localOnly: true, sidebarHidden: true },
   { to: '/gameconfig',  label: 'Game Config',  icon: 'Sliders',         group: 'data', ownerOnly: true },
   { to: '/experimental', label: 'Experimental Lab', icon: 'FlaskConical',   group: 'data', ownerOnly: true },
   { to: '/gameplay',    label: 'Gameplay Admin', icon: 'Gamepad2',        group: 'data' },

--- a/webui/src/pages/Commands.tsx
+++ b/webui/src/pages/Commands.tsx
@@ -29,6 +29,8 @@ import { isLocalViewer } from '../util/viewer'
 import type { Command, CommandsResponse } from '../api/types'
 import { usePortalAuth } from '../auth/PortalAuthGate'
 import { canAccessCommand } from '../auth/commandAccess'
+import { useNavigate } from '../router'
+import { getVisibleCommandPageLinks, type CommandPageLink } from '../util/commandPageLinks'
 
 type LaunchResult = {
   ok: boolean
@@ -114,6 +116,37 @@ function CommandButtonInner({
         )}
       </button>
     </>
+  )
+}
+
+function CommandPageLinkButton({
+  link,
+  onOpen,
+}: {
+  link: CommandPageLink
+  onOpen: () => void
+}) {
+  return (
+    <div className={COMMAND_BUTTON_CLASS}>
+      <div className="shrink-0 -ml-1 flex items-center justify-center w-6 text-accent">
+        <Icon name={link.icon} size={15} />
+      </div>
+      <button
+        type="button"
+        onClick={onOpen}
+        title={link.description}
+        className="flex-1 text-left"
+      >
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-medium text-sm text-text">{link.label}</span>
+          <span className="pill-info shrink-0">
+            <Icon name="Monitor" size={10} />
+            Local
+          </span>
+        </div>
+        <p className="mt-1.5 text-xs text-text-muted">{link.description}</p>
+      </button>
+    </div>
   )
 }
 
@@ -262,6 +295,7 @@ function SectionTitle({
 // ---------- Page -----------------------------------------------------------
 
 export function Commands() {
+  const navigate = useNavigate()
   const portalAuth = usePortalAuth()
   const portalRole = portalAuth?.status.account?.role ?? null
   const { forceRefresh } = useStatus()
@@ -491,6 +525,7 @@ export function Commands() {
   // commands render (see `grouped`), and layout editing — drag/reorder, rename,
   // reset — is disabled so a remote user can't rearrange the host's layout.
   const readOnly = !isLocalViewer()
+  const pageLinks = getVisibleCommandPageLinks(!readOnly)
 
   return (
     <>
@@ -554,6 +589,8 @@ export function Commands() {
         <section className="space-y-5">
           {SECTION_INDICES.map(idx => {
             const items = grouped[idx]
+            const links = idx === 2 ? pageLinks : []
+            const actionCount = items.length + links.length
             return (
               <div key={idx} className="card p-5">
                 <div className="flex items-center justify-between gap-3 mb-4">
@@ -564,14 +601,14 @@ export function Commands() {
                     disabled={savingLayout || readOnly}
                   />
                   <span className="text-xs text-text-dim shrink-0">
-                    {items.length} {items.length === 1 ? 'command' : 'commands'}
+                    {actionCount} {actionCount === 1 ? 'action' : 'actions'}
                   </span>
                 </div>
                 <SortableContext
                   items={items.map(c => c.name)}
                   strategy={rectSortingStrategy}
                 >
-                  <SectionDropZone sectionIdx={idx} count={items.length} isOver={overSection === idx}>
+                  <SectionDropZone sectionIdx={idx} count={actionCount} isOver={overSection === idx}>
                     {items.map(c => (
                       <SortableCommandButton
                         key={c.name}
@@ -579,6 +616,13 @@ export function Commands() {
                         sectionIdx={idx}
                         onRun={runCommand}
                         busy={running.has(c.name)}
+                      />
+                    ))}
+                    {links.map(link => (
+                      <CommandPageLinkButton
+                        key={link.to}
+                        link={link}
+                        onOpen={() => navigate(link.to)}
                       />
                     ))}
                   </SectionDropZone>

--- a/webui/src/util/commandPageLinks.ts
+++ b/webui/src/util/commandPageLinks.ts
@@ -1,0 +1,21 @@
+export type CommandPageLink = {
+  to: string
+  label: string
+  description: string
+  icon: string
+  localOnly?: boolean
+}
+
+const COMMAND_PAGE_LINKS: readonly CommandPageLink[] = [
+  {
+    to: '/terminal',
+    label: 'Open PowerShell',
+    description: 'Open DST\'s embedded PowerShell terminal on this computer.',
+    icon: 'SquareTerminal',
+    localOnly: true,
+  },
+]
+
+export function getVisibleCommandPageLinks(local: boolean): readonly CommandPageLink[] {
+  return COMMAND_PAGE_LINKS.filter(link => !link.localOnly || local)
+}

--- a/webui/tests/commandPageLinks.test.ts
+++ b/webui/tests/commandPageLinks.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { getVisibleCommandPageLinks } from '../src/util/commandPageLinks'
+
+describe('Commands page links', () => {
+  it('offers the embedded PowerShell terminal only to local viewers', () => {
+    expect(getVisibleCommandPageLinks(true)).toContainEqual(expect.objectContaining({
+      to: '/terminal',
+      label: 'Open PowerShell',
+      localOnly: true,
+    }))
+    expect(getVisibleCommandPageLinks(false)).toEqual([])
+  })
+})

--- a/webui/tests/sidebarHotfix.test.tsx
+++ b/webui/tests/sidebarHotfix.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { Sidebar } from '../src/layout/Sidebar'
+import { BrowserRouter } from '../src/router'
+
+vi.mock('../src/hooks/useUpdateCheck', () => ({
+  useUpdateCheck: () => ({ data: null }),
+}))
+
+vi.mock('../src/auth/portalAccess', () => ({
+  usePortalAccess: () => ({ canAccessOwnerSurfaces: true }),
+}))
+
+afterEach(() => cleanup())
+
+function renderSidebar(collapsed: boolean) {
+  return render(
+    <BrowserRouter>
+      <Sidebar collapsed={collapsed} />
+    </BrowserRouter>,
+  )
+}
+
+describe('sidebar hotfix links', () => {
+  it('restores Buy Me a Coffee in the expanded sidebar and removes PowerShell', () => {
+    renderSidebar(false)
+
+    const support = screen.getByRole('link', { name: 'Buy Me a Coffee' })
+    expect(support).toHaveAttribute('href', 'https://buymeacoffee.com/coastal_dst')
+    expect(support).toHaveClass('flex')
+    expect(screen.queryByRole('link', { name: 'PowerShell' })).not.toBeInTheDocument()
+  })
+
+  it('keeps the support link available when the sidebar is collapsed', () => {
+    renderSidebar(true)
+
+    const support = screen.getByTitle('Support development — Buy Me a Coffee')
+    expect(support).toHaveClass('flex')
+  })
+})


### PR DESCRIPTION
## Summary
- publish the staged Cloudflare deprecation guidance in v14.0.1
- framework modification
- move the local embedded PowerShell entry from the desktop sidebar to a local-only Commands action
- update release stamps, changelog, README, and bug-report guidance

## Validation
- 209 web UI tests pass
- web UI production build succeeds
- full installer build succeeds with all five version stamps at 14.0.1
- staged secret scan reports no leaks

## Installer
- `app/installer/output/DuneServerSetup.exe`
- 80,613,897 bytes
- SHA-256: `623ABD6EE16276C3E23540AFE7DF95F5803863CC1F201E8799BAFE5561106EDB`