### PR TITLE
Prepare v15.0.0-test7 release metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,10 @@ body:
         > bundle also includes `world-restart-state.json` when available,
         > recording restart/rollback steps and recovery-lock state. The
         > `manifest.txt` lists what's inside, leads with any health finding, and
-        > records any sanitization warnings.
+        > records any sanitization warnings. For Maps Live state reports,
+        > `maps-platform.txt` adds row-free cache integrity, structural
+        > fingerprints, source timing/backoff, and map/dimension evidence
+        > without cached rows, identifiers, payloads, paths, or coordinates.
 
         **✅ Do open an issue here** when the tool shows you a problem, e.g.:
         - The **Server Health** page shows the battlegroup as **Unknown** with
@@ -82,7 +85,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-test6"
+      placeholder: "v15.0.0-test7"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
-Candidate metadata prepared for v15.0.0-test6; semantic version remains 15.0.0.
+## [15.0.0-test7] - 2026-08-30
+
+Candidate metadata prepared for v15.0.0-test7; semantic version remains 15.0.0.
 
 ### Added
 


### PR DESCRIPTION
## Summary

- roll the complete cumulative Unreleased notes into `15.0.0-test7` dated 2026-08-30 and leave a fresh empty Unreleased section
- retain the established prerelease version split: all five authoritative runtime/package stamps remain matching at semantic `15.0.0`, while the candidate identity is `v15.0.0-test7`
- update the bug-report version placeholder and document the row-free `maps-platform.txt` evidence already added by PR #765
- preserve the Live Map, unified sidebar, and Sponsors & Credits reporting guidance added by PR #764

## Validation

- exact `Build-Installer.ps1` five-file version-stamp preflight: all five match `15.0.0`
- normalized changelog comparison against `origin/main`: complete prior Unreleased content preserved, with only test6 candidate metadata advanced to test7
- issue-template YAML parse and `tool_version` assertion
- `git diff --check`
- staged and committed gitleaks scans
- local-only path scan

No installer build, merge, tag, release, or auto-merge is included. The final installer must be built from the eventual merge commit on `main` with `-Prerelease -BuildTag v15.0.0-test7`.