### PR TITLE
Prevent prerelease installer identity mismatches

### DIFF
--- a/.github/workflows/release-signed.yml
+++ b/.github/workflows/release-signed.yml
@@ -113,6 +113,7 @@ jobs:
           BUILD_TAG: ${{ inputs.attach_to_release_tag }}
         run: |
           $biArgs = @{ SkipInstaller = $true }
+          if ($env:BUILD_TAG) { $biArgs.BuildCommit = (& git rev-parse HEAD).Trim() }
           if ('${{ inputs.skip_version_check }}' -eq 'true') { $biArgs.SkipVersionCheck = $true }
           if ('${{ inputs.prerelease_build }}' -eq 'true') { $biArgs.Prerelease = $true }
           if ($env:BUILD_TAG) { $biArgs.BuildTag = $env:BUILD_TAG }
@@ -220,6 +221,7 @@ jobs:
             SkipSoloBuild = $true
             SkipPlatformBuild = $true
           }
+          if ($env:BUILD_TAG) { $biArgs.BuildCommit = (& git rev-parse HEAD).Trim() }
           if ('${{ inputs.skip_version_check }}' -eq 'true') { $biArgs.SkipVersionCheck = $true }
           if ('${{ inputs.prerelease_build }}' -eq 'true') { $biArgs.Prerelease = $true }
           if ($env:BUILD_TAG) { $biArgs.BuildTag = $env:BUILD_TAG }
@@ -267,6 +269,29 @@ jobs:
           } else {
             Write-Host "::warning::Installer is UNSIGNED (SignPath not configured)."
           }
+
+      - name: Verify release artifact identity
+        if: inputs.attach_to_release_tag != ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_TAG: ${{ inputs.attach_to_release_tag }}
+        run: |
+          $releaseJson = gh api "repos/${{ github.repository }}/releases/tags/$env:BUILD_TAG"
+          if ($LASTEXITCODE -ne 0) { throw "Could not read GitHub release $env:BUILD_TAG." }
+          $release = $releaseJson | ConvertFrom-Json
+          if ([string]$release.tag_name -cne $env:BUILD_TAG) {
+           throw "GitHub release tag mismatch: requested '$env:BUILD_TAG', API returned '$($release.tag_name)'."
+          }
+          $tagCommit = "$(& git rev-parse --verify "refs/tags/$env:BUILD_TAG^{commit}")".Trim().ToLowerInvariant()
+          if ($LASTEXITCODE -ne 0 -or $tagCommit -notmatch '^[0-9a-f]{40}$') {
+           throw "Could not resolve release tag $env:BUILD_TAG to an immutable commit."
+          }
+          & '${{ github.workspace }}\app\build\Verify-ReleaseArtifact.ps1' `
+           -ExecutablePath '${{ github.workspace }}\app\build\output\DuneServer.exe' `
+           -ExpectedTag $env:BUILD_TAG `
+           -ExpectedCommit $tagCommit `
+           -ExpectedPrerelease:([bool]$release.prerelease)
 
       - name: Upload installer as workflow artifact
         uses: actions/upload-artifact@v4

--- a/app/build/BuildHelpers.ps1
+++ b/app/build/BuildHelpers.ps1
@@ -57,3 +57,198 @@ function Get-DuneExistingTagCommit {
     }
     return $commit
 }
