### PR TITLE
Carry stable shell fixes into v15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ here cover everything those tags shipped.
 
 - Fixed autostart and always-on sessions losing their tray icon when the app
   window was closed. With Minimize to tray enabled, X now hides the shell back
+<<<<<<< HEAD
   to the tray; only **Quit (stops server)** exits the shell and backend.
 - Fixed installed Windows builds failing to create the first cached Maps
   generation when the elevated helper could not duplicate the UAC linked token;
@@ -75,6 +76,11 @@ here cover everything those tags shipped.
   replacement and API publication.
 - Fixed diagnostics packages leaving the game login password visible inside
   server-state log messages; JSON `loginPassword` values are now redacted.
+=======
+  to the tray; only **Quit (stops server)** exits the shell and backend. Opening
+  the tray icon now restores the window before showing it, instead of immediately
+  returning to a minimized taskbar entry.
+>>>>>>> a5c85016 (fix: restore shell before showing tray window)
 
 ## [14.0.3] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,13 +60,16 @@ here cover everything those tags shipped.
 - Added a fail-closed online-player warning before every manual action that can
   stop or restart game services or the VM, with connected player details and an
   explicit operator override when disconnection is intentional.
+- Clarified the native startup screen that backend loading after an update or
+  service restoration normally takes 10-15 seconds.
 
 ### Fixed
 
-- Fixed autostart and always-on sessions losing their tray icon when the app
-  window was closed. With Minimize to tray enabled, X now hides the shell back
-<<<<<<< HEAD
-  to the tray; only **Quit (stops server)** exits the shell and backend.
+- Fixed tray lifecycle behavior so opening the tray icon restores the window
+  before showing it, X retains the shell only when Windows startup is enabled,
+  and the always-on service can keep the backend running without a tray icon.
+- Kept completed blueprint downloads available in the WebView2 Downloads
+  flyout for 10 seconds before closing it automatically.
 - Fixed installed Windows builds failing to create the first cached Maps
   generation when the elevated helper could not duplicate the UAC linked token;
   the helper now falls back to the same user's unelevated shell token with
@@ -76,11 +79,6 @@ here cover everything those tags shipped.
   replacement and API publication.
 - Fixed diagnostics packages leaving the game login password visible inside
   server-state log messages; JSON `loginPassword` values are now redacted.
-=======
-  to the tray; only **Quit (stops server)** exits the shell and backend. Opening
-  the tray icon now restores the window before showing it, instead of immediately
-  returning to a minimized taskbar entry.
->>>>>>> a5c85016 (fix: restore shell before showing tray window)
 
 ## [14.0.3] - 2026-08-24
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -737,10 +737,9 @@ $script:DuneKeepAliveAfterShellClose = [bool]$script:DuneHeadlessMode -or $scrip
 if (($script:DuneAutostartRegistered -or $script:DuneServiceModeRegistered) -and -not $script:DuneHeadlessMode) {
     Write-DuneLog "Autostart/service task registered for this user - closing the DuneShell window will leave the backend console running; click the shortcut again to re-open the viewer, or stop the backend explicitly via the tray / console window"
 }
-# Sync the on-disk keep-alive sentinel so DuneShell's FormClosing teardown
-# knows to skip its /api/shutdown + DuneServer.exe sweep
-# when keep-alive is active. Refreshed at runtime by Register-/Unregister-
-# DuneAutostart so toggling the Help menu takes effect without restart.
+# Sync the on-disk backend keep-alive and shell close-to-tray sentinels.
+# The former includes service/headless mode; the latter is autostart-only.
+# Both are refreshed when either scheduled-task mode changes.
 if (Get-Command Update-DuneKeepAliveFlag -ErrorAction SilentlyContinue) {
     try { [void](Update-DuneKeepAliveFlag) } catch {}
 }

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -158,6 +158,7 @@ internal sealed class MainForm : Form
 
         core.NewWindowRequested += OnNewWindowRequested;
         core.NavigationCompleted += OnNavigationCompleted;
+        core.DownloadStarting += OnDownloadStarting;
         core.WebMessageReceived += OnWebMessageReceived;
         core.DocumentTitleChanged += (_, _) =>
         {
@@ -393,6 +394,34 @@ internal sealed class MainForm : Form
         _firstLoadDone = true;
         _status.Visible = false;
         _web.Visible = true;
+    }
+
+    private void OnDownloadStarting(object? sender, CoreWebView2DownloadStartingEventArgs e)
+    {
+        CoreWebView2DownloadOperation operation = e.DownloadOperation;
+
+        void CloseWhenFinished(object? _, object __)
+        {
+            if (operation.State == CoreWebView2DownloadState.InProgress) return;
+            operation.StateChanged -= CloseWhenFinished;
+            try
+            {
+                BeginInvoke(new Action(() =>
+                {
+                    CoreWebView2? core = _web.CoreWebView2;
+                    if (core?.IsDefaultDownloadDialogOpen == true)
+                        core.CloseDefaultDownloadDialog();
+                }));
+            }
+            catch
+            {
+                // The shell may already be closing; the flyout will close with it.
+            }
+        }
+
+        operation.StateChanged += CloseWhenFinished;
+        if (operation.State != CoreWebView2DownloadState.InProgress)
+            CloseWhenFinished(operation, new object());
     }
 
     private void OnNewWindowRequested(object? sender, CoreWebView2NewWindowRequestedEventArgs e)

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -28,8 +28,8 @@ internal sealed class MainForm : Form
     // ----- Minimize-to-tray state --------------------------------------------
     // When enabled, minimizing the window hides it (and its taskbar button) and
     // leaves a single NotifyIcon in the system tray that reopens the portal.
