### PR TITLE
Preserve complete WebView diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-test1"
+      placeholder: "v15.0.0-test2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ here cover everything those tags shipped.
 
 ### Changed
 
+- Diagnostics packages now include the complete redacted WebView2 debug log
+  instead of only its last 200 KB. The desktop shell already bounds the source
+  file at 2 MB, so startup failures remain available without unbounded bundles.
 - Reorganized the web portal into lazy-loaded server-management and gameplay
   workspaces while preserving legacy URL, query-string, and hash navigation.
 - Adapted Server Health's Game Servers card into compact stacked pod summaries

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -186,11 +186,14 @@ function Get-DstWebView2Version {
     return '(not installed / not detected)'
 }
 
-# Read a file that may be open for append (logs). Returns the LAST $MaxBytes
-# of content, or $null on failure. Uses FileShare.ReadWrite so a writer that
-# holds the file open doesn't block us.
-function Read-DstLogTail {
-    param([string]$Path, [int]$MaxBytes = 204800)
+# Read a file that may be open for append. Returns the complete file unless
+# TailBytes requests a bounded tail. Uses FileShare.ReadWrite so a writer that
+# holds the file open does not block diagnostics collection.
+function Read-DstLogText {
+    param(
+        [string]$Path,
+        [Nullable[int]]$TailBytes = $null
+    )
     if (-not (Test-Path -LiteralPath $Path)) { return $null }
     try {
         $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open,
@@ -198,8 +201,8 @@ function Read-DstLogTail {
                                             [System.IO.FileShare]::ReadWrite)
         try {
             $len = $fs.Length
-            if ($len -gt $MaxBytes) {
-                [void]$fs.Seek($len - $MaxBytes, [System.IO.SeekOrigin]::Begin)
+            if ($null -ne $TailBytes -and $TailBytes -gt 0 -and $len -gt $TailBytes) {
+                [void]$fs.Seek($len - $TailBytes, [System.IO.SeekOrigin]::Begin)
             }
             $reader = New-Object System.IO.StreamReader($fs, [System.Text.Encoding]::UTF8, $true)
             try { return $reader.ReadToEnd() } finally { $reader.Dispose() }
@@ -207,6 +210,11 @@ function Read-DstLogTail {
     } catch {
         return $null
     }
+}
+
+function Read-DstLogTail {
+    param([string]$Path, [int]$MaxBytes = 204800)
+    return Read-DstLogText -Path $Path -TailBytes $MaxBytes
 }
 
 # Builds the diagnostic bundle. Returns a hashtable with the same shape the
@@ -277,18 +285,19 @@ function New-DstDiagnosticBundle {
         $warnings.Add("dune-server.config not found at $cfgPath.")
     }
 
-    # 5) WebView2 debug log (tail, sanitized) --------------------------------
+    # 5) WebView2 debug log (complete, sanitized) ----------------------------
+    # The desktop shell rotates this source at 2 MB, so preserving the complete
+    # log is bounded and retains startup failures that a tail would discard.
     $wv2 = Join-Path $env:APPDATA 'DuneServer\webview2-debug.log'
-    $wv2Tail = Read-DstLogTail -Path $wv2 -MaxBytes 204800
-    if ($null -ne $wv2Tail) {
+    $wv2Log = Read-DstLogText -Path $wv2
+    if ($null -ne $wv2Log) {
         try {
             $wv2Bytes  = (Get-Item -LiteralPath $wv2 -ErrorAction Stop).Length
-            $header    = "# webview2-debug.log (tail, sanitized; source size: $wv2Bytes bytes)`r`n# Path: $wv2`r`n`r`n"
-            $san       = $header + (Invoke-DstRedaction -Text $wv2Tail @redactArgs)
+            $header    = "# webview2-debug.log (complete, sanitized; source size: $wv2Bytes bytes)`r`n# Path: $wv2`r`n`r`n"
+            $san       = $header + (Invoke-DstRedaction -Text $wv2Log @redactArgs)
             $out       = Join-Path $stageDir 'webview2-debug.log'
             Set-Content -LiteralPath $out -Value $san -Encoding UTF8
             $included.Add(@{ name = 'webview2-debug.log'; bytes = (Get-Item -LiteralPath $out).Length })
-            if ($wv2Bytes -gt 204800) { $warnings.Add('webview2-debug.log was truncated to the last 200 KB.') }
         } catch {
             $warnings.Add("Failed to copy webview2-debug.log: $($_.Exception.Message)")
         }

--- a/tests/Diagnostics.Tests.ps1
+++ b/tests/Diagnostics.Tests.ps1
@@ -79,6 +79,31 @@ Describe 'Invoke-DstRedaction' -Tag 'Pure' {
     }
 }
 
+Describe 'Read-DstLogText' -Tag 'Pure' {
+    It 'preserves a complete WebView2-sized log larger than the old 200 KB limit' {
+        $path = Join-Path $TestDrive 'webview2-debug.log'
+        $start = '[shell] startup failure'
+        $end = '[console.error] latest failure'
+        $padding = 'x' * 225000
+        [IO.File]::WriteAllText($path, "$start`n$padding`n$end", [Text.UTF8Encoding]::new($false))
+
+        $content = Read-DstLogText -Path $path
+
+        $content | Should -Match ([regex]::Escape($start))
+        $content | Should -Match ([regex]::Escape($end))
+        ([Text.Encoding]::UTF8.GetByteCount($content)) | Should -BeGreaterThan 204800
+    }
+
+    It 'retains bounded tail reads for other diagnostic logs' {
+        $path = Join-Path $TestDrive 'cli.log'
+        [IO.File]::WriteAllText($path, ('a' * 1024) + 'END', [Text.UTF8Encoding]::new($false))
+
+        $content = Read-DstLogTail -Path $path -MaxBytes 128
+
+        $content | Should -Be (('a' * 125) + 'END')
+    }
+}
+
 Describe 'ConvertTo-DstWorldRestartDiagnosticState' -Tag 'Pure' {
     It 'exports operational state without player identities or paths' {
         $state = [pscustomobject]@{
@@ -111,6 +136,15 @@ Describe 'Diagnostics route registration' -Tag 'Pure' {
         $source | Should -Match 'update-result-\[A-Za-z0-9\._-\]'
         $source | Should -Match 'Invoke-DstRedaction -Text \$tail'
         $source | Should -Not -Match "Get-ChildItem.+DuneServerSetup.+included"
+    }
+
+    It 'includes the complete bounded WebView2 debug log' {
+        $routeFile = Join-Path (Get-DstRepoRoot) 'app\server\routes\Diagnostics.ps1'
+        $source = Get-Content -LiteralPath $routeFile -Raw
+
+        $source | Should -Match 'Read-DstLogText -Path \$wv2'
+        $source | Should -Match 'webview2-debug\.log \(complete, sanitized'
+        $source | Should -Not -Match 'webview2-debug\.log was truncated'
     }
 
     It 'registers failed database operation cleanup at script scope' {


### PR DESCRIPTION
## Summary
- include the complete redacted WebView2 debug log in diagnostics bundles
- preserve bounded tail reads for other logs
- identify the field build as v15.0.0-test2 in bug reports

## Validation
- Diagnostics.Tests.ps1: 16/16 passed
- Diagnostics.ps1 parse check passed