### PR TITLE
Trim legacy website release history

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -11,7 +11,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "check": "astro check"
+    "check": "astro check",
+    "test:changelog": "node --experimental-strip-types scripts/check-changelog.mts"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.10",

--- a/site/scripts/check-changelog.mts
+++ b/site/scripts/check-changelog.mts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { trimChangelogForSite } from "../src/lib/changelog.ts";
+
+const source = `# Changelog
+
+Introductory copy.
+
+## [Unreleased]
+
+- Pending change.
+
+## [14.2.0] - 2026-08-20
+
+- Recent release.
+
+## [13.0.0] - 2026-07-30
+
+- Oldest detailed release.
+
+## [12.21.3] - 2026-07-27
+
+- Legacy detail that should be removed.
+
+## [14.0.0] - unexpected ordering
+
+- Content after the cutoff should not return.
+`;
+
+const trimmed = trimChangelogForSite(source);
+assert.match(trimmed, /^# Changelog/m);
+assert.match(trimmed, /^## \[Unreleased\]/m);
+assert.match(trimmed, /^## \[14\.2\.0\]/m);
+assert.match(trimmed, /^## \[13\.0\.0\]/m);
+assert.doesNotMatch(trimmed, /^## \[12\.21\.3\]/m);
+assert.doesNotMatch(trimmed, /Legacy detail that should be removed/);
+assert.doesNotMatch(trimmed, /unexpected ordering/);
+assert.match(trimmed, /^## Legacy releases \(v1-v12\)$/m);
+assert.match(
+  trimmed,
+  /https:\/\/github\.com\/coastal-ms\/DST-DuneServerTool\/blob\/main\/CHANGELOG\.md/,
+);
+
+const currentOnly = `# Changelog
+
+## [Unreleased]
+
+## [13.0.0] - 2026-07-30
+`;
+assert.equal(trimChangelogForSite(currentOnly), currentOnly);
+
+const malformed = `# Changelog
+
+## [Unreleased]
+
+## Legacy archive
+`;
+assert.equal(trimChangelogForSite(malformed), malformed);
+
+console.log("Changelog transformation checks passed.");

--- a/site/src/lib/changelog.ts
+++ b/site/src/lib/changelog.ts
@@ -1,14 +1,35 @@
-// Reads the repo CHANGELOG.md at build time and exposes its raw content.
-// Rendered on /changelog via Astro's built-in markdown.
-
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 const CHANGELOG_PATH = join(process.cwd(), "..", "CHANGELOG.md");
+const DETAILED_RELEASE_MAJOR = 13;
+const NUMERIC_RELEASE_HEADING = /^## \[(\d+)\.[^\]]+\][^\r\n]*$/gm;
+const LEGACY_SUMMARY = `## Legacy releases (v1-v12)
+
+Earlier releases established DST's core server-management experience and expanded it through successive administration and reliability improvements.
+
+- **v12** — Major expansion of gameplay administration and supporting server workflows.
+- **v9-v11** — Iterative additions and refinements across configuration, diagnostics, and operator workflows.
+- **v1-v8** — Foundation releases for setup, updates, the desktop app, and core server management.
+
+[View the complete changelog on GitHub](https://github.com/coastal-ms/DST-DuneServerTool/blob/main/CHANGELOG.md) for every legacy release and patch.`;
+
+export function trimChangelogForSite(source: string): string {
+  const firstLegacyRelease = [...source.matchAll(NUMERIC_RELEASE_HEADING)].find(
+    (match) => Number(match[1]) < DETAILED_RELEASE_MAJOR,
+  );
+
+  if (firstLegacyRelease?.index === undefined) {
+    return source;
+  }
+
+  return `${source.slice(0, firstLegacyRelease.index).trimEnd()}\n\n${LEGACY_SUMMARY}\n`;
+}
 
 export async function getChangelog(): Promise<string> {
   try {
-    return await readFile(CHANGELOG_PATH, "utf8");
+    const source = await readFile(CHANGELOG_PATH, "utf8");
+    return trimChangelogForSite(source);
   } catch (err) {
     console.warn("[changelog] read failed:", err);
     return "# Changelog\n\n_Changelog could not be loaded._";

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -15,7 +15,7 @@ const html = marked.parse(raw, { gfm: true, breaks: false });
   <PageHeader
     eyebrow="History"
     title="Changelog"
-    intro="Rendered from the repository's CHANGELOG.md on every build."
+    intro="Detailed notes for v13 and newer, followed by a concise legacy summary with a link to the complete history."
   />
 
   <section class="mx-auto max-w-3xl px-6 pb-20">


### PR DESCRIPTION
## Summary
- keep detailed website changelog entries for v13 and newer
- replace older entries with a concise v12 / v9-v11 / v1-v8 legacy summary
- link to the canonical GitHub changelog for complete historical details
- preserve malformed or current-only changelog input unchanged
- add focused transformation coverage without changing canonical `CHANGELOG.md`

## Validation
- `npm run test:changelog`
- `npm run check`
- `npm run build`
- Impeccable detector
- `git diff --check`
- gitleaks and local-only changed-path scan