### PR TITLE
Add bounded desktop sidebar ordering

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-test5"
+      placeholder: "v15.0.0-test6"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+Candidate metadata prepared for v15.0.0-test6; semantic version remains 15.0.0.
+
 ### Added
 
 - Added per-device desktop sidebar customization with explicit edit mode,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ here cover everything those tags shipped.
 
 ### Added
 
+- Added per-device desktop sidebar customization with explicit edit mode,
+  pointer and keyboard reordering within fixed navigation sections, and reset
+  controls. Permissions remain authoritative, and newly available pages append
+  safely without restoring stale entries.
 - Added the next-generation workspace foundation for the v15 test line, with a
   server-first primary navigation rail and one Gameplay Admin gateway containing
   Overview, Map, Players, Bases, Vehicles, and Economy destinations.

--- a/webui/src/hooks/useSidebarNavigationOrder.ts
+++ b/webui/src/hooks/useSidebarNavigationOrder.ts
@@ -1,0 +1,140 @@
+import { useCallback, useMemo, useState } from 'react'
+import { arrayMove } from '@dnd-kit/sortable'
+import { GROUP_ORDER, type NavGroup, type NavItem } from '../nav'
+
+export const SIDEBAR_ORDER_STORAGE_KEY = 'dst.sidebar.navigation-order.v1'
+
+export type SidebarNavigationOrder = {
+  version: 1
+  groups: Partial<Record<NavGroup, string[]>>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function normalizeSidebarNavigationOrder(
+  saved: unknown,
+  canonicalItems: readonly NavItem[],
+): SidebarNavigationOrder {
+  const savedGroups = isRecord(saved)
+    && saved.version === 1
+    && isRecord(saved.groups)
+    ? saved.groups
+    : {}
+  const groups: Partial<Record<NavGroup, string[]>> = {}
+
+  for (const group of GROUP_ORDER) {
+    const canonicalIds = canonicalItems
+      .filter(item => item.group === group)
+      .map(item => item.to)
+    if (canonicalIds.length === 0) continue
+
+    const validIds = new Set(canonicalIds)
+    const seen = new Set<string>()
+    const candidate = Array.isArray(savedGroups[group]) ? savedGroups[group] : []
+    const kept = candidate.filter((id): id is string => {
+      if (typeof id !== 'string' || !validIds.has(id) || seen.has(id)) return false
+      seen.add(id)
+      return true
+    })
+    groups[group] = [...kept, ...canonicalIds.filter(id => !seen.has(id))]
+  }
+
+  return { version: 1, groups }
+}
+
+export function reorderSidebarNavigationItem(
+  order: SidebarNavigationOrder,
+  group: NavGroup,
+  activeId: string,
+  overId: string,
+): SidebarNavigationOrder {
+  const groupOrder = order.groups[group] ?? []
+  const oldIndex = groupOrder.indexOf(activeId)
+  const newIndex = groupOrder.indexOf(overId)
+  if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return order
+
+  return {
+    ...order,
+    groups: {
+      ...order.groups,
+      [group]: arrayMove(groupOrder, oldIndex, newIndex),
+    },
+  }
+}
+
+export function applySidebarNavigationOrder(
+  canonicalItems: readonly NavItem[],
+  order: SidebarNavigationOrder,
+): NavItem[] {
+  const byId = new Map(canonicalItems.map(item => [item.to, item]))
+  return GROUP_ORDER.flatMap(group => (
+    (order.groups[group] ?? [])
+      .map(id => byId.get(id))
+      .filter((item): item is NavItem => item?.group === group)
+  ))
+}
+
+function loadSavedOrder(): unknown {
+  try {
+    const raw = localStorage.getItem(SIDEBAR_ORDER_STORAGE_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+function saveOrder(order: SidebarNavigationOrder) {
+  try {
+    localStorage.setItem(SIDEBAR_ORDER_STORAGE_KEY, JSON.stringify(order))
+  } catch {
+    // Browser storage can be unavailable; the in-memory order still works.
+  }
+}
+
+function ordersMatch(left: SidebarNavigationOrder, right: SidebarNavigationOrder) {
+  return GROUP_ORDER.every(group => {
+    const leftIds = left.groups[group] ?? []
+    const rightIds = right.groups[group] ?? []
+    return leftIds.length === rightIds.length
+      && leftIds.every((id, index) => id === rightIds[index])
+  })
+}
+
+export function useSidebarNavigationOrder(canonicalItems: readonly NavItem[]) {
+  const [savedOrder, setSavedOrder] = useState<unknown>(loadSavedOrder)
+  const normalizedOrder = useMemo(
+    () => normalizeSidebarNavigationOrder(savedOrder, canonicalItems),
+    [savedOrder, canonicalItems],
+  )
+  const defaultOrder = useMemo(
+    () => normalizeSidebarNavigationOrder(null, canonicalItems),
+    [canonicalItems],
+  )
+  const orderedItems = useMemo(
+    () => applySidebarNavigationOrder(canonicalItems, normalizedOrder),
+    [canonicalItems, normalizedOrder],
+  )
+
+  const reorder = useCallback((group: NavGroup, activeId: string, overId: string) => {
+    setSavedOrder((current: unknown) => {
+      const currentOrder = normalizeSidebarNavigationOrder(current, canonicalItems)
+      const next = reorderSidebarNavigationItem(currentOrder, group, activeId, overId)
+      if (next !== currentOrder) saveOrder(next)
+      return next
+    })
+  }, [canonicalItems])
+
+  const reset = useCallback(() => {
+    try { localStorage.removeItem(SIDEBAR_ORDER_STORAGE_KEY) } catch { /* ignore */ }
+    setSavedOrder(null)
+  }, [])
+
+  return {
+    orderedItems,
+    reorder,
+    reset,
+    isCustomized: !ordersMatch(normalizedOrder, defaultOrder),
+  }
+}

--- a/webui/src/layout/AppShell.tsx
+++ b/webui/src/layout/AppShell.tsx
@@ -17,7 +17,7 @@ const IMMERSIVE_ROUTES = new Set<string>([])
 export function AppShell({ children }: { children: ReactNode }) {
   const mainRef = useRef<HTMLElement | null>(null)
   const { canAccessOwnerSurfaces } = usePortalAccess()
-  const { collapsed, toggle } = useSidebarCollapsed()
+  const { collapsed, setCollapsed, toggle } = useSidebarCollapsed()
   const { pathname } = useLocation()
   const immersive = IMMERSIVE_ROUTES.has(pathname)
 
@@ -38,7 +38,7 @@ export function AppShell({ children }: { children: ReactNode }) {
       <DecoupleNoticeModal />
       <MenuBar sidebarCollapsed={collapsed} onToggleSidebar={toggle} />
       <div className="flex-1 flex overflow-hidden min-h-0">
-        <Sidebar collapsed={collapsed} />
+        <Sidebar collapsed={collapsed} onExpand={() => setCollapsed(false)} />
         <div className="flex-1 flex flex-col min-w-0">
           {canAccessOwnerSurfaces && <UpdateBanner />}
           <StatusBar />

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -1,9 +1,33 @@
 import { Link, NavLink, useLocation, useSearch } from '../router'
-import { useState, useRef } from 'react'
+import { useMemo, useState, useRef } from 'react'
 import { createPortal } from 'react-dom'
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { Icon } from '../components/Icon'
-import { GROUP_ORDER, getVisibleGroupLabel, getVisibleNavItems, isNavItemActive } from '../nav'
+import {
+  GROUP_ORDER,
+  getVisibleGroupLabel,
+  getVisibleNavItems,
+  isNavItemActive,
+  type NavGroup,
+  type NavItem,
+} from '../nav'
 import { useUpdateCheck } from '../hooks/useUpdateCheck'
+import { useSidebarNavigationOrder } from '../hooks/useSidebarNavigationOrder'
 import { api } from '../api/client'
 import { fmtToolVersion } from '../format'
 import { isLocalViewer, isWindowsViewer } from '../util/viewer'
@@ -22,9 +46,10 @@ function getWebView2(): WebView2Host | null {
 
 type Props = {
   collapsed: boolean
+  onExpand?: () => void
 }
 
-export function Sidebar({ collapsed }: Props) {
+export function Sidebar({ collapsed, onExpand }: Props) {
   const { pathname } = useLocation()
   const search = useSearch()
   const { canAccessOwnerSurfaces } = usePortalAccess()
@@ -34,6 +59,7 @@ export function Sidebar({ collapsed }: Props) {
   const [showPortalConfirm, setShowPortalConfirm] = useState(false)
   const [portalDetaching, setPortalDetaching] = useState(false)
   const [portalError, setPortalError] = useState<string | null>(null)
+  const [customizing, setCustomizing] = useState(false)
   // Issue #280 recovery flow: after handing the portal to the default browser
   // we keep the app window open until the browser checks in with the server.
   // 'confirm' = pre-flight dialog · 'waiting' = browser opened, polling for
@@ -136,15 +162,23 @@ export function Sidebar({ collapsed }: Props) {
     } catch { /* clipboard blocked — the URL is shown in the box to copy manually */ }
   }
 
-  const visibleItems = getVisibleNavItems({
-    local: isLocalViewer(),
-    windows: isWindowsViewer(),
+  const localViewer = isLocalViewer()
+  const windowsViewer = isWindowsViewer()
+  const visibleItems = useMemo(() => getVisibleNavItems({
+    local: localViewer,
+    windows: windowsViewer,
     canAccessOwnerSurfaces,
     includeSidebarHidden: false,
-  })
+  }), [canAccessOwnerSurfaces, localViewer, windowsViewer])
+  const {
+    orderedItems,
+    reorder,
+    reset: resetNavigationOrder,
+    isCustomized,
+  } = useSidebarNavigationOrder(visibleItems)
   const groups = GROUP_ORDER.map(g => ({
     key: g,
-    items: visibleItems.filter(i => i.group === g),
+    items: orderedItems.filter(i => i.group === g),
   })).filter(g => g.items.length > 0).map(g => ({
     ...g,
     label: getVisibleGroupLabel(g.key),
@@ -221,6 +255,31 @@ export function Sidebar({ collapsed }: Props) {
           collapsed ? 'px-1.5 py-2' : 'px-2 py-1.5'
         } ${collapsed ? '' : 'space-y-2'}`}
       >
+        {customizing && !collapsed && (
+          <div className="sticky top-0 z-10 mb-2 rounded-lg border border-accent/30 bg-surface px-3 py-2 shadow-[0_4px_14px_-8px_rgba(0,0,0,0.8)]">
+            <div className="text-xs font-semibold text-text">Customize navigation</div>
+            <p className="mt-0.5 text-[11px] leading-snug text-text-dim">
+              Drag within a section. Sections stay fixed.
+            </p>
+            <div className="mt-2 flex gap-2">
+              <button
+                type="button"
+                className="btn-secondary min-h-8 flex-1 justify-center px-2 py-1 text-[10px]"
+                onClick={resetNavigationOrder}
+                disabled={!isCustomized}
+              >
+                <Icon name="RotateCcw" size={12} /> Reset layout
+              </button>
+              <button
+                type="button"
+                className="btn-primary min-h-8 flex-1 justify-center px-2 py-1 text-[10px]"
+                onClick={() => setCustomizing(false)}
+              >
+                <Icon name="Check" size={12} /> Done
+              </button>
+            </div>
+          </div>
+        )}
         {groups.map((g, idx) => (
           <div key={g.key}>
             {/* In collapsed mode we draw a thin divider between groups instead
@@ -232,11 +291,21 @@ export function Sidebar({ collapsed }: Props) {
                   {g.label}
                 </div>
               )}
-            <ul className={collapsed ? 'space-y-1' : 'space-y-0.5'}>
-              {g.items.map(item => (
-                <li key={item.to}>{renderItem(item)}</li>
-              ))}
-            </ul>
+            {customizing && !collapsed ? (
+              <SortableSidebarGroup
+                group={g.key}
+                items={g.items}
+                pathname={pathname}
+                search={search}
+                onReorder={reorder}
+              />
+            ) : (
+              <ul className={collapsed ? 'space-y-1' : 'space-y-0.5'}>
+                {g.items.map(item => (
+                  <li key={item.to}>{renderItem(item)}</li>
+                ))}
+              </ul>
+            )}
           </div>
         ))}
       </nav>
@@ -246,6 +315,26 @@ export function Sidebar({ collapsed }: Props) {
           collapsed ? 'px-1.5 py-2' : 'px-4 py-3'
         } border-t border-border text-[10px] text-text-dim space-y-2`}
       >
+        {!customizing && (
+          <button
+            type="button"
+            onClick={() => {
+              if (collapsed) onExpand?.()
+              setCustomizing(true)
+            }}
+            aria-label="Customize navigation"
+            title={collapsed ? 'Expand and customize navigation' : 'Reorder navigation within each section'}
+            disabled={collapsed && !onExpand}
+            className={
+              collapsed
+                ? 'w-full flex items-center justify-center h-8 rounded-md border border-border text-text-dim hover:text-text hover:bg-surface-2/60 transition-colors disabled:opacity-50'
+                : 'w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-border text-text-muted hover:text-text hover:bg-surface-2/60 transition-colors uppercase tracking-widest'
+            }
+          >
+            <Icon name="ListRestart" size={collapsed ? 14 : 11} />
+            {!collapsed && <span>Customize navigation</span>}
+          </button>
+        )}
         {inShellWindow && (
           <button
             type="button"
@@ -406,6 +495,91 @@ export function Sidebar({ collapsed }: Props) {
         document.body,
       )}
     </aside>
+  )
+}
+
+function SortableSidebarGroup({
+  group,
+  items,
+  pathname,
+  search,
+  onReorder,
+}: {
+  group: NavGroup
+  items: NavItem[]
+  pathname: string
+  search: string
+  onReorder: (group: NavGroup, activeId: string, overId: string) => void
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return
+    onReorder(group, String(active.id), String(over.id))
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={items.map(item => item.to)} strategy={verticalListSortingStrategy}>
+        <ul className="space-y-0.5">
+          {items.map(item => (
+            <SortableSidebarItem
+              key={item.to}
+              item={item}
+              active={isNavItemActive(item, pathname, search)}
+            />
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  )
+}
+
+function SortableSidebarItem({ item, active }: { item: NavItem; active: boolean }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.to })
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.45 : undefined,
+      }}
+      className={`flex min-h-9 items-center gap-1 rounded-lg border px-1.5 py-1 text-sm ${
+        active
+          ? 'bg-accent/15 text-accent-bright border-accent/30 shadow-inner'
+          : 'bg-surface-2/30 text-text-muted border-border/70'
+      }`}
+    >
+      <button
+        type="button"
+        className="flex min-h-7 min-w-7 shrink-0 touch-none cursor-grab items-center justify-center rounded text-text-dim hover:bg-surface-2 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent active:cursor-grabbing"
+        aria-label={`Reorder ${item.label}`}
+        title={`Drag to reorder ${item.label} within this section`}
+        {...attributes}
+        {...listeners}
+      >
+        <Icon name="GripVertical" size={14} />
+      </button>
+      <Icon name={item.icon} size={15} />
+      <span className="min-w-0 flex-1 truncate">{item.label}</span>
+      {item.badge && (
+        <span className="shrink-0 rounded border border-sky-400/40 bg-sky-400/15 px-1 py-0.5 text-[8px] font-semibold uppercase tracking-wider text-sky-400">
+          {item.badge}
+        </span>
+      )}
+    </li>
   )
 }
 

--- a/webui/tests/sidebarHotfix.test.tsx
+++ b/webui/tests/sidebarHotfix.test.tsx
@@ -1,8 +1,10 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import React from 'react'
+import React, { useState } from 'react'
+import userEvent from '@testing-library/user-event'
 import { Sidebar } from '../src/layout/Sidebar'
 import { BrowserRouter } from '../src/router'
+import { SIDEBAR_ORDER_STORAGE_KEY } from '../src/hooks/useSidebarNavigationOrder'
 
 vi.mock('../src/hooks/useUpdateCheck', () => ({
   useUpdateCheck: () => ({ data: null }),
@@ -12,12 +14,16 @@ vi.mock('../src/auth/portalAccess', () => ({
   usePortalAccess: () => ({ canAccessOwnerSurfaces: true }),
 }))
 
-afterEach(() => cleanup())
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  window.history.replaceState(null, '', '/')
+})
 
-function renderSidebar(collapsed: boolean) {
+function renderSidebar(collapsed: boolean, onExpand?: () => void) {
   return render(
     <BrowserRouter>
-      <Sidebar collapsed={collapsed} />
+      <Sidebar collapsed={collapsed} onExpand={onExpand} />
     </BrowserRouter>,
   )
 }
@@ -46,5 +52,46 @@ describe('sidebar hotfix links', () => {
     expect(screen.queryByRole('link', { name: 'Map' })).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Gameplay Admin' })).toHaveAttribute('aria-current', 'page')
     expect(screen.getAllByRole('link').filter(link => link.hasAttribute('aria-current'))).toHaveLength(1)
+  })
+
+  it('requires explicit edit mode and prevents navigation while sorting', () => {
+    renderSidebar(false)
+
+    expect(screen.queryByRole('button', { name: /Reorder Server Overview/ })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Customize navigation' }))
+
+    expect(screen.getByRole('button', { name: /Reorder Server Overview/ })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Server Overview' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(screen.getByRole('link', { name: 'Server Overview' })).toBeInTheDocument()
+  })
+
+  it('expands the collapsed sidebar before entering edit mode', () => {
+    function CollapsedHarness() {
+      const [collapsed, setCollapsed] = useState(true)
+      return <Sidebar collapsed={collapsed} onExpand={() => setCollapsed(false)} />
+    }
+    render(
+      <BrowserRouter>
+        <CollapsedHarness />
+      </BrowserRouter>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Customize navigation' }))
+
+    expect(screen.getByRole('button', { name: /Reorder Server Overview/ })).toBeInTheDocument()
+  })
+
+  it('supports keyboard sorting from the drag handle', async () => {
+    const user = userEvent.setup()
+    renderSidebar(false)
+    await user.click(screen.getByRole('button', { name: 'Customize navigation' }))
+    const operationsHandle = screen.getByRole('button', { name: 'Reorder Operations' })
+    await user.click(operationsHandle)
+    await user.keyboard('[Space][ArrowUp][Space]')
+
+    const saved = JSON.parse(localStorage.getItem(SIDEBAR_ORDER_STORAGE_KEY) ?? 'null')
+    expect(saved.groups.overview).toEqual(['/operations', '/', '/pods'])
   })
 })

--- a/webui/tests/sidebarNavigationOrder.test.ts
+++ b/webui/tests/sidebarNavigationOrder.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  SIDEBAR_ORDER_STORAGE_KEY,
+  applySidebarNavigationOrder,
+  normalizeSidebarNavigationOrder,
+  reorderSidebarNavigationItem,
+} from '../src/hooks/useSidebarNavigationOrder'
+import type { NavItem } from '../src/nav'
+
+const items: NavItem[] = [
+  { to: '/', label: 'Overview', icon: 'Home', group: 'overview' },
+  { to: '/operations', label: 'Operations', icon: 'Activity', group: 'overview' },
+  { to: '/pods', label: 'Pods', icon: 'Boxes', group: 'overview' },
+  { to: '/commands', label: 'Commands', icon: 'Zap', group: 'terminal' },
+  { to: '/gameconfig', label: 'Game Config', icon: 'Sliders', group: 'terminal' },
+]
+
+beforeEach(() => localStorage.clear())
+
+describe('sidebar navigation order', () => {
+  it('normalizes persisted order and removes stale or duplicate IDs', () => {
+    localStorage.setItem(SIDEBAR_ORDER_STORAGE_KEY, JSON.stringify({
+      version: 1,
+      groups: {
+        overview: ['/operations', '/missing', '/operations', '/'],
+      },
+    }))
+    const saved = JSON.parse(localStorage.getItem(SIDEBAR_ORDER_STORAGE_KEY) ?? 'null')
+
+    expect(normalizeSidebarNavigationOrder(saved, items).groups.overview)
+      .toEqual(['/operations', '/', '/pods'])
+  })
+
+  it('keeps every item inside its canonical category', () => {
+    const normalized = normalizeSidebarNavigationOrder({
+      version: 1,
+      groups: {
+        overview: ['/commands', '/operations'],
+        terminal: ['/', '/gameconfig'],
+      },
+    }, items)
+
+    expect(normalized.groups.overview).toEqual(['/operations', '/', '/pods'])
+    expect(normalized.groups.terminal).toEqual(['/gameconfig', '/commands'])
+  })
+
+  it('appends newly introduced or newly visible items in canonical order', () => {
+    const normalized = normalizeSidebarNavigationOrder({
+      version: 1,
+      groups: {
+        overview: ['/operations', '/'],
+        terminal: ['/commands'],
+      },
+    }, items)
+
+    expect(normalized.groups.overview).toEqual(['/operations', '/', '/pods'])
+    expect(normalized.groups.terminal).toEqual(['/commands', '/gameconfig'])
+  })
+
+  it('reorders only within the requested category', () => {
+    const normalized = normalizeSidebarNavigationOrder(null, items)
+    const moved = reorderSidebarNavigationItem(normalized, 'overview', '/pods', '/')
+    const blocked = reorderSidebarNavigationItem(moved, 'overview', '/commands', '/')
+    const ordered = applySidebarNavigationOrder(items, blocked)
+
+    expect(moved.groups.overview).toEqual(['/pods', '/', '/operations'])
+    expect(blocked).toBe(moved)
+    expect(ordered.map(item => item.to)).toEqual([
+      '/pods',
+      '/',
+      '/operations',
+      '/commands',
+      '/gameconfig',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- add an explicit desktop Sidebar customization mode with clear pointer/keyboard drag handles, Done, and Reset layout controls
- constrain sorting to each item's existing category through independent per-group drag contexts and typed normalization
- persist per-device order under a versioned key while ignoring stale IDs and appending newly visible or introduced pages canonically
- expand the collapsed rail before customization and preserve all existing visibility/permission filters

## Validation
- `npm test -- --run tests/sidebarNavigationOrder.test.ts tests/sidebarHotfix.test.tsx` (10 tests)
- changed-file ESLint
- `npm run build`
- Impeccable detector: no new findings; it reports the pre-existing gradient treatment on the Hawk credit