+
+function Test-DunePrereleaseTag {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$BuildTag)
+
+    return $BuildTag.Trim() -match '^v?\d+\.\d+\.\d+-.+$'
+}
+
+function Assert-DuneTagPrereleaseConsistency {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$BuildTag,
+        [switch]$Prerelease
+    )
+
+    $tag = $BuildTag.Trim()
+    if ($tag -notmatch '^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+        throw 'BuildTag must be a release tag such as v15.0.0 or v15.0.0-test9.'
+    }
+    $tagIsPrerelease = Test-DunePrereleaseTag -BuildTag $tag
+    if ($tagIsPrerelease -and -not $Prerelease) {
+        throw "Prerelease tag $tag requires -Prerelease."
+    }
+    if (-not $tagIsPrerelease -and $Prerelease) {
+        throw "Stable tag $tag must not use -Prerelease."
+    }
+}
+
+function Get-DuneReleaseTagsAtCommit {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [Parameter(Mandatory)][string]$Commit
+    )
+
+    $output = @(& git -C $RepoRoot tag --points-at $Commit 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not inspect release tags at commit $Commit."
+    }
+    return @($output |
+        ForEach-Object { "$_".Trim() } |
+        Where-Object { $_ -match '^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' } |
+        Sort-Object -Unique)
+}
+
+function Resolve-DuneBuildIdentity {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RepoRoot,
+        [string]$BuildCommit = '',
+        [string]$BuildTag = '',
+        [switch]$Prerelease,
+        [switch]$BuildCommitSpecified
+    )
+
+    $headCommit = "$(& git -C $RepoRoot rev-parse HEAD 2>$null)".Trim().ToLowerInvariant()
+    if ($LASTEXITCODE -ne 0 -or $headCommit -notmatch '^[0-9a-f]{40}$') {
+        throw 'Could not resolve checkout HEAD to a full Git commit id.'
+    }
+
+    $tag = $BuildTag.Trim()
+    if (-not $tag) {
+        $headTags = @(Get-DuneReleaseTagsAtCommit -RepoRoot $RepoRoot -Commit $headCommit)
+        if ($headTags.Count -gt 0) {
+            $tagList = $headTags -join ', '
+            $exampleTag = $headTags[0]
+            $prereleaseArg = if (Test-DunePrereleaseTag -BuildTag $exampleTag) { '-Prerelease ' } else { '' }
+            $example = "& '.\app\installer\Build-Installer.ps1' $prereleaseArg-BuildCommit $headCommit -BuildTag $exampleTag"
+            if ($headTags.Count -gt 1) {
+                throw "Checkout HEAD $headCommit has multiple release tags ($tagList), but -BuildTag was omitted. Refusing an ambiguous manual build. Specify the intended immutable tag and commit explicitly, for example: $example"
+            }
+            throw "Checkout HEAD $headCommit already has release tag $exampleTag, but -BuildTag was omitted. Refusing to embed '(manual)' identity. Run: $example"
+        }
+        if ($Prerelease) {
+            throw 'Prerelease installer builds require an existing -BuildTag and an explicit full -BuildCommit.'
+        }
+
+        $commit = if ($BuildCommitSpecified) { $BuildCommit.Trim().ToLowerInvariant() } else { $headCommit }
+        if ($commit -and $commit -notmatch '^[0-9a-f]{7,40}$') {
+            throw 'BuildCommit must be a 7-40 character hexadecimal Git commit id.'
+        }
+        return [pscustomobject]@{
+            Commit = $commit
+            Tag = ''
+            Prerelease = $false
+            HeadCommit = $headCommit
+        }
+    }
+
+    Assert-DuneTagPrereleaseConsistency -BuildTag $tag -Prerelease:$Prerelease
+    if (-not $BuildCommitSpecified) {
+        throw "Tagged build $tag requires an explicit full -BuildCommit."
+    }
+    $commit = $BuildCommit.Trim().ToLowerInvariant()
+    if ($commit -notmatch '^[0-9a-f]{40}$') {
+        throw "Tagged build $tag requires a full 40-character BuildCommit."
+    }
+
+    $tagCommit = Get-DuneExistingTagCommit -RepoRoot $RepoRoot -BuildTag $tag
+    if (-not $tagCommit) {
+        throw "Tagged build $tag requires an existing immutable Git tag."
+    }
+    if ($headCommit -ne $tagCommit) {
+        throw "Existing release tag $tag resolves to $tagCommit, but checkout HEAD is $headCommit. Check out the exact tag before rebuilding its installer."
+    }
+    if ($commit -ne $tagCommit) {
+        throw "BuildCommit $commit does not match existing release tag $tag at $tagCommit."
+    }
+
+    return [pscustomobject]@{
+        Commit = $tagCommit
+        Tag = $tag
+        Prerelease = [bool]$Prerelease
+        HeadCommit = $headCommit
+    }
+}
+
+function Get-DuneExecutableBuildMetadata {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$ExecutablePath)
+
+    $path = [IO.Path]::GetFullPath($ExecutablePath)
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "DuneServer executable was not found: $path"
+    }
+
+    $assembly = [Reflection.Assembly]::LoadFile($path)
+    $resourceNames = @($assembly.GetManifestResourceNames() | Where-Object {
+        $_ -match '^DuneServer(?:\.[0-9a-f]{32})?\.generated\.ps1$'
+    })
+    if ($resourceNames.Count -ne 1) {
+        throw "DuneServer executable has $($resourceNames.Count) recognized embedded script resources."
+    }
+
+    $stream = $assembly.GetManifestResourceStream($resourceNames[0])
+    if (-not $stream) {
+        throw 'DuneServer executable has no readable embedded script resource.'
+    }
+    $reader = [IO.StreamReader]::new($stream, [Text.Encoding]::UTF8, $true)
+    try {
+        $text = $reader.ReadToEnd()
+    } finally {
+        $reader.Dispose()
+        $stream.Dispose()
+    }
+
+    $presentMatch = [regex]::Match($text, '(?m)^\$script:DuneBuildMetadataPresent\s*=\s*\$true\s*$')
+    $commitMatch = [regex]::Match($text, "(?m)^\`$script:DuneBuildCommit\s*=\s*'([^']*)'\s*$")
+    $prereleaseMatch = [regex]::Match($text, '(?m)^\$script:DuneBuildPrerelease\s*=\s*\$(true|false)\s*$')
+    $tagMatch = [regex]::Match($text, "(?m)^\`$script:DuneBuildTag\s*=\s*'([^']*)'\s*$")
+    return [pscustomobject]@{
+        present = $presentMatch.Success
+        valid = $presentMatch.Success -and $commitMatch.Success -and $prereleaseMatch.Success -and $tagMatch.Success
+        commit = if ($commitMatch.Success) { $commitMatch.Groups[1].Value.Trim().ToLowerInvariant() } else { '' }
+        prerelease = $prereleaseMatch.Success -and $prereleaseMatch.Groups[1].Value -eq 'true'
+        tag = if ($tagMatch.Success) { $tagMatch.Groups[1].Value.Trim() } else { '' }
+        resource = $resourceNames[0]
+    }
+}
+
+function Assert-DuneBuildMetadataMatches {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]$Metadata,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$ExpectedTag,
+        [Parameter(Mandatory)][string]$ExpectedCommit,
+        [switch]$ExpectedPrerelease
+    )
+
+    $tag = $ExpectedTag.Trim()
+    $commit = $ExpectedCommit.Trim().ToLowerInvariant()
+    if ($tag) {
+        Assert-DuneTagPrereleaseConsistency -BuildTag $tag -Prerelease:$ExpectedPrerelease
+    } elseif ($ExpectedPrerelease) {
+        throw 'Expected prerelease metadata requires a release tag.'
+    }
+    $commitPattern = if ($tag) { '^[0-9a-f]{40}$' } else { '^[0-9a-f]{7,40}$' }
+    if ($commit -notmatch $commitPattern) {
+        throw $(if ($tag) {
+            'ExpectedCommit must be a full 40-character Git commit id for a release build.'
+        } else {
+            'ExpectedCommit must be a 7-40 character hexadecimal Git commit id.'
+        })
+    }
+
+    $matches = [bool]$Metadata.present -and [bool]$Metadata.valid -and
+        ([string]$Metadata.tag -ceq $tag) -and
+        ([string]$Metadata.commit -ceq $commit) -and
+        ([bool]$Metadata.prerelease -eq [bool]$ExpectedPrerelease)
+    if (-not $matches) {
+        $actual = "tag='$([string]$Metadata.tag)', commit='$([string]$Metadata.commit)', prerelease=$([bool]$Metadata.prerelease), present=$([bool]$Metadata.present), valid=$([bool]$Metadata.valid)"
+        throw "Built DuneServer.exe identity mismatch. Expected tag='$tag', commit='$commit', prerelease=$([bool]$ExpectedPrerelease); found $actual."
+    }
+    return $Metadata
+}

