### PR TITLE
Batch online package delivery

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -121,7 +121,7 @@ body:
         - Web portal — Gameplay Admin — Market / Market Bot
         - Web portal — Gameplay Admin — Players
         - Web portal — Gameplay Admin — Players — Specs (Set level / Apply level rewards / Repair Pattern / Max / Reset)
-        - Web portal — Gameplay Admin — Players — Give Item / Give Package / Give Vehicle Kit / Grant Cosmetic / Max Augment Attributes / Variant (incl. "Allow overflow")
+        - Web portal — Gameplay Admin — Players — Give Item / Give Package / Give Vehicle Kit / Grant Cosmetic / All House Swatches / Max Augment Attributes / Variant (incl. "Allow overflow")
         - Web portal — Gameplay Admin — Players — Cheat Scripts / Dev-Perf Scripts (Live)
         - Web portal — Gameplay Admin — Players — Journey (node browser / complete / post-NPE reset to Find the Fremen / chosen starter-tree refund)
         - Web portal — Gameplay Admin — Players — Unlock Trainers (skill-tree ownership status) / Unlock Main Quest / Complete Contract (clear stuck contract) / Apply Quick Preset (Progression)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -85,7 +85,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-test8"
+      placeholder: "v15.0.0-test9"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ here cover everything those tags shipped.
 
 ### Added
 
-- Added a missing-only **All House Swatches** cosmetic preset with offline
-  gating, an exact preview count, and post-grant ownership verification.
+- Added a missing-only **All House Swatches** cosmetic preset that requires the
+  player online and applies live unlocks without creating backpack items.
 
 ## [15.0.0-test8] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,18 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.0-test9] - 2026-09-01
+
+Candidate metadata prepared for v15.0.0-test9; semantic version remains 15.0.0.
+
 ### Added
 
-- Added a missing-only **All House Swatches** cosmetic preset that requires the
-  player online and applies live unlocks without creating backpack items.
+- Added a missing-only **All House Swatches** cosmetic preset that delivers
+  physical unlock tokens through the live game, activates them while the player
+  remains online, and forces overflow if the backpack cannot hold them.
+- Batched online vehicle kits and saved item packages through one RMQ broker
+  session so every package entry is enqueued immediately without a separate
+  SSH/Kubernetes round trip or delay for each item.
 
 ## [15.0.0-test8] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- Added a missing-only **All House Swatches** cosmetic preset with offline
+  gating, an exact preview count, and post-grant ownership verification.
+
 ## [15.0.0-test8] - 2026-08-31
 
 Candidate metadata prepared for v15.0.0-test8; semantic version remains 15.0.0.

--- a/app/data/platform-route-policies.json
+++ b/app/data/platform-route-policies.json
@@ -163,7 +163,7 @@
     { "source": "PlayersAdmin.ps1", "capabilityId": "player.manage", "routeCount": 7, "sha256": "dc4f7da7eb846e1113f08a7ef04a1eb30878c5d05168c886ba1be4183e83883d" },
     { "source": "PlayersRead.ps1", "capabilityId": "player.view", "routeCount": 17, "sha256": "28e6db36d3b0f3f5f1ac92358d3eae529fdbb14cb4d069ab5af9378bba377cc0" },
     { "source": "PlayersRmq.ps1", "capabilityId": "player.manage", "routeCount": 10, "sha256": "b789053cad3a7c53140a41a5d4d70ab44354583750380a4d06835898c8010876" },
-    { "source": "PlayersWrites.ps1", "capabilityId": "player.manage", "routeCount": 36, "sha256": "93d72401d34ecec82c1ed817483d9352cc94a6a549e914d3b9a0a7405b665cd7" },
+    { "source": "PlayersWrites.ps1", "capabilityId": "player.manage", "routeCount": 37, "sha256": "655d27fb0a9873e0f7f57babb5cdc2c4e876e18102bfc8bd240aae90584a5662" },
     { "source": "Pods.ps1", "capabilityId": "operation.runtime", "routeCount": 3, "sha256": "86b85eb9a8fbc348525424496d562dd79589f8bf2b68feee0c096004bbdad749" },
     { "source": "Portal.ps1", "capabilityId": "platform.access", "routeCount": 4, "sha256": "5157a5616533c8ef9d71d691c9a01811ab69e87cdf6ce09ea60796bbc4cd260d" },
     { "source": "PortalAuth.ps1", "capabilityId": "platform.access", "routeCount": 13, "sha256": "35a10866afe87089d19960d895826b58b66d783cbc1d95078d62fb90bce56e6b" },

--- a/app/server/lib/Broadcast.ps1
+++ b/app/server/lib/Broadcast.ps1
@@ -194,29 +194,28 @@ rabbit_queue_type:publish_at_most_once(X, Msg).
     }
 }
 
-# Internal: package an Erlang expression as a single base64-encoded blob,
-# pipe it over SSH into the mq-game pod, and run it through `rabbitmqctl eval`.
+# Internal: stream an Erlang expression over SSH stdin into the mq-game pod and
+# run it through `rabbitmqctl eval`. Keeping the payload off the command line
+# avoids Windows process-argument limits for large command batches.
 function _Invoke-V6BroadcastErl {
     param(
         [Parameter(Mandatory)] [string] $Ip,
         [Parameter(Mandatory)] $Pod,
         [Parameter(Mandatory)] [string] $Erl,
         [string] $Action = 'broadcast',
-        [hashtable] $Extra
+        [hashtable] $Extra,
+        [int] $TimeoutSec = 30
     )
     # Strip CRs — heredoc above is CRLF-terminated when read from a CRLF .ps1.
     $clean = ($Erl -replace "`r","")
-    $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($clean))
 
-    # The inner remote script: base64-decode the Erlang into a temp file,
-    # ensure the RabbitMQ + Erlang binaries are on PATH, then run rabbitmqctl
-    # eval with the script contents. PATH mirrors the upstream
-    # send-dune-broadcast script.
+    # Keep the remote command tiny and feed the Erlang through Invoke-V6Ssh's
+    # redirected stdin. PATH mirrors the upstream send-dune-broadcast script.
     $remote = "set -eu; export PATH=/opt/rabbitmq/sbin:/opt/erlang/lib/erlang/bin:/opt/erlang/lib/erlang/erts-14.2.5.12/bin:/bin:/usr/bin:/usr/local/bin:`$PATH; expr=`$(cat); /opt/rabbitmq/sbin/rabbitmqctl eval `"`$expr`""
     $remoteB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($remote))
 
-    $sshCmd = "echo $b64 | base64 -d | sudo kubectl exec -i -n $($Pod.ns) $($Pod.name) -- sh -lc `"`$(echo $remoteB64 | base64 -d)`" 2>&1"
-    $out = Invoke-V6Ssh -Ip $Ip -Cmd $sshCmd -TimeoutSec 30
+    $sshCmd = "sudo kubectl exec -i -n $($Pod.ns) $($Pod.name) -- sh -lc `"`$(echo $remoteB64 | base64 -d)`" 2>&1"
+    $out = Invoke-V6Ssh -Ip $Ip -Cmd $sshCmd -TimeoutSec $TimeoutSec -StdinData $clean
     $text = (($out -join "`n")).Trim()
 
     # rabbitmqctl eval returns "{ok,enqueued}." or similar on success and

--- a/app/server/lib/Gameplay.ps1
+++ b/app/server/lib/Gameplay.ps1
@@ -187,6 +187,16 @@ function Get-DuneCosmeticsCatalog {
     return @{ ok = $true; templates = $out; total = $out.Count }
 }
 
+function Get-DuneHouseSwatchCatalog {
+    $catalog = Get-DuneCosmeticsCatalog
+    return @($catalog.templates |
+        Where-Object {
+            [string]$_.group -eq 'Swatches (Dyes)' -and
+            [string]$_.name -match '^House .+ Swatch$'
+        } |
+        Sort-Object { $_.name }, { $_.template })
+}
+
 # Stats blob for a freshly-inserted give-item row. The game cannot deserialize an
 # item with empty stats ('{}') and silently drops it on zone/login load, so the
 # row exists in the DB but never materializes in-game. It also needs the SHAPE

--- a/app/server/lib/PlayersRead.ps1
+++ b/app/server/lib/PlayersRead.ps1
@@ -115,12 +115,40 @@ function Get-DuneProgressionPresetCatalog {
     return $script:DuneProgressionPresetCatalog
 }
 
