### PR TITLE
Fix tray lifecycle in v15 test builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-test2"
+      placeholder: "v15.0.0-test3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ here cover everything those tags shipped.
 
 ### Fixed
 
+- Fixed autostart and always-on sessions losing their tray icon when the app
+  window was closed. With Minimize to tray enabled, X now hides the shell back
+  to the tray; only **Quit (stops server)** exits the shell and backend.
 - Fixed installed Windows builds failing to create the first cached Maps
   generation when the elevated helper could not duplicate the UAC linked token;
   the helper now falls back to the same user's unelevated shell token with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ here cover everything those tags shipped.
 
 ### Changed
 
+- Reused the last recent Server Health snapshot during update restarts, launched
+  the desktop shell before backend bootstrap, and warmed WebView2 in parallel so
+  the app shows immediately and repaints while live health probes refresh.
 - Diagnostics packages now include the complete redacted WebView2 debug log
   instead of only its last 200 KB. The desktop shell already bounds the source
   file at 2 MB, so startup failures remain available without unbounded bundles.

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -113,13 +113,9 @@ internal sealed class MainForm : Form
             return;
         }
 
-        string? url = await ResolveUrlAsync();
-        if (string.IsNullOrWhiteSpace(url))
-        {
-            _status.Text = "Could not find the Dune Server Tool URL.\r\n" +
-                           "Start the server first, then reopen this window.";
-            return;
-        }
+        // Warm WebView2 while the backend starts. Both cold paths take several
+        // seconds, and neither depends on the other until navigation.
+        Task<string?> urlTask = ResolveUrlAsync();
 
         try
         {
@@ -137,6 +133,14 @@ internal sealed class MainForm : Form
         catch (Exception ex)
         {
             _status.Text = "WebView2 failed to initialize.\r\n" + ex.Message;
+            return;
+        }
+
+        string? url = await urlTask;
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            _status.Text = "Could not find the Dune Server Tool URL.\r\n" +
+                           "Start the server first, then reopen this window.";
             return;
         }
 
@@ -771,12 +775,13 @@ internal sealed class MainForm : Form
             "DuneServer", "last-url.txt");
 
         bool backendWasRunning = Process.GetProcessesByName("DuneServer").Length > 0;
-
-        string? candidate = await PollForReachableUrlAsync(file, MaxWaitFilePollAttempts);
-        if (candidate != null) return candidate;
+        string? candidate;
 
         if (backendWasRunning)
         {
+            candidate = await PollForReachableUrlAsync(file, MaxWaitFilePollAttempts);
+            if (candidate != null) return candidate;
+
             // A DuneServer.exe is already alive but never came up within the
             // wait window (hung listener, very slow host, etc). Don't pile a
             // second backend on top of it — hand back whatever is on disk
@@ -785,6 +790,8 @@ internal sealed class MainForm : Form
             return await TryReadUrlFileAsync(file);
         }
 
+        // A stale last-url file cannot be reachable without a backend process.
+        // Start immediately instead of spending 20 seconds probing it first.
         candidate = await TryStartBackendAsync(file);
         return candidate ?? await TryReadUrlFileAsync(file);
     }

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -28,12 +28,13 @@ internal sealed class MainForm : Form
     // ----- Minimize-to-tray state --------------------------------------------
     // When enabled, minimizing the window hides it (and its taskbar button) and
     // leaves a single NotifyIcon in the system tray that reopens the portal.
-    // Closing the window via the X still tears the backend down as before; the
-    // tray's "Quit (stops server)" is the explicit shutdown from the tray.
+    // In backend keep-alive mode, X also hides to the tray; the tray's explicit
+    // Quit action bypasses that interception and shuts down normally.
     private NotifyIcon? _tray;
     private ToolStripMenuItem? _trayMinItem;
     private bool _minimizeToTray;
     private bool _trayBalloonShown;
+    private bool _quitFromTray;
     private FormWindowState _restoreState = FormWindowState.Normal;
 
     public MainForm(string? initialUrl, bool useWaitFile)