--- a/app/build/Verify-ReleaseArtifact.ps1
+++ b/app/build/Verify-ReleaseArtifact.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$ExecutablePath,
+    [Parameter(Mandatory)][string]$ExpectedTag,
+    [Parameter(Mandatory)][string]$ExpectedCommit,
+    [switch]$ExpectedPrerelease
+)
+
+$ErrorActionPreference = 'Stop'
+$helpers = Join-Path $PSScriptRoot 'BuildHelpers.ps1'
+if (-not (Test-Path -LiteralPath $helpers -PathType Leaf)) {
+    throw "Build helpers not found: $helpers"
+}
+. $helpers
+
+$metadata = Get-DuneExecutableBuildMetadata -ExecutablePath $ExecutablePath
+$null = Assert-DuneBuildMetadataMatches `
+    -Metadata $metadata `
+    -ExpectedTag $ExpectedTag `
+    -ExpectedCommit $ExpectedCommit `
+    -ExpectedPrerelease:$ExpectedPrerelease
+
+Write-Host "Verified built DuneServer.exe identity: tag=$($metadata.tag), commit=$($metadata.commit), prerelease=$($metadata.prerelease)" -ForegroundColor Green

--- a/app/installer/Build-Installer.ps1
+++ b/app/installer/Build-Installer.ps1
@@ -64,6 +64,30 @@ try {
         throw 'Another installer build is already running for this checkout.'
     }
 
