### PR TITLE
Release v14.0.3 PTC schema compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header. Auto-filled when launched from **Help → Create GitHub Issue** in the top menu bar, or from the CLI `report-issue` command.
-      placeholder: "v14.0.2"
+      placeholder: "v14.0.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [14.0.3] - 2026-08-24
+
+### Fixed
+
+- Solo Mode now recognizes the August 24 PTC save schema, which adds the
+  game-owned sandstorm schedule table without changing DST-managed data.
+
 ## [14.0.2] - 2026-08-23
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '14.0.2'
+$script:DuneToolVersion = '14.0.3'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '14.0.2',
+    [string]$Version = '14.0.3',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/data/solo-ptc-v1.json
+++ b/app/data/solo-ptc-v1.json
@@ -3,7 +3,8 @@
   "wrapper_version": 1,
   "schema_fingerprint": "feede0b0d0629b1b8553e9ad9434e5009f4422b9d662ec6bbc44f6c3d3291518",
   "compatible_schema_fingerprints": [
-    "abb4dd3b358668f5d79ef10215d38e7ebe3801a37347374d4c3d66a1557dc223"
+    "abb4dd3b358668f5d79ef10215d38e7ebe3801a37347374d4c3d66a1557dc223",
+    "421d15955599ea223b3a72d1b418eb94befe333b7be9c20babd40ddf60274130"
   ],
   "specializations": {
     "max_level": 100,

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>14.0.2</Version>
+    <Version>14.0.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "14.0.2"
+#define MyAppVersion "14.0.3"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "14.0.2"
+$script:ToolVersion = "14.0.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/SoloMode.Tests.ps1
+++ b/tests/SoloMode.Tests.ps1
@@ -549,6 +549,7 @@ Describe 'Solo Mode PTC progression catalogs' {
         $ptc.complete_npe.node_count | Should -Be 140
         $ptcNodes.Count | Should -Be 140
         @($ptcNodes | Sort-Object -Unique).Count | Should -Be 140
+        @($ptc.compatible_schema_fingerprints) | Should -Contain '421d15955599ea223b3a72d1b418eb94befe333b7be9c20babd40ddf60274130'
         $extras | Should -Be @(
             'DA_MQ_ANewBeginning.Dangerous Mission No 2.BaseBackupTool'
             'DA_MQ_ANewBeginning.Dangerous Mission No 2.BaseBackupTool.CraftBaseBackupTool'


### PR DESCRIPTION
## What changed

- Recognize the August 24 PTC save fingerprint after its game-owned `sandstorm_schedule` table migration.
- Preserve fail-closed handling for every unknown schema.
- Stamp v14.0.3, roll the changelog, and refresh the bug-report version.

## Risk boundary

The migrated save adds one table with no removals or changes to existing tables, Solo settings, or progression keys. DST does not read or write the new table.

## Validation

- 1,068 PowerShell tests
- 209 WebUI tests
- Solo helper dependency audit and self-test
- Same-value progression write against a temporary migrated-save copy
- Full installer build
- Gitleaks commit scan