+# Convert Funcom's persisted House Swatch IDs back to the grant-token template
+# exposed by the catalog. These IDs use four prefix families and retain several
+# shipped spelling inconsistencies.
+function ConvertFrom-DuneHouseSwatchCustomizationId {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+    if ($Value -notmatch '^(?<prefix>HArmCharDyepack|LArmCharDyepack|StillSCharDyepack|PlaceableDyePack)(?<house>[A-Za-z0-9]+)$') {
+        return ''
+    }
+
+    $prefix = [string]$Matches['prefix']
+    $house = [string]$Matches['house']
+    if ($house -ieq 'Talgari') { $house = 'Taligari' }
+    if ($prefix -ieq 'PlaceableDyePack' -and $house -ieq 'Wayku') { $house = 'Wakyu' }
+
+    $kind = switch -Regex ($prefix) {
+        '^HArmCharDyepack$'   { 'HeavyArmor'; break }
+        '^LArmCharDyepack$'   { 'LightArmor'; break }
+        '^StillSCharDyepack$' { 'Stillsuit'; break }
+        '^PlaceableDyePack$'  { 'Placeables'; break }
+        default               { return '' }
+    }
+    return "${house}_${kind}_Swatch"
+}
+
 # Convert both persisted customization IDs and grant-wrapper catalog entries to
 # the same semantic key. Funcom changes word order, abbreviates vehicle names,
 # stores armor slots instead of set wrappers, and occasionally ships typos.
 function Get-DuneCosmeticCanonicalKey {
     param([string]$Value)
     if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+
+    $houseSwatchTemplate = ConvertFrom-DuneHouseSwatchCustomizationId -Value $Value
+    if ($houseSwatchTemplate) { $Value = $houseSwatchTemplate }
 
     $expanded = $Value -replace '^(?i:MTX)_B\d+C\d+_', 'MTX_'
     $expanded = $expanded -creplace '([a-z0-9])([A-Z])', '$1_$2'

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -439,7 +439,11 @@ function Invoke-DunePlayerGrantHouseSwatches {
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
 
     $off = Test-DunePlayerOffline -Ip $Ip -PawnId $PawnId
-    if (-not $off.ok) { return @{ ok = $false; error = $off.reason } }
+    if ($off.ok) {
+        return @{ ok = $false; error = 'Player must be online so House Swatches unlock immediately instead of becoming backpack items.' }
+    }
+    $fls = Resolve-DuneFlsIdOrError -Ip $Ip -ActorId $PawnId
+    if (-not $fls.ok) { return @{ ok = $false; error = $fls.error } }
 
     $houseSwatches = @(Get-DuneHouseSwatchCatalog)
     if ($houseSwatches.Count -eq 0) {
@@ -463,102 +467,44 @@ function Invoke-DunePlayerGrantHouseSwatches {
             total = $houseSwatches.Count
             already_owned = $alreadyOwned
             requested = 0
-            verified = 0
-            unresolved = @()
+            granted = 0
+            failed = @()
         }
     }
 
-    $values = [System.Collections.Generic.List[string]]::new()
+    $failed = [System.Collections.Generic.List[string]]::new()
+    $granted = 0
     foreach ($entry in $missing) {
         $template = [string]$entry.template
-        $valid = Test-DuneValidGiveTemplate -TemplateId $template
-        if (-not $valid.ok) {
-            return @{ ok = $false; error = "invalid House Swatch '$template': $($valid.error)" }
+        if ($granted -gt 0) { Start-Sleep -Milliseconds 200 }
+        $result = Invoke-DunePlayerGiveItemLive -Ip $Ip -ActorId 0 -FlsId ([string]$fls.fls_id) `
+            -Template $template -Quantity 1 -Durability 1.0 -AllowOverflow $true
+        if ($result.ok) {
+            $granted++
+        } else {
+            $failed.Add($template)
         }
-        $safeTemplate = ConvertTo-DuneSqlString $template
-        $statsJson = ConvertTo-DuneSqlString (Get-DuneGiveItemStatsJson -TemplateId $template)
-        $values.Add("('$safeTemplate'::text, '$statsJson'::jsonb)")
     }
-    $valuesClause = $values -join ",`n        "
-    $sql = @"
-WITH inv AS (
-    SELECT id
-    FROM dune.inventories
-    WHERE actor_id = $PawnId::bigint AND inventory_type = 0
-    ORDER BY id
-    LIMIT 1
-),
-payload(template_id, stats) AS (
-    VALUES
-        $valuesClause
-),
-base AS (
-    SELECT inv.id AS inventory_id,
-           COALESCE(MAX(i.position_index), -1)::bigint + 1 AS first_position
-    FROM inv
-    LEFT JOIN dune.items i ON i.inventory_id = inv.id
-    GROUP BY inv.id
-),
-inserted AS (
-    INSERT INTO dune.items (
-        inventory_id, stack_size, position_index, template_id,
-        quality_level, acquisition_time, stats
-    )
-    SELECT base.inventory_id,
-           1::bigint,
-           base.first_position + ROW_NUMBER() OVER (ORDER BY payload.template_id) - 1,
-           payload.template_id,
-           0::bigint,
-           EXTRACT(EPOCH FROM now())::bigint,
-           payload.stats
-    FROM base
-    CROSS JOIN payload
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM dune.items existing
-        WHERE existing.inventory_id = base.inventory_id
-          AND existing.template_id = payload.template_id
-    )
-    RETURNING template_id
-)
-SELECT COALESCE(jsonb_agg(template_id ORDER BY template_id), '[]'::jsonb)::text AS inserted
-FROM inserted;
-"@
-    $write = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 60 -Bulk
-    if (-not $write.ok) { return @{ ok = $false; error = "grant House Swatches: $($write.error)" } }
-
-    $after = Get-DunePlayerOwnedCosmeticsLive -Ip $Ip -AccountId $AccountId
-    if (-not $after.ok) {
-        return @{ ok = $false; error = "verify House Swatch ownership: $($after.error)" }
-    }
-    $ownedAfter = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-    foreach ($id in @($after.owned)) {
-        if (-not [string]::IsNullOrWhiteSpace([string]$id)) { [void]$ownedAfter.Add([string]$id) }
-    }
-    $unresolved = @($missing |
-        Where-Object { -not $ownedAfter.Contains([string]$_.template) } |
-        ForEach-Object { [string]$_.template })
-    $verified = $missing.Count - $unresolved.Count
-    if ($unresolved.Count -gt 0) {
+    if ($failed.Count -gt 0) {
         return @{
             ok = $false
-            error = "$verified/$($missing.Count) missing House Swatches verified; $($unresolved.Count) did not register."
+            error = "$granted/$($missing.Count) House Swatch live grants were accepted; $($failed.Count) failed."
             total = $houseSwatches.Count
             already_owned = $alreadyOwned
             requested = $missing.Count
-            verified = $verified
-            unresolved = $unresolved
+            granted = $granted
+            failed = $failed.ToArray()
         }
     }
 
     return @{
         ok = $true
-        message = "Granted and verified $verified missing House Swatch$(if ($verified -eq 1) { '' } else { 'es' })."
+        message = "Granted $granted missing House Swatch$(if ($granted -eq 1) { '' } else { 'es' }) live with no backpack items."
         total = $houseSwatches.Count
         already_owned = $alreadyOwned
         requested = $missing.Count
-        verified = $verified
-        unresolved = @()
+        granted = $granted
+        failed = @()
     }
 }
 

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -433,6 +433,135 @@ function Invoke-DunePlayerGiveItemsBulk {
     return @{ ok = $ok; message = $msg; results = $results.ToArray(); failures = $failures; total = $total }
 }
 
+function Invoke-DunePlayerGrantHouseSwatches {
+    param([string]$Ip, [long]$PawnId, [long]$AccountId)
+    if ($PawnId -le 0) { return @{ ok = $false; error = 'pawn_id is required.' } }
+    if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
+
+    $off = Test-DunePlayerOffline -Ip $Ip -PawnId $PawnId
+    if (-not $off.ok) { return @{ ok = $false; error = $off.reason } }
+
+    $houseSwatches = @(Get-DuneHouseSwatchCatalog)
+    if ($houseSwatches.Count -eq 0) {
+        return @{ ok = $false; error = 'House Swatch catalog is empty.' }
+    }
+
+    $before = Get-DunePlayerOwnedCosmeticsLive -Ip $Ip -AccountId $AccountId
+    if (-not $before.ok) {
+        return @{ ok = $false; error = "read current House Swatch ownership: $($before.error)" }
+    }
+    $ownedBefore = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($id in @($before.owned)) {
+        if (-not [string]::IsNullOrWhiteSpace([string]$id)) { [void]$ownedBefore.Add([string]$id) }
+    }
+    $missing = @($houseSwatches | Where-Object { -not $ownedBefore.Contains([string]$_.template) })
+    $alreadyOwned = $houseSwatches.Count - $missing.Count
+    if ($missing.Count -eq 0) {
+        return @{
+            ok = $true
+            message = "All $($houseSwatches.Count) House Swatches are already owned."
+            total = $houseSwatches.Count
+            already_owned = $alreadyOwned
+            requested = 0
+            verified = 0
+            unresolved = @()
+        }
+    }
+
+    $values = [System.Collections.Generic.List[string]]::new()
+    foreach ($entry in $missing) {
+        $template = [string]$entry.template
+        $valid = Test-DuneValidGiveTemplate -TemplateId $template
+        if (-not $valid.ok) {
+            return @{ ok = $false; error = "invalid House Swatch '$template': $($valid.error)" }
+        }
+        $safeTemplate = ConvertTo-DuneSqlString $template
+        $statsJson = ConvertTo-DuneSqlString (Get-DuneGiveItemStatsJson -TemplateId $template)
+        $values.Add("('$safeTemplate'::text, '$statsJson'::jsonb)")
+    }
+    $valuesClause = $values -join ",`n        "
+    $sql = @"
+WITH inv AS (
+    SELECT id
+    FROM dune.inventories
+    WHERE actor_id = $PawnId::bigint AND inventory_type = 0
+    ORDER BY id
+    LIMIT 1
+),
+payload(template_id, stats) AS (
+    VALUES
+        $valuesClause
+),
+base AS (
+    SELECT inv.id AS inventory_id,
+           COALESCE(MAX(i.position_index), -1)::bigint + 1 AS first_position
+    FROM inv
+    LEFT JOIN dune.items i ON i.inventory_id = inv.id
+    GROUP BY inv.id
+),
+inserted AS (
+    INSERT INTO dune.items (
+        inventory_id, stack_size, position_index, template_id,
+        quality_level, acquisition_time, stats
+    )
+    SELECT base.inventory_id,
+           1::bigint,
+           base.first_position + ROW_NUMBER() OVER (ORDER BY payload.template_id) - 1,
+           payload.template_id,
+           0::bigint,
+           EXTRACT(EPOCH FROM now())::bigint,
+           payload.stats
+    FROM base
+    CROSS JOIN payload
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM dune.items existing
+        WHERE existing.inventory_id = base.inventory_id
+          AND existing.template_id = payload.template_id
+    )
+    RETURNING template_id
+)
+SELECT COALESCE(jsonb_agg(template_id ORDER BY template_id), '[]'::jsonb)::text AS inserted
+FROM inserted;
+"@
+    $write = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 60 -Bulk
+    if (-not $write.ok) { return @{ ok = $false; error = "grant House Swatches: $($write.error)" } }
+
+    $after = Get-DunePlayerOwnedCosmeticsLive -Ip $Ip -AccountId $AccountId
+    if (-not $after.ok) {
+        return @{ ok = $false; error = "verify House Swatch ownership: $($after.error)" }
+    }
+    $ownedAfter = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($id in @($after.owned)) {
+        if (-not [string]::IsNullOrWhiteSpace([string]$id)) { [void]$ownedAfter.Add([string]$id) }
+    }
+    $unresolved = @($missing |
+        Where-Object { -not $ownedAfter.Contains([string]$_.template) } |
+        ForEach-Object { [string]$_.template })
+    $verified = $missing.Count - $unresolved.Count
+    if ($unresolved.Count -gt 0) {
+        return @{
+            ok = $false
+            error = "$verified/$($missing.Count) missing House Swatches verified; $($unresolved.Count) did not register."
+            total = $houseSwatches.Count
+            already_owned = $alreadyOwned
+            requested = $missing.Count
+            verified = $verified
+            unresolved = $unresolved
+        }
+    }
+
+    return @{
+        ok = $true
+        message = "Granted and verified $verified missing House Swatch$(if ($verified -eq 1) { '' } else { 'es' })."
+        total = $houseSwatches.Count
+        already_owned = $alreadyOwned
+        requested = $missing.Count
+        verified = $verified
+        unresolved = @()
+    }
+}
+
 # Repair equipped gear — OFFLINE only. Sets every durability item in the gear
 # inventory types to GREATEST(catalog.max_durability, item.MaxDurability,
 # item.CurrentDurability, item.DecayedMaxDurability), so a buggy/decayed

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -365,8 +365,9 @@ WHERE template_id = 'ContractItem'
 # §3 — Items / inventory
 # ---------------------------------------------------------------------------
 
-# Bulk give: loops the existing single-template give. Items is an array of
-# @{ template = '...'; qty = N; quality = M }.
+# Bulk give. Online default-quality entries with forced overflow share one
+# broker session; guarded-capacity, custom-quality, and offline writes retain
+# their existing per-item paths.
 function Invoke-DunePlayerGiveItemsBulk {
     param([string]$Ip, [long]$PawnId, $Items, [string]$FlsId, [bool]$AllowOverflow = $true)
     if ($PawnId -le 0) { return @{ ok = $false; error = 'pawn_id is required.' } }
@@ -386,30 +387,42 @@ function Invoke-DunePlayerGiveItemsBulk {
         $fr = Resolve-DuneFlsIdOrError -Ip $Ip -ActorId $PawnId
         if ($fr.ok) { $fls = [string]$fr.fls_id }
     }
-    $results = New-Object System.Collections.Generic.List[object]
-    $failures = 0
-    # Each RMQ ServerCommand is applied asynchronously by the game; firing several
-    # AddItemToInventory commands back-to-back can outrun the deposit so later items
-    # (often the bulky vehicle modules at the end of a kit) silently never land.
-    # Space consecutive live gives so the game finishes depositing each before the next.
-    $rmqGives = 0
-    $rmqSpacingMs = 500
-    foreach ($it in $Items) {
+    $sourceItems = @($Items)
+    $results = [object[]]::new($sourceItems.Count)
+    $batchEntries = [System.Collections.Generic.List[object]]::new()
+    $batchIndices = [System.Collections.Generic.List[int]]::new()
+    $rmqSpacingMs = 0
+    for ($index = 0; $index -lt $sourceItems.Count; $index++) {
+        $it = $sourceItems[$index]
         $tmpl = [string](Get-DuneBodyValue -Body $it -Name 'template')
         $qty = [int64](Get-DuneBodyInt -Body $it -Name 'qty')
         $qlevel = Get-DuneBodyInt -Body $it -Name 'quality'
         if ($null -eq $qlevel) { $qlevel = 0L }
         if (-not $tmpl) {
-            $results.Add(@{ ok = $false; error = 'template missing' })
-            $failures++; continue
+            $results[$index] = @{ ok = $false; error = 'template missing' }
+            continue
         }
         if ($qty -le 0) { $qty = 1 }
         if ($isOnline -and $qlevel -le 0 -and -not [string]::IsNullOrWhiteSpace($fls)) {
-            # Online + default quality → RMQ live (instant, no relog)
-            if ($rmqGives -gt 0) { Start-Sleep -Milliseconds $rmqSpacingMs }
-            $r = Invoke-DunePlayerGiveItemLive -Ip $Ip -ActorId $PawnId -FlsId $fls -Template $tmpl -Quantity ([int]$qty) -Durability 1.0 -AllowOverflow $AllowOverflow
+            if ($AllowOverflow) {
+                $tv = Test-DuneValidGiveTemplate -TemplateId $tmpl
+                if (-not $tv.ok) {
+                    $results[$index] = @{ ok = $false; error = $tv.error }
+                    continue
+                }
+                $batchEntries.Add([pscustomobject]@{
+                    ItemName = $tmpl
+                    Quantity = [int]$qty
+                    Durability = 1.0
+                })
+                $batchIndices.Add($index)
+                continue
+            }
+            # Capacity-guarded gives remain sequential because each deposit changes
+            # the available-space calculation for the next package entry.
+            $r = Invoke-DunePlayerGiveItemLive -Ip $Ip -ActorId $PawnId -FlsId $fls `
+                -Template $tmpl -Quantity ([int]$qty) -Durability 1.0 -AllowOverflow $false
             if ($r.ok -and -not $r.path) { $r['path'] = 'rmq' }
-            $rmqGives++
         } else {
             # Offline, OR online with custom quality / unresolved fls → SQL
             $r = Invoke-DunePlayerGiveItem -Ip $Ip -PawnId $PawnId -Template $tmpl -Qty $qty -Quality ([int64]$qlevel)
@@ -420,17 +433,30 @@ function Invoke-DunePlayerGiveItemsBulk {
                 }
             }
         }
-        $results.Add($r)
-        if (-not $r.ok) { $failures++ }
+        $results[$index] = $r
     }
-    $total = @($Items).Count
+
+    if ($batchEntries.Count -gt 0) {
+        $batchResult = Invoke-DuneRmqAddItemEntriesToInventoryBatch -FlsId $fls `
+            -Items $batchEntries.ToArray() -SpacingMilliseconds $rmqSpacingMs
+        foreach ($index in $batchIndices) {
+            $results[$index] = if ($batchResult.ok) {
+                @{ ok = $true; path = 'rmq'; message = 'Accepted in live item batch.' }
+            } else {
+                @{ ok = $false; error = $batchResult.message }
+            }
+        }
+    }
+
+    $failures = @($results | Where-Object { -not $_.ok }).Count
+    $total = $sourceItems.Count
     $ok = $failures -lt $total
     $msg = if ($failures -eq 0) {
         "Gave $total item template(s) to pawn $PawnId."
     } else {
         "$($total - $failures)/$total item templates gave OK; $failures failed."
     }
-    return @{ ok = $ok; message = $msg; results = $results.ToArray(); failures = $failures; total = $total }
+    return @{ ok = $ok; message = $msg; results = $results; failures = $failures; total = $total }
 }
 
 function Invoke-DunePlayerGrantHouseSwatches {
@@ -440,7 +466,7 @@ function Invoke-DunePlayerGrantHouseSwatches {
 
     $off = Test-DunePlayerOffline -Ip $Ip -PawnId $PawnId
     if ($off.ok) {
-        return @{ ok = $false; error = 'Player must be online so House Swatches unlock immediately instead of becoming backpack items.' }
+        return @{ ok = $false; error = 'Player must be online so House Swatch tokens can be delivered through the live game.' }
     }
     $fls = Resolve-DuneFlsIdOrError -Ip $Ip -ActorId $PawnId
     if (-not $fls.ok) { return @{ ok = $false; error = $fls.error } }
@@ -472,39 +498,34 @@ function Invoke-DunePlayerGrantHouseSwatches {
         }
     }
 
-    $failed = [System.Collections.Generic.List[string]]::new()
-    $granted = 0
-    foreach ($entry in $missing) {
-        $template = [string]$entry.template
-        if ($granted -gt 0) { Start-Sleep -Milliseconds 200 }
-        $result = Invoke-DunePlayerGiveItemLive -Ip $Ip -ActorId 0 -FlsId ([string]$fls.fls_id) `
-            -Template $template -Quantity 1 -Durability 1.0 -AllowOverflow $true
-        if ($result.ok) {
-            $granted++
-        } else {
-            $failed.Add($template)
-        }
-    }
-    if ($failed.Count -gt 0) {
+    $missingTemplates = @($missing | ForEach-Object { [string]$_.template })
+    $result = Invoke-DuneRmqAddItemsToInventoryBatch -FlsId ([string]$fls.fls_id) `
+        -ItemNames $missingTemplates -SpacingMilliseconds 200
+    if (-not $result.ok) {
         return @{
             ok = $false
-            error = "$granted/$($missing.Count) House Swatch live grants were accepted; $($failed.Count) failed."
+            error = "House Swatch token batch failed: $($result.message)"
             total = $houseSwatches.Count
             already_owned = $alreadyOwned
             requested = $missing.Count
-            granted = $granted
-            failed = $failed.ToArray()
+            granted = 0
+            failed = $missingTemplates
+            delivery = 'tokens'
+            overflow = $true
         }
     }
 
+    $granted = $missing.Count
     return @{
         ok = $true
-        message = "Granted $granted missing House Swatch$(if ($granted -eq 1) { '' } else { 'es' }) live with no backpack items."
+        message = "Delivered $granted missing House Swatch token$(if ($granted -eq 1) { '' } else { 's' }) through the live game. Delivery starts immediately; the player must remain online until the activation cascade starts and completely stops. This usually takes about a minute. Overflow drops beside the player."
         total = $houseSwatches.Count
         already_owned = $alreadyOwned
         requested = $missing.Count
         granted = $granted
         failed = @()
+        delivery = 'tokens'
+        overflow = $true
     }
 }
 

--- a/app/server/lib/Rmq.ps1
+++ b/app/server/lib/Rmq.ps1
@@ -61,6 +61,71 @@ rabbit_queue_type:publish_at_most_once(X, Msg).
     return _Invoke-V6BroadcastErl -Ip $ip -Pod $pod -Erl $erl -Action $Action -Extra $Extra
 }
 
+# Publish several ServerCommands through one rabbitmqctl invocation. Keeping the
+# pacing inside the broker session avoids an SSH/kubectl round trip per item.
+function Send-DuneRmqServerCommandBatch {
+    param(
+        [Parameter(Mandatory)] [hashtable[]] $Fields,
+        [ValidateRange(0, 5000)] [int] $SpacingMilliseconds = 0,
+        [string] $Action = 'server-command-batch',
+        [hashtable] $Extra
+    )
+
+    if ($Fields.Count -eq 0) {
+        return @{ ok = $false; status = 400; message = 'At least one ServerCommand is required.' }
+    }
+
+    $ctx = Get-V6BroadcastContext
+    if (-not $ctx.ok) { return $ctx }
+    $ip = $ctx.vm.ip
+    try { $pod = Find-V6MqGamePod -Ip $ip } catch {
+        return @{ ok = $false; status = 503; message = $_.Exception.Message }
+    }
+
+    $encoded = [System.Collections.Generic.List[string]]::new()
+    for ($i = 0; $i -lt $Fields.Count; $i++) {
+        $innerJson = ConvertTo-Json $Fields[$i] -Depth 8 -Compress
+        $envelope = [ordered]@{
+            Version        = 2
+            AuthToken      = $script:DuneRmqAuthToken
+            MessageContent = $innerJson
+        }
+        $outerJson = ConvertTo-Json $envelope -Depth 8 -Compress
+        $outerB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($outerJson))
+        $encoded.Add("{base64:decode(<<`"$outerB64`">>), $i}")
+    }
+
+    $messageList = $encoded -join ",`n"
+    $stamp = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+    $erl = @"
+XName = rabbit_misc:r(<<"/">>, exchange, <<"heartbeats">>),
+X = rabbit_exchange:lookup_or_die(XName),
+Messages = [$messageList],
+lists:foreach(fun({Outer, Index}) ->
+    MsgId = list_to_binary("dune-tool-batch-$stamp-" ++ integer_to_list(Index)),
+    P = {list_to_atom("P_basic"), <<"Content">>, undefined, [], undefined,
+         undefined, undefined, undefined, undefined, MsgId, undefined,
+         undefined, <<"fls">>, <<"fls_backend">>, undefined},
+    Content = rabbit_basic:build_content(P, Outer),
+    {ok, Msg} = rabbit_basic:message(XName, <<"notifications">>, Content),
+    rabbit_queue_type:publish_at_most_once(X, Msg),
+    timer:sleep($SpacingMilliseconds)
+end, Messages),
+{ok, enqueued, length(Messages)}.
+"@
+
+    $batchExtra = @{
+        total      = $Fields.Count
+        spacing_ms = $SpacingMilliseconds
+    }
+    if ($Extra) {
+        foreach ($key in $Extra.Keys) { $batchExtra[$key] = $Extra[$key] }
+    }
+    $timeoutSec = [Math]::Max(30, [int][Math]::Ceiling(($Fields.Count * $SpacingMilliseconds) / 1000.0) + 20)
+    return _Invoke-V6BroadcastErl -Ip $ip -Pod $pod -Erl $erl -Action $Action `
+        -Extra $batchExtra -TimeoutSec $timeoutSec
+}
+
 # Send-DuneRmqCourierMessage
 # Publishes a courier-system message (chat/whisper). Routing differs from
 # ServerCommand: exchange + routing key are channel-specific and the basic
@@ -274,6 +339,54 @@ function Invoke-DuneRmqAddItemToInventory {
         Quantity      = $Quantity
         Durability    = $Durability
     } -Action 'give-item-live'
+}
+
+function Invoke-DuneRmqAddItemEntriesToInventoryBatch {
+    param(
+        [Parameter(Mandatory)] [string] $FlsId,
+        [Parameter(Mandatory)] [object[]] $Items,
+        [ValidateRange(0, 5000)] [int] $SpacingMilliseconds = 200
+    )
+
+    if ($Items.Count -eq 0) {
+        return @{ ok = $false; status = 400; message = 'At least one item is required.' }
+    }
+
+    $commands = [System.Collections.Generic.List[hashtable]]::new()
+    foreach ($item in $Items) {
+        $itemName = [string]$item.ItemName
+        if ([string]::IsNullOrWhiteSpace($itemName)) {
+            return @{ ok = $false; status = 400; message = 'Item templates cannot be blank.' }
+        }
+        $quantity = [int]$item.Quantity
+        if ($quantity -le 0) { $quantity = 1 }
+        $durability = [double]$item.Durability
+        if ($durability -le 0) { $durability = 1.0 }
+        $commands.Add(@{
+            ServerCommand = 'AddItemToInventory'
+            PlayerId      = $FlsId
+            ItemName      = $itemName
+            Quantity      = $quantity
+            Durability    = $durability
+        })
+    }
+
+    return Send-DuneRmqServerCommandBatch -Fields $commands.ToArray() `
+        -SpacingMilliseconds $SpacingMilliseconds -Action 'give-items-live-batch'
+}
+
+function Invoke-DuneRmqAddItemsToInventoryBatch {
+    param(
+        [Parameter(Mandatory)] [string] $FlsId,
+        [Parameter(Mandatory)] [string[]] $ItemNames,
+        [ValidateRange(0, 5000)] [int] $SpacingMilliseconds = 200
+    )
+
+    $items = @($ItemNames | ForEach-Object {
+        [pscustomobject]@{ ItemName = $_; Quantity = 1; Durability = 1.0 }
+    })
+    return Invoke-DuneRmqAddItemEntriesToInventoryBatch -FlsId $FlsId -Items $items `
+        -SpacingMilliseconds $SpacingMilliseconds
 }
 
 function Invoke-DuneRmqCheatScript {

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -25,6 +25,23 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-items' -Handle
     }
 }
 
+# POST /api/gameplay/players/grant-house-swatches  { pawn_id, account_id }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/grant-house-swatches' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        $account = Get-DuneBodyInt -Body $body -Name 'account_id'
+        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
+        if ($null -eq $account -or $account -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action {
+            param($ip)
+            Invoke-DunePlayerGrantHouseSwatches -Ip $ip -PawnId $pawn -AccountId $account
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Grant House Swatches failed: $($_.Exception.Message)"
+    }
+}
+
 # POST /api/gameplay/players/repair-gear  { pawn_id }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/repair-gear' -Handler {
     param($req, $res, $routeParams, $body)

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -4451,12 +4451,12 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=14.16"
       }
     },
     "node_modules/deepmerge": {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -3976,9 +3976,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4042,9 +4042,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4061,11 +4061,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4111,9 +4111,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4543,9 +4543,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.376",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
-      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6841,9 +6841,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8532,9 +8532,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [
         {
           "type": "opencollective",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -32,6 +32,7 @@
   },
   "private": true,
   "overrides": {
+    "decode-uri-component": "0.5.0",
     "nanoid": "3.3.18",
     "uuid": "11.1.1"
   }

--- a/tests/Broadcast.Tests.ps1
+++ b/tests/Broadcast.Tests.ps1
@@ -1,0 +1,39 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+
+    $script:sshArgs = $null
+    function global:Invoke-V6Ssh {
+        param($Ip, $Cmd, $TimeoutSec, $StdinData)
+        $script:sshArgs = @{
+            Ip = $Ip
+            Cmd = $Cmd
+            TimeoutSec = $TimeoutSec
+            StdinData = $StdinData
+        }
+        return '{ok,enqueued,103}.'
+    }
+
+    $broadcastPath = Join-Path (Get-DstRepoRoot) 'app\server\lib\Broadcast.ps1'
+    . $broadcastPath
+    Set-Item function:global:_Invoke-V6BroadcastErl -Value ${function:_Invoke-V6BroadcastErl}
+}
+
+AfterAll {
+    Remove-Item function:global:Invoke-V6Ssh -ErrorAction SilentlyContinue
+}
+
+Describe '_Invoke-V6BroadcastErl transport' -Tag 'Rmq' {
+    It 'streams large Erlang payloads over stdin instead of the SSH command line' {
+        $erl = 'X' * 50000
+
+        $r = _Invoke-V6BroadcastErl -Ip '10.0.0.5' `
+            -Pod @{ ns = 'test-ns'; name = 'mq-test' } `
+            -Erl $erl -Action 'large-batch' -TimeoutSec 75
+
+        $r.ok | Should -BeTrue
+        $script:sshArgs.StdinData | Should -Be $erl
+        $script:sshArgs.Cmd.Length | Should -BeLessThan 1000
+        $script:sshArgs.Cmd | Should -Not -Match ([regex]::Escape($erl.Substring(0, 100)))
+        $script:sshArgs.TimeoutSec | Should -Be 75
+    }
+}

--- a/tests/PlatformContracts.Tests.ps1
+++ b/tests/PlatformContracts.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'Complete route classification' {
     It 'classifies the exact registered HTTP and WebSocket inventory' {
         $records = @(Get-PlatformRouteRecords)
         $manifest = Get-DuneRoutePolicyManifest
-        $records.Count | Should -Be 354
+        $records.Count | Should -Be 355
         $sources = @($records.SourceFile | Sort-Object -Unique)
         @($manifest.groups.source | Sort-Object) | Should -Be $sources
 
@@ -302,7 +302,7 @@ $result = @{
         $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
         $resultLine = @($output | Where-Object { [string]$_ -like 'ROUTE_RESULT:*' })[-1]
         $result = ([string]$resultLine).Substring('ROUTE_RESULT:'.Length) | ConvertFrom-Json
-        $result.total | Should -Be 354
+        $result.total | Should -Be 355
         $result.unclassified | Should -Be 0
         $result.incompatible | Should -Be 0
         $result.podsCleanup | Should -Be 1

--- a/tests/PlayerCosmeticOwnership.Tests.ps1
+++ b/tests/PlayerCosmeticOwnership.Tests.ps1
@@ -68,6 +68,21 @@ Describe 'Get-DunePlayerOwnedCosmeticsLive' -Tag 'Pure' {
         Get-DuneCosmeticCanonicalKey 'MTX_Smug_Formal01_Bottom' | Should -Be (
             Get-DuneCosmeticCanonicalKey 'MTX_SmugFormalSetVariant_Bottom'
         )
+        Get-DuneCosmeticCanonicalKey 'HArmCharDyepackAgrosaz' | Should -Be (
+            Get-DuneCosmeticCanonicalKey 'Agrosaz_HeavyArmor_Swatch'
+        )
+        Get-DuneCosmeticCanonicalKey 'LArmCharDyepackEcaz' | Should -Be (
+            Get-DuneCosmeticCanonicalKey 'Ecaz_LightArmor_Swatch'
+        )
+        Get-DuneCosmeticCanonicalKey 'StillSCharDyepackTalgari' | Should -Be (
+            Get-DuneCosmeticCanonicalKey 'Taligari_Stillsuit_Swatch'
+        )
+        Get-DuneCosmeticCanonicalKey 'PlaceableDyePackArgosaz' | Should -Be (
+            Get-DuneCosmeticCanonicalKey 'Argosaz_Placeables_Swatch'
+        )
+        Get-DuneCosmeticCanonicalKey 'PlaceableDyePackWayku' | Should -Be (
+            Get-DuneCosmeticCanonicalKey 'Wakyu_Placeables_Swatch'
+        )
     }
 
     It 'queries all persistence locations read by the ownership filter' {

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -158,6 +158,7 @@ Describe 'Invoke-DunePlayerGiveItemsBulk overflow' -Tag 'Pure' {
             if ($null -ne $Body -and $Body.PSObject.Properties[$Name]) { return $Body.$Name }
             return $null
         }
+
         function global:Get-DuneBodyInt {
             param($Body, [string]$Name)
             $v = Get-DuneBodyValue -Body $Body -Name $Name
@@ -192,6 +193,60 @@ Describe 'Invoke-DunePlayerGiveItemsBulk overflow' -Tag 'Pure' {
         $script:liveArgs.AllowOverflow | Should -BeTrue
         $script:liveArgs.Template | Should -Be 'Ammo'
         $script:liveArgs.Quantity | Should -Be 500
+    }
+}
+
+Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
+    BeforeEach {
+        $script:ownershipReads = 0
+        $script:capturedSql = ''
+        function global:Test-DunePlayerOffline { return @{ ok = $true } }
+        function global:Get-DuneHouseSwatchCatalog {
+            return @(
+                @{ template = 'Ecaz_HeavyArmor_Swatch'; name = 'House Ecaz Garment Swatch'; group = 'Swatches (Dyes)' },
+                @{ template = 'Ecaz_Placeables_Swatch'; name = 'House Ecaz Placeables Swatch'; group = 'Swatches (Dyes)' }
+            )
+        }
+        function global:Get-DunePlayerOwnedCosmeticsLive {
+            $script:ownershipReads++
+            if ($script:ownershipReads -eq 1) {
+                return @{ ok = $true; owned = @('Ecaz_HeavyArmor_Swatch') }
+            }
+            return @{ ok = $true; owned = @('Ecaz_HeavyArmor_Swatch', 'Ecaz_Placeables_Swatch') }
+        }
+        function global:Invoke-DuneSqlQuery {
+            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec, [switch]$Bulk)
+            $script:capturedSql = $Sql
+            return @{ ok = $true; message = 'SELECT 1' }
+        }
+    }
+
+    AfterEach {
+        Remove-Item function:global:Test-DunePlayerOffline -ErrorAction SilentlyContinue
+        Remove-Item function:global:Get-DuneHouseSwatchCatalog -ErrorAction SilentlyContinue
+        Remove-Item function:global:Get-DunePlayerOwnedCosmeticsLive -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+    }
+
+    It 'rejects an online player before writing' {
+        function global:Test-DunePlayerOffline { return @{ ok = $false; reason = 'Player must be offline.' } }
+        $r = Invoke-DunePlayerGrantHouseSwatches -Ip '1.2.3.4' -PawnId 10 -AccountId 20
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'offline'
+        $script:capturedSql | Should -Be ''
+    }
+
+    It 'writes all missing swatches in one SQL statement and verifies them' {
+        $r = Invoke-DunePlayerGrantHouseSwatches -Ip '1.2.3.4' -PawnId 10 -AccountId 20
+        $r.ok | Should -BeTrue -Because $r.error
+        $r.total | Should -Be 2
+        $r.already_owned | Should -Be 1
+        $r.requested | Should -Be 1
+        $r.verified | Should -Be 1
+        $script:ownershipReads | Should -Be 2
+        $script:capturedSql | Should -Match 'Ecaz_Placeables_Swatch'
+        $script:capturedSql | Should -Not -Match 'Ecaz_HeavyArmor_Swatch'
+        ([regex]::Matches($script:capturedSql, 'INSERT INTO dune\.items')).Count | Should -Be 1
     }
 }
 

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -152,6 +152,7 @@ Describe 'Invoke-DunePlayerUpdateTags' -Tag 'TagsDelta' {
 Describe 'Invoke-DunePlayerGiveItemsBulk overflow' -Tag 'Pure' {
     BeforeEach {
         $script:liveArgs = $null
+        $script:batchArgs = $null
         function global:Get-DuneBodyValue {
             param($Body, [string]$Name)
             if ($Body -is [System.Collections.IDictionary] -and $Body.Contains($Name)) { return $Body[$Name] }
@@ -175,6 +176,14 @@ Describe 'Invoke-DunePlayerGiveItemsBulk overflow' -Tag 'Pure' {
             }
             return @{ ok = $true; path = 'rmq' }
         }
+        function global:Test-DuneValidGiveTemplate { return @{ ok = $true } }
+        function global:Invoke-DuneRmqAddItemEntriesToInventoryBatch {
+            param($FlsId, $Items, $SpacingMilliseconds)
+            $script:batchArgs = @{
+                FlsId = $FlsId; Items = @($Items); SpacingMilliseconds = $SpacingMilliseconds
+            }
+            return @{ ok = $true }
+        }
     }
     AfterEach {
         Remove-Item function:global:Get-DuneBodyValue -ErrorAction SilentlyContinue
@@ -182,24 +191,47 @@ Describe 'Invoke-DunePlayerGiveItemsBulk overflow' -Tag 'Pure' {
         Remove-Item function:global:Test-DunePlayerOffline -ErrorAction SilentlyContinue
         Remove-Item function:global:Resolve-DuneFlsIdOrError -ErrorAction SilentlyContinue
         Remove-Item function:global:Invoke-DunePlayerGiveItemLive -ErrorAction SilentlyContinue
+        Remove-Item function:global:Test-DuneValidGiveTemplate -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DuneRmqAddItemEntriesToInventoryBatch -ErrorAction SilentlyContinue
     }
 
-    It 'passes AllowOverflow to live package item gives' {
-        $items = @(@{ template = 'Ammo'; qty = 500; quality = 0 })
+    It 'publishes online overflow packages through one paced broker session' {
+        $items = @(
+            @{ template = 'Ammo'; qty = 500; quality = 0 },
+            @{ template = 'FuelCell'; qty = 2; quality = 0 }
+        )
 
         $r = Invoke-DunePlayerGiveItemsBulk -Ip '1.2.3.4' -PawnId 24 -Items $items -AllowOverflow $true
 
         $r.ok | Should -BeTrue
-        $script:liveArgs.AllowOverflow | Should -BeTrue
+        $script:liveArgs | Should -BeNullOrEmpty
+        $script:batchArgs.FlsId | Should -Be 'fls-test'
+        $script:batchArgs.SpacingMilliseconds | Should -Be 0
+        $script:batchArgs.Items.Count | Should -Be 2
+        $script:batchArgs.Items[0].ItemName | Should -Be 'Ammo'
+        $script:batchArgs.Items[0].Quantity | Should -Be 500
+        $script:batchArgs.Items[1].ItemName | Should -Be 'FuelCell'
+        $r.results.path | Should -Be @('rmq', 'rmq')
+    }
+
+    It 'keeps capacity-guarded online package delivery sequential' {
+        $items = @(@{ template = 'Ammo'; qty = 500; quality = 0 })
+
+        $r = Invoke-DunePlayerGiveItemsBulk -Ip '1.2.3.4' -PawnId 24 -Items $items -AllowOverflow $false
+
+        $r.ok | Should -BeTrue
+        $script:batchArgs | Should -BeNullOrEmpty
+        $script:liveArgs.AllowOverflow | Should -BeFalse
         $script:liveArgs.Template | Should -Be 'Ammo'
-        $script:liveArgs.Quantity | Should -Be 500
     }
 }
 
 Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
     BeforeEach {
         $script:ownershipReads = 0
-        $script:liveTemplates = [System.Collections.Generic.List[string]]::new()
+        $script:batchCalls = 0
+        $script:batchTemplates = @()
+        $script:batchSpacing = 0
         function global:Test-DunePlayerOffline { return @{ ok = $false; reason = 'Player is online.' } }
         function global:Resolve-DuneFlsIdOrError { return @{ ok = $true; fls_id = 'fls-test' } }
         function global:Get-DuneHouseSwatchCatalog {
@@ -215,9 +247,11 @@ Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
             }
             return @{ ok = $true; owned = @('Ecaz_HeavyArmor_Swatch') }
         }
-        function global:Invoke-DunePlayerGiveItemLive {
-            param($Ip, $ActorId, $FlsId, $Template, $Quantity, $Durability, $AllowOverflow)
-            $script:liveTemplates.Add($Template)
+        function global:Invoke-DuneRmqAddItemsToInventoryBatch {
+            param($FlsId, $ItemNames, $SpacingMilliseconds)
+            $script:batchCalls++
+            $script:batchTemplates = @($ItemNames)
+            $script:batchSpacing = $SpacingMilliseconds
             return @{ ok = $true }
         }
     }
@@ -227,7 +261,7 @@ Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
         Remove-Item function:global:Resolve-DuneFlsIdOrError -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DuneHouseSwatchCatalog -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DunePlayerOwnedCosmeticsLive -ErrorAction SilentlyContinue
-        Remove-Item function:global:Invoke-DunePlayerGiveItemLive -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DuneRmqAddItemsToInventoryBatch -ErrorAction SilentlyContinue
     }
 
     It 'rejects an offline player before granting' {
@@ -235,7 +269,7 @@ Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
         $r = Invoke-DunePlayerGrantHouseSwatches -Ip '1.2.3.4' -PawnId 10 -AccountId 20
         $r.ok | Should -BeFalse
         $r.error | Should -Match 'online'
-        $script:liveTemplates.Count | Should -Be 0
+        $script:batchCalls | Should -Be 0
     }
 
     It 'grants only missing swatches through the live path' {
@@ -245,8 +279,14 @@ Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
         $r.already_owned | Should -Be 1
         $r.requested | Should -Be 1
         $r.granted | Should -Be 1
+        $r.delivery | Should -Be 'tokens'
+        $r.overflow | Should -BeTrue
+        $r.message | Should -Match 'remain online'
+        $r.message | Should -Match 'cascade'
         $script:ownershipReads | Should -Be 1
-        $script:liveTemplates.ToArray() | Should -Be @('Ecaz_Placeables_Swatch')
+        $script:batchCalls | Should -Be 1
+        $script:batchTemplates | Should -Be @('Ecaz_Placeables_Swatch')
+        $script:batchSpacing | Should -Be 200
     }
 }
 

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -199,8 +199,9 @@ Describe 'Invoke-DunePlayerGiveItemsBulk overflow' -Tag 'Pure' {
 Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
     BeforeEach {
         $script:ownershipReads = 0
-        $script:capturedSql = ''
-        function global:Test-DunePlayerOffline { return @{ ok = $true } }
+        $script:liveTemplates = [System.Collections.Generic.List[string]]::new()
+        function global:Test-DunePlayerOffline { return @{ ok = $false; reason = 'Player is online.' } }
+        function global:Resolve-DuneFlsIdOrError { return @{ ok = $true; fls_id = 'fls-test' } }
         function global:Get-DuneHouseSwatchCatalog {
             return @(
                 @{ template = 'Ecaz_HeavyArmor_Swatch'; name = 'House Ecaz Garment Swatch'; group = 'Swatches (Dyes)' },
@@ -212,41 +213,40 @@ Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
             if ($script:ownershipReads -eq 1) {
                 return @{ ok = $true; owned = @('Ecaz_HeavyArmor_Swatch') }
             }
-            return @{ ok = $true; owned = @('Ecaz_HeavyArmor_Swatch', 'Ecaz_Placeables_Swatch') }
+            return @{ ok = $true; owned = @('Ecaz_HeavyArmor_Swatch') }
         }
-        function global:Invoke-DuneSqlQuery {
-            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec, [switch]$Bulk)
-            $script:capturedSql = $Sql
-            return @{ ok = $true; message = 'SELECT 1' }
+        function global:Invoke-DunePlayerGiveItemLive {
+            param($Ip, $ActorId, $FlsId, $Template, $Quantity, $Durability, $AllowOverflow)
+            $script:liveTemplates.Add($Template)
+            return @{ ok = $true }
         }
     }
 
     AfterEach {
         Remove-Item function:global:Test-DunePlayerOffline -ErrorAction SilentlyContinue
+        Remove-Item function:global:Resolve-DuneFlsIdOrError -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DuneHouseSwatchCatalog -ErrorAction SilentlyContinue
         Remove-Item function:global:Get-DunePlayerOwnedCosmeticsLive -ErrorAction SilentlyContinue
-        Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DunePlayerGiveItemLive -ErrorAction SilentlyContinue
     }
 
-    It 'rejects an online player before writing' {
-        function global:Test-DunePlayerOffline { return @{ ok = $false; reason = 'Player must be offline.' } }
+    It 'rejects an offline player before granting' {
+        function global:Test-DunePlayerOffline { return @{ ok = $true } }
         $r = Invoke-DunePlayerGrantHouseSwatches -Ip '1.2.3.4' -PawnId 10 -AccountId 20
         $r.ok | Should -BeFalse
-        $r.error | Should -Match 'offline'
-        $script:capturedSql | Should -Be ''
+        $r.error | Should -Match 'online'
+        $script:liveTemplates.Count | Should -Be 0
     }
 
-    It 'writes all missing swatches in one SQL statement and verifies them' {
+    It 'grants only missing swatches through the live path' {
         $r = Invoke-DunePlayerGrantHouseSwatches -Ip '1.2.3.4' -PawnId 10 -AccountId 20
         $r.ok | Should -BeTrue -Because $r.error
         $r.total | Should -Be 2
         $r.already_owned | Should -Be 1
         $r.requested | Should -Be 1
-        $r.verified | Should -Be 1
-        $script:ownershipReads | Should -Be 2
-        $script:capturedSql | Should -Match 'Ecaz_Placeables_Swatch'
-        $script:capturedSql | Should -Not -Match 'Ecaz_HeavyArmor_Swatch'
-        ([regex]::Matches($script:capturedSql, 'INSERT INTO dune\.items')).Count | Should -Be 1
+        $r.granted | Should -Be 1
+        $script:ownershipReads | Should -Be 1
+        $script:liveTemplates.ToArray() | Should -Be @('Ecaz_Placeables_Swatch')
     }
 }
 

--- a/tests/Rmq.Tests.ps1
+++ b/tests/Rmq.Tests.ps1
@@ -16,11 +16,13 @@ BeforeAll {
     $script:lastErl    = $null
     $script:lastExtra  = $null
     $script:lastAction = $null
+    $script:lastTimeoutSec = $null
     function global:_Invoke-V6BroadcastErl {
-        param($Ip, $Pod, $Erl, $Action, $Extra)
+        param($Ip, $Pod, $Erl, $Action, $Extra, $TimeoutSec)
         $script:lastErl    = $Erl
         $script:lastExtra  = $Extra
         $script:lastAction = $Action
+        $script:lastTimeoutSec = $TimeoutSec
         return @{ ok = $true; action = $Action; pod = $Pod; ip = $Ip }
     }
 
@@ -38,6 +40,7 @@ Describe 'Send-DuneRmqServerCommand envelope' -Tag 'Rmq' {
         $script:lastErl    = $null
         $script:lastExtra  = $null
         $script:lastAction = $null
+        $script:lastTimeoutSec = $null
     }
 
     It 'returns the broadcast context error when SSH context fails' {
@@ -90,6 +93,60 @@ Describe 'Send-DuneRmqServerCommand envelope' -Tag 'Rmq' {
         Send-DuneRmqServerCommand -Fields @{ ServerCommand = 'KickPlayer' } -Extra @{ player_id = 'abc' } | Out-Null
         $script:lastExtra | Should -Not -BeNullOrEmpty
         $script:lastExtra.player_id | Should -Be 'abc'
+    }
+}
+
+Describe 'Send-DuneRmqServerCommandBatch envelope' -Tag 'Rmq' {
+    BeforeEach {
+        $script:lastErl = $null
+        $script:lastExtra = $null
+        $script:lastAction = $null
+    }
+
+    It 'publishes every command in one paced broker invocation' {
+        $commands = @(
+            @{ ServerCommand = 'AddItemToInventory'; PlayerId = 'abc123'; ItemName = 'First_Swatch'; Quantity = 1; Durability = 1.0 },
+            @{ ServerCommand = 'AddItemToInventory'; PlayerId = 'abc123'; ItemName = 'Second_Swatch'; Quantity = 1; Durability = 1.0 }
+        )
+
+        $r = Send-DuneRmqServerCommandBatch -Fields $commands -SpacingMilliseconds 200 -Action 'swatch-batch'
+
+        $r.ok | Should -BeTrue
+        $script:lastAction | Should -Be 'swatch-batch'
+        $script:lastTimeoutSec | Should -Be 30
+        $script:lastExtra.total | Should -Be 2
+        $script:lastExtra.spacing_ms | Should -Be 200
+        $script:lastErl | Should -Match 'lists:foreach'
+        $script:lastErl | Should -Match 'timer:sleep\(200\)'
+        $script:lastErl | Should -Match 'dune-tool-batch-\d+-'
+
+        $matches = [regex]::Matches($script:lastErl, 'base64:decode\(<<"([A-Za-z0-9+/=]+)">>\)')
+        $matches.Count | Should -Be 2
+        $itemNames = @($matches | ForEach-Object {
+            $json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($_.Groups[1].Value))
+            (($json | ConvertFrom-Json).MessageContent | ConvertFrom-Json).ItemName
+        })
+        $itemNames | Should -Be @('First_Swatch', 'Second_Swatch')
+    }
+
+    It 'preserves per-item quantities in inventory batches' {
+        Invoke-DuneRmqAddItemEntriesToInventoryBatch -FlsId 'abc123' -Items @(
+            [pscustomobject]@{ ItemName = 'Ammo'; Quantity = 500; Durability = 1.0 },
+            [pscustomobject]@{ ItemName = 'FuelCell'; Quantity = 2; Durability = 0.5 }
+        ) -SpacingMilliseconds 500 | Out-Null
+
+        $matches = [regex]::Matches($script:lastErl, 'base64:decode\(<<"([A-Za-z0-9+/=]+)">>\)')
+        $payloads = @($matches | ForEach-Object {
+            $json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($_.Groups[1].Value))
+            (($json | ConvertFrom-Json).MessageContent | ConvertFrom-Json)
+        })
+        $payloads[0].ItemName | Should -Be 'Ammo'
+        $payloads[0].Quantity | Should -Be 500
+        $payloads[1].ItemName | Should -Be 'FuelCell'
+        $payloads[1].Quantity | Should -Be 2
+        $payloads[1].Durability | Should -Be 0.5
+        $script:lastErl | Should -Match 'timer:sleep\(500\)'
+        $script:lastTimeoutSec | Should -Be 30
     }
 }
 

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -2110,9 +2110,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2146,9 +2146,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2166,11 +2166,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2180,9 +2180,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -2359,9 +2359,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.361",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
-      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3406,9 +3406,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4008,9 +4008,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1865,6 +1865,24 @@ export function giveItems(pawnId: number, items: GiveItemEntry[], allowOverflow 
   })
 }
 
+export interface HouseSwatchGrantResult extends Record<string, unknown> {
+  total: number
+  already_owned: number
+  requested: number
+  verified: number
+  unresolved: string[]
+}
+
+export interface HouseSwatchGrantResponse extends WriteResult {
+  result?: HouseSwatchGrantResult
+}
+
+export function grantHouseSwatches(pawnId: number, accountId: number) {
+  return api<HouseSwatchGrantResponse>('/api/gameplay/players/grant-house-swatches', {
+    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, account_id: accountId }),
+  })
+}
+
 // Admin-defined item packages — a saved, named bundle of items an admin can
 // hand to any player in one click (delivered via giveItems). Persisted
 // server-side (%APPDATA%\DuneServer\item-packages.json) so they survive restarts

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1869,8 +1869,8 @@ export interface HouseSwatchGrantResult extends Record<string, unknown> {
   total: number
   already_owned: number
   requested: number
-  verified: number
-  unresolved: string[]
+  granted: number
+  failed: string[]
 }
 
 export interface HouseSwatchGrantResponse extends WriteResult {

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1207,6 +1207,12 @@ interface CosmeticsResponse { templates?: CosmeticEntry[]; total?: number }
 let _cosmeticsCache: CosmeticEntry[] | null = null
 let _cosmeticsPromise: Promise<CosmeticEntry[]> | null = null
 
+export function getHouseSwatchCosmetics(catalog: CosmeticEntry[]): CosmeticEntry[] {
+  return catalog
+    .filter(entry => entry.group === 'Swatches (Dyes)' && /^House .+ Swatch$/i.test(entry.name))
+    .sort((a, b) => a.name.localeCompare(b.name) || a.template.localeCompare(b.template))
+}
+
 export function filterCosmeticsCatalog(catalog: CosmeticEntry[], query: string): CosmeticEntry[] {
   const q = query.trim().toLowerCase()
   if (!q) return catalog

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1871,6 +1871,8 @@ export interface HouseSwatchGrantResult extends Record<string, unknown> {
   requested: number
   granted: number
   failed: string[]
+  delivery: 'tokens'
+  overflow: boolean
 }
 
 export interface HouseSwatchGrantResponse extends WriteResult {

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -1095,7 +1095,7 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
               })} />
           ) : def.custom === 'grant-cosmetic' ? (
             <GrantCosmeticForm busy={busy} playerName={player.name} accountId={player.account_id}
-              playerOnline={['online', 'loggingout'].includes((player.online_status || '').toLowerCase())}
+              playerOnline={(player.online_status || '').toLowerCase() === 'online'}
               onGrant={async (tpl, label) => {
                 let succeeded = false
                 await runAction(def, async () => {
@@ -1422,7 +1422,7 @@ function GrantCosmeticForm({ busy, playerName, accountId, playerOnline, onGrant,
           <div>
             <div className="text-sm font-medium text-text">All House Swatches</div>
             <div className="text-[11px] text-text-dim">
-              Grants only missing vendor House Swatch unlocks. Player must be fully offline.
+              Grants only missing House Swatches live, without placing unlock items in the backpack.
             </div>
           </div>
           <span className="text-[11px] text-text-dim whitespace-nowrap">
@@ -1432,12 +1432,12 @@ function GrantCosmeticForm({ busy, playerName, accountId, playerOnline, onGrant,
         <button
           type="button"
           className="btn-secondary w-full"
-          disabled={busy || playerOnline || missingHouseSwatches.length === 0}
-          title={playerOnline ? 'Player must be fully offline' : undefined}
+          disabled={busy || !playerOnline || missingHouseSwatches.length === 0}
+          title={!playerOnline ? 'Player must be online' : undefined}
           onClick={async () => {
             if (!window.confirm(
               `Grant ${missingHouseSwatches.length} missing House Swatch unlock${missingHouseSwatches.length === 1 ? '' : 's'} to ${playerName}?\n\n` +
-              'The player must remain fully offline until the grant completes.'
+              'The player must remain online until the live grants complete.'
             )) return
             if (await onGrantHouseSwatches()) {
               setOwned(current => {
@@ -1454,8 +1454,8 @@ function GrantCosmeticForm({ busy, playerName, accountId, playerOnline, onGrant,
               ? <><Icon name="Check" size={13} /> All House Swatches owned</>
               : <><Icon name="Palette" size={13} /> Grant {missingHouseSwatches.length} missing House Swatches</>}
         </button>
-        {playerOnline && (
-          <div className="text-[11px] text-warning">Player is online. Fully log out before using this preset.</div>
+        {!playerOnline && (
+          <div className="text-[11px] text-warning">Player must be online so the swatches unlock directly instead of becoming backpack items.</div>
         )}
       </div>
       <label className="flex items-center justify-between gap-3 text-xs text-text-dim">

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -27,7 +27,7 @@ import {
   setFactionTier, setSkillPoints,
   setStarterClass, spawnVehicle, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, resetFaction, snapshotBuilds, getFreshStartSnapshots, restoreBuilds, grantAllSkills,
   chatWhisper, isValidTemplateId, getItemCatalog, getCosmeticsCatalog, getPlayerOwnedCosmetics, filterCosmeticsCatalog, getHouseSwatchCosmetics, type CosmeticEntry,
-  parseTcnoPackageText,
+  parseTcnoPackageText, grantHouseSwatches,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
   getLandsraadOverview, getLandsraadPlayerContributions, setLandsraadContribution,
   getPlayerJourneyNodes, completeJourneyNode, resetJourneyNode,
@@ -1105,30 +1105,12 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
                 })
                 return succeeded
               }}
-              onGrantHouseSwatches={async entries => {
+              onGrantHouseSwatches={async () => {
                 let succeeded = false
                 await runAction(def, async () => {
-                  const r = await giveItems(
-                    player.id,
-                    entries.map(entry => ({ template: entry.template, qty: 1, quality: 0 })),
-                    false,
-                  )
-                  if (!r.ok) throw new Error(r.message || 'House Swatch grant failed.')
-
-                  const verified = await getPlayerOwnedCosmetics(player.account_id)
-                  const ownedAfter = new Set((verified.owned || []).map(id => id.toLowerCase()))
-                  const unresolved = entries.filter(entry => !ownedAfter.has(entry.template.toLowerCase()))
-                  if (unresolved.length > 0) {
-                    throw new Error(
-                      `${entries.length - unresolved.length}/${entries.length} House Swatches verified; ` +
-                      `${unresolved.length} did not register.`,
-                    )
-                  }
-
+                  const r = await grantHouseSwatches(player.id, player.account_id)
                   succeeded = true
-                  return {
-                    message: `Granted and verified ${entries.length} missing House Swatch${entries.length === 1 ? '' : 'es'} for ${player.name}.`,
-                  }
+                  return { message: r.message || `House Swatches updated for ${player.name}.` }
                 })
                 return succeeded
               }} />
@@ -1367,7 +1349,7 @@ function GrantCosmeticForm({ busy, playerName, accountId, playerOnline, onGrant,
   accountId: number
   playerOnline: boolean
   onGrant: (template: string, label: string) => Promise<boolean>
-  onGrantHouseSwatches: (entries: CosmeticEntry[]) => Promise<boolean>
+  onGrantHouseSwatches: () => Promise<boolean>
 }) {
   const [catalog, setCatalog] = useState<CosmeticEntry[] | null>(null)
   const [err, setErr] = useState<string | null>(null)
@@ -1457,7 +1439,7 @@ function GrantCosmeticForm({ busy, playerName, accountId, playerOnline, onGrant,
               `Grant ${missingHouseSwatches.length} missing House Swatch unlock${missingHouseSwatches.length === 1 ? '' : 's'} to ${playerName}?\n\n` +
               'The player must remain fully offline until the grant completes.'
             )) return
-            if (await onGrantHouseSwatches(missingHouseSwatches)) {
+            if (await onGrantHouseSwatches()) {
               setOwned(current => {
                 const next = new Set(current)
                 for (const entry of missingHouseSwatches) next.add(entry.template.toLowerCase())

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -607,7 +607,7 @@ interface ActionDef {
   offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   experimental?: boolean  // unverified — may not take effect in-game; shown with an EXPERIMENTAL badge
   fields?: ActionField[]
-  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'funcom-spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'complete-contract' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'teleport-player' | 'teleport-location' | 'set-respawn' | 'reset-faction' | 'grant-cosmetic' | 'fresh-start'
+  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'funcom-spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'complete-contract' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'teleport-player' | 'teleport-location' | 'set-respawn' | 'reset-faction' | 'grant-cosmetic' | 'grant-house-swatches' | 'fresh-start'
   balance?: 'solari' | 'scrip' | 'intel'  // show the player's current balance read-only above the form
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
@@ -721,6 +721,9 @@ const ACTIONS: ActionDef[] = [
     run: () => Promise.resolve({ message: '' }) },
   { id: 'grant-cosmetic', group: 'Items', label: 'Grant Cosmetic / Building Set', icon: 'Shirt', custom: 'grant-cosmetic',
     rowNote: 'Private-server unlock only; does not grant account ownership or availability elsewhere.',
+    run: () => Promise.resolve({ message: '' }) },
+  { id: 'grant-house-swatches', group: 'Items', label: 'All House Swatches', icon: 'Palette', custom: 'grant-house-swatches', liveOnly: true,
+    rowNote: 'Online required. Delivery starts immediately; remain online until the activation cascade starts and completely stops (about a minute).',
     run: () => Promise.resolve({ message: '' }) },
   { id: 'repair-gear', group: 'Items', label: 'Repair All Items', icon: 'Wrench',
     run: p => repairGear(p.id) },
@@ -1011,7 +1014,11 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
           ) : def.custom === 'spawn-vehicle' || def.custom === 'vehicle-kit' ? (
             <VehicleKitForm busy={busy}
               onSubmit={(veh, parts, overflow) => runAction(def, async () => {
-                for (const tpl of parts) await giveItem(player.id, tpl, veh.qty?.[tpl] ?? 1, 0, overflow)
+                await giveItems(player.id, parts.map(tpl => ({
+                  template: tpl,
+                  qty: veh.qty?.[tpl] ?? 1,
+                  quality: 0,
+                })), overflow)
                 const count = veh.kit.length + veh.unique.length
                 return { message: `Gave ${veh.label} kit — ${count} part${count === 1 ? '' : 's'} + Large Fuel Cell + Welding Torch Mk5 to ${player.name}.` }
               })} />
@@ -1095,7 +1102,6 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
               })} />
           ) : def.custom === 'grant-cosmetic' ? (
             <GrantCosmeticForm busy={busy} playerName={player.name} accountId={player.account_id}
-              playerOnline={(player.online_status || '').toLowerCase() === 'online'}
               onGrant={async (tpl, label) => {
                 let succeeded = false
                 await runAction(def, async () => {
@@ -1104,8 +1110,11 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
                   return { message: r.message || `Granted "${label}" to ${player.name}.` }
                 })
                 return succeeded
-              }}
-              onGrantHouseSwatches={async () => {
+              }} />
+          ) : def.custom === 'grant-house-swatches' ? (
+            <GrantHouseSwatchesForm busy={busy} playerName={player.name} accountId={player.account_id}
+              playerOnline={(player.online_status || '').toLowerCase() === 'online'}
+              onGrant={async () => {
                 let succeeded = false
                 await runAction(def, async () => {
                   const r = await grantHouseSwatches(player.id, player.account_id)
@@ -1343,13 +1352,11 @@ function DestinationForm({ busy, submitLabel, icon, note, onSubmit }: {
 // swatches, vehicle skins) and delivers the chosen template via the normal
 // give-item path so the player unlocks the appearance. Loads the catalog on
 // mount; filters by name/template; groups results by type.
-function GrantCosmeticForm({ busy, playerName, accountId, playerOnline, onGrant, onGrantHouseSwatches }: {
+function GrantCosmeticForm({ busy, playerName, accountId, onGrant }: {
   busy: boolean
   playerName: string
   accountId: number
-  playerOnline: boolean
   onGrant: (template: string, label: string) => Promise<boolean>
-  onGrantHouseSwatches: () => Promise<boolean>
 }) {
   const [catalog, setCatalog] = useState<CosmeticEntry[] | null>(null)
   const [err, setErr] = useState<string | null>(null)
@@ -1391,11 +1398,6 @@ function GrantCosmeticForm({ busy, playerName, accountId, playerOnline, onGrant,
     () => (catalog && owned ? catalog.filter(e => owned.has(e.template.toLowerCase())).length : 0),
     [catalog, owned],
   )
-  const houseSwatches = useMemo(() => getHouseSwatchCosmetics(catalog || []), [catalog])
-  const missingHouseSwatches = useMemo(
-    () => houseSwatches.filter(entry => !owned?.has(entry.template.toLowerCase())),
-    [houseSwatches, owned],
-  )
   const groups = useMemo(() => {
     const m = new Map<string, CosmeticEntry[]>()
     for (const e of matches) { const a = m.get(e.group); if (a) a.push(e); else m.set(e.group, [e]) }
@@ -1417,47 +1419,6 @@ function GrantCosmeticForm({ busy, playerName, accountId, playerOnline, onGrant,
         </p>
       </div>
       {ownershipWarning && <div className="text-xs text-warning">{ownershipWarning}</div>}
-      <div className="rounded-lg border border-border bg-surface-2 p-3 space-y-2">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <div className="text-sm font-medium text-text">All House Swatches</div>
-            <div className="text-[11px] text-text-dim">
-              Grants only missing House Swatches live, without placing unlock items in the backpack.
-            </div>
-          </div>
-          <span className="text-[11px] text-text-dim whitespace-nowrap">
-            {houseSwatches.length - missingHouseSwatches.length}/{houseSwatches.length} owned
-          </span>
-        </div>
-        <button
-          type="button"
-          className="btn-secondary w-full"
-          disabled={busy || !playerOnline || missingHouseSwatches.length === 0}
-          title={!playerOnline ? 'Player must be online' : undefined}
-          onClick={async () => {
-            if (!window.confirm(
-              `Grant ${missingHouseSwatches.length} missing House Swatch unlock${missingHouseSwatches.length === 1 ? '' : 's'} to ${playerName}?\n\n` +
-              'The player must remain online until the live grants complete.'
-            )) return
-            if (await onGrantHouseSwatches()) {
-              setOwned(current => {
-                const next = new Set(current)
-                for (const entry of missingHouseSwatches) next.add(entry.template.toLowerCase())
-                return next
-              })
-            }
-          }}
-        >
-          {busy
-            ? <><Icon name="Loader2" size={13} className="animate-spin" /> Granting House Swatches...</>
-            : missingHouseSwatches.length === 0
-              ? <><Icon name="Check" size={13} /> All House Swatches owned</>
-              : <><Icon name="Palette" size={13} /> Grant {missingHouseSwatches.length} missing House Swatches</>}
-        </button>
-        {!playerOnline && (
-          <div className="text-[11px] text-warning">Player must be online so the swatches unlock directly instead of becoming backpack items.</div>
-        )}
-      </div>
       <label className="flex items-center justify-between gap-3 text-xs text-text-dim">
         <span className="flex items-center gap-2">
           <input type="checkbox" checked={showOwned} disabled={busy}
@@ -1493,6 +1454,117 @@ function GrantCosmeticForm({ busy, playerName, accountId, playerOnline, onGrant,
           }
         }}>
         {busy ? <Icon name="Loader2" size={13} className="animate-spin" /> : <Icon name="Shirt" size={13} />} Grant
+      </button>
+    </div>
+  )
+}
+
+function GrantHouseSwatchesForm({ busy, playerName, accountId, playerOnline, onGrant }: {
+  busy: boolean
+  playerName: string
+  accountId: number
+  playerOnline: boolean
+  onGrant: () => Promise<boolean>
+}) {
+  const [catalog, setCatalog] = useState<CosmeticEntry[] | null>(null)
+  const [owned, setOwned] = useState<Set<string> | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+  const [ownershipWarning, setOwnershipWarning] = useState('')
+  const [activationQueued, setActivationQueued] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    Promise.all([getCosmeticsCatalog(), getPlayerOwnedCosmetics(accountId)])
+      .then(([entries, ownership]) => {
+        if (!alive) return
+        setCatalog(entries)
+        setOwned(new Set((ownership.owned || []).map(id => id.toLowerCase())))
+        if (ownership.liveError) setOwnershipWarning(`Ownership unavailable: ${ownership.liveError}. The full House Swatch set will be offered.`)
+      })
+      .catch(e => {
+        if (!alive) return
+        setErr(e instanceof Error ? e.message : String(e))
+      })
+    return () => { alive = false }
+  }, [accountId])
+
+  const houseSwatches = useMemo(() => getHouseSwatchCosmetics(catalog || []), [catalog])
+  const missingHouseSwatches = useMemo(
+    () => houseSwatches.filter(entry => !owned?.has(entry.template.toLowerCase())),
+    [houseSwatches, owned],
+  )
+
+  useEffect(() => {
+    if (!activationQueued || houseSwatches.length === 0) return
+
+    let alive = true
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const refreshOwnership = async () => {
+      try {
+        const ownership = await getPlayerOwnedCosmetics(accountId)
+        if (!alive) return
+        const nextOwned = new Set((ownership.owned || []).map(id => id.toLowerCase()))
+        setOwned(nextOwned)
+        if (houseSwatches.every(entry => nextOwned.has(entry.template.toLowerCase()))) {
+          setActivationQueued(false)
+          setOwnershipWarning('')
+          return
+        }
+        timer = setTimeout(() => void refreshOwnership(), 2000)
+      } catch (e) {
+        if (!alive) return
+        setOwnershipWarning(`Could not refresh activation progress: ${e instanceof Error ? e.message : String(e)}`)
+        timer = setTimeout(() => void refreshOwnership(), 5000)
+      }
+    }
+
+    timer = setTimeout(() => void refreshOwnership(), 2000)
+    return () => {
+      alive = false
+      if (timer) clearTimeout(timer)
+    }
+  }, [accountId, activationQueued, houseSwatches])
+
+  if (err) return <ErrorBox msg={err} />
+  if (!catalog || !owned) return <div className="text-sm text-text-dim flex items-center gap-2"><Icon name="Loader2" size={13} className="animate-spin" /> Loading House Swatches and player ownership...</div>
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="text-xs text-text-dim leading-relaxed">
+          Delivers verified physical House Swatch tokens through Funcom's live RMQ item command. Tokens use backpack slots; forced overflow drops excess tokens beside the player.
+        </div>
+        <span className="text-[11px] text-text-dim whitespace-nowrap">
+          {houseSwatches.length - missingHouseSwatches.length}/{houseSwatches.length} detected
+        </span>
+      </div>
+      <div className="rounded-lg bg-warning/10 border border-warning/40 p-3 text-warning text-xs leading-relaxed">
+        Online required. Delivery starts immediately, then Dune activates each token in a cascade. Remain online until the notifications start and completely stop, usually about a minute. DST skips persisted unlocks and tokens still in the player's inventory. Forced overflow drops excess tokens beside the player; Funcom does not link those loot bags back to a player, so pick up any overflow tokens before running this action again.
+      </div>
+      {ownershipWarning && <div className="text-xs text-warning">{ownershipWarning}</div>}
+      {!playerOnline && <div className="text-xs text-warning">Player must be online to receive House Swatch tokens.</div>}
+      <button
+        type="button"
+        className="btn-primary w-full"
+        disabled={busy || !playerOnline || missingHouseSwatches.length === 0 || activationQueued}
+        title={!playerOnline ? 'Player must be online' : undefined}
+        onClick={async () => {
+          if (!window.confirm(
+            `Deliver ${missingHouseSwatches.length} missing House Swatch token${missingHouseSwatches.length === 1 ? '' : 's'} to ${playerName}?\n\n` +
+            'Online required. Delivery starts immediately. Remain online until the activation notifications start and completely stop, usually about a minute.\n\nDST forces overflow, so excess tokens drop beside the player. Pick up all dropped tokens before running this action again.'
+          )) return
+          if (await onGrant()) {
+            setActivationQueued(true)
+          }
+        }}
+      >
+        {busy
+          ? <><Icon name="Loader2" size={13} className="animate-spin" /> Delivering House Swatch tokens...</>
+          : activationQueued
+            ? <><Icon name="Loader2" size={13} className="animate-spin" /> Activation cascade running — remain online</>
+          : missingHouseSwatches.length === 0
+            ? <><Icon name="Check" size={13} /> All House Swatches detected</>
+            : <><Icon name="Palette" size={13} /> Deliver {missingHouseSwatches.length} missing House Swatch tokens</>}
       </button>
     </div>
   )

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -26,7 +26,7 @@ import {
   restoreDestroyed,
   setFactionTier, setSkillPoints,
   setStarterClass, spawnVehicle, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, resetFaction, snapshotBuilds, getFreshStartSnapshots, restoreBuilds, grantAllSkills,
-  chatWhisper, isValidTemplateId, getItemCatalog, getCosmeticsCatalog, getPlayerOwnedCosmetics, filterCosmeticsCatalog, type CosmeticEntry,
+  chatWhisper, isValidTemplateId, getItemCatalog, getCosmeticsCatalog, getPlayerOwnedCosmetics, filterCosmeticsCatalog, getHouseSwatchCosmetics, type CosmeticEntry,
   parseTcnoPackageText,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
   getLandsraadOverview, getLandsraadPlayerContributions, setLandsraadContribution,
@@ -1095,12 +1095,40 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
               })} />
           ) : def.custom === 'grant-cosmetic' ? (
             <GrantCosmeticForm busy={busy} playerName={player.name} accountId={player.account_id}
+              playerOnline={['online', 'loggingout'].includes((player.online_status || '').toLowerCase())}
               onGrant={async (tpl, label) => {
                 let succeeded = false
                 await runAction(def, async () => {
                   const r = await giveItem(player.id, tpl, 1, 0, true)
                   succeeded = true
                   return { message: r.message || `Granted "${label}" to ${player.name}.` }
+                })
+                return succeeded
+              }}
+              onGrantHouseSwatches={async entries => {
+                let succeeded = false
+                await runAction(def, async () => {
+                  const r = await giveItems(
+                    player.id,
+                    entries.map(entry => ({ template: entry.template, qty: 1, quality: 0 })),
+                    false,
+                  )
+                  if (!r.ok) throw new Error(r.message || 'House Swatch grant failed.')
+
+                  const verified = await getPlayerOwnedCosmetics(player.account_id)
+                  const ownedAfter = new Set((verified.owned || []).map(id => id.toLowerCase()))
+                  const unresolved = entries.filter(entry => !ownedAfter.has(entry.template.toLowerCase()))
+                  if (unresolved.length > 0) {
+                    throw new Error(
+                      `${entries.length - unresolved.length}/${entries.length} House Swatches verified; ` +
+                      `${unresolved.length} did not register.`,
+                    )
+                  }
+
+                  succeeded = true
+                  return {
+                    message: `Granted and verified ${entries.length} missing House Swatch${entries.length === 1 ? '' : 'es'} for ${player.name}.`,
+                  }
                 })
                 return succeeded
               }} />
@@ -1333,11 +1361,13 @@ function DestinationForm({ busy, submitLabel, icon, note, onSubmit }: {
 // swatches, vehicle skins) and delivers the chosen template via the normal
 // give-item path so the player unlocks the appearance. Loads the catalog on
 // mount; filters by name/template; groups results by type.
-function GrantCosmeticForm({ busy, playerName, accountId, onGrant }: {
+function GrantCosmeticForm({ busy, playerName, accountId, playerOnline, onGrant, onGrantHouseSwatches }: {
   busy: boolean
   playerName: string
   accountId: number
+  playerOnline: boolean
   onGrant: (template: string, label: string) => Promise<boolean>
+  onGrantHouseSwatches: (entries: CosmeticEntry[]) => Promise<boolean>
 }) {
   const [catalog, setCatalog] = useState<CosmeticEntry[] | null>(null)
   const [err, setErr] = useState<string | null>(null)
@@ -1379,6 +1409,11 @@ function GrantCosmeticForm({ busy, playerName, accountId, onGrant }: {
     () => (catalog && owned ? catalog.filter(e => owned.has(e.template.toLowerCase())).length : 0),
     [catalog, owned],
   )
+  const houseSwatches = useMemo(() => getHouseSwatchCosmetics(catalog || []), [catalog])
+  const missingHouseSwatches = useMemo(
+    () => houseSwatches.filter(entry => !owned?.has(entry.template.toLowerCase())),
+    [houseSwatches, owned],
+  )
   const groups = useMemo(() => {
     const m = new Map<string, CosmeticEntry[]>()
     for (const e of matches) { const a = m.get(e.group); if (a) a.push(e); else m.set(e.group, [e]) }
@@ -1400,6 +1435,47 @@ function GrantCosmeticForm({ busy, playerName, accountId, onGrant }: {
         </p>
       </div>
       {ownershipWarning && <div className="text-xs text-warning">{ownershipWarning}</div>}
+      <div className="rounded-lg border border-border bg-surface-2 p-3 space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-sm font-medium text-text">All House Swatches</div>
+            <div className="text-[11px] text-text-dim">
+              Grants only missing vendor House Swatch unlocks. Player must be fully offline.
+            </div>
+          </div>
+          <span className="text-[11px] text-text-dim whitespace-nowrap">
+            {houseSwatches.length - missingHouseSwatches.length}/{houseSwatches.length} owned
+          </span>
+        </div>
+        <button
+          type="button"
+          className="btn-secondary w-full"
+          disabled={busy || playerOnline || missingHouseSwatches.length === 0}
+          title={playerOnline ? 'Player must be fully offline' : undefined}
+          onClick={async () => {
+            if (!window.confirm(
+              `Grant ${missingHouseSwatches.length} missing House Swatch unlock${missingHouseSwatches.length === 1 ? '' : 's'} to ${playerName}?\n\n` +
+              'The player must remain fully offline until the grant completes.'
+            )) return
+            if (await onGrantHouseSwatches(missingHouseSwatches)) {
+              setOwned(current => {
+                const next = new Set(current)
+                for (const entry of missingHouseSwatches) next.add(entry.template.toLowerCase())
+                return next
+              })
+            }
+          }}
+        >
+          {busy
+            ? <><Icon name="Loader2" size={13} className="animate-spin" /> Granting House Swatches...</>
+            : missingHouseSwatches.length === 0
+              ? <><Icon name="Check" size={13} /> All House Swatches owned</>
+              : <><Icon name="Palette" size={13} /> Grant {missingHouseSwatches.length} missing House Swatches</>}
+        </button>
+        {playerOnline && (
+          <div className="text-[11px] text-warning">Player is online. Fully log out before using this preset.</div>
+        )}
+      </div>
       <label className="flex items-center justify-between gap-3 text-xs text-text-dim">
         <span className="flex items-center gap-2">
           <input type="checkbox" checked={showOwned} disabled={busy}

--- a/webui/tests/api/filterCatalog.test.ts
+++ b/webui/tests/api/filterCatalog.test.ts
@@ -7,6 +7,7 @@ import {
   catalogCategories,
   filterCatalog,
   filterCosmeticsCatalog,
+  getHouseSwatchCosmetics,
   type CatalogItem,
   type CosmeticEntry,
 } from '../../src/api/gameplay'
@@ -60,6 +61,9 @@ describe('filterCosmeticsCatalog', () => {
   const cosmetics: CosmeticEntry[] = [
     { template: 'Atreides_Buggy_Variant', name: 'Atreides Buggy Variant', group: 'Vehicle Skins' },
     { template: 'D_Choam_HeavyArmor_Swatch', name: 'CHOAM Heavy Armor Swatch', group: 'Swatches (Dyes)' },
+    { template: 'Ecaz_HeavyArmor_Swatch', name: 'House Ecaz Garment Swatch', group: 'Swatches (Dyes)' },
+    { template: 'Ecaz_Placeables_Swatch', name: 'House Ecaz Placeables Swatch', group: 'Swatches (Dyes)' },
+    { template: 'NotASwatch', name: 'House Example Swatch', group: 'Other Customization' },
   ]
 
   it('uses contains matching instead of prefix-only matching', () => {
@@ -69,5 +73,9 @@ describe('filterCosmeticsCatalog', () => {
 
   it('matches group names so vehicle search returns every vehicle skin', () => {
     expect(filterCosmeticsCatalog(cosmetics, 'vehicle')).toEqual([cosmetics[0]])
+  })
+
+  it('selects only vendor House Swatches in stable name order', () => {
+    expect(getHouseSwatchCosmetics(cosmetics)).toEqual([cosmetics[2], cosmetics[3]])
   })
 })


### PR DESCRIPTION
## Summary
- add missing-only All House Swatches delivery with ownership tracking
- batch online saved packages and vehicle kits through one RMQ broker session
- stream large Erlang payloads through SSH stdin and cover batching behavior with tests

## Validation
- 83 targeted Pester tests passed
- web UI production build passed
- full installer build passed
- live House Swatch delivery completed 103/103