### PR TITLE
Prepare v15 next-generation test line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- Experimental features.
+
 ## [14.0.3] - 2026-08-24
 
 ### Fixed

--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -341,17 +341,11 @@ function Invoke-DuneVehicleSpawnLive {
     # Spawn at the target's pawn when no explicit coords were supplied. The UI
     # passes the player's pawn/actor id; read its live location from dune.actors
     # so the vehicle drops on the player rather than at map origin (0,0,0).
-    # NOTE: this query intentionally uses the legacy `location->>'X'` shape. On
-    # the current game build dune.actors has no `location` column (coords moved to
-    # the `transform` composite), so this lookup fails, coords stay 0,0,0, and the
-    # vehicle is delivered to the player's INVENTORY via RMQ - the desired
-    # behavior. Do NOT "fix" this to (transform).location.x: that would resolve a
-    # world coordinate and spawn the vehicle in the world instead of inventory.
     if ($X -eq 0.0 -and $Y -eq 0.0 -and $Z -eq 0.0 -and $ActorId -gt 0) {
         $locSql = @"
-SELECT (location->>'X')::float8 AS x,
-       (location->>'Y')::float8 AS y,
-       (location->>'Z')::float8 AS z
+SELECT (transform).location.x::float8 AS x,
+       (transform).location.y::float8 AS y,
+       (transform).location.z::float8 AS z
 FROM dune.actors WHERE id = $ActorId::bigint;
 "@
         $lr = Invoke-DuneSqlQuery -Ip $Ip -Sql $locSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10

--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -329,7 +329,8 @@ function Invoke-DuneVehicleSpawnLive {
         [string] $Ip,
         [string] $FlsId,
         [long]   $ActorId = 0,
-        [Parameter(Mandatory)] [string] $ClassName,
+        [Parameter(Mandatory)] [string] $VehicleId,
+        [Parameter(Mandatory)] [string] $ActorClass,
         [double] $X = 0.0, [double] $Y = 0.0, [double] $Z = 0.0,
         [double] $Rotation = 0.0,
         [string] $TemplateName,
@@ -338,26 +339,127 @@ function Invoke-DuneVehicleSpawnLive {
     )
     $r = Resolve-DuneFlsIdOrError -Ip $Ip -FlsId $FlsId -ActorId $ActorId
     if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
-    # Spawn at the target's pawn when no explicit coords were supplied. The UI
-    # passes the player's pawn/actor id; read its live location from dune.actors
-    # so the vehicle drops on the player rather than at map origin (0,0,0).
+    $controllerId = 0L
+
+    # Funcom's command expects an open spawn point rather than the pawn's exact
+    # coordinates. Resolve the live transform and place the vehicle 10 meters in
+    # front of the player using the pawn's horizontal forward vector.
     if ($X -eq 0.0 -and $Y -eq 0.0 -and $Z -eq 0.0 -and $ActorId -gt 0) {
         $locSql = @"
-SELECT (transform).location.x::float8 AS x,
-       (transform).location.y::float8 AS y,
-       (transform).location.z::float8 AS z
-FROM dune.actors WHERE id = $ActorId::bigint;
+SELECT ps.player_controller_id::bigint AS controller_id,
+       ((a.transform).location).x::float8 AS x,
+       ((a.transform).location).y::float8 AS y,
+       ((a.transform).location).z::float8 AS z,
+       ((a.transform).rotation).x::float8 AS qx,
+       ((a.transform).rotation).y::float8 AS qy,
+       ((a.transform).rotation).z::float8 AS qz,
+       ((a.transform).rotation).w::float8 AS qw
+FROM dune.player_state ps
+JOIN dune.actors a ON a.id = ps.player_pawn_id
+WHERE ps.player_pawn_id = $ActorId::bigint
+  AND ps.online_status::text = 'Online'
+LIMIT 1;
 "@
         $lr = Invoke-DuneSqlQuery -Ip $Ip -Sql $locSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
-        if ($lr.ok) {
-            $lmaps = ConvertTo-DuneRowMaps -Result $lr
-            if ($lmaps.Count -gt 0 -and $null -ne $lmaps[0]['x']) {
-                $X = [double]$lmaps[0]['x']; $Y = [double]$lmaps[0]['y']; $Z = [double]$lmaps[0]['z']
+        if (-not $lr.ok) { return @{ ok = $false; error = $lr.error } }
+        $lmaps = ConvertTo-DuneRowMaps -Result $lr
+        if ($lmaps.Count -eq 0) {
+            return @{ ok = $false; error = 'The player must be online with a live pawn location before spawning a vehicle.' }
+        }
+        $loc = $lmaps[0]
+        $controllerId = [long]$loc['controller_id']
+        $baseX = [double]$loc['x']; $baseY = [double]$loc['y']; $Z = [double]$loc['z']
+        $qx = [double]$loc['qx']; $qy = [double]$loc['qy']; $qz = [double]$loc['qz']; $qw = [double]$loc['qw']
+        $forwardX = 1.0 - (2.0 * (($qy * $qy) + ($qz * $qz)))
+        $forwardY = 2.0 * (($qx * $qy) + ($qw * $qz))
+        $forwardLength = [Math]::Sqrt(($forwardX * $forwardX) + ($forwardY * $forwardY))
+        if ($forwardLength -lt 0.000001) {
+            $yaw = [Math]::Atan2(
+                2.0 * (($qw * $qz) + ($qx * $qy)),
+                1.0 - (2.0 * (($qy * $qy) + ($qz * $qz)))
+            )
+            $forwardX = [Math]::Cos($yaw)
+            $forwardY = [Math]::Sin($yaw)
+        } else {
+            $forwardX /= $forwardLength
+            $forwardY /= $forwardLength
+            $yaw = [Math]::Atan2($forwardY, $forwardX)
+        }
+        $X = $baseX + ($forwardX * 1000.0)
+        $Y = $baseY + ($forwardY * 1000.0)
+        $Rotation = $yaw * 180.0 / [Math]::PI
+    }
+
+    $maxSql = 'SELECT COALESCE(MAX(id), 0)::bigint AS max_id FROM dune.vehicles;'
+    $maxResult = Invoke-DuneSqlQuery -Ip $Ip -Sql $maxSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    if (-not $maxResult.ok) { return @{ ok = $false; error = $maxResult.error } }
+    $maxRows = ConvertTo-DuneRowMaps -Result $maxResult
+    $beforeVehicleId = if ($maxRows.Count -gt 0) { [long]$maxRows[0]['max_id'] } else { 0L }
+
+    # Funcom expects the short vehicle id (for example "Tank"), not the Unreal
+    # actor-class path used to identify the resulting database row.
+    $res = Invoke-DuneRmqSpawnVehicleAt -FlsId $r.fls_id -ClassName $VehicleId -X $X -Y $Y -Z $Z -Rotation $Rotation -TemplateName $TemplateName -Persistent $Persistent -Faction $Faction
+    if (-not $res.ok) { return $res }
+
+    $safeActorClass = $ActorClass -replace "'", "''"
+    $permissionRepaired = $false
+    if ($controllerId -gt 0) {
+        for ($attempt = 0; $attempt -lt 10; $attempt++) {
+            Start-Sleep -Seconds 1
+            $repairSql = @"
+WITH candidate AS (
+    SELECT a.id
+    FROM dune.vehicles v
+    JOIN dune.actors a ON a.id = v.id
+    WHERE v.id > $beforeVehicleId::bigint
+      AND a.class = '$safeActorClass'
+      AND a.transform IS NOT NULL
+      AND ABS(((a.transform).location).x::float8 - ($X)::float8) <= 5000
+      AND ABS(((a.transform).location).y::float8 - ($Y)::float8) <= 5000
+      AND ABS(((a.transform).location).z::float8 - ($Z)::float8) <= 5000
+    ORDER BY
+      POWER(((a.transform).location).x::float8 - ($X)::float8, 2) +
+      POWER(((a.transform).location).y::float8 - ($Y)::float8, 2) +
+      POWER(((a.transform).location).z::float8 - ($Z)::float8, 2),
+      a.id DESC
+    LIMIT 1
+),
+permission_row AS (
+    INSERT INTO dune.permission_actor(actor_id, actor_name, actor_type, access_level, is_child)
+    SELECT c.id, '##' || REGEXP_REPLACE(SPLIT_PART(SPLIT_PART(a.class, '.', 2), '_C', 1), '^BP_', ''), 2, 3, false
+    FROM candidate c
+    JOIN dune.actors a ON a.id = c.id
+    ON CONFLICT (actor_id) DO NOTHING
+    RETURNING actor_id
+)
+INSERT INTO dune.permission_actor_rank(permission_actor_id, player_id, rank)
+SELECT c.id, $controllerId::bigint, 1
+FROM candidate c
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM dune.permission_actor_rank existing
+    WHERE existing.permission_actor_id = c.id
+      AND existing.player_id = $controllerId::bigint
+)
+RETURNING permission_actor_id;
+"@
+            $repair = Invoke-DuneSqlQuery -Ip $Ip -Sql $repairSql -ReadOnly $false -MaxRows 1 -TimeoutSec 15
+            if ($repair.ok) {
+                $repairRows = ConvertTo-DuneRowMaps -Result $repair
+                if ($repairRows.Count -gt 0) {
+                    $permissionRepaired = $true
+                    break
+                }
             }
         }
     }
-    $res = Invoke-DuneRmqSpawnVehicleAt -FlsId $r.fls_id -ClassName $ClassName -X $X -Y $Y -Z $Z -Rotation $Rotation -TemplateName $TemplateName -Persistent $Persistent -Faction $Faction
-    if ($res.ok) { $res.message = "Spawn $ClassName command sent for $($r.fls_id)." }
+
+    $res.permission_repaired = $permissionRepaired
+    $res.message = if ($permissionRepaired) {
+        "Spawned $VehicleId for $($r.fls_id) and granted rank-1 vehicle permission."
+    } else {
+        "Sent the $VehicleId spawn command, but no new matching vehicle was found for permission repair."
+    }
     return $res
 }
 

--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -335,10 +335,14 @@ function Invoke-DuneVehicleSpawnLive {
         [double] $Rotation = 0.0,
         [string] $TemplateName,
         [bool]   $Persistent = $false,
-        [string] $Faction
+        [string] $Faction,
+        [int]    $VerificationDelaySeconds = 2
     )
     $r = Resolve-DuneFlsIdOrError -Ip $Ip -FlsId $FlsId -ActorId $ActorId
     if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    if (-not $Persistent) {
+        return @{ ok = $false; error = 'Persistent must be enabled so DST can assign and verify vehicle ownership.' }
+    }
     $controllerId = 0L
 
     # Funcom's command expects an open spawn point rather than the pawn's exact
@@ -454,12 +458,38 @@ RETURNING permission_actor_id;
         }
     }
 
-    $res.permission_repaired = $permissionRepaired
-    $res.message = if ($permissionRepaired) {
-        "Spawned $VehicleId for $($r.fls_id) and granted rank-1 vehicle permission."
-    } else {
-        "Sent the $VehicleId spawn command, but no new matching vehicle was found for permission repair."
+    if ($VerificationDelaySeconds -gt 0) {
+        Start-Sleep -Seconds $VerificationDelaySeconds
     }
+    $survivalSql = @"
+SELECT a.id::bigint AS vehicle_id
+FROM dune.vehicles v
+JOIN dune.actors a ON a.id = v.id
+WHERE v.id > $beforeVehicleId::bigint
+  AND a.class = '$safeActorClass'
+  AND a.transform IS NOT NULL
+  AND EXISTS (
+      SELECT 1
+      FROM dune.permission_actor_rank par
+      WHERE par.permission_actor_id = a.id
+        AND par.player_id = $controllerId::bigint
+        AND par.rank = 1
+  )
+ORDER BY a.id DESC
+LIMIT 1;
+"@
+    $survival = Invoke-DuneSqlQuery -Ip $Ip -Sql $survivalSql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
+    $survivalRows = if ($survival.ok) { ConvertTo-DuneRowMaps -Result $survival } else { @() }
+    $vehicleSurvived = $survivalRows.Count -gt 0
+
+    $res['permission_repaired'] = $permissionRepaired
+    $res['vehicle_survived'] = $vehicleSurvived
+    if (-not $vehicleSurvived) {
+        $res['ok'] = $false
+        $res['error'] = "Funcom accepted the $VehicleId command, but the vehicle did not survive with a valid actor and owner permission."
+        return $res
+    }
+    $res['message'] = "Spawned $VehicleId for $($r.fls_id) and verified rank-1 owner permission."
     return $res
 }
 

--- a/app/server/routes/PlayersRmq.ps1
+++ b/app/server/routes/PlayersRmq.ps1
@@ -122,14 +122,16 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/grant-live' -Handle
     } catch { Write-DuneError -Response $res -Status 500 -Message "Grant live failed: $($_.Exception.Message)" }
 }
 