@@ -57,6 +58,12 @@ internal sealed class MainForm : Form
         FormClosing += (_, e) =>
         {
             SaveWindowState();
+            if (ShouldHideToTrayOnClose(e.CloseReason))
+            {
+                e.Cancel = true;
+                HideToTray();
+                return;
+            }
             if (!_restartShellOnly && !StopCompanionProcesses())
             {
                 e.Cancel = true;
@@ -927,7 +934,11 @@ internal sealed class MainForm : Form
                 Checked = _minimizeToTray,
             };
 
-            var quit = new ToolStripMenuItem("Quit (stops server)", null, (_, _) => Close());
+            var quit = new ToolStripMenuItem("Quit (stops server)", null, (_, _) =>
+            {
+                _quitFromTray = true;
+                Close();
+            });
 
             menu.Items.Add(open);
             menu.Items.Add(_trayMinItem);
@@ -1003,6 +1014,30 @@ internal sealed class MainForm : Form
         // CheckOnClick has already flipped the menu item before this fires.
         _minimizeToTray = _trayMinItem?.Checked ?? false;
         SaveWindowState();
+    }
+
+    private bool ShouldHideToTrayOnClose(CloseReason closeReason)
+    {
+        return closeReason == CloseReason.UserClosing
+            && !_restartShellOnly
+            && !_quitFromTray
+            && _minimizeToTray
+            && IsBackendKeepAliveActive();
+    }
+
+    private static bool IsBackendKeepAliveActive()
+    {
+        try
+        {
+            string keepAliveFlag = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "DuneServer", "keep-alive.flag");
+            return File.Exists(keepAliveFlag);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private void DisposeTrayIcon()
@@ -1218,14 +1253,7 @@ internal sealed class MainForm : Form
         // refreshed live by the backend on startup AND on every autostart
         // toggle, so this reflects current intent rather than launch-time
         // state.
-        try
-        {
-            string keepAliveFlag = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "DuneServer", "keep-alive.flag");
-            if (File.Exists(keepAliveFlag)) return true;
-        }
-        catch { /* defensive -- fall through to the normal teardown */ }
+        if (IsBackendKeepAliveActive()) return true;
 
         if (IsWorldRestartActive())
         {

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -35,6 +35,7 @@ internal sealed class MainForm : Form
     private bool _minimizeToTray;
     private bool _trayBalloonShown;
     private bool _quitFromTray;
+    private bool _closeRequestedByPortal;
     private FormWindowState _restoreState = FormWindowState.Normal;
 
     public MainForm(string? initialUrl, bool useWaitFile)
@@ -61,12 +62,14 @@ internal sealed class MainForm : Form
             if (ShouldHideToTrayOnClose(e.CloseReason))
             {
                 e.Cancel = true;
+                ResetOneShotCloseIntent();
                 HideToTray();
                 return;
             }
             if (!_restartShellOnly && !StopCompanionProcesses(_quitFromTray))
             {
                 e.Cancel = true;
+                ResetOneShotCloseIntent();
                 return;
             }
             DisposeTrayIcon();
@@ -453,7 +456,7 @@ internal sealed class MainForm : Form
             if (!string.IsNullOrWhiteSpace(url)) OpenExternal(url);
             // Defer the actual close to the next message loop tick so the
             // WebMessageReceived handler can return cleanly first.
-            BeginInvoke(new Action(() => { try { Close(); } catch { } }));
+            BeginInvoke(CloseFromPortal);
         }
         else if (string.Equals(action, "open", StringComparison.OrdinalIgnoreCase))
         {
@@ -467,7 +470,7 @@ internal sealed class MainForm : Form
         else if (string.Equals(action, "close", StringComparison.OrdinalIgnoreCase))
         {
             // Browser confirmed it reached the server — safe to close now.
-            BeginInvoke(new Action(() => { try { Close(); } catch { } }));
+            BeginInvoke(CloseFromPortal);
         }
         else if (string.Equals(action, "pick-save-file", StringComparison.OrdinalIgnoreCase))
         {
@@ -1028,8 +1031,28 @@ internal sealed class MainForm : Form
         return closeReason == CloseReason.UserClosing
             && !_restartShellOnly
             && !_quitFromTray
+            && !_closeRequestedByPortal
             && _minimizeToTray
             && IsBackendKeepAliveActive();
+    }
+
+    private void CloseFromPortal()
+    {
+        _closeRequestedByPortal = true;
+        try
+        {
+            Close();
+        }
+        catch
+        {
+            _closeRequestedByPortal = false;
+        }
+    }
+
+    private void ResetOneShotCloseIntent()
+    {
+        _quitFromTray = false;
+        _closeRequestedByPortal = false;
     }
 
     private static bool IsBackendKeepAliveActive()

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -64,7 +64,7 @@ internal sealed class MainForm : Form
                 HideToTray();
                 return;
             }