-    // In backend keep-alive mode, X also hides to the tray; the tray's explicit
-    // Quit action bypasses that interception and shuts down normally.
+    // With Windows autostart enabled, X also hides to the tray; the tray's
+    // explicit Quit action bypasses that interception and shuts down normally.
     private NotifyIcon? _tray;
     private ToolStripMenuItem? _trayMinItem;
     private bool _minimizeToTray;
@@ -1067,7 +1067,7 @@ internal sealed class MainForm : Form
             && !_quitFromTray
             && !_closeRequestedByPortal
             && _minimizeToTray
-            && IsBackendKeepAliveActive();
+            && IsShellCloseToTrayActive();
     }
 
     private void CloseFromPortal()
@@ -1097,6 +1097,21 @@ internal sealed class MainForm : Form
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "DuneServer", "keep-alive.flag");
             return File.Exists(keepAliveFlag);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsShellCloseToTrayActive()
+    {
+        try
+        {
+            string closeToTrayFlag = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "DuneServer", "shell-close-to-tray.flag");
+            return File.Exists(closeToTrayFlag);
         }
         catch
         {

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -1011,11 +1011,16 @@ internal sealed class MainForm : Form
 
     private void RestoreFromTray()
     {
-        Show();
-        ShowInTaskbar = true;
-        WindowState = _restoreState == FormWindowState.Minimized
+        FormWindowState targetState = _restoreState == FormWindowState.Minimized
             ? FormWindowState.Normal
             : _restoreState;
+
+        // Restore before showing. Showing a still-minimized form fires Resize,
+        // which would immediately hide it back to the tray.
+        WindowState = targetState;
+        ShowInTaskbar = true;
+        Show();
+        BringToFront();
         Activate();
     }
 

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -400,10 +400,12 @@ internal sealed class MainForm : Form
     {
         CoreWebView2DownloadOperation operation = e.DownloadOperation;
 
-        void CloseWhenFinished(object? _, object __)
+        async void CloseWhenFinished(object? _, object __)
         {
             if (operation.State == CoreWebView2DownloadState.InProgress) return;
             operation.StateChanged -= CloseWhenFinished;
+            if (operation.State == CoreWebView2DownloadState.Completed)
+                await Task.Delay(TimeSpan.FromSeconds(10));
             try
             {
                 BeginInvoke(new Action(() =>

--- a/app/desktop/DuneShell/MainForm.cs
+++ b/app/desktop/DuneShell/MainForm.cs
@@ -905,7 +905,7 @@ internal sealed class MainForm : Form
             return null;
         }
 
-        _status.Text = "Starting the Dune Server Tool backend…";
+        _status.Text = "Loading backend after recent update or service restoration… Estimated 10–15 seconds.";
         try
         {
             Process.Start(new ProcessStartInfo
@@ -927,7 +927,7 @@ internal sealed class MainForm : Form
         // generously longer window than the initial wait above.
         for (int i = 0; i < MaxBackendStartPollAttempts; i++)
         {
-            _status.Text = $"Starting the Dune Server Tool backend… ({i + 1})";
+            _status.Text = "Loading backend after recent update or service restoration… Estimated 10–15 seconds.";
             string? candidate = await TryReadUrlFileAsync(file);
             if (candidate != null && await IsUrlReachableAsync(candidate))
                 return candidate;

--- a/app/server/lib/ConsoleHost.ps1
+++ b/app/server/lib/ConsoleHost.ps1
@@ -105,17 +105,19 @@ function Test-DunePortalBrowserCheckin {
 
 # Sentinel file consumed by DuneShell's FormClosing teardown AND by the
 # app-window watcher runspace. When this file exists, neither side should
-# tear the backend down on shell close -- the user has opted into
-# "background service" semantics (autostart registered or --headless launch),
-# so the backend is expected to outlive any manually-opened DuneShell.
+# tear the backend down on shell close -- the backend is expected to outlive
+# any manually-opened DuneShell.
 #
-# Live state: rewritten on every startup AND on every autostart toggle
-# (Register-/Unregister-DuneAutostart), so closing the shell mid-run
-# always reflects the user's current intent rather than the snapshot
-# captured at process startup.
+# Live state: rewritten on startup and whenever either scheduled-task mode
+# changes, so shell close always reflects the user's current intent.
 function Get-DuneKeepAliveStateFile {
     $dir = Join-Path $env:LOCALAPPDATA 'DuneServer'
     return (Join-Path $dir 'keep-alive.flag')
+}
+
+function Get-DuneShellCloseToTrayStateFile {
+    $dir = Join-Path $env:LOCALAPPDATA 'DuneServer'
+    return (Join-Path $dir 'shell-close-to-tray.flag')
 }
 
 function Set-DuneKeepAliveFlag {
@@ -142,6 +144,26 @@ function Clear-DuneKeepAliveFlag {
     } catch { }
 }
 
+function Set-DuneShellCloseToTrayFlag {
+    try {
+        $file = Get-DuneShellCloseToTrayStateFile
+        $dir = Split-Path -Parent $file
+        if (-not (Test-Path -LiteralPath $dir)) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        }
+        Set-Content -LiteralPath $file -Value $PID -Encoding ASCII -Force
+    } catch { }
+}
+
+function Clear-DuneShellCloseToTrayFlag {
+    try {
+        $file = Get-DuneShellCloseToTrayStateFile
+        if (Test-Path -LiteralPath $file) {
+            Remove-Item -LiteralPath $file -Force -ErrorAction SilentlyContinue
+        }
+    } catch { }
+}
+
 # Recompute the effective keep-alive state from live inputs (headless mode +
 # whether the autostart task is currently registered for this user) and write
 # or remove the sentinel file accordingly. Safe to call repeatedly.
@@ -160,6 +182,10 @@ function Update-DuneKeepAliveFlag {
     } catch { $service = $false }
     $keep = [bool]$script:DuneHeadlessMode -or $autostart -or $service
     if ($keep) { Set-DuneKeepAliveFlag } else { Clear-DuneKeepAliveFlag }
+    # X retains the shell and tray only for the explicit "Run at Windows
+    # startup" mode. Service/headless mode may retain the backend, but must not
+    # leave the frontend resident after its window is closed.
+    if ($autostart) { Set-DuneShellCloseToTrayFlag } else { Clear-DuneShellCloseToTrayFlag }
     return $keep
 }
 

--- a/tests/ConsoleHostTrayPolicy.Tests.ps1
+++ b/tests/ConsoleHostTrayPolicy.Tests.ps1
@@ -1,0 +1,49 @@
+Describe 'DuneShell close-to-tray policy' {
+    BeforeAll {
+        $script:originalLocalAppData = $env:LOCALAPPDATA
+        $env:LOCALAPPDATA = Join-Path $TestDrive 'LocalAppData'
+        . (Join-Path $PSScriptRoot '..\app\server\lib\ConsoleHost.ps1')
+
+        function global:Test-DuneAutostartEnabled { return $script:testAutostart }
+        function global:Test-DuneServiceEnabled { return $script:testService }
+        $script:DuneHeadlessMode = $false
+    }
+
+    AfterAll {
+        Remove-Item Function:\Test-DuneAutostartEnabled -ErrorAction SilentlyContinue
+        Remove-Item Function:\Test-DuneServiceEnabled -ErrorAction SilentlyContinue
+        $env:LOCALAPPDATA = $script:originalLocalAppData
+    }
+
+    BeforeEach {
+        $script:testAutostart = $false
+        $script:testService = $false
+        Clear-DuneKeepAliveFlag
+        Clear-DuneShellCloseToTrayFlag
+    }
+
+    It 'retains both backend and shell when Windows autostart is enabled' {
+        $script:testAutostart = $true
+
+        Update-DuneKeepAliveFlag | Should -BeTrue
+
+        Test-Path (Get-DuneKeepAliveStateFile) | Should -BeTrue
+        Test-Path (Get-DuneShellCloseToTrayStateFile) | Should -BeTrue
+    }
+
+    It 'retains only the backend when service mode is enabled' {
+        $script:testService = $true
+
+        Update-DuneKeepAliveFlag | Should -BeTrue
+
+        Test-Path (Get-DuneKeepAliveStateFile) | Should -BeTrue
+        Test-Path (Get-DuneShellCloseToTrayStateFile) | Should -BeFalse
+    }
+
+    It 'retains neither backend nor shell when both modes are disabled' {
+        Update-DuneKeepAliveFlag | Should -BeFalse
+
+        Test-Path (Get-DuneKeepAliveStateFile) | Should -BeFalse
+        Test-Path (Get-DuneShellCloseToTrayStateFile) | Should -BeFalse
+    }
+}

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -421,7 +421,9 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
                   <span className="block text-[11px] text-text-dim">
                     {autostart.enabled
                       ? 'Enabled — server keeps running when you close this window'
-                      : 'Disabled — closing this window stops the server'}
+                      : service?.enabled
+                        ? 'Disabled — closing removes DST; background service stays online'
+                        : 'Disabled — closing this window stops the server'}
                   </span>
                 </span>
                 {autostart.enabled && (


### PR DESCRIPTION
## Summary
- restore tray windows before showing them and separate shell close-to-tray policy from backend keep-alive
- keep completed blueprint downloads visible for 10 seconds
- carry the clarified 10-15 second backend startup expectation and accurate lifecycle copy into v15
- retain the focused tray-policy coverage

## Validation
- Web UI production build
- DuneShell Release build
- ConsoleHostTrayPolicy Pester tests (3 passed)
- gitleaks scan of the branch (no findings)

The rejected cached-frontend startup experiment is intentionally not included.