-# POST /api/gameplay/vehicles/spawn  { fls_id?, actor_id?, class_name, x?, y?, z?, rotation?, template_name?, persistent?, faction? }
+# POST /api/gameplay/vehicles/spawn  { fls_id?, actor_id?, vehicle_id, actor_class, x?, y?, z?, rotation?, template_name?, persistent?, faction? }
 Register-DuneRoute -Method POST -Path '/api/gameplay/vehicles/spawn' -Handler {
     param($req, $res, $routeParams, $body)
     try {
         $fls = _DuneRmqFlsId $body; $aid = _DuneRmqActor $body
         if (-not (_DuneRmqRequireTarget -Response $res -FlsId $fls -ActorId $aid)) { return }
-        $cls = [string](Get-DuneBodyValue -Body $body -Name 'class_name')
-        if ([string]::IsNullOrWhiteSpace($cls)) { Write-DuneError -Response $res -Status 400 -Message 'class_name is required.'; return }
+        $vehicleId = [string](Get-DuneBodyValue -Body $body -Name 'vehicle_id')
+        if ([string]::IsNullOrWhiteSpace($vehicleId)) { Write-DuneError -Response $res -Status 400 -Message 'vehicle_id is required.'; return }
+        $actorClass = [string](Get-DuneBodyValue -Body $body -Name 'actor_class')
+        if ([string]::IsNullOrWhiteSpace($actorClass)) { Write-DuneError -Response $res -Status 400 -Message 'actor_class is required.'; return }
         $xv = Get-DuneBodyValue -Body $body -Name 'x'; $x = if ($null -ne $xv) { try { [double]$xv } catch { 0.0 } } else { 0.0 }
         $yv = Get-DuneBodyValue -Body $body -Name 'y'; $y = if ($null -ne $yv) { try { [double]$yv } catch { 0.0 } } else { 0.0 }
         $zv = Get-DuneBodyValue -Body $body -Name 'z'; $z = if ($null -ne $zv) { try { [double]$zv } catch { 0.0 } } else { 0.0 }
@@ -138,7 +140,7 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/vehicles/spawn' -Handler {
         $persRaw = Get-DuneBodyValue -Body $body -Name 'persistent'
         $pers = $false; if ($null -ne $persRaw) { $pers = [bool]$persRaw }
         $fac = [string](Get-DuneBodyValue -Body $body -Name 'faction')
-        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DuneVehicleSpawnLive -Ip $ip -FlsId $fls -ActorId $aid -ClassName $cls -X $x -Y $y -Z $z -Rotation $rot -TemplateName $tname -Persistent $pers -Faction $fac }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip) Invoke-DuneVehicleSpawnLive -Ip $ip -FlsId $fls -ActorId $aid -VehicleId $vehicleId -ActorClass $actorClass -X $x -Y $y -Z $z -Rotation $rot -TemplateName $tname -Persistent $pers -Faction $fac }
     } catch { Write-DuneError -Response $res -Status 500 -Message "Spawn vehicle failed: $($_.Exception.Message)" }
 }
 