+# Resolve and validate artifact identity before any build work starts.
+$buildCommitSpecified = $PSBoundParameters.ContainsKey('BuildCommit') -and
+    -not [string]::IsNullOrWhiteSpace($BuildCommit)
+$identity = Resolve-DuneBuildIdentity `
+    -RepoRoot $repoRoot `
+    -BuildCommit $BuildCommit `
+    -BuildTag $BuildTag `
+    -Prerelease:$Prerelease `
+    -BuildCommitSpecified:$buildCommitSpecified
+$BuildCommit = $identity.Commit
+$BuildTag = $identity.Tag
+
+if ($BuildTag) {
+    $dirty = @(& git -C $repoRoot status --porcelain --untracked-files=all)
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Could not verify checkout cleanliness for tagged build.'
+    }
+    if ($dirty.Count -gt 0) {
+        throw "Tagged build $BuildTag requires a clean checkout."
+    }
+}
+Write-Host "Build identity: prerelease=$([bool]$Prerelease), tag=$(if ($BuildTag) { $BuildTag } else { '(manual)' }), commit=$BuildCommit" -ForegroundColor Cyan
+Write-Host ''
+
 # ---------------------------------------------------------------------------
 # Pre-flight: version-stamp sync check.
 #
@@ -112,42 +136,6 @@ if (-not $SkipVersionCheck) {
     Write-Host "  All 5 stamps match: $($distinct[0])" -ForegroundColor Green
     Write-Host ""
 }
-
-# Resolve immutable artifact metadata without changing any version stamp.
-if (-not $BuildCommit) {
-    try { $BuildCommit = (& git -C $repoRoot rev-parse HEAD 2>$null).Trim() } catch { $BuildCommit = '' }
-}
-$BuildCommit = $BuildCommit.Trim().ToLowerInvariant()
-if ($BuildCommit -and $BuildCommit -notmatch '^[0-9a-f]{7,40}$') {
-    throw 'BuildCommit must be a 7-40 character hexadecimal Git commit id.'
-}
-$BuildTag = $BuildTag.Trim()
-if ($BuildTag -and $BuildTag -notmatch '^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
-    throw 'BuildTag must be a release tag such as v14.0.0 or v14.0.0-test6.'
-}
-if ($BuildTag) {
-    $dirty = @(& git -C $repoRoot status --porcelain --untracked-files=all)
-    if ($LASTEXITCODE -ne 0) {
-        throw 'Could not verify checkout cleanliness for tagged build.'
-    }
-    if ($dirty.Count -gt 0) {
-        throw "Tagged build $BuildTag requires a clean checkout."
-    }
-    $tagCommit = Get-DuneExistingTagCommit -RepoRoot $repoRoot -BuildTag $BuildTag
-    if ($tagCommit) {
-        $headCommit = (& git -C $repoRoot rev-parse HEAD 2>$null).Trim().ToLowerInvariant()
-        $tagCommit = $tagCommit.ToLowerInvariant()
-        if ($headCommit -ne $tagCommit) {
-            throw "Existing release tag $BuildTag resolves to $tagCommit, but checkout HEAD is $headCommit. Check out the exact tag before rebuilding its installer."
-        }
-        if ($BuildCommit -and $BuildCommit -ne $tagCommit) {
-            throw "BuildCommit $BuildCommit does not match existing release tag $BuildTag at $tagCommit."
-        }
-        $BuildCommit = $tagCommit
-    }
-}
-Write-Host "Build identity: prerelease=$([bool]$Prerelease), tag=$(if ($BuildTag) { $BuildTag } else { '(manual)' }), commit=$(if ($BuildCommit) { $BuildCommit } else { '(unknown)' })" -ForegroundColor Cyan
-Write-Host ''
 
 # Locate ISCC.exe
 $isccCandidates = @(
@@ -274,6 +262,14 @@ if (-not $SkipExeBuild) {
 if (-not (Test-Path $exePath)) {
     throw "DuneServer.exe not found at $exePath - run Build-Exe.ps1 first (or omit -SkipExeBuild)"
 }
+$builtMetadata = Get-DuneExecutableBuildMetadata -ExecutablePath $exePath
+$null = Assert-DuneBuildMetadataMatches `
+    -Metadata $builtMetadata `
+    -ExpectedTag $BuildTag `
+    -ExpectedCommit $BuildCommit `
+    -ExpectedPrerelease:$Prerelease
+Write-Host "  DuneServer.exe identity verified from embedded resource." -ForegroundColor Green
+Write-Host ""
 
 # Build the standalone WebView2 app window (DuneShell.exe). Self-contained
 # single-file publish; the .iss bundles it beside DuneServer.exe. Requires the

--- a/tests/BuildMetadata.Tests.ps1
+++ b/tests/BuildMetadata.Tests.ps1
@@ -2,6 +2,25 @@ BeforeAll {
     . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
     Import-DstLib 'BuildMetadata.ps1'
     . (Join-Path (Split-Path $PSScriptRoot -Parent) 'app\build\BuildHelpers.ps1')
+
+    function New-BuildIdentityTestRepo {
+        param(
+            [Parameter(Mandatory)][string]$Path,
+            [string[]]$Tags = @()
+        )
+
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+        & git -C $Path init --quiet
+        & git -C $Path config user.name 'DST Tests'
+        & git -C $Path config user.email 'dst-tests@example.invalid'
+        Set-Content -LiteralPath (Join-Path $Path 'tracked.txt') -Value 'test'
+        & git -C $Path add tracked.txt
+        & git -C $Path commit --quiet -m 'test commit'
+        foreach ($tag in $Tags) {
+            & git -C $Path tag $tag
+        }
+        return "$(& git -C $Path rev-parse HEAD)".Trim().ToLowerInvariant()
+    }
 }
 
 Describe 'Build artifact metadata' {
@@ -47,7 +66,7 @@ Describe 'Build artifact metadata' {
         $installer | Should -Match '-Prerelease:\$Prerelease'
         $installer | Should -Match 'DST-BuildInstaller-'
         $installer | Should -Match 'Another installer build is already running'
-        $installer | Should -Match 'Existing release tag .* resolves to'
+        $helpers | Should -Match 'Existing release tag .* resolves to'
         $installer | Should -Match 'Tagged build .* requires a clean checkout'
         $helpers | Should -Match 'refs/tags/\$BuildTag\^\{commit\}'
         $installer | Should -Match '\[string\]\$BuildTag'
@@ -61,6 +80,10 @@ Describe 'Build artifact metadata' {
         $workflow | Should -Not -Match 'github\.ref.*Prerelease'
         $workflow | Should -Match '\$biArgs\s*=\s*@\{'
         $workflow | Should -Match '\$biArgs\.BuildTag\s*='
+        $workflow | Should -Match '\$biArgs\.BuildCommit\s*='
+        $workflow | Should -Match 'Verify-ReleaseArtifact\.ps1'
+        $workflow | Should -Match 'release\.prerelease'
+        $workflow | Should -Match 'refs/tags/\$env:BUILD_TAG\^\{commit\}'
         $workflow | Should -Not -Match '\$biArgs\s*=\s*@\('
         $workflow | Should -Not -Match '\$biArgs\s*\+='
     }
@@ -85,6 +108,130 @@ Describe 'Build artifact metadata' {
         Get-DuneExistingTagCommit `
             -RepoRoot $repo `
             -BuildTag 'v999.999.999-test-new-tag-regression' | Should -Be ''
+    }
+
+    It 'rejects the original plain installer build on a prerelease-tagged HEAD' {
+        $repo = Join-Path $TestDrive 'tagged-omission'
+        $null = New-BuildIdentityTestRepo -Path $repo -Tags 'v15.0.0-test9'
+
+        {
+            Resolve-DuneBuildIdentity -RepoRoot $repo
+        } | Should -Throw "*already has release tag v15.0.0-test9*BuildTag was omitted*Refusing to embed '(manual)' identity*"
+    }
+
+    It 'fails closed when an omitted build tag is ambiguous' {
+        $repo = Join-Path $TestDrive 'multiple-tags'
+        $null = New-BuildIdentityTestRepo -Path $repo -Tags @('v15.0.0-test9', 'v15.0.0-test10')
+
+        {
+            Resolve-DuneBuildIdentity -RepoRoot $repo
+        } | Should -Throw '*multiple release tags*Refusing an ambiguous manual build*'
+    }
+
+    It 'preserves stable manual builds on an untagged HEAD' {
+        $repo = Join-Path $TestDrive 'untagged-stable'
+        $head = New-BuildIdentityTestRepo -Path $repo
+
+        $identity = Resolve-DuneBuildIdentity -RepoRoot $repo
+
+        $identity.Tag | Should -Be ''
+        $identity.Prerelease | Should -BeFalse
+        $identity.Commit | Should -BeExactly $head
+    }
+
+    It 'requires prerelease-style tags to use the prerelease flag' {
+        {
+            Assert-DuneTagPrereleaseConsistency -BuildTag 'v15.0.0-test9'
+        } | Should -Throw '*requires -Prerelease*'
+    }
+
+    It 'rejects the prerelease flag for stable tags' {
+        {
+            Assert-DuneTagPrereleaseConsistency -BuildTag 'v15.0.0' -Prerelease
+        } | Should -Throw '*must not use -Prerelease*'
+    }
+
+    It 'requires an explicit full commit for tagged builds' {
+        $repo = Join-Path $TestDrive 'tagged-commit'
+        $head = New-BuildIdentityTestRepo -Path $repo -Tags 'v15.0.0-test9'
+
+        {
+            Resolve-DuneBuildIdentity -RepoRoot $repo -BuildTag 'v15.0.0-test9' -Prerelease
+        } | Should -Throw '*requires an explicit full -BuildCommit*'
+        {
+            Resolve-DuneBuildIdentity -RepoRoot $repo -BuildTag 'v15.0.0-test9' -BuildCommit $head.Substring(0, 12) -BuildCommitSpecified -Prerelease
+        } | Should -Throw '*requires a full 40-character BuildCommit*'
+        {
+            Resolve-DuneBuildIdentity -RepoRoot $repo -BuildTag 'v15.0.0-test9' -BuildCommit ('a' * 40) -BuildCommitSpecified -Prerelease
+        } | Should -Throw '*does not match existing release tag*'
+    }
+
+    It 'accepts only the exact tag commit for a tagged build' {
+        $repo = Join-Path $TestDrive 'exact-tagged-commit'
+        $head = New-BuildIdentityTestRepo -Path $repo -Tags 'v15.0.0-test9'
+
+        $identity = Resolve-DuneBuildIdentity `
+            -RepoRoot $repo `
+            -BuildTag 'v15.0.0-test9' `
+            -BuildCommit $head `
+            -BuildCommitSpecified `
+            -Prerelease
+
+        $identity.Commit | Should -BeExactly $head
+        $identity.Tag | Should -BeExactly 'v15.0.0-test9'
+        $identity.Prerelease | Should -BeTrue
+    }
+
+    It 'rejects compiled metadata that differs from the target release' {
+        $metadata = [pscustomobject]@{
+            present = $true
+            valid = $true
+            tag = 'v15.0.0-test9'
+            commit = 'a' * 40
+            prerelease = $false
+        }
+
+        {
+            Assert-DuneBuildMetadataMatches `
+               -Metadata $metadata `
+               -ExpectedTag 'v15.0.0-test9' `
+               -ExpectedCommit ('a' * 40) `
+               -ExpectedPrerelease
+        } | Should -Throw '*Built DuneServer.exe identity mismatch*'
+    }
+
+    It 'accepts matching stable manual compiled metadata' {
+        $metadata = [pscustomobject]@{
+            present = $true
+            valid = $true
+            tag = ''
+            commit = 'a' * 40
+            prerelease = $false
+        }
+
+        {
+            $null = Assert-DuneBuildMetadataMatches `
+                -Metadata $metadata `
+                -ExpectedTag '' `
+                -ExpectedCommit ('a' * 40)
+        } | Should -Not -Throw
+    }
+
+    It 'preserves abbreviated commit metadata for stable manual builds' {
+        $metadata = [pscustomobject]@{
+            present = $true
+            valid = $true
+            tag = ''
+            commit = 'abcdef123456'
+            prerelease = $false
+        }
+
+        {
+            $null = Assert-DuneBuildMetadataMatches `
+                -Metadata $metadata `
+                -ExpectedTag '' `
+                -ExpectedCommit 'abcdef123456'
+        } | Should -Not -Throw
     }
 
     It 'injects immutable build identity into API worker runspaces' {


### PR DESCRIPTION
## Summary
- reject manual identity when HEAD already carries one or more release tags
- require prerelease/stable tag flags and exact existing tag plus full commit identity
- inspect the compiled DuneServer.exe embedded resource before packaging and again before signed release upload

## Validation
- 16 focused Pester tests passed
- real PS2EXE metadata extraction and release identity verification passed