### PR TITLE
Refine test7 release and navigation presentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,6 +123,13 @@ A session worktree may not have warm `webui/node_modules` — run `npm ci` in
   notes, and other release-facing summaries. Do not identify the underlying
   records, entities, or implementation details there; source data remains
   authoritative.
+- **Stable/test release surfaces.** Stable is always the primary/default install.
+  During an active test cycle, app and website release selectors show the stable
+  release plus only the newest and immediately previous test builds. Outside an
+  active test cycle, publish the stable bits as the `test1` mirror so users who
+  remain on the Test channel are not stranded. GitHub Releases-page cleanup is
+  separate and manual-only: never delete releases or tags unless the maintainer
+  explicitly calls for that cleanup.
 - **Every GitHub release MUST attach `DuneServerSetup.exe` as its sole asset.**
   Code-only releases break the in-app updater (it gates on an asset being
   present and silently reports "up to date"). After publishing, verify with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ Candidate metadata prepared for v15.0.0-test7; semantic version remains 15.0.0.
 
 ### Changed
 
+- Made Stable the primary release download, bounded visible test history to the
+  newest two builds, and kept direct local-browser handoff behind Help while
+  steering remote access through the supported setup flow.
+- Increased sidebar section-label contrast and restored the footer support
+  action while moving the page-level support block above the credits list.
 - Maps Live State now reuses successful structural schema probes for 30 minutes
   while failures retry only under per-source backoff, reports refresh timing and
   source map/dimension evidence in diagnostics, samples unchanged observations

--- a/app/server/routes/Update.ps1
+++ b/app/server/routes/Update.ps1
@@ -171,12 +171,23 @@ function Get-DuneReleases {
     return $script:DuneReleasesCache.releases
 }
 