--- a/tests/PlayersRmq.Tests.ps1
+++ b/tests/PlayersRmq.Tests.ps1
@@ -58,3 +58,53 @@ Describe 'Resolve-DuneStackMax' -Tag 'Pure' {
         $r.free_slots | Should -Be 111
     }
 }
+
+Describe 'Invoke-DuneVehicleSpawnLive' -Tag 'Pure' {
+    BeforeEach {
+        $script:spawnArgs = $null
+        $script:spawnSql = $null
+
+        function global:Resolve-DuneFlsIdOrError {
+            return @{ ok = $true; fls_id = 'fls-test' }
+        }
+        function global:Invoke-DuneSqlQuery {
+            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
+            $script:spawnSql = $Sql
+            return @{
+                ok = $true
+                columns = @('x', 'y', 'z')
+                rows = @(, @('10.5', '20.25', '30.75'))
+            }
+        }
+        function global:Invoke-DuneRmqSpawnVehicleAt {
+            param($FlsId, $ClassName, $X, $Y, $Z, $Rotation, $TemplateName, $Persistent, $Faction)
+            $script:spawnArgs = @{
+                FlsId = $FlsId; ClassName = $ClassName
+                X = $X; Y = $Y; Z = $Z
+                TemplateName = $TemplateName; Persistent = $Persistent
+            }
+            return @{ ok = $true }
+        }
+    }
+
+    AfterEach {
+        Remove-Item function:global:Resolve-DuneFlsIdOrError -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DuneRmqSpawnVehicleAt -ErrorAction SilentlyContinue
+    }
+
+    It 'resolves the current transform and sends the vehicle to that location' {
+        $r = Invoke-DuneVehicleSpawnLive -Ip '1.2.3.4' -ActorId 42 `
+            -ClassName '/Game/Test/BP_Tank.BP_Tank_C' `
+            -TemplateName 'T6_CombatFire' -Persistent $true
+
+        $r.ok | Should -BeTrue
+        $script:spawnSql | Should -Match '\(transform\)\.location\.x'
+        $script:spawnArgs.FlsId | Should -Be 'fls-test'
+        $script:spawnArgs.X | Should -Be 10.5
+        $script:spawnArgs.Y | Should -Be 20.25
+        $script:spawnArgs.Z | Should -Be 30.75
+        $script:spawnArgs.TemplateName | Should -Be 'T6_CombatFire'
+        $script:spawnArgs.Persistent | Should -BeTrue
+    }
+}