-            if (!_restartShellOnly && !StopCompanionProcesses())
+            if (!_restartShellOnly && !StopCompanionProcesses(_quitFromTray))
             {
                 e.Cancel = true;
                 return;
@@ -1240,7 +1240,7 @@ internal sealed class MainForm : Form
     /// in that mode the shell wasn't started by the backend launcher and we
     /// must not assume there's a paired DuneServer process to stop.
     /// </summary>
-    private bool StopCompanionProcesses()
+    private bool StopCompanionProcesses(bool ignoreKeepAlive = false)
     {
         if (!_useWaitFile) return true;
 
@@ -1253,7 +1253,7 @@ internal sealed class MainForm : Form
         // refreshed live by the backend on startup AND on every autostart
         // toggle, so this reflects current intent rather than launch-time
         // state.
-        if (IsBackendKeepAliveActive()) return true;
+        if (!ignoreKeepAlive && IsBackendKeepAliveActive()) return true;
 
         if (IsWorldRestartActive())
         {

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -166,15 +166,17 @@ Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -Com
 ; Install mobile/remote app bridge (loopback proxy + self-healing task)
 Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\helper\bridge\Install-Bridge.ps1"""; Flags: runhidden waituntilterminated
 
-; Launch immediately after install. Two entries so both interactive AND
-; silent (auto-update) installs relaunch the app:
+; Launch the shell immediately after install. It starts DuneServer.exe with
+; --reattach when needed, so the user sees startup progress while the backend
+; bootstraps instead of waiting on a blank desktop. Two entries cover both
+; interactive AND silent (auto-update) installs:
 ;   * Interactive: postinstall shows the "Launch Dune Server" checkbox on
 ;     the Finished page (skipifsilent hides it during silent install).
 ;   * Silent: a plain [Run] entry that fires only in silent mode (Check:
 ;     WizardSilent). Without this, /VERYSILENT updates would leave the app
 ;     uninstalled-but-not-restarted and the portal would go dark forever.
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent runascurrentuser runminimized
-Filename: "{app}\{#MyAppExeName}"; Flags: nowait runascurrentuser runminimized; Check: WizardSilent
+Filename: "{app}\DuneShell.exe"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent runascurrentuser
+Filename: "{app}\DuneShell.exe"; Flags: nowait runascurrentuser; Check: WizardSilent
 
 [UninstallDelete]
 ; Belt-and-suspenders: clear any junk inside install dir that isn't tracked

--- a/webui/src/hooks/useStatus.tsx
+++ b/webui/src/hooks/useStatus.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, type ReactNode } from 'react'
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import { useApi } from './useApi'
 import type { StatusSnapshot } from '../api/types'
 import { api } from '../api/client'
@@ -13,10 +13,60 @@ type StatusCtx = {
 
 const Ctx = createContext<StatusCtx | null>(null)
 
+export const STATUS_CACHE_KEY = 'dst.status.last.v1'
+export const STATUS_CACHE_MAX_AGE_MS = 30 * 60 * 1000
+
+type StatusStorage = Pick<Storage, 'getItem' | 'setItem'>
+
+export function readCachedStatus(
+  storage: StatusStorage = localStorage,
+  now = Date.now(),
+): StatusSnapshot | null {
+  try {
+    const raw = storage.getItem(STATUS_CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as {
+      savedAt?: unknown
+      status?: Partial<StatusSnapshot>
+    }
+    if (
+      typeof parsed.savedAt !== 'number'
+      || !Number.isFinite(parsed.savedAt)
+      || parsed.savedAt > now
+      || now - parsed.savedAt > STATUS_CACHE_MAX_AGE_MS
+      || !parsed.status
+      || typeof parsed.status.ts !== 'string'
+      || !parsed.status.vm
+      || typeof parsed.status.vm !== 'object'
+    ) return null
+    return parsed.status as StatusSnapshot
+  } catch {
+    return null
+  }
+}
+
+export function writeCachedStatus(
+  status: StatusSnapshot,
+  storage: StatusStorage = localStorage,
+  now = Date.now(),
+): void {
+  try {
+    storage.setItem(STATUS_CACHE_KEY, JSON.stringify({ savedAt: now, status }))
+  } catch {
+    // Storage may be disabled or full; live status remains authoritative.
+  }
+}
+
 export function StatusProvider({ children }: { children: ReactNode }) {
   const s = useApi<StatusSnapshot>('/api/status', { intervalMs: 10_000 })
+  const [cachedStatus] = useState<StatusSnapshot | null>(() => readCachedStatus())
+
+  useEffect(() => {
+    if (s.data) writeCachedStatus(s.data)
+  }, [s.data])
+
   const value: StatusCtx = {
-    status:   s.data,
+    status:   s.data ?? cachedStatus,
     loading:  s.loading,
     error:    s.error,
     refresh:  s.refresh,

--- a/webui/tests/statusCache.test.ts
+++ b/webui/tests/statusCache.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import type { StatusSnapshot } from '../src/api/types'
+import {
+  readCachedStatus,
+  STATUS_CACHE_KEY,
+  STATUS_CACHE_MAX_AGE_MS,
+  writeCachedStatus,
+} from '../src/hooks/useStatus'
+
+function makeStorage(): Pick<Storage, 'getItem' | 'setItem'> {
+  const values = new Map<string, string>()
+  return {
+    getItem: key => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value) },
+  }
+}
+
+const snapshot: StatusSnapshot = {
+  vm: {
+    exists: true,
+    name: 'dune-awakening',
+    state: 'Running',
+    running: true,
+    ip: '192.0.2.10',
+    uptime: 60,
+  },
+  bg: null,
+  ports: null,
+  ts: '2026-08-29T16:00:00.000Z',
+}
+
+describe('Server Health status cache', () => {
+  it('restores a recent status snapshot across app reloads', () => {
+    const storage = makeStorage()
+    writeCachedStatus(snapshot, storage, 1_000)
+
+    expect(readCachedStatus(storage, 2_000)).toEqual(snapshot)
+  })
+
+  it('rejects expired, future, and malformed snapshots', () => {
+    const storage = makeStorage()
+    writeCachedStatus(snapshot, storage, 1_000)
+    expect(readCachedStatus(storage, 1_000 + STATUS_CACHE_MAX_AGE_MS + 1)).toBeNull()
+
+    writeCachedStatus(snapshot, storage, 2_000)
+    expect(readCachedStatus(storage, 1_999)).toBeNull()
+
+    storage.setItem(STATUS_CACHE_KEY, '{"savedAt":2000,"status":{"ts":4}}')
+    expect(readCachedStatus(storage, 2_001)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- hide the desktop shell back to the tray when X is clicked during autostart or Always-on Service Mode
- preserve the tray icon so the running backend can always be reopened
- make **Quit (stops server)** explicitly bypass keep-alive and stop the backend
- prepare bug-report and changelog metadata for `v15.0.0-test3`

## Validation
- compiled `DuneShell` successfully
- built the full prerelease installer from commit `35a26e83`
- DuneSoloDb and DunePlatformStore self-tests passed during the installer build
- gitleaks found no leaks in the two release commits

## Field verification after release
1. Enable Minimize to tray with autostart or Always-on Service Mode active.
2. Click X and confirm the shell leaves the taskbar but remains in the tray.
3. Reopen DST from the tray.
4. Select **Quit (stops server)** and confirm both shell and backend exit.