-# Test-channel candidates: published pre-releases that actually carry the
-# installer asset, newest-first. These populate the Settings dropdown.
+function Test-DuneStableMirrorRelease {
+    param($Release)
+    $text = "$($Release.name)`n$($Release.releaseNotes)"
+    return ($text -match '(?i)\b(?:test|stable)(?:[-\s]+channel)?[-\s]+mirror\b')
+}
+
+# Test-channel candidates: the newest two published pre-releases that carry the
+# installer asset. A newest stable mirror stands alone so old test-cycle builds
+# do not remain selectable after the stable release ships.
 function Get-DunePreReleaseList {
     param([switch]$Force)
-    return @(Get-DuneReleases -Force:$Force |
+    $candidates = @(Get-DuneReleases -Force:$Force |
         Where-Object { $_.isPrerelease -and -not $_.isDraft -and $_.assetUrl })
+    if ($candidates.Count -gt 0 -and (Test-DuneStableMirrorRelease -Release $candidates[0])) {
+        return @($candidates[0])
+    }
+    return @($candidates | Select-Object -First 2)
 }
 
 # Resolve which release the in-app updater should act on for THIS install,
@@ -560,9 +571,9 @@ Register-DuneRoute -Method GET -Path '/api/update/check' -Handler {
 }
 
 # GET /api/update/prereleases[?force=1] — list test-channel candidate builds
-# (published pre-releases that carry the installer asset, newest-first) for the
-# Settings pre-release picker. `selectedTag` echoes the currently pinned tag;
-# an empty pin means "latest" (the first item).
+# (newest two published pre-releases that carry the installer asset) for the
+# Settings picker. Stable is always the primary channel; an empty pin means
+# "latest" (the first test item).
 Register-DuneRoute -Method GET -Path '/api/update/prereleases' -Handler {
     param($req, $res, $routeParams, $body)
     try {

--- a/app/server/routes/Update.ps1
+++ b/app/server/routes/Update.ps1
@@ -187,7 +187,9 @@ function Get-DunePreReleaseList {
     if ($candidates.Count -gt 0 -and (Test-DuneStableMirrorRelease -Release $candidates[0])) {
         return @($candidates[0])
     }
-    return @($candidates | Select-Object -First 2)
+    return @($candidates |
+        Where-Object { -not (Test-DuneStableMirrorRelease -Release $_) } |
+        Select-Object -First 2)
 }
 
 # Resolve which release the in-app updater should act on for THIS install,

--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "test:changelog": "node --experimental-strip-types scripts/check-changelog.mts"
+    "test:changelog": "node --experimental-strip-types scripts/check-changelog.mts",
+    "test:testing": "node --experimental-strip-types scripts/check-testing.mts"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.10",

--- a/site/scripts/check-testing.mts
+++ b/site/scripts/check-testing.mts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import {
+  getActiveTestReleases,
+  getLatestStableRelease,
+  type GitHubTestRelease,
+} from "../src/lib/testing.ts";
+
+const releases: GitHubTestRelease[] = [
+  {
+    tag_name: "v15.0.0-test1",
+    name: "stable channel mirror",
+    prerelease: true,
+    published_at: "2026-08-31T03:00:00Z",
+    assets: [{ name: "DuneServerSetup.exe", browser_download_url: "https://x/mirror.exe" }],
+  },
+  {
+    tag_name: "v15.0.0-test3",
+    prerelease: true,
+    published_at: "2026-08-31T02:00:00Z",
+    assets: [{ name: "DuneServerSetup.exe", browser_download_url: "https://x/test3.exe" }],
+  },
+  {
+    tag_name: "v14.0.5",
+    prerelease: false,
+    published_at: "2026-08-31T01:00:00Z",
+    assets: [{ name: "DuneServerSetup.exe", browser_download_url: "https://x/stable.exe" }],
+  },
+  {
+    tag_name: "v15.0.0-test2",
+    prerelease: true,
+    published_at: "2026-08-30T02:00:00Z",
+    assets: [{ name: "DuneServerSetup.exe", browser_download_url: "https://x/test2.exe" }],
+  },
+  {
+    tag_name: "v15.0.0-test1-old",
+    prerelease: true,
+    published_at: "2026-08-29T02:00:00Z",
+    assets: [{ name: "DuneServerSetup.exe", browser_download_url: "https://x/test1.exe" }],
+  },
+];
+
+assert.equal(getLatestStableRelease(releases)?.tag, "v14.0.5");
+assert.deepEqual(
+  getActiveTestReleases(releases).map((release) => release.tag),
+  ["v15.0.0-test3", "v15.0.0-test2"],
+);
+
+console.log("Testing release retention checks passed.");

--- a/site/src/lib/testing.ts
+++ b/site/src/lib/testing.ts
@@ -23,6 +23,30 @@ export interface ActiveTestRelease {
   publishedAt: string | null;
 }
 
+function publishedAtDescending(a: ActiveTestRelease, b: ActiveTestRelease): number {
+  const at = a.publishedAt ? Date.parse(a.publishedAt) : 0;
+  const bt = b.publishedAt ? Date.parse(b.publishedAt) : 0;
+  return bt - at;
+}
+
+function mapRelease(release: GitHubTestRelease): ActiveTestRelease | null {
+  const installer = release.assets?.find(
+    (asset) => asset.name === "DuneServerSetup.exe" && asset.browser_download_url,
+  );
+  if (!installer?.browser_download_url) return null;
+
+  return {
+    tag: release.tag_name ?? "untagged-release",
+    name: release.name || release.tag_name || "DST release",
+    notes: release.body?.trim() || "No release notes were provided.",
+    htmlUrl:
+      release.html_url ??
+      "https://github.com/coastal-ms/DST-DuneServerTool/releases",
+    installerUrl: installer.browser_download_url,
+    publishedAt: release.published_at ?? null,
+  };
+}
+
 export function isStableMirror(release: GitHubTestRelease): boolean {
   const text = `${release.name ?? ""}\n${release.body ?? ""}`;
   return /\b(?:test|stable)(?:[-\s]+channel)?[-\s]+mirror\b/i.test(text);
@@ -42,24 +66,18 @@ export function getActiveTestReleases(
           Boolean(asset.browser_download_url),
       );
     })
-    .map((release) => {
-      const installer = release.assets?.find(
-        (asset) => asset.name === "DuneServerSetup.exe",
-      );
-      return {
-        tag: release.tag_name ?? "untagged-test",
-        name: release.name || release.tag_name || "DST test build",
-        notes: release.body?.trim() || "No testing notes were provided.",
-        htmlUrl:
-          release.html_url ??
-          "https://github.com/coastal-ms/DST-DuneServerTool/releases",
-        installerUrl: installer?.browser_download_url ?? "",
-        publishedAt: release.published_at ?? null,
-      };
-    })
-    .sort((a, b) => {
-      const at = a.publishedAt ? Date.parse(a.publishedAt) : 0;
-      const bt = b.publishedAt ? Date.parse(b.publishedAt) : 0;
-      return bt - at;
-    });
+    .map(mapRelease)
+    .filter((release): release is ActiveTestRelease => release !== null)
+    .sort(publishedAtDescending)
+    .slice(0, 2);
+}
+
+export function getLatestStableRelease(
+  releases: GitHubTestRelease[],
+): ActiveTestRelease | null {
+  return releases
+    .filter((release) => !release.prerelease && !release.draft)
+    .map(mapRelease)
+    .filter((release): release is ActiveTestRelease => release !== null)
+    .sort(publishedAtDescending)[0] ?? null;
 }

--- a/site/src/pages/testing.astro
+++ b/site/src/pages/testing.astro
@@ -66,6 +66,8 @@ import PageHeader from "../components/PageHeader.astro";
   const stableRoot = document.querySelector<HTMLDivElement>("#stable-release");
   const releasesUrl =
     "https://api.github.com/repos/coastal-ms/DST-DuneServerTool/releases?per_page=30";
+  const latestStableUrl =
+    "https://api.github.com/repos/coastal-ms/DST-DuneServerTool/releases/latest";
 
   function link(
     label: string,
@@ -142,6 +144,35 @@ import PageHeader from "../components/PageHeader.astro";
     root.replaceChildren(box);
   }
 
+  async function loadStable(): Promise<void> {
+    if (!stableRoot) return;
+    let stable: ActiveTestRelease | null = null;
+    try {
+      const response = await fetch(latestStableUrl, {
+        headers: {
+          Accept: "application/vnd.github+json",
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`GitHub returned HTTP ${response.status}`);
+      }
+      const payload = (await response.json()) as GitHubTestRelease;
+      stable = getLatestStableRelease([payload]);
+    } catch {
+      stable = null;
+    }
+
+    if (stable) {
+      stableRoot.replaceChildren(releaseCard(stable, true));
+      return;
+    }
+    const message = document.createElement("div");
+    message.className =
+      "rounded-xl border border-dune-border bg-dune-surface p-7 text-dune-muted";
+    message.textContent = "The stable release could not be loaded. Open GitHub Releases or try again shortly.";
+    stableRoot.replaceChildren(message);
+  }
+
   async function loadTests(): Promise<void> {
     if (!root) return;
     try {
@@ -154,19 +185,7 @@ import PageHeader from "../components/PageHeader.astro";
         throw new Error(`GitHub returned HTTP ${response.status}`);
       }
       const payload = (await response.json()) as GitHubTestRelease[];
-      const stable = getLatestStableRelease(payload);
       const releases = getActiveTestReleases(payload);
-      if (stableRoot) {
-        if (stable) {
-          stableRoot.replaceChildren(releaseCard(stable, true));
-        } else {
-          const message = document.createElement("div");
-          message.className =
-            "rounded-xl border border-dune-border bg-dune-surface p-7 text-dune-muted";
-          message.textContent = "The stable release could not be loaded. Open GitHub Releases or try again shortly.";
-          stableRoot.replaceChildren(message);
-        }
-      }
       if (releases.length === 0) {
         showMessage(
           "No active tests",
@@ -178,9 +197,6 @@ import PageHeader from "../components/PageHeader.astro";
       const cards = releases.map((release) => releaseCard(release, false));
       root.replaceChildren(...cards);
     } catch (error) {
-      if (stableRoot) {
-        stableRoot.replaceChildren();
-      }
       showMessage(
         "Could not load active tests",
         `${error instanceof Error ? error.message : String(error)}. Open GitHub Releases or try again shortly.`,
@@ -188,5 +204,6 @@ import PageHeader from "../components/PageHeader.astro";
     }
   }
 
+  void loadStable();
   void loadTests();
 </script>

--- a/site/src/pages/testing.astro
+++ b/site/src/pages/testing.astro
@@ -8,14 +8,21 @@ import PageHeader from "../components/PageHeader.astro";
   description="Current DST pre-release builds, what they change, and how to test them."
 >
   <PageHeader
-    eyebrow="Pre-release"
-    title="Active test builds"
-    intro="Targeted builds awaiting real-world validation. These are experimental, may restart services, and are not the stable release."
+    eyebrow="Downloads"
+    title="Stable and test releases"
+    intro="Stable is the recommended install. Test builds are retained only for focused validation and remain secondary."
   />
 
   <section class="mx-auto max-w-5xl px-6 pb-20">
+    <div id="stable-release" class="mb-8" aria-live="polite">
+      <div class="rounded-xl border border-dune-accent/50 bg-dune-surface p-6 text-dune-muted">
+        Loading the recommended stable release from GitHub…
+      </div>
+    </div>
+
+    <h2 class="mb-3 text-xl font-semibold text-dune-text">Current test builds</h2>
     <div
-      class="mb-8 rounded-xl border border-amber-500/40 bg-amber-500/10 px-5 py-4 text-sm text-amber-200"
+      class="mb-6 rounded-xl border border-amber-500/40 bg-amber-500/10 px-5 py-4 text-sm text-amber-200"
     >
       <strong>Use test builds only when their notes match what you are testing.</strong>
       Back up first, follow the listed steps, and report results in the
@@ -50,10 +57,13 @@ import PageHeader from "../components/PageHeader.astro";
 <script>
   import {
     getActiveTestReleases,
+    getLatestStableRelease,
+    type ActiveTestRelease,
     type GitHubTestRelease,
   } from "../lib/testing";
 
   const root = document.querySelector<HTMLDivElement>("#active-tests");
+  const stableRoot = document.querySelector<HTMLDivElement>("#stable-release");
   const releasesUrl =
     "https://api.github.com/repos/coastal-ms/DST-DuneServerTool/releases?per_page=30";
 
@@ -71,6 +81,50 @@ import PageHeader from "../components/PageHeader.astro";
       ? "inline-flex items-center rounded-lg bg-dune-accent hover:bg-dune-accent-soft text-dune-bg font-medium px-4 py-2 transition-colors"
       : "inline-flex items-center rounded-lg border border-dune-border hover:border-dune-accent text-dune-text px-4 py-2 transition-colors";
     return a;
+  }
+
+  function releaseCard(
+    release: ActiveTestRelease,
+    stable: boolean,
+  ): HTMLElement {
+    const article = document.createElement("article");
+    article.className = stable
+      ? "rounded-xl border border-dune-accent/60 bg-dune-surface p-6 sm:p-8"
+      : "rounded-xl border border-dune-border bg-dune-surface p-6 sm:p-8";
+
+    const meta = document.createElement("div");
+    meta.className =
+      "font-mono text-xs uppercase tracking-wider text-dune-accent mb-2";
+    const date = release.publishedAt
+      ? new Date(release.publishedAt).toLocaleDateString()
+      : "Date unavailable";
+    meta.textContent = `${stable ? "Recommended stable" : "Test build"} · ${release.tag} · ${date}`;
+
+    const heading = document.createElement("h2");
+    heading.className = "text-2xl font-semibold text-dune-text";
+    heading.textContent = release.name;
+
+    const notes = document.createElement("pre");
+    notes.className =
+      "mt-5 whitespace-pre-wrap break-words font-sans text-sm leading-relaxed text-dune-muted";
+    notes.textContent = release.notes;
+
+    const actions = document.createElement("div");
+    actions.className = "mt-6 flex flex-wrap gap-3";
+    actions.append(
+      link(
+        stable ? "Download stable installer" : "Download test installer",
+        release.installerUrl,
+        stable,
+      ),
+      link("Open release notes", release.htmlUrl),
+    );
+    if (!stable) {
+      actions.append(link("Report test result", "https://discord.gg/tj2x7cywSC"));
+    }
+
+    article.append(meta, heading, notes, actions);
+    return article;
   }
 
   function showMessage(title: string, body: string): void {
@@ -99,9 +153,20 @@ import PageHeader from "../components/PageHeader.astro";
       if (!response.ok) {
         throw new Error(`GitHub returned HTTP ${response.status}`);
       }
-      const releases = getActiveTestReleases(
-        (await response.json()) as GitHubTestRelease[],
-      );
+      const payload = (await response.json()) as GitHubTestRelease[];
+      const stable = getLatestStableRelease(payload);
+      const releases = getActiveTestReleases(payload);
+      if (stableRoot) {
+        if (stable) {
+          stableRoot.replaceChildren(releaseCard(stable, true));
+        } else {
+          const message = document.createElement("div");
+          message.className =
+            "rounded-xl border border-dune-border bg-dune-surface p-7 text-dune-muted";
+          message.textContent = "The stable release could not be loaded. Open GitHub Releases or try again shortly.";
+          stableRoot.replaceChildren(message);
+        }
+      }
       if (releases.length === 0) {
         showMessage(
           "No active tests",
@@ -110,41 +175,12 @@ import PageHeader from "../components/PageHeader.astro";
         return;
       }
 
-      const cards = releases.map((release) => {
-        const article = document.createElement("article");
-        article.className =
-          "rounded-xl border border-dune-border bg-dune-surface p-6 sm:p-8";
-
-        const meta = document.createElement("div");
-        meta.className =
-          "font-mono text-xs uppercase tracking-wider text-dune-accent mb-2";
-        const date = release.publishedAt
-          ? new Date(release.publishedAt).toLocaleDateString()
-          : "Date unavailable";
-        meta.textContent = `${release.tag} · ${date}`;
-
-        const heading = document.createElement("h2");
-        heading.className = "text-2xl font-semibold text-dune-text";
-        heading.textContent = release.name;
-
-        const notes = document.createElement("pre");
-        notes.className =
-          "mt-5 whitespace-pre-wrap break-words font-sans text-sm leading-relaxed text-dune-muted";
-        notes.textContent = release.notes;
-
-        const actions = document.createElement("div");
-        actions.className = "mt-6 flex flex-wrap gap-3";
-        actions.append(
-          link("Download test installer", release.installerUrl, true),
-          link("Open release notes", release.htmlUrl),
-          link("Report test result", "https://discord.gg/tj2x7cywSC"),
-        );
-
-        article.append(meta, heading, notes, actions);
-        return article;
-      });
+      const cards = releases.map((release) => releaseCard(release, false));
       root.replaceChildren(...cards);
     } catch (error) {
+      if (stableRoot) {
+        stableRoot.replaceChildren();
+      }
       showMessage(
         "Could not load active tests",
         `${error instanceof Error ? error.message : String(error)}. Open GitHub Releases or try again shortly.`,

--- a/tests/UpdateChannel.Tests.ps1
+++ b/tests/UpdateChannel.Tests.ps1
@@ -10,6 +10,7 @@ BeforeAll {
     function global:New-DstReleaseFixture {
         @(
             [pscustomobject]@{ tag='v12.9.5';        name='v12.9.5';        isPrerelease=$false; isDraft=$false; assetUrl='https://x/final.exe';  assetName='DuneServerSetup.exe'; assetSize=100; htmlUrl='u'; publishedAt='2026-06-21'; releaseNotes='' }
+            [pscustomobject]@{ tag='v12.9.6-test3';  name='Spec fix test3'; isPrerelease=$true;  isDraft=$false; assetUrl='https://x/t3.exe';     assetName='DuneServerSetup.exe'; assetSize=100; htmlUrl='u'; publishedAt='2026-06-21'; releaseNotes='' }
             [pscustomobject]@{ tag='v12.9.6-test2';  name='Spec fix test2'; isPrerelease=$true;  isDraft=$false; assetUrl='https://x/t2.exe';     assetName='DuneServerSetup.exe'; assetSize=100; htmlUrl='u'; publishedAt='2026-06-20'; releaseNotes='' }
             [pscustomobject]@{ tag='v12.9.6-test1';  name='Spec fix test1'; isPrerelease=$true;  isDraft=$false; assetUrl='https://x/t1.exe';     assetName='DuneServerSetup.exe'; assetSize=100; htmlUrl='u'; publishedAt='2026-06-19'; releaseNotes='' }
             [pscustomobject]@{ tag='v12.9.6-test0';  name='no asset';       isPrerelease=$true;  isDraft=$false; assetUrl=$null;                  assetName=$null;                 assetSize=0;   htmlUrl='u'; publishedAt='2026-06-18'; releaseNotes='' }
@@ -66,17 +67,30 @@ Describe 'Get-DunePreReleaseList filtering' {
     BeforeEach {
         function global:Get-DuneReleases { param([switch]$Force) New-DstReleaseFixture }
     }
-    It 'keeps only published pre-releases carrying the installer asset, newest-first' {
+    It 'keeps only the newest two published pre-releases carrying the installer asset' {
         $list = Get-DunePreReleaseList
         @($list).Count | Should -Be 2
-        $list[0].tag | Should -Be 'v12.9.6-test2'
-        $list[1].tag | Should -Be 'v12.9.6-test1'
+        $list[0].tag | Should -Be 'v12.9.6-test3'
+        $list[1].tag | Should -Be 'v12.9.6-test2'
     }
     It 'excludes finals, drafts and asset-less pre-releases' {
         $tags = (Get-DunePreReleaseList).tag
         $tags | Should -Not -Contain 'v12.9.5'
+        $tags | Should -Not -Contain 'v12.9.6-test1'
         $tags | Should -Not -Contain 'v12.9.6-test0'
         $tags | Should -Not -Contain 'v12.9.7-draft'
+    }
+    It 'shows only the test1 stable mirror when it is the newest prerelease' {
+        function global:Get-DuneReleases {
+            param([switch]$Force)
+            @(
+                [pscustomobject]@{ tag='v12.9.6-test1'; name='Stable channel mirror'; releaseNotes='same bits'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/mirror.exe' }
+                [pscustomobject]@{ tag='v12.9.5-test9'; name='Old test'; releaseNotes=''; isPrerelease=$true; isDraft=$false; assetUrl='https://x/old.exe' }
+            )
+        }
+        $list = Get-DunePreReleaseList
+        @($list).Count | Should -Be 1
+        $list[0].tag | Should -Be 'v12.9.6-test1'
     }
 }
 
@@ -108,21 +122,27 @@ Describe 'Get-DuneSelectedRelease channel resolution' {
     It 'test channel with no pin selects the newest prerelease' {
         function global:Get-DuneUpdateChannel { 'test' }
         $r = Get-DuneSelectedRelease
-        $r.tag | Should -Be 'v12.9.6-test2'
+        $r.tag | Should -Be 'v12.9.6-test3'
         $r.channel | Should -Be 'test'
         $r.isPrerelease | Should -BeTrue
     }
 
     It 'test channel honors a valid pinned tag' {
         function global:Get-DuneUpdateChannel { 'test' }
-        function global:Get-DuneUpdatePreReleaseTag { 'v12.9.6-test1' }
-        (Get-DuneSelectedRelease).tag | Should -Be 'v12.9.6-test1'
+        function global:Get-DuneUpdatePreReleaseTag { 'v12.9.6-test2' }
+        (Get-DuneSelectedRelease).tag | Should -Be 'v12.9.6-test2'
     }
 
     It 'test channel falls back to newest when the pinned tag is gone' {
         function global:Get-DuneUpdateChannel { 'test' }
         function global:Get-DuneUpdatePreReleaseTag { 'v12.9.6-test99' }
-        (Get-DuneSelectedRelease).tag | Should -Be 'v12.9.6-test2'
+        (Get-DuneSelectedRelease).tag | Should -Be 'v12.9.6-test3'
+    }
+
+    It 'falls back to newest when a pin is older than the retained test history' {
+        function global:Get-DuneUpdateChannel { 'test' }
+        function global:Get-DuneUpdatePreReleaseTag { 'v12.9.6-test1' }
+        (Get-DuneSelectedRelease).tag | Should -Be 'v12.9.6-test3'
     }
 
     It 'test channel falls back to stable when no prereleases exist' {

--- a/tests/UpdateChannel.Tests.ps1
+++ b/tests/UpdateChannel.Tests.ps1
@@ -92,6 +92,20 @@ Describe 'Get-DunePreReleaseList filtering' {
         @($list).Count | Should -Be 1
         $list[0].tag | Should -Be 'v12.9.6-test1'
     }
+    It 'does not let an older stable mirror displace the previous active test' {
+        function global:Get-DuneReleases {
+            param([switch]$Force)
+            @(
+                [pscustomobject]@{ tag='v13.0.0-test3'; name='Current test'; releaseNotes=''; isPrerelease=$true; isDraft=$false; assetUrl='https://x/current.exe' }
+                [pscustomobject]@{ tag='v12.9.6-test1'; name='Stable channel mirror'; releaseNotes='same bits'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/mirror.exe' }
+                [pscustomobject]@{ tag='v13.0.0-test2'; name='Previous test'; releaseNotes=''; isPrerelease=$true; isDraft=$false; assetUrl='https://x/previous.exe' }
+            )
+        }
+        $list = Get-DunePreReleaseList
+        @($list).Count | Should -Be 2
+        $list[0].tag | Should -Be 'v13.0.0-test3'
+        $list[1].tag | Should -Be 'v13.0.0-test2'
+    }
 }
 
 Describe 'Get-DuneSelectedRelease channel resolution' {

--- a/webui/src/data/sponsors.ts
+++ b/webui/src/data/sponsors.ts
@@ -1,25 +1,25 @@
 export type SupporterCredit = {
   displayName: string
-  recognition: 'Project Supporter' | 'Discord Sponsor'
+  thanks: string
 }
 
 export const SUPPORTER_CREDITS: readonly SupporterCredit[] = [
-  { displayName: 'Decker (@decker177)', recognition: 'Project Supporter' },
-  { displayName: 'Ogmosis (@ogmosis)', recognition: 'Project Supporter' },
-  { displayName: 'boosterfuel (@boosterfuel)', recognition: 'Project Supporter' },
-  { displayName: 'Techtonic (@techtonic001)', recognition: 'Project Supporter' },
-  { displayName: 'Ken (@krazy2168)', recognition: 'Project Supporter' },
-  { displayName: 'Pat (@pat.)', recognition: 'Project Supporter' },
-  { displayName: 'Brandon M', recognition: 'Project Supporter' },
-  { displayName: 'Daddy STATZY (@spiderstatz)', recognition: 'Project Supporter' },
-  { displayName: 'Vosper (@vosper61)', recognition: 'Project Supporter' },
-  { displayName: 'Murm (@murm9000)', recognition: 'Project Supporter' },
-  { displayName: 'Derkuli (@ichbinderkuli)', recognition: 'Project Supporter' },
-  { displayName: 'gd.py (@gd.py)', recognition: 'Project Supporter' },
-  { displayName: 'Chumdizzle (@chumdizzle)', recognition: 'Project Supporter' },
-  { displayName: 'Fargenbasteg (@fargenbasteg)', recognition: 'Project Supporter' },
-  { displayName: 'elwicki (@elwicki)', recognition: 'Project Supporter' },
-  { displayName: 'Maggie Malone (@magiemalone)', recognition: 'Project Supporter' },
-  { displayName: 'William', recognition: 'Project Supporter' },
-  { displayName: 'Ed O.', recognition: 'Discord Sponsor' },
+  { displayName: 'Decker (@decker177)', thanks: 'Thank you for backing the build.' },
+  { displayName: 'Ogmosis (@ogmosis)', thanks: 'You help keep DST moving forward.' },
+  { displayName: 'boosterfuel (@boosterfuel)', thanks: 'Thanks for fueling the next release.' },
+  { displayName: 'Techtonic (@techtonic001)', thanks: 'Your support keeps the servers humming.' },
+  { displayName: 'Ken (@krazy2168)', thanks: 'Thank you for standing behind DST.' },
+  { displayName: 'Pat (@pat.)', thanks: 'Your support makes the polish possible.' },
+  { displayName: 'Brandon M', thanks: 'Thanks for helping DST grow.' },
+  { displayName: 'Daddy STATZY (@spiderstatz)', thanks: 'You make the long build nights lighter.' },
+  { displayName: 'Vosper (@vosper61)', thanks: 'Thank you for supporting the journey.' },
+  { displayName: 'Murm (@murm9000)', thanks: 'Your generosity means a great deal.' },
+  { displayName: 'Derkuli (@ichbinderkuli)', thanks: 'Thanks for keeping the project strong.' },
+  { displayName: 'gd.py (@gd.py)', thanks: 'You help turn ideas into releases.' },
+  { displayName: 'Chumdizzle (@chumdizzle)', thanks: 'Thank you for giving DST a boost.' },
+  { displayName: 'Fargenbasteg (@fargenbasteg)', thanks: 'Your support helps make every test count.' },
+  { displayName: 'elwicki (@elwicki)', thanks: 'Thanks for helping the project thrive.' },
+  { displayName: 'Maggie Malone (@magiemalone)', thanks: 'Your kindness keeps the work going.' },
+  { displayName: 'William', thanks: 'Thank you for helping sustain DST.' },
+  { displayName: 'Ed O.', thanks: 'Your support strengthens the whole community.' },
 ]

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -410,13 +410,13 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <button
                 type="button"
                 onClick={() => { requestPortalHandoff(); setOpen(null) }}
-                className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-xs text-text-dim hover:text-text-muted hover:bg-surface-2/60 transition-colors text-left"
+                className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text hover:bg-surface-2 transition-colors text-left"
                 title="Advanced local-only handoff. Remote users should use Remote Portal Setup."
               >
                 <Icon name="ExternalLink" size={13} className="mt-0.5" />
                 <span className="flex-1">
                   <span className="block">Open local portal in browser</span>
-                  <span className="block text-[10px] text-text-dim">
+                  <span className="block text-[11px] text-text-dim">
                     Advanced local handoff
                   </span>
                 </span>

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -10,6 +10,8 @@ import { getConsoleState, setConsoleVisible, type ConsoleState } from '../api/co
 import { isLocalViewer, isWindowsViewer } from '../util/viewer'
 import { isHorizontalSwipe, type TouchPoint } from '../util/mobileNavigationGesture'
 import { usePortalAccess } from '../auth/portalAccess'
+import { isShellHost } from '../util/shellBridge'
+import { requestPortalHandoff } from '../util/portalHandoff'
 
 type MenuKey = NavGroup | 'help'
 
@@ -387,6 +389,39 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               </span>
               <Icon name="ExternalLink" size={11} className="text-text-dim mt-1" />
             </a>
+            <a
+              href="https://coastal-ms.github.io/DST-DuneServerTool/remote"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setOpen(null)}
+              className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors text-left"
+              title="Set up durable remote portal access with Tailscale Funnel."
+            >
+              <Icon name="ShieldCheck" size={14} className="mt-0.5" />
+              <span className="flex-1">
+                <span className="block">Remote Portal Setup</span>
+                <span className="block text-[11px] text-text-dim">
+                  Recommended Tailscale Funnel setup
+                </span>
+              </span>
+              <Icon name="ExternalLink" size={11} className="text-text-dim mt-1" />
+            </a>
+            {isShellHost() && (
+              <button
+                type="button"
+                onClick={() => { requestPortalHandoff(); setOpen(null) }}
+                className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-xs text-text-dim hover:text-text-muted hover:bg-surface-2/60 transition-colors text-left"
+                title="Advanced local-only handoff. Remote users should use Remote Portal Setup."
+              >
+                <Icon name="ExternalLink" size={13} className="mt-0.5" />
+                <span className="flex-1">
+                  <span className="block">Open local portal in browser</span>
+                  <span className="block text-[10px] text-text-dim">
+                    Advanced local handoff
+                  </span>
+                </span>
+              </button>
+            )}
             {canAccessOwnerSurfaces && (
               <button
                 type="button"

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -377,7 +377,7 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               target="_blank"
               rel="noopener noreferrer"
               onClick={() => setOpen(null)}
-              className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors text-left"
+              className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text hover:bg-surface-2 transition-colors text-left"
               title="Join the DST community Discord — install/setup help, hosting questions, Game Config tips, and release announcements."
             >
               <Icon name="MessagesSquare" size={14} className="mt-0.5" />
@@ -394,10 +394,10 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               target="_blank"
               rel="noopener noreferrer"
               onClick={() => setOpen(null)}
-              className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors text-left"
+              className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text hover:bg-surface-2 transition-colors text-left"
               title="Set up durable remote portal access with Tailscale Funnel."
             >
-              <Icon name="ShieldCheck" size={14} className="mt-0.5" />
+              <Icon name="ShieldCheck" size={14} className="mt-0.5 text-accent-bright" />
               <span className="flex-1">
                 <span className="block">Remote Portal Setup</span>
                 <span className="block text-[11px] text-text-dim">
@@ -426,7 +426,7 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               <button
                 type="button"
                 onClick={onCreateDiagnosticsPackage}
-                className="w-full min-h-11 flex items-start gap-2 px-2.5 py-2 rounded text-sm text-text-muted hover:text-text hover:bg-surface-2 transition-colors text-left"
+                className="w-full min-h-11 flex items-start gap-2 px-2.5 py-2 rounded text-sm text-text hover:bg-surface-2 transition-colors text-left"
                 title="Creates a redacted diagnostics ZIP on the server host and opens it in Explorer."
               >
                 <Icon name="FileArchive" size={14} className="mt-0.5" />

--- a/webui/src/layout/MenuBar.tsx
+++ b/webui/src/layout/MenuBar.tsx
@@ -397,7 +397,7 @@ export function MenuBar({ sidebarCollapsed, onToggleSidebar }: Props) {
               className="w-full flex items-start gap-2 px-2.5 py-1.5 rounded text-sm text-text hover:bg-surface-2 transition-colors text-left"
               title="Set up durable remote portal access with Tailscale Funnel."
             >
-              <Icon name="ShieldCheck" size={14} className="mt-0.5 text-accent-bright" />
+              <Icon name="ShieldCheck" size={14} className="mt-0.5" />
               <span className="flex-1">
                 <span className="block">Remote Portal Setup</span>
                 <span className="block text-[11px] text-text-dim">

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -349,8 +349,8 @@ export function Sidebar({ collapsed, onExpand }: Props) {
                     <li
                       key={entry.id}
                       className={collapsed
-                        ? `${index === 0 ? 'hidden' : 'my-2'} border-t border-accent/35`
-                        : 'mb-1 mt-2 flex items-center gap-2 px-3 text-[10px] font-semibold uppercase tracking-widest text-accent-bright/80 before:h-px before:flex-1 before:bg-accent/30 after:h-px after:flex-1 after:bg-accent/30'}
+                        ? `${index === 0 ? 'hidden' : 'my-2'} border-t border-accent/55`
+                        : 'mb-1 mt-2 flex items-center gap-2 px-3 text-[10px] font-semibold uppercase tracking-widest text-accent-bright before:h-px before:flex-1 before:bg-accent/55 after:h-px after:flex-1 after:bg-accent/55'}
                     >
                       {!collapsed && entry.label}
                     </li>
@@ -631,7 +631,7 @@ function SortableSidebarDivider({
         transition,
         opacity: isDragging ? 0.45 : undefined,
       }}
-      className="mt-2 flex min-h-11 items-center gap-1 rounded-lg border border-dashed border-accent/45 bg-accent/[0.08] px-1.5 py-1 shadow-sm shadow-black/30"
+      className="mt-2 flex min-h-11 items-center gap-1 rounded-lg border border-dashed border-accent/65 bg-accent/[0.14] px-1.5 py-1 shadow-sm shadow-black/30"
     >
       <button
         type="button"
@@ -658,7 +658,7 @@ function SortableSidebarDivider({
             event.currentTarget.blur()
           }
         }}
-        className="min-h-9 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1.5 text-[10px] font-semibold uppercase tracking-widest text-accent-bright/90 focus:border-accent/60 focus:bg-surface focus:outline-none focus:ring-2 focus:ring-ibad"
+        className="min-h-9 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1.5 text-[10px] font-semibold uppercase tracking-widest text-accent-bright focus:border-accent/70 focus:bg-surface focus:outline-none focus:ring-2 focus:ring-ibad"
       />
       <button
         type="button"

--- a/webui/src/layout/Sidebar.tsx
+++ b/webui/src/layout/Sidebar.tsx
@@ -34,11 +34,10 @@ import { fmtToolVersion } from '../format'
 import { isLocalViewer, isWindowsViewer } from '../util/viewer'
 import { getTestBuildIdentity } from '../util/testBuildIdentity'
 import { usePortalAccess } from '../auth/portalAccess'
+import { PORTAL_HANDOFF_REQUEST_EVENT } from '../util/portalHandoff'
 
 // WebView2 host bridge — present only when the portal is rendered inside the
-// native DuneShell.exe app window (not in a regular browser tab). We use it to
-// hand the shell an "open URL in default browser then close yourself" message
-// when the user clicks "Web Portal" below.
+// native DuneShell.exe app window (not in a regular browser tab).
 type WebView2Host = { postMessage: (data: unknown) => void }
 function getWebView2(): WebView2Host | null {
   const w = window as unknown as { chrome?: { webview?: WebView2Host } }
@@ -71,10 +70,6 @@ export function Sidebar({ collapsed, onExpand }: Props) {
   const [portalUrl, setPortalUrl] = useState<string | null>(null)
   const [portalCopied, setPortalCopied] = useState(false)
   const portalCancelRef = useRef(false)
-
-  // "Web Portal" is meaningful only inside the native shell. In a regular
-  // browser tab the user is already in their browser, so we hide the button.
-  const inShellWindow = getWebView2() !== null
 
   const onOpenWebPortal = async () => {
     if (portalDetaching) return
@@ -163,6 +158,16 @@ export function Sidebar({ collapsed, onExpand }: Props) {
       setTimeout(() => setPortalCopied(false), 2000)
     } catch { /* clipboard blocked — the URL is shown in the box to copy manually */ }
   }
+
+  useEffect(() => {
+    const openPortalHandoff = () => {
+      setPortalError(null)
+      setPortalPhase('confirm')
+      setShowPortalConfirm(true)
+    }
+    window.addEventListener(PORTAL_HANDOFF_REQUEST_EVENT, openPortalHandoff)
+    return () => window.removeEventListener(PORTAL_HANDOFF_REQUEST_EVENT, openPortalHandoff)
+  }, [])
 
   const localViewer = isLocalViewer()
   const windowsViewer = isWindowsViewer()
@@ -344,8 +349,8 @@ export function Sidebar({ collapsed, onExpand }: Props) {
                     <li
                       key={entry.id}
                       className={collapsed
-                        ? `${index === 0 ? 'hidden' : 'my-2'} border-t border-border/70`
-                        : 'px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-widest text-text-dim'}
+                        ? `${index === 0 ? 'hidden' : 'my-2'} border-t border-accent/35`
+                        : 'mb-1 mt-2 flex items-center gap-2 px-3 text-[10px] font-semibold uppercase tracking-widest text-accent-bright/80 before:h-px before:flex-1 before:bg-accent/30 after:h-px after:flex-1 after:bg-accent/30'}
                     >
                       {!collapsed && entry.label}
                     </li>
@@ -380,21 +385,21 @@ export function Sidebar({ collapsed, onExpand }: Props) {
             {!collapsed && <span>Customize navigation</span>}
           </button>
         )}
-        {inShellWindow && (
-          <button
-            type="button"
-            onClick={() => { setPortalError(null); setPortalPhase('confirm'); setShowPortalConfirm(true) }}
-            title="Open the portal in your default web browser (the app window stays open until the browser connects)"
-            className={
-              collapsed
-                ? 'w-full flex items-center justify-center h-8 rounded-md border border-accent/30 text-accent-bright/90 hover:text-accent-bright hover:bg-accent/10 hover:border-accent/50 transition-colors'
-                : 'w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-accent/30 text-accent-bright/90 hover:text-accent-bright hover:bg-accent/10 hover:border-accent/50 transition-colors uppercase tracking-widest'
-            }
-          >
-            <Icon name="ExternalLink" size={collapsed ? 14 : 11} />
-            {!collapsed && <span>Web Portal</span>}
-          </button>
-        )}
+        <a
+          href="https://buymeacoffee.com/coastal_dst"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Support DST on Buy Me a Coffee"
+          className={
+            collapsed
+              ? 'w-full flex items-center justify-center h-8 rounded-md border border-accent/30 text-accent-bright/90 hover:text-accent-bright hover:bg-accent/10 hover:border-accent/50 transition-colors'
+              : 'w-full flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md border border-accent/30 text-accent-bright/90 hover:text-accent-bright hover:bg-accent/10 hover:border-accent/50 transition-colors uppercase tracking-widest'
+          }
+        >
+          <Icon name="Coffee" size={collapsed ? 14 : 11} />
+          {!collapsed && <span>Buy Me a Coffee</span>}
+          {!collapsed && <Icon name="ExternalLink" size={9} className="text-text-dim" />}
+        </a>
         {collapsed && testBuild && (
           <NavLink
             to="/settings"
@@ -626,11 +631,11 @@ function SortableSidebarDivider({
         transition,
         opacity: isDragging ? 0.45 : undefined,
       }}
-      className="mt-2 flex min-h-11 items-center gap-1 rounded-lg border border-dashed border-border-bright bg-surface-2/45 px-1.5 py-1"
+      className="mt-2 flex min-h-11 items-center gap-1 rounded-lg border border-dashed border-accent/45 bg-accent/[0.08] px-1.5 py-1 shadow-sm shadow-black/30"
     >
       <button
         type="button"
-        className="flex min-h-9 min-w-9 shrink-0 touch-none cursor-grab items-center justify-center rounded text-text-dim hover:bg-surface-3 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent active:cursor-grabbing"
+        className="flex min-h-9 min-w-9 shrink-0 touch-none cursor-grab items-center justify-center rounded text-accent/75 hover:bg-accent/10 hover:text-accent-bright focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent active:cursor-grabbing"
         aria-label={`Reorder section ${divider.label}`}
         title={`Drag to reorder section ${divider.label}`}
         {...attributes}
@@ -653,7 +658,7 @@ function SortableSidebarDivider({
             event.currentTarget.blur()
           }
         }}
-        className="min-h-9 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1.5 text-[10px] font-semibold uppercase tracking-widest text-text-muted focus:border-border-bright focus:bg-surface focus:outline-none focus:ring-2 focus:ring-ibad"
+        className="min-h-9 min-w-0 flex-1 rounded border border-transparent bg-transparent px-1.5 text-[10px] font-semibold uppercase tracking-widest text-accent-bright/90 focus:border-accent/60 focus:bg-surface focus:outline-none focus:ring-2 focus:ring-ibad"
       />
       <button
         type="button"

--- a/webui/src/pages/SponsorsCredits.tsx
+++ b/webui/src/pages/SponsorsCredits.tsx
@@ -42,10 +42,13 @@ export function SponsorsCredits() {
 
         <ul className="mt-7 divide-y divide-border" aria-label="Project supporters">
           {SUPPORTER_CREDITS.map(credit => (
-            <li key={credit.displayName} className="flex items-center justify-between gap-4 py-4 first:pt-0 last:pb-0">
+            <li
+              key={credit.displayName}
+              className="flex flex-col gap-1 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+            >
               <span className="text-lg font-semibold text-text">{credit.displayName}</span>
-              <span className="shrink-0 text-xs font-medium uppercase tracking-wider text-text-dim">
-                {credit.recognition}
+              <span className="text-sm leading-5 text-text-dim sm:max-w-xs sm:text-right">
+                {credit.thanks}
               </span>
             </li>
           ))}

--- a/webui/src/pages/SponsorsCredits.tsx
+++ b/webui/src/pages/SponsorsCredits.tsx
@@ -11,7 +11,25 @@ export function SponsorsCredits() {
         description="Recognizing the people who help sustain Dune Server Tool."
       />
 
-      <section aria-labelledby="project-supporters-title" className="border-y border-border py-7 sm:py-9">
+      <section aria-labelledby="support-dst-title" className="border-y border-border py-7 sm:py-9">
+        <h2 id="support-dst-title" className="text-base font-semibold text-text">Support DST</h2>
+        <p className="mt-2 max-w-[68ch] text-sm leading-6 text-text-muted">
+          If DST is useful to you and you would like to support its continued development,
+          you can do so through Buy Me a Coffee.
+        </p>
+        <a
+          href="https://buymeacoffee.com/coastal_dst"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn-secondary mt-4 min-h-11"
+        >
+          <Icon name="Coffee" size={16} />
+          Buy Me a Coffee
+          <Icon name="ExternalLink" size={13} className="text-text-dim" />
+        </a>
+      </section>
+
+      <section aria-labelledby="project-supporters-title" className="py-7 sm:py-9">
         <div className="max-w-2xl">
           <h2 id="project-supporters-title" className="text-lg font-semibold text-text">
             Project Supporters
@@ -32,24 +50,6 @@ export function SponsorsCredits() {
             </li>
           ))}
         </ul>
-      </section>
-
-      <section aria-labelledby="support-dst-title" className="py-7 sm:py-9">
-        <h2 id="support-dst-title" className="text-base font-semibold text-text">Support DST</h2>
-        <p className="mt-2 max-w-[68ch] text-sm leading-6 text-text-muted">
-          If DST is useful to you and you would like to support its continued development,
-          you can do so through Buy Me a Coffee.
-        </p>
-        <a
-          href="https://buymeacoffee.com/coastal_dst"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="btn-secondary mt-4 min-h-11"
-        >
-          <Icon name="Coffee" size={16} />
-          Buy Me a Coffee
-          <Icon name="ExternalLink" size={13} className="text-text-dim" />
-        </a>
       </section>
     </div>
   )

--- a/webui/src/util/portalHandoff.ts
+++ b/webui/src/util/portalHandoff.ts
@@ -1,0 +1,5 @@
+export const PORTAL_HANDOFF_REQUEST_EVENT = 'dst:portal-handoff-request'
+
+export function requestPortalHandoff() {
+  window.dispatchEvent(new Event(PORTAL_HANDOFF_REQUEST_EVENT))
+}

--- a/webui/tests/sidebarHotfix.test.tsx
+++ b/webui/tests/sidebarHotfix.test.tsx
@@ -71,8 +71,8 @@ describe('sidebar hotfix links', () => {
     expect(screen.getByRole('button', { name: /Reorder Server Overview/ })).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: /Rename section Server Management/ })).toBeInTheDocument()
     const divider = screen.getByRole('textbox', { name: /Rename section Server Management/ })
-    expect(divider).toHaveClass('text-accent-bright/90')
-    expect(divider.parentElement).toHaveClass('border-accent/45', 'bg-accent/[0.08]')
+    expect(divider).toHaveClass('text-accent-bright')
+    expect(divider.parentElement).toHaveClass('border-accent/65', 'bg-accent/[0.14]')
     expect(screen.queryByRole('link', { name: 'Server Overview' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Done' }))

--- a/webui/tests/sidebarHotfix.test.tsx
+++ b/webui/tests/sidebarHotfix.test.tsx
@@ -8,6 +8,7 @@ import {
   SIDEBAR_ORDER_STORAGE_KEY,
   SIDEBAR_ORDER_V1_STORAGE_KEY,
 } from '../src/hooks/useSidebarNavigationOrder'
+import { PORTAL_HANDOFF_REQUEST_EVENT } from '../src/util/portalHandoff'
 
 vi.mock('../src/hooks/useUpdateCheck', () => ({
   useUpdateCheck: () => ({ data: null }),
@@ -36,7 +37,10 @@ describe('sidebar hotfix links', () => {
     renderSidebar(false)
 
     expect(screen.getByRole('link', { name: 'Sponsors & Credits' })).toHaveAttribute('href', '/sponsors')
-    expect(screen.queryByRole('link', { name: 'Buy Me a Coffee' })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Buy Me a Coffee' })).toHaveAttribute(
+      'href',
+      'https://buymeacoffee.com/coastal_dst',
+    )
     expect(screen.queryByRole('link', { name: 'PowerShell' })).not.toBeInTheDocument()
     expect(screen.getAllByText('Thank you Hawk_I5')).toHaveLength(1)
     expect(screen.queryByText('Decker (@decker177)')).not.toBeInTheDocument()
@@ -66,10 +70,20 @@ describe('sidebar hotfix links', () => {
 
     expect(screen.getByRole('button', { name: /Reorder Server Overview/ })).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: /Rename section Server Management/ })).toBeInTheDocument()
+    const divider = screen.getByRole('textbox', { name: /Rename section Server Management/ })
+    expect(divider).toHaveClass('text-accent-bright/90')
+    expect(divider.parentElement).toHaveClass('border-accent/45', 'bg-accent/[0.08]')
     expect(screen.queryByRole('link', { name: 'Server Overview' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Done' }))
     expect(screen.getByRole('link', { name: 'Server Overview' })).toBeInTheDocument()
+  })
+
+  it('opens the local browser handoff only through the advanced Help request', () => {
+    renderSidebar(false)
+    fireEvent(window, new Event(PORTAL_HANDOFF_REQUEST_EVENT))
+
+    expect(screen.getByRole('heading', { name: 'Open in web browser' })).toBeInTheDocument()
   })
 
   it('expands the collapsed sidebar before entering edit mode', () => {

--- a/webui/tests/sponsorsCredits.test.tsx
+++ b/webui/tests/sponsorsCredits.test.tsx
@@ -7,6 +7,9 @@ import { SponsorsCredits } from '../src/pages/SponsorsCredits'
 import { LEGACY_ROUTE_MANIFEST } from '../src/platform/routes'
 import { getVisibleNavItems } from '../src/nav'
 import { BrowserRouter } from '../src/router'
+import { PORTAL_HANDOFF_REQUEST_EVENT } from '../src/util/portalHandoff'
+
+const shellHost = vi.hoisted(() => vi.fn(() => true))
 
 vi.mock('../src/auth/portalAccess', () => ({
   usePortalAccess: () => ({ canAccessOwnerSurfaces: false }),
@@ -15,6 +18,10 @@ vi.mock('../src/auth/portalAccess', () => ({
 vi.mock('../src/util/viewer', () => ({
   isLocalViewer: () => false,
   isWindowsViewer: () => true,
+}))
+
+vi.mock('../src/util/shellBridge', () => ({
+  isShellHost: shellHost,
 }))
 
 const EXPECTED_CREDIT_NAMES = [
@@ -70,6 +77,29 @@ describe('Sponsors & Credits', () => {
       'href',
       'https://buymeacoffee.com/coastal_dst',
     )
+    const supportHeading = screen.getByRole('heading', { name: 'Support DST' })
+    const creditsHeading = screen.getByRole('heading', { name: 'Project Supporters' })
+    expect(supportHeading.compareDocumentPosition(creditsHeading) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy()
+  })
+
+  it('puts durable remote setup first and hides local portal handoff inside Help', () => {
+    const onPortalHandoff = vi.fn()
+    window.addEventListener(PORTAL_HANDOFF_REQUEST_EVENT, onPortalHandoff, { once: true })
+    render(
+      <BrowserRouter>
+        <MenuBar sidebarCollapsed={false} onToggleSidebar={vi.fn()} />
+      </BrowserRouter>,
+    )
+
+    expect(screen.queryByRole('button', { name: 'Open local portal in browser' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Help' }))
+    expect(screen.getByRole('link', { name: /Remote Portal Setup/ })).toHaveAttribute(
+      'href',
+      'https://coastal-ms.github.io/DST-DuneServerTool/remote',
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Open local portal in browser/ }))
+    expect(onPortalHandoff).toHaveBeenCalledTimes(1)
   })
 
   it('is public and preserves one direct top-menu route without crowding intermediate widths', () => {

--- a/webui/tests/sponsorsCredits.test.tsx
+++ b/webui/tests/sponsorsCredits.test.tsx
@@ -93,11 +93,15 @@ describe('Sponsors & Credits', () => {
 
     expect(screen.queryByRole('button', { name: 'Open local portal in browser' })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Help' }))
-    expect(screen.getByRole('link', { name: /Remote Portal Setup/ })).toHaveAttribute(
+    const remoteSetup = screen.getByRole('link', { name: /Remote Portal Setup/ })
+    expect(remoteSetup).toHaveAttribute(
       'href',
       'https://coastal-ms.github.io/DST-DuneServerTool/remote',
     )
-    fireEvent.click(screen.getByRole('button', { name: /Open local portal in browser/ }))
+    expect(remoteSetup).toHaveClass('text-text')
+    const localHandoff = screen.getByRole('button', { name: /Open local portal in browser/ })
+    expect(localHandoff).toHaveClass('text-text-dim')
+    fireEvent.click(localHandoff)
     expect(onPortalHandoff).toHaveBeenCalledTimes(1)
   })
 

--- a/webui/tests/sponsorsCredits.test.tsx
+++ b/webui/tests/sponsorsCredits.test.tsx
@@ -54,10 +54,8 @@ describe('Sponsors & Credits', () => {
   it('uses the typed source as the complete, unique public credit list', () => {
     expect(SUPPORTER_CREDITS.map(credit => credit.displayName)).toEqual(EXPECTED_CREDIT_NAMES)
     expect(new Set(SUPPORTER_CREDITS.map(credit => credit.displayName)).size).toBe(18)
-    expect(SUPPORTER_CREDITS.filter(credit => credit.recognition === 'Project Supporter')).toHaveLength(17)
-    expect(SUPPORTER_CREDITS.filter(credit => credit.recognition === 'Discord Sponsor')).toEqual([
-      { displayName: 'Ed O.', recognition: 'Discord Sponsor' },
-    ])
+    expect(new Set(SUPPORTER_CREDITS.map(credit => credit.thanks)).size).toBe(18)
+    expect(SUPPORTER_CREDITS.every(credit => credit.thanks.startsWith('Thank') || credit.thanks.startsWith('You') || credit.thanks.startsWith('Your'))).toBe(true)
   })
 
   it('renders every public credit once with one separate support action', () => {
@@ -70,8 +68,9 @@ describe('Sponsors & Credits', () => {
       expect(within(credits).getAllByText(name, { exact: true })).toHaveLength(1)
     }
     expect(within(credits).queryByText('Hawk_I5')).not.toBeInTheDocument()
-    expect(within(credits).getAllByText('Project Supporter')).toHaveLength(17)
-    expect(within(credits).getByText('Discord Sponsor')).toBeInTheDocument()
+    for (const credit of SUPPORTER_CREDITS) {
+      expect(within(credits).getByText(credit.thanks)).toBeInTheDocument()
+    }
     expect(screen.getAllByRole('link', { name: /Buy Me a Coffee/ })).toHaveLength(1)
     expect(screen.getByRole('link', { name: /Buy Me a Coffee/ })).toHaveAttribute(
       'href',

--- a/webui/tests/sponsorsCredits.test.tsx
+++ b/webui/tests/sponsorsCredits.test.tsx
@@ -100,7 +100,7 @@ describe('Sponsors & Credits', () => {
     )
     expect(remoteSetup).toHaveClass('text-text')
     const localHandoff = screen.getByRole('button', { name: /Open local portal in browser/ })
-    expect(localHandoff).toHaveClass('text-text-dim')
+    expect(localHandoff).toHaveClass('text-text')
     fireEvent.click(localHandoff)
     expect(onPortalHandoff).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
## Summary

- Keeps stable releases primary while retaining only the current and previous active test builds.
- Polishes navigation, support credits, and remote-access presentation based on test7 review.

## Validation

- Update-channel and focused WebUI tests
- WebUI and testing-site production builds
- Prerelease installer build from the exact commit