--- a/tests/PlayersRmq.Tests.ps1
+++ b/tests/PlayersRmq.Tests.ps1
@@ -62,18 +62,38 @@ Describe 'Resolve-DuneStackMax' -Tag 'Pure' {
 Describe 'Invoke-DuneVehicleSpawnLive' -Tag 'Pure' {
     BeforeEach {
         $script:spawnArgs = $null
-        $script:spawnSql = $null
+        $script:spawnSql = @()
+        $script:spawnQueryCount = 0
 
         function global:Resolve-DuneFlsIdOrError {
             return @{ ok = $true; fls_id = 'fls-test' }
         }
         function global:Invoke-DuneSqlQuery {
             param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
-            $script:spawnSql = $Sql
-            return @{
-                ok = $true
-                columns = @('x', 'y', 'z')
-                rows = @(, @('10.5', '20.25', '30.75'))
+            $script:spawnSql += $Sql
+            $script:spawnQueryCount++
+            switch ($script:spawnQueryCount) {
+                1 {
+                    return @{
+                        ok = $true
+                        columns = @('controller_id', 'x', 'y', 'z', 'qx', 'qy', 'qz', 'qw')
+                        rows = @(, @('99', '10.5', '20.25', '30.75', '0', '0', '0', '1'))
+                    }
+                }
+                2 {
+                    return @{
+                        ok = $true
+                        columns = @('max_id')
+                        rows = @(, @('8000'))
+                    }
+                }
+                default {
+                    return @{
+                        ok = $true
+                        columns = @('permission_actor_id')
+                        rows = @(, @('8001'))
+                    }
+                }
             }
         }
         function global:Invoke-DuneRmqSpawnVehicleAt {
@@ -81,6 +101,7 @@ Describe 'Invoke-DuneVehicleSpawnLive' -Tag 'Pure' {
             $script:spawnArgs = @{
                 FlsId = $FlsId; ClassName = $ClassName
                 X = $X; Y = $Y; Z = $Z
+                Rotation = $Rotation
                 TemplateName = $TemplateName; Persistent = $Persistent
             }
             return @{ ok = $true }
@@ -95,16 +116,20 @@ Describe 'Invoke-DuneVehicleSpawnLive' -Tag 'Pure' {
 
     It 'resolves the current transform and sends the vehicle to that location' {
         $r = Invoke-DuneVehicleSpawnLive -Ip '1.2.3.4' -ActorId 42 `
-            -ClassName '/Game/Test/BP_Tank.BP_Tank_C' `
+            -VehicleId 'Tank' -ActorClass '/Game/Test/BP_Tank.BP_Tank_C' `
             -TemplateName 'T6_CombatFire' -Persistent $true
 
         $r.ok | Should -BeTrue
-        $script:spawnSql | Should -Match '\(transform\)\.location\.x'
+        $script:spawnSql[0] | Should -Match '\(a\.transform\)\.location'
+        $script:spawnArgs.ClassName | Should -Be 'Tank'
         $script:spawnArgs.FlsId | Should -Be 'fls-test'
-        $script:spawnArgs.X | Should -Be 10.5
+        $script:spawnArgs.X | Should -Be 1010.5
         $script:spawnArgs.Y | Should -Be 20.25
         $script:spawnArgs.Z | Should -Be 30.75
+        $script:spawnArgs.Rotation | Should -Be 0
         $script:spawnArgs.TemplateName | Should -Be 'T6_CombatFire'
         $script:spawnArgs.Persistent | Should -BeTrue
+        $script:spawnSql[2] | Should -Match 'permission_actor_rank'
+        $r.permission_repaired | Should -BeTrue
     }
 }

--- a/tests/PlayersRmq.Tests.ps1
+++ b/tests/PlayersRmq.Tests.ps1
@@ -64,6 +64,7 @@ Describe 'Invoke-DuneVehicleSpawnLive' -Tag 'Pure' {
         $script:spawnArgs = $null
         $script:spawnSql = @()
         $script:spawnQueryCount = 0
+        $script:spawnSurvives = $true
 
         function global:Resolve-DuneFlsIdOrError {
             return @{ ok = $true; fls_id = 'fls-test' }
@@ -87,11 +88,18 @@ Describe 'Invoke-DuneVehicleSpawnLive' -Tag 'Pure' {
                         rows = @(, @('8000'))
                     }
                 }
-                default {
+                3 {
                     return @{
                         ok = $true
                         columns = @('permission_actor_id')
                         rows = @(, @('8001'))
+                    }
+                }
+                default {
+                    return @{
+                        ok = $true
+                        columns = @('vehicle_id')
+                        rows = if ($script:spawnSurvives) { @(, @('8001')) } else { @() }
                     }
                 }
             }
@@ -117,7 +125,7 @@ Describe 'Invoke-DuneVehicleSpawnLive' -Tag 'Pure' {
     It 'resolves the current transform and sends the vehicle to that location' {
         $r = Invoke-DuneVehicleSpawnLive -Ip '1.2.3.4' -ActorId 42 `
             -VehicleId 'Tank' -ActorClass '/Game/Test/BP_Tank.BP_Tank_C' `
-            -TemplateName 'T6_CombatFire' -Persistent $true
+            -TemplateName 'T6_CombatFire' -Persistent $true -VerificationDelaySeconds 0
 
         $r.ok | Should -BeTrue
         $script:spawnSql[0] | Should -Match '\(a\.transform\)\.location'
@@ -131,5 +139,29 @@ Describe 'Invoke-DuneVehicleSpawnLive' -Tag 'Pure' {
         $script:spawnArgs.Persistent | Should -BeTrue
         $script:spawnSql[2] | Should -Match 'permission_actor_rank'
         $r.permission_repaired | Should -BeTrue
+        $r.vehicle_survived | Should -BeTrue
+    }
+
+    It 'fails when Funcom removes the vehicle after accepting the command' {
+        $script:spawnSurvives = $false
+
+        $r = Invoke-DuneVehicleSpawnLive -Ip '1.2.3.4' -ActorId 42 `
+            -VehicleId 'Tank' -ActorClass '/Game/Test/BP_Tank.BP_Tank_C' `
+            -TemplateName 'T6_CombatFire' -Persistent $true -VerificationDelaySeconds 0
+
+        $r.ok | Should -BeFalse
+        $r.permission_repaired | Should -BeTrue
+        $r.vehicle_survived | Should -BeFalse
+        $r.error | Should -Match 'did not survive'
+    }
+
+    It 'rejects transient spawns because they cannot receive durable ownership' {
+        $r = Invoke-DuneVehicleSpawnLive -Ip '1.2.3.4' -ActorId 42 `
+            -VehicleId 'TreadWheel' -ActorClass '/Game/Test/BP_TreadWheel.BP_TreadWheel_C' `
+            -TemplateName 'T6_Boost' -Persistent $false -VerificationDelaySeconds 0
+
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'Persistent must be enabled'
+        $script:spawnArgs | Should -BeNullOrEmpty
     }
 }

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -2145,14 +2145,18 @@ export function grantLive(controllerId: number, template: string, amount: number
 
 export interface SpawnVehicleInput {
   target: PlayerTarget
-  className: string
+  vehicleId: string
+  actorClass: string
   templateName?: string
   persistent?: boolean
   faction?: string
   location?: { x: number; y: number; z: number }
 }
 export function spawnVehicle(input: SpawnVehicleInput) {
-  const body: Record<string, unknown> = { class_name: input.className }
+  const body: Record<string, unknown> = {
+    vehicle_id: input.vehicleId,
+    actor_class: input.actorClass,
+  }
   if (input.target.fls_id)      body.fls_id        = input.target.fls_id
   if (input.target.actor_id)    body.actor_id      = input.target.actor_id
   if (input.templateName)       body.template_name = input.templateName

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -731,7 +731,7 @@ const ACTIONS: ActionDef[] = [
     confirm: p => `Give vehicle parts to ${p.name}'s inventory? They'll need to assemble at a Vehicle Assembly. Works online or offline.`,
     run: () => Promise.resolve({ message: '' }) },
   { id: 'funcom-spawn-vehicle', group: 'Vehicle', label: 'Funcom Spawn Vehicle', icon: 'CarFront', custom: 'funcom-spawn-vehicle', liveOnly: true, experimental: true,
-    rowNote: 'Sends Funcom’s live SpawnVehicleAt command at the selected player. Unconfirmed; create a fresh backup before testing.',
+    rowNote: 'Sends Funcom’s persistent SpawnVehicleAt command and assigns owner permission. Unconfirmed; create a fresh backup before testing.',
     confirm: p => `Send Funcom's unconfirmed live vehicle-spawn command at ${p.name}?\n\nThe player must be online and a fresh backup must exist before testing.`,
     run: () => Promise.resolve({ message: '' }) },
   { id: 'refuel-vehicle', group: 'Vehicle', label: 'Refuel Vehicle', icon: 'Fuel', custom: 'refuel-vehicle',
@@ -1826,7 +1826,6 @@ function FuncomSpawnVehicleForm({ busy, onSubmit }: {
   const [catErr, setCatErr] = useState(false)
   const [vid, setVid] = useState('')
   const [tpl, setTpl] = useState('')
-  const [persistent, setPersistent] = useState(false)
   const selectCls = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50'
 
   useEffect(() => {
@@ -1864,16 +1863,14 @@ function FuncomSpawnVehicleForm({ busy, onSubmit }: {
           {veh.templates.map(t => <option key={t} value={t}>{t}</option>)}
         </select>
       </div>
-      <label className="flex items-center gap-2 text-sm text-text-muted">
-        <input type="checkbox" checked={persistent} disabled={busy}
-          onChange={e => setPersistent(e.target.checked)} />
-        Persistent (request survival across server restarts)
-      </label>
+      <div className="text-xs text-text-muted">
+        Persistent is always enabled so DST can assign owner permission and verify the vehicle survives.
+      </div>
       <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-text-muted">
         Experimental Funcom command. A successful API response only means the command was sent; verify the vehicle in game.
       </div>
       <button className="btn-primary w-full" disabled={busy}
-        onClick={() => onSubmit(veh, tpl, persistent)}>
+        onClick={() => onSubmit(veh, tpl, true)}>
         {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="CarFront" size={13} />} Send Funcom Spawn Command
       </button>
     </div>

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -25,7 +25,7 @@ import {
   resetAllKeystones, resetAllSpecs, resetJourney, resetProgressionLive, resetSpec,
   restoreDestroyed,
   setFactionTier, setSkillPoints,
-  setStarterClass, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, resetFaction, snapshotBuilds, getFreshStartSnapshots, restoreBuilds, grantAllSkills,
+  setStarterClass, spawnVehicle, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, resetFaction, snapshotBuilds, getFreshStartSnapshots, restoreBuilds, grantAllSkills,
   chatWhisper, isValidTemplateId, getItemCatalog, getCosmeticsCatalog, getPlayerOwnedCosmetics, filterCosmeticsCatalog, type CosmeticEntry,
   parseTcnoPackageText,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
@@ -591,7 +591,7 @@ interface ActionDef {
   offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   experimental?: boolean  // unverified — may not take effect in-game; shown with an EXPERIMENTAL badge
   fields?: ActionField[]
-  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'complete-contract' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'teleport-player' | 'teleport-location' | 'set-respawn' | 'reset-faction' | 'grant-cosmetic' | 'fresh-start'
+  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'funcom-spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'complete-contract' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'teleport-player' | 'teleport-location' | 'set-respawn' | 'reset-faction' | 'grant-cosmetic' | 'fresh-start'
   balance?: 'solari' | 'scrip' | 'intel'  // show the player's current balance read-only above the form
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
@@ -729,6 +729,10 @@ const ACTIONS: ActionDef[] = [
   { id: 'spawn-vehicle', group: 'Vehicle', label: 'Spawn Vehicle', icon: 'Car', custom: 'spawn-vehicle',
     rowNote: 'Hands unassembled Mk6 parts — assemble at a Vehicle Assembly. Works online or offline',
     confirm: p => `Give vehicle parts to ${p.name}'s inventory? They'll need to assemble at a Vehicle Assembly. Works online or offline.`,
+    run: () => Promise.resolve({ message: '' }) },
+  { id: 'funcom-spawn-vehicle', group: 'Vehicle', label: 'Funcom Spawn Vehicle', icon: 'CarFront', custom: 'funcom-spawn-vehicle', liveOnly: true, experimental: true,
+    rowNote: 'Sends Funcom’s live SpawnVehicleAt command at the selected player. Unconfirmed; create a fresh backup before testing.',
+    confirm: p => `Send Funcom's unconfirmed live vehicle-spawn command at ${p.name}?\n\nThe player must be online and a fresh backup must exist before testing.`,
     run: () => Promise.resolve({ message: '' }) },
   { id: 'refuel-vehicle', group: 'Vehicle', label: 'Refuel Vehicle', icon: 'Fuel', custom: 'refuel-vehicle',
     run: () => Promise.resolve({ message: '' }) },
@@ -985,6 +989,15 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
           ) : def.custom === 'whisper' ? (
             <WhisperForm busy={busy}
               onSubmit={msg => runAction(def, () => chatWhisper(String(player.id), msg))} />
+          ) : def.custom === 'funcom-spawn-vehicle' ? (
+            <FuncomSpawnVehicleForm busy={busy}
+              onSubmit={(className, templateName, persistent) => runAction(def, () =>
+                spawnVehicle({
+                  target: { actor_id: player.id },
+                  className,
+                  templateName: templateName || undefined,
+                  persistent,
+                }))} />
           ) : def.custom === 'spawn-vehicle' || def.custom === 'vehicle-kit' ? (
             <VehicleKitForm busy={busy}
               onSubmit={(veh, parts, overflow) => runAction(def, async () => {
@@ -1803,14 +1816,76 @@ export function GivePackageForm({ busy, giveDisabled = false, playerName, target
   )
 }
 
+// Sends Funcom's live SpawnVehicleAt command for field testing. Unlike vehicle
+// kits, this includes vehicles with no inventory-form parts, such as the Tank.
+function FuncomSpawnVehicleForm({ busy, onSubmit }: {
+  busy: boolean; onSubmit: (className: string, templateName: string, persistent: boolean) => void
+}) {
+  const [catalog, setCatalog] = useState<VehicleKitCatalog | null>(null)
+  const [catErr, setCatErr] = useState(false)
+  const [vid, setVid] = useState('')
+  const [tpl, setTpl] = useState('')
+  const [persistent, setPersistent] = useState(false)
+  const selectCls = 'w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text text-sm focus:outline-none focus:ring-2 focus:ring-ibad focus:border-ibad/50'
+
+  useEffect(() => {
+    let cancelled = false
+    getVehicleKitCatalog()
+      .then(cat => {
+        if (cancelled) return
+        setCatalog(cat)
+        if (cat.vehicles.length > 0) setVid(cat.vehicles[0].id)
+      })
+      .catch(() => { if (!cancelled) setCatErr(true) })
+    return () => { cancelled = true }
+  }, [])
+
+  if (catErr) return <div className="text-sm text-danger">Failed to load vehicle catalog.</div>
+  if (!catalog) return <div className="text-sm text-text-muted">Loading vehicle catalog…</div>
+
+  const veh = catalog.vehicles.find(v => v.id === vid) || catalog.vehicles[0]
+  if (!veh) return <div className="text-sm text-text-muted">No Funcom vehicle definitions available.</div>
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Vehicle</label>
+        <select value={vid} disabled={busy} className={selectCls}
+          onChange={e => { setVid(e.target.value); setTpl('') }}>
+          {catalog.vehicles.map(v => <option key={v.id} value={v.id}>{v.label}</option>)}
+        </select>
+      </div>
+      <div>
+        <label className="block text-[11px] uppercase tracking-wider text-text-dim mb-1">Funcom template</label>
+        <select value={tpl} disabled={busy} className={selectCls}
+          onChange={e => setTpl(e.target.value)}>
+          <option value="">Base (no template)</option>
+          {veh.templates.map(t => <option key={t} value={t}>{t}</option>)}
+        </select>
+      </div>
+      <label className="flex items-center gap-2 text-sm text-text-muted">
+        <input type="checkbox" checked={persistent} disabled={busy}
+          onChange={e => setPersistent(e.target.checked)} />
+        Persistent (request survival across server restarts)
+      </label>
+      <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-text-muted">
+        Experimental Funcom command. A successful API response only means the command was sent; verify the vehicle in game.
+      </div>
+      <button className="btn-primary w-full" disabled={busy}
+        onClick={() => onSubmit(veh.className, tpl, persistent)}>
+        {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="CarFront" size={13} />} Send Funcom Spawn Command
+      </button>
+    </div>
+  )
+}
+
 // Self-contained vehicle-parts form. Picks a vehicle that has discrete part
 // items and previews its Mk6 parts list; submitting hands every part plus a
 // Large Vehicle Fuel Cell and a Welding Torch Mk5 into the player's inventory
 // via the normal give-item path (works online or offline). Vehicles the game
 // has no part items for (Tank / Treadwheel / Container) are omitted — there is
-// no DST path to deliver those because the game has no inventory-form of their
-// chassis/modules. Shared by both the "Spawn Vehicle" and "Give Vehicle Kit"
-// actions, which call the same handler.
+// no DST kit path to deliver those because the game has no inventory-form of
+// their chassis/modules. Shared by the two existing package actions.
 function VehicleKitForm({ busy, onSubmit }: {
   busy: boolean; onSubmit: (veh: VehicleTemplate, parts: string[], allowOverflow: boolean) => void
 }) {

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -991,10 +991,11 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
               onSubmit={msg => runAction(def, () => chatWhisper(String(player.id), msg))} />
           ) : def.custom === 'funcom-spawn-vehicle' ? (
             <FuncomSpawnVehicleForm busy={busy}
-              onSubmit={(className, templateName, persistent) => runAction(def, () =>
+              onSubmit={(vehicle, templateName, persistent) => runAction(def, () =>
                 spawnVehicle({
                   target: { actor_id: player.id },
-                  className,
+                  vehicleId: vehicle.id,
+                  actorClass: vehicle.className,
                   templateName: templateName || undefined,
                   persistent,
                 }))} />
@@ -1819,7 +1820,7 @@ export function GivePackageForm({ busy, giveDisabled = false, playerName, target
 // Sends Funcom's live SpawnVehicleAt command for field testing. Unlike vehicle
 // kits, this includes vehicles with no inventory-form parts, such as the Tank.
 function FuncomSpawnVehicleForm({ busy, onSubmit }: {
-  busy: boolean; onSubmit: (className: string, templateName: string, persistent: boolean) => void
+  busy: boolean; onSubmit: (vehicle: VehicleTemplate, templateName: string, persistent: boolean) => void
 }) {
   const [catalog, setCatalog] = useState<VehicleKitCatalog | null>(null)
   const [catErr, setCatErr] = useState(false)
@@ -1872,7 +1873,7 @@ function FuncomSpawnVehicleForm({ busy, onSubmit }: {
         Experimental Funcom command. A successful API response only means the command was sent; verify the vehicle in game.
       </div>
       <button className="btn-primary w-full" disabled={busy}
-        onClick={() => onSubmit(veh.className, tpl, persistent)}>
+        onClick={() => onSubmit(veh, tpl, persistent)}>
         {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="CarFront" size={13} />} Send Funcom Spawn Command
       </button>
     </div>

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -248,17 +248,27 @@ describe('Phase G+H — RMQ live commands (PlayerTarget shape)', () => {
   })
 
   it('spawnVehicle copies fls_id/actor_id + optional location', async () => {
-    await gp.spawnVehicle({ target: { fls_id: 'F-x' }, className: 'tpl.ornithopter' })
+    await gp.spawnVehicle({
+      target: { fls_id: 'F-x' },
+      vehicleId: 'OrnithopterLight',
+      actorClass: 'tpl.ornithopter',
+    })
     expect(last().url).toBe('/api/gameplay/vehicles/spawn')
-    expect(last().body).toEqual({ class_name: 'tpl.ornithopter', fls_id: 'F-x' })
+    expect(last().body).toEqual({
+      vehicle_id: 'OrnithopterLight',
+      actor_class: 'tpl.ornithopter',
+      fls_id: 'F-x',
+    })
 
     await gp.spawnVehicle({
       target: { actor_id: 1 },
-      className: 'tpl.sandbike',
+      vehicleId: 'Sandbike',
+      actorClass: 'tpl.sandbike',
       location: { x: 1, y: 2, z: 3 },
     })
     expect(last().body).toEqual({
-      class_name: 'tpl.sandbike',
+      vehicle_id: 'Sandbike',
+      actor_class: 'tpl.sandbike',
       actor_id: 1,
       x: 1, y: 2, z: 3,
     })


### PR DESCRIPTION
## Summary
- introduce the v15 server-first workspace and platform foundation
- add the bounded twilight field-test harness and next-generation Maps cache/live-state slice
- retain the verified Experimental Funcom vehicle spawn action
- replace GitHub issue launching with direct redacted diagnostics packaging
- restore Map SpinUp and map restarts under Server Controls
- redact game login passwords from diagnostic server-state logs

## Validation
- targeted PowerShell/Pester suites pass
- WebUI Vitest, build/typecheck, performance, and targeted ESLint pass
- installer builds cleanly as `v15.0.0-test1`
- gitleaks found no secrets in `origin/main..HEAD`

## Release boundary
This PR prepares the `v15.0.0-test1` prerelease for field testing. Twilight remains experimental until the 30-minute lighting and simulation-timer proof is complete. No Discord announcement is planned.