### PR TITLE
Fix shutdown player safety verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ here cover everything those tags shipped.
   access, protected destinations stay visible, and Reset restores visibility and
   order.
 
+### Fixed
+
+- Fixed disruptive-action player checks incorrectly treating a verified empty
+  server as an unanswered query. Real verification failures remain fail-closed
+  with distinct timeout, server-error, no-response, and invalid-response details,
+  shown in an accessible DST confirmation dialog instead of a browser prompt.
+
 ## [15.0.0-test9] - 2026-09-01
 
 Candidate metadata prepared for v15.0.0-test9; semantic version remains 15.0.0.

--- a/app/lib/Db-Postgres.ps1
+++ b/app/lib/Db-Postgres.ps1
@@ -386,7 +386,7 @@ function ConvertFrom-V6PsqlJson {
 # map player-count query.
 function Get-DuneOnlinePlayersSql {
     return @"
-SELECT json_agg(row_to_json(t)) FROM (
+SELECT COALESCE(json_agg(row_to_json(t)), '[]'::json) FROM (
   SELECT eps.player_pawn_id::text  AS id,
          decrypt_user_data(eps.encrypted_character_name) AS name,
          eps.online_status::text   AS status
@@ -418,22 +418,48 @@ function Get-V6OnlinePlayers {
 # Disruptive actions must distinguish a verified empty roster from an
 # unavailable or malformed database response. The ordinary mutation guard keeps
 # its historical fail-open behavior through Get-V6OnlinePlayers.
+function New-V6OnlinePlayerQueryException {
+    param(
+        [Parameter(Mandatory)][string]$Failure,
+        [Parameter(Mandatory)][string]$Message
+    )
+    $exception = [System.InvalidOperationException]::new($Message)
+    $exception.Data['DunePlayerVerificationFailure'] = $Failure
+    return $exception
+}
+
 function Get-V6OnlinePlayersStrict {
     param([string]$Ip)
-    $raw = Invoke-V6Psql -Ip $Ip -Sql (Get-DuneOnlinePlayersSql)
+    try {
+        $raw = Invoke-V6Psql -Ip $Ip -Sql (Get-DuneOnlinePlayersSql)
+    } catch {
+        $failure = if ($_.Exception.Message -match '(?i)timed?\s*out|timeout') { 'timeout' } else { 'server_error' }
+        $message = if ($failure -eq 'timeout') {
+            "The online-player query timed out: $($_.Exception.Message)"
+        } else {
+            "The online-player query failed: $($_.Exception.Message)"
+        }
+        throw (New-V6OnlinePlayerQueryException -Failure $failure -Message $message)
+    }
     if ([string]::IsNullOrWhiteSpace($raw)) {
-        throw 'The online-player query returned no response.'
+        throw (New-V6OnlinePlayerQueryException -Failure 'no_response' -Message 'The online-player query returned no response.')
+    }
+    if ($raw -match '(?i)timed?\s*out|timeout') {
+        throw (New-V6OnlinePlayerQueryException -Failure 'timeout' -Message "The online-player query timed out: $raw")
     }
     if ($raw -match '(?i)^(ERROR:|FATAL:)|\bERROR:|\bFATAL:' -or
         (Test-DunePsqlConnError -Output $raw)) {
-        throw "The online-player query failed: $raw"
+        throw (New-V6OnlinePlayerQueryException -Failure 'server_error' -Message "The online-player query failed: $raw")
     }
+    if ($raw -match '^\s*\[\s*\]\s*$') { return @() }
     try {
         $list = $raw | ConvertFrom-Json -ErrorAction Stop
     } catch {
-        throw "The online-player query returned an invalid response: $($_.Exception.Message)"
+        throw (New-V6OnlinePlayerQueryException -Failure 'invalid_response' -Message "The online-player query returned an invalid response: $($_.Exception.Message)")
     }
-    if ($null -eq $list) { return @() }
+    if ($null -eq $list) {
+        throw (New-V6OnlinePlayerQueryException -Failure 'invalid_response' -Message 'The online-player query returned JSON null instead of a roster.')
+    }
     return @($list)
 }
 

--- a/app/lib/Db-Postgres.ps1
+++ b/app/lib/Db-Postgres.ps1
@@ -444,21 +444,20 @@ function Get-V6OnlinePlayersStrict {
     if ([string]::IsNullOrWhiteSpace($raw)) {
         throw (New-V6OnlinePlayerQueryException -Failure 'no_response' -Message 'The online-player query returned no response.')
     }
-    if ($raw -match '(?i)timed?\s*out|timeout') {
-        throw (New-V6OnlinePlayerQueryException -Failure 'timeout' -Message "The online-player query timed out: $raw")
-    }
-    if ($raw -match '(?i)^(ERROR:|FATAL:)|\bERROR:|\bFATAL:' -or
-        (Test-DunePsqlConnError -Output $raw)) {
-        throw (New-V6OnlinePlayerQueryException -Failure 'server_error' -Message "The online-player query failed: $raw")
-    }
-    if ($raw -match '^\s*\[\s*\]\s*$') { return @() }
     try {
         $list = $raw | ConvertFrom-Json -ErrorAction Stop
     } catch {
+        if ($raw -match '(?i)timed?\s*out|timeout') {
+            throw (New-V6OnlinePlayerQueryException -Failure 'timeout' -Message "The online-player query timed out: $raw")
+        }
+        if ($raw -match '(?i)^(ERROR:|FATAL:)|\bERROR:|\bFATAL:' -or
+            (Test-DunePsqlConnError -Output $raw)) {
+            throw (New-V6OnlinePlayerQueryException -Failure 'server_error' -Message "The online-player query failed: $raw")
+        }
         throw (New-V6OnlinePlayerQueryException -Failure 'invalid_response' -Message "The online-player query returned an invalid response: $($_.Exception.Message)")
     }
-    if ($null -eq $list) {
-        throw (New-V6OnlinePlayerQueryException -Failure 'invalid_response' -Message 'The online-player query returned JSON null instead of a roster.')
+    if ($raw.TrimStart()[0] -ne '[') {
+        throw (New-V6OnlinePlayerQueryException -Failure 'invalid_response' -Message 'The online-player query returned JSON that was not a roster array.')
     }
     return @($list)
 }

--- a/app/server/lib/PlayerGuard.ps1
+++ b/app/server/lib/PlayerGuard.ps1
@@ -70,13 +70,17 @@ function Test-DuneDisruptiveActionGuard {
     }
 
     if ([string]::IsNullOrWhiteSpace($Ip)) {
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "player safety verification failed before ${Action}: context_unavailable (no VM/database address)" 'WARN'
+        }
         Write-DuneJson -Response $Res -Status 409 -Body @{
-            ok            = $false
-            conflict      = 'player_status_unknown'
-            playersOnline = $null
-            playerNames   = @()
-            players       = @()
-            message       = "DST could not verify whether players are online before $Action."
+            ok                  = $false
+            conflict            = 'player_status_unknown'
+            verificationFailure = 'context_unavailable'
+            playersOnline       = $null
+            playerNames         = @()
+            players             = @()
+            message             = "DST could not verify whether players are online before $Action. The running VM or database address is unavailable."
         }
         return $false
     }
@@ -84,13 +88,21 @@ function Test-DuneDisruptiveActionGuard {
     try {
         $players = @(Get-V6OnlinePlayersStrict -Ip $Ip)
     } catch {
+        $failure = 'server_error'
+        if ($_.Exception.Data -and $_.Exception.Data.Contains('DunePlayerVerificationFailure')) {
+            $failure = [string]$_.Exception.Data['DunePlayerVerificationFailure']
+        }
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "player safety verification failed before ${Action}: $failure ($($_.Exception.Message))" 'WARN'
+        }
         Write-DuneJson -Response $Res -Status 409 -Body @{
-            ok            = $false
-            conflict      = 'player_status_unknown'
-            playersOnline = $null
-            playerNames   = @()
-            players       = @()
-            message       = "DST could not verify whether players are online before $Action. $($_.Exception.Message)"
+            ok                  = $false
+            conflict            = 'player_status_unknown'
+            verificationFailure = $failure
+            playersOnline       = $null
+            playerNames         = @()
+            players             = @()
+            message             = "DST could not verify whether players are online before $Action. $($_.Exception.Message)"
         }
         return $false
     }

--- a/tests/PlayerGuard.Tests.ps1
+++ b/tests/PlayerGuard.Tests.ps1
@@ -3,6 +3,7 @@ BeforeAll {
     Import-DstLib 'PlayerGuard.ps1'
     . (Join-Path (Get-DstRepoRoot) 'app\lib\Db-Postgres.ps1')
     function Write-DuneJson {}
+    function Write-DuneLog { param($Message, $Level) }
     function Get-DuneDbContext {}
 }
 
@@ -13,6 +14,7 @@ Describe 'Disruptive action player guard' {
             param($Response, $Status, $Body)
             $script:guardResponse = @{ status = $Status; body = $Body }
         }
+        Mock Write-DuneLog {}
         Mock Get-DuneDbContext { @{ ok = $true; ip = '192.0.2.1' } }
     }
 
@@ -42,6 +44,23 @@ Describe 'Disruptive action player guard' {
             Should -BeFalse
         $script:guardResponse.status | Should -Be 409
         $script:guardResponse.body.conflict | Should -Be 'player_status_unknown'
+        $script:guardResponse.body.verificationFailure | Should -Be 'server_error'
+        Should -Invoke Write-DuneLog -Times 1 -ParameterFilter {
+            $Message -match 'player safety verification failed' -and $Level -eq 'WARN'
+        }
+    }
+
+    It 'reports an unavailable VM/database context separately' {
+        Mock Get-DuneDbContext { @{ ok = $false } }
+        Mock Get-V6OnlinePlayersStrict { throw 'should not be called' }
+        $request = [pscustomobject]@{ QueryString = @{} }
+
+        Test-DuneDisruptiveActionGuard -Req $request -Res $null -Action 'stopping the battlegroup' |
+            Should -BeFalse
+
+        $script:guardResponse.body.verificationFailure | Should -Be 'context_unavailable'
+        $script:guardResponse.body.message | Should -Match 'address is unavailable'
+        Should -Invoke Get-V6OnlinePlayersStrict -Times 0
     }
 
     It 'allows an explicit force retry without querying player state' {
@@ -56,7 +75,7 @@ Describe 'Disruptive action player guard' {
 
     Describe 'Strict online-player roster query' {
         It 'accepts a verified empty JSON roster' {
-            Mock Invoke-V6Psql { 'null' }
+            Mock Invoke-V6Psql { '[]' }
             @(Get-V6OnlinePlayersStrict -Ip '192.0.2.1').Count | Should -Be 0
         }
 
@@ -67,10 +86,33 @@ Describe 'Disruptive action player guard' {
             $players[0].name | Should -Be 'Vospers'
         }
 
-        It 'throws on transport, database, or malformed responses' {
-            foreach ($response in @('', 'ERROR: ssh timed out after 30s', 'FATAL: database unavailable', 'not-json')) {
-                Mock Invoke-V6Psql { $response }
-                { Get-V6OnlinePlayersStrict -Ip '192.0.2.1' } | Should -Throw
+        It 'distinguishes no response, timeout, server errors, and invalid responses' {
+            $cases = @(
+                @{ response = ''; failure = 'no_response' }
+                @{ response = 'ERROR: ssh timed out after 30s'; failure = 'timeout' }
+                @{ response = 'FATAL: database unavailable'; failure = 'server_error' }
+                @{ response = 'not-json'; failure = 'invalid_response' }
+                @{ response = 'null'; failure = 'invalid_response' }
+            )
+            foreach ($case in $cases) {
+                $script:queryResponse = $case.response
+                Mock Invoke-V6Psql { $script:queryResponse }
+                try {
+                    Get-V6OnlinePlayersStrict -Ip '192.0.2.1'
+                    throw 'Expected strict online-player query to fail.'
+                } catch {
+                    $_.Exception.Data['DunePlayerVerificationFailure'] | Should -Be $case.failure
+                }
+            }
+        }
+
+        It 'classifies thrown transport timeouts separately from other transport failures' {
+            Mock Invoke-V6Psql { throw 'Operation timed out while opening SSH' }
+            try {
+                Get-V6OnlinePlayersStrict -Ip '192.0.2.1'
+                throw 'Expected strict online-player query to fail.'
+            } catch {
+                $_.Exception.Data['DunePlayerVerificationFailure'] | Should -Be 'timeout'
             }
         }
     }

--- a/tests/PlayerGuard.Tests.ps1
+++ b/tests/PlayerGuard.Tests.ps1
@@ -86,6 +86,13 @@ Describe 'Disruptive action player guard' {
             $players[0].name | Should -Be 'Vospers'
         }
 
+        It 'does not classify transport keywords inside a valid roster' {
+            Mock Invoke-V6Psql { '[{"id":"10","name":"Timeout FATAL:","status":"Online"}]' }
+            $players = @(Get-V6OnlinePlayersStrict -Ip '192.0.2.1')
+            $players.Count | Should -Be 1
+            $players[0].name | Should -Be 'Timeout FATAL:'
+        }
+
         It 'distinguishes no response, timeout, server errors, and invalid responses' {
             $cases = @(
                 @{ response = ''; failure = 'no_response' }
@@ -93,6 +100,8 @@ Describe 'Disruptive action player guard' {
                 @{ response = 'FATAL: database unavailable'; failure = 'server_error' }
                 @{ response = 'not-json'; failure = 'invalid_response' }
                 @{ response = 'null'; failure = 'invalid_response' }
+                @{ response = '{}'; failure = 'invalid_response' }
+                @{ response = '"Timeout"'; failure = 'invalid_response' }
             )
             foreach ($case in $cases) {
                 $script:queryResponse = $case.response

--- a/tests/PlayerGuardSql.Tests.ps1
+++ b/tests/PlayerGuardSql.Tests.ps1
@@ -32,4 +32,7 @@ Describe 'Get-DuneOnlinePlayersSql' {
         $script:OnlineSql | Should -Match 'player_pawn_id::text'
         $script:OnlineSql | Should -Match 'decrypt_user_data\(eps\.encrypted_character_name\)'
     }
+    It 'returns an explicit empty JSON roster when no players are online' {
+        $script:OnlineSql | Should -Match "COALESCE\(json_agg\(row_to_json\(t\)\), '\[\]'::json\)"
+    }
 }

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -59,6 +59,8 @@ export class ApiError extends Error {
   }
 }
 
+export class PlayerGuardCancelledError extends ApiError {}
+
 export async function api<T = unknown>(
   path: string,
   init: RequestInit = {},
@@ -115,19 +117,49 @@ export function wsUrl(path: string): string {
 export interface PlayersOnlineConflict {
   ok: false
   conflict: 'players_online' | 'player_status_unknown'
+  verificationFailure?: 'context_unavailable' | 'no_response' | 'timeout' | 'server_error' | 'invalid_response'
   playersOnline: number | null
   playerNames: string[]
   players: Array<{ id: string; name: string; status: string }>
   message: string
 }
 
+type OnlinePlayerConfirmationHandler = (
+  conflict: Partial<PlayersOnlineConflict>,
+) => Promise<boolean>
+
+let onlinePlayerConfirmationHandler: OnlinePlayerConfirmationHandler | null = null
+
+export function registerOnlinePlayerConfirmationHandler(
+  handler: OnlinePlayerConfirmationHandler,
+): () => void {
+  const previous = onlinePlayerConfirmationHandler
+  onlinePlayerConfirmationHandler = handler
+  return () => {
+    if (onlinePlayerConfirmationHandler === handler) {
+      onlinePlayerConfirmationHandler = previous
+    }
+  }
+}
+
+async function requestOnlinePlayerConfirmation(
+  conflict: Partial<PlayersOnlineConflict>,
+): Promise<boolean> {
+  if (!onlinePlayerConfirmationHandler) {
+    throw new ApiError(
+      409,
+      'Player safety confirmation is unavailable. The action was not started.',
+      conflict,
+    )
+  }
+  return onlinePlayerConfirmationHandler(conflict)
+}
+
 /**
  * Wraps a mutation that accepts an optional `force` flag. The first attempt
  * runs without `force`; if the server returns 409 with the players-online
- * conflict body, the user is prompted, and on confirmation the call is
- * retried with `force=true`. If the user declines, an ApiError(409) is
- * thrown so the caller's existing error handling reports it the same way
- * as any other failed save.
+ * conflict body, the registered DST confirmation UI is shown, and on explicit
+ * confirmation the call is retried with `force=true`.
  */
 export async function withOnlinePlayerGuard<T>(
   fn: (force: boolean) => Promise<T>,
@@ -138,27 +170,21 @@ export async function withOnlinePlayerGuard<T>(
     if (e instanceof ApiError && e.status === 409) {
       const body = e.body as Partial<PlayersOnlineConflict> | undefined
       if (body && body.conflict === 'players_online') {
-        const names = body.playerNames ?? []
-        const count = body.playersOnline ?? names.length
-        const list = names.length > 0
-          ? names.slice(0, 8).join(', ') + (names.length > 8 ? `, +${names.length - 8} more` : '')
-          : `${count} player(s)`
-        const ok = window.confirm(
-          `${count} player${count === 1 ? '' : 's'} currently online:\n  ${list}\n\n`
-          + `${body.message ?? 'This action may affect connected players.'}\n\n`
-          + 'Continue anyway?',
-        )
+        const ok = await requestOnlinePlayerConfirmation(body)
         if (!ok) {
-          throw new ApiError(409, 'Action cancelled because players are online.', body)
+          throw new PlayerGuardCancelledError(409, 'Action cancelled because players are online.', body)
         }
         return await fn(true)
       }
       if (body && body.conflict === 'player_status_unknown') {
-        const ok = window.confirm(
-          `${body.message ?? 'DST could not verify whether players are online.'}\n\n`
-          + 'Continue without verification? Connected players may be disconnected.',
-        )
-        if (!ok) throw new ApiError(409, 'Action cancelled because player status is unknown.', body)
+        const ok = await requestOnlinePlayerConfirmation(body)
+        if (!ok) {
+          throw new PlayerGuardCancelledError(
+            409,
+            'Action cancelled because player status is unknown.',
+            body,
+          )
+        }
         return await fn(true)
       }
     }

--- a/webui/src/components/ConfirmationModal.tsx
+++ b/webui/src/components/ConfirmationModal.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useId, useRef, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { Icon } from './Icon'
+
+type Props = {
+  title: string
+  description: string
+  confirmLabel: string
+  onConfirm: () => void
+  onCancel: () => void
+  children?: ReactNode
+}
+
+export function ConfirmationModal({
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+  children,
+}: Props) {
+  const titleId = useId()
+  const descriptionId = useId()
+  const modalRef = useRef<HTMLDivElement | null>(null)
+  const cancelRef = useRef<HTMLButtonElement | null>(null)
+  const onCancelRef = useRef(onCancel)
+  onCancelRef.current = onCancel
+
+  useEffect(() => {
+    const previousFocus = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null
+    const previousOverflow = document.body.style.overflow
+    const root = document.getElementById('root')
+    const previousInert = root?.inert ?? false
+    document.body.style.overflow = 'hidden'
+    if (root) root.inert = true
+    cancelRef.current?.focus()
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCancelRef.current()
+        return
+      }
+      if (event.key !== 'Tab') return
+      const focusable = Array.from(modalRef.current?.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ) ?? [])
+      if (focusable.length === 0) {
+        event.preventDefault()
+        cancelRef.current?.focus()
+        return
+      }
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.body.style.overflow = previousOverflow
+      if (root) root.inert = previousInert
+      document.removeEventListener('keydown', onKeyDown)
+      previousFocus?.focus()
+    }
+  }, [])
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[12000] flex items-center justify-center bg-black/70 p-3 sm:p-5"
+      role="presentation"
+      onClick={onCancel}
+    >
+      <div
+        ref={modalRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className="w-full max-w-lg overflow-hidden rounded-xl border border-danger/40 bg-surface shadow-[0_8px_0_rgba(0,0,0,0.18),0_28px_70px_-18px_rgba(0,0,0,0.85)]"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="flex items-start gap-3 border-b border-border px-4 py-4 sm:px-5">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-danger/30 bg-danger/15 text-danger">
+            <Icon name="TriangleAlert" size={20} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 id={titleId} className="text-base font-semibold text-text sm:text-lg">
+              {title}
+            </h2>
+            <p id={descriptionId} className="mt-1 text-sm leading-relaxed text-text-muted">
+              {description}
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Cancel and close"
+            className="btn-icon min-h-11 min-w-11 shrink-0"
+            onClick={onCancel}
+          >
+            <Icon name="X" size={17} />
+          </button>
+        </header>
+
+        {children && (
+          <div className="max-h-[55dvh] overflow-y-auto px-4 py-4 sm:px-5">
+            {children}
+          </div>
+        )}
+
+        <footer className="flex flex-col gap-2 border-t border-border px-4 py-4 sm:flex-row sm:justify-end sm:px-5">
+          <button
+            ref={cancelRef}
+            type="button"
+            className="btn-secondary min-h-11 justify-center"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn-danger min-h-11 justify-center"
+            onClick={onConfirm}
+          >
+            <Icon name="TriangleAlert" size={15} />
+            {confirmLabel}
+          </button>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/webui/src/components/OnlinePlayerGuardModal.tsx
+++ b/webui/src/components/OnlinePlayerGuardModal.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  registerOnlinePlayerConfirmationHandler,
+  type PlayersOnlineConflict,
+} from '../api/client'
+import { ConfirmationModal } from './ConfirmationModal'
+
+type PendingConfirmation = {
+  conflict: Partial<PlayersOnlineConflict>
+  resolve: (confirmed: boolean) => void
+}
+
+const FAILURE_LABELS: Record<
+  NonNullable<PlayersOnlineConflict['verificationFailure']>,
+  string
+> = {
+  context_unavailable: 'Server address unavailable',
+  no_response: 'No response received',
+  timeout: 'Verification timed out',
+  server_error: 'Server query failed',
+  invalid_response: 'Invalid response received',
+}
+
+export function OnlinePlayerGuardModal() {
+  const [pending, setPending] = useState<PendingConfirmation | null>(null)
+  const pendingRef = useRef<PendingConfirmation | null>(null)
+
+  useEffect(() => {
+    const unregister = registerOnlinePlayerConfirmationHandler((conflict) => {
+      if (pendingRef.current) return Promise.resolve(false)
+      return new Promise<boolean>((resolve) => {
+        const request = { conflict, resolve }
+        pendingRef.current = request
+        setPending(request)
+      })
+    })
+    return () => {
+      unregister()
+      pendingRef.current?.resolve(false)
+      pendingRef.current = null
+    }
+  }, [])
+
+  if (!pending) return null
+
+  const settle = (confirmed: boolean) => {
+    pending.resolve(confirmed)
+    pendingRef.current = null
+    setPending(null)
+  }
+  const { conflict } = pending
+  const unknown = conflict.conflict === 'player_status_unknown'
+  const names = conflict.playerNames ?? []
+  const count = conflict.playersOnline ?? names.length
+  const title = unknown
+    ? 'Player verification failed'
+    : `${count} connected player${count === 1 ? '' : 's'} detected`
+  const description = conflict.message ?? (
+    unknown
+      ? 'DST could not verify whether players are online before this action.'
+      : 'This action may disconnect connected players.'
+  )
+  const failureLabel = conflict.verificationFailure
+    ? FAILURE_LABELS[conflict.verificationFailure]
+    : 'Player status unknown'
+
+  return (
+    <ConfirmationModal
+      title={title}
+      description={description}
+      confirmLabel={unknown ? 'Continue without verification' : 'Continue anyway'}
+      onCancel={() => settle(false)}
+      onConfirm={() => settle(true)}
+    >
+      <div className="space-y-3 text-sm">
+        {unknown ? (
+          <>
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-border bg-surface-2 px-3 py-2">
+              <span className="text-text-muted">Verification status</span>
+              <strong className="text-right font-medium text-warning">{failureLabel}</strong>
+            </div>
+            <div className="rounded-lg border border-danger/40 bg-danger/10 px-3 py-3 text-danger">
+              <strong className="block font-semibold">Connected players may still be online.</strong>
+              <span className="mt-1 block leading-relaxed">
+                Continuing can disconnect them. Cancel is the safe choice until player status can be verified.
+              </span>
+            </div>
+          </>
+        ) : (
+          <div className="rounded-lg border border-danger/40 bg-danger/10 px-3 py-3 text-danger">
+            <strong className="block font-semibold">
+              Continuing will disconnect {count === 1 ? 'this player' : 'these players'}.
+            </strong>
+            {names.length > 0 && (
+              <span className="mt-1 block break-words leading-relaxed text-text">
+                {names.slice(0, 8).join(', ')}
+                {names.length > 8 ? `, +${names.length - 8} more` : ''}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </ConfirmationModal>
+  )
+}

--- a/webui/src/layout/AppShell.tsx
+++ b/webui/src/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import { DecoupleNoticeModal } from '../components/DecoupleNoticeModal'
 import { useSidebarCollapsed } from '../hooks/useSidebarCollapsed'
 import { usePortalAccess } from '../auth/portalAccess'
 import { SectionJumpNav } from '../components/SectionJumpNav'
+import { OnlinePlayerGuardModal } from '../components/OnlinePlayerGuardModal'
 
 // Routes that should render full-bleed below the menu bar — no sidebar, no
 // status bar, no update banner, no max-width / padding. Keep the top menu bar
@@ -25,6 +26,7 @@ export function AppShell({ children }: { children: ReactNode }) {
     return (
       <div className="h-full w-full max-w-full flex flex-col overflow-hidden">
         <DecoupleNoticeModal />
+        <OnlinePlayerGuardModal />
         <MenuBar sidebarCollapsed={collapsed} onToggleSidebar={toggle} />
         <main className="flex-1 min-h-0 min-w-0 max-w-full overflow-hidden">
           {children}
@@ -36,6 +38,7 @@ export function AppShell({ children }: { children: ReactNode }) {
   return (
     <div className="h-full w-full max-w-full flex flex-col overflow-hidden">
       <DecoupleNoticeModal />
+      <OnlinePlayerGuardModal />
       <MenuBar sidebarCollapsed={collapsed} onToggleSidebar={toggle} />
       <div className="flex-1 flex overflow-hidden min-h-0">
         <Sidebar collapsed={collapsed} onExpand={() => setCollapsed(false)} />

--- a/webui/src/pages/Commands.tsx
+++ b/webui/src/pages/Commands.tsx
@@ -24,7 +24,7 @@ import { PageHeader } from '../components/PageHeader'
 import { Icon } from '../components/Icon'
 import { useStatus } from '../hooks/useStatus'
 import { useApi } from '../hooks/useApi'
-import { api, withOnlinePlayerGuard } from '../api/client'
+import { api, PlayerGuardCancelledError, withOnlinePlayerGuard } from '../api/client'
 import { isLocalViewer } from '../util/viewer'
 import type { Command, CommandsResponse } from '../api/types'
 import { usePortalAuth } from '../auth/PortalAuthGate'
@@ -347,6 +347,7 @@ export function Commands() {
       showToast('ok', `Launched '${r.name}'${r.pid ? ` (PID ${r.pid})` : ''} in a new console window.`)
       window.setTimeout(() => { void forceRefresh(); void cmdsState.refresh() }, 1500)
     } catch (e) {
+      if (e instanceof PlayerGuardCancelledError) return
       const msg = e instanceof Error ? e.message : String(e)
       showToast('err', `Launch failed: ${msg}`)
     } finally {

--- a/webui/tests/api/client.test.ts
+++ b/webui/tests/api/client.test.ts
@@ -1,15 +1,29 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ApiError, withOnlinePlayerGuard } from '../../src/api/client'
+import {
+  ApiError,
+  PlayerGuardCancelledError,
+  registerOnlinePlayerConfirmationHandler,
+  withOnlinePlayerGuard,
+} from '../../src/api/client'
+
+let unregisterConfirmation: (() => void) | null = null
+
+function confirmWith(result: boolean) {
+  const handler = vi.fn(async () => result)
+  unregisterConfirmation = registerOnlinePlayerConfirmationHandler(handler)
+  return handler
+}
 
 afterEach(() => {
+  unregisterConfirmation?.()
+  unregisterConfirmation = null
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
 })
 
 describe('online player guard', () => {
   it('shows player details and retries only after confirmation', async () => {
-    const confirm = vi.fn(() => true)
-    vi.stubGlobal('confirm', confirm)
+    const confirm = confirmWith(true)
     const operation = vi.fn(async (force: boolean) => {
       if (!force) {
         throw new ApiError(409, 'conflict', {
@@ -26,12 +40,14 @@ describe('online player guard', () => {
 
     await expect(withOnlinePlayerGuard(operation)).resolves.toBe('done')
     expect(operation.mock.calls).toEqual([[false], [true]])
-    expect(confirm.mock.calls[0][0]).toContain('Vospers, Fargan')
-    expect(confirm.mock.calls[0][0]).toContain('Restarting will disconnect them.')
+    expect(confirm).toHaveBeenCalledWith(expect.objectContaining({
+      playerNames: ['Vospers', 'Fargan'],
+      message: 'Restarting will disconnect them.',
+    }))
   })
 
   it('does not retry when the operator cancels', async () => {
-    vi.stubGlobal('confirm', vi.fn(() => false))
+    confirmWith(false)
     const operation = vi.fn(async () => {
       throw new ApiError(409, 'conflict', {
         conflict: 'players_online',
@@ -40,15 +56,12 @@ describe('online player guard', () => {
       })
     })
 
-    await expect(withOnlinePlayerGuard(operation)).rejects.toThrow(
-      'Action cancelled because players are online.',
-    )
+    await expect(withOnlinePlayerGuard(operation)).rejects.toBeInstanceOf(PlayerGuardCancelledError)
     expect(operation).toHaveBeenCalledTimes(1)
   })
 
   it('requires confirmation before forcing when player status is unknown', async () => {
-    const confirm = vi.fn(() => true)
-    vi.stubGlobal('confirm', confirm)
+    const confirm = confirmWith(true)
     const operation = vi.fn(async (force: boolean) => {
       if (!force) {
         throw new ApiError(409, 'conflict', {
@@ -63,6 +76,23 @@ describe('online player guard', () => {
 
     await expect(withOnlinePlayerGuard(operation)).resolves.toBe('forced')
     expect(operation.mock.calls).toEqual([[false], [true]])
-    expect(confirm.mock.calls[0][0]).toContain('Continue without verification?')
+    expect(confirm).toHaveBeenCalledWith(expect.objectContaining({
+      conflict: 'player_status_unknown',
+    }))
+  })
+
+  it('fails closed when the DST confirmation host is unavailable', async () => {
+    const operation = vi.fn(async () => {
+      throw new ApiError(409, 'conflict', {
+        conflict: 'player_status_unknown',
+        playersOnline: null,
+        playerNames: [],
+      })
+    })
+
+    await expect(withOnlinePlayerGuard(operation)).rejects.toThrow(
+      'Player safety confirmation is unavailable. The action was not started.',
+    )
+    expect(operation).toHaveBeenCalledTimes(1)
   })
 })

--- a/webui/tests/components/OnlinePlayerGuardModal.test.tsx
+++ b/webui/tests/components/OnlinePlayerGuardModal.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React, { useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ApiError,
+  PlayerGuardCancelledError,
+  withOnlinePlayerGuard,
+} from '../../src/api/client'
+import { OnlinePlayerGuardModal } from '../../src/components/OnlinePlayerGuardModal'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function Harness({ operation }: { operation: (force: boolean) => Promise<string> }) {
+  const [status, setStatus] = useState('idle')
+  const run = async () => {
+    try {
+      setStatus(await withOnlinePlayerGuard(operation))
+    } catch (error) {
+      setStatus(error instanceof PlayerGuardCancelledError ? 'cancelled' : 'failed')
+    }
+  }
+  return (
+    <>
+      <OnlinePlayerGuardModal />
+      <button type="button" onClick={() => { void run() }}>Run guarded action</button>
+      <output>{status}</output>
+    </>
+  )
+}
+
+function unknownConflict() {
+  return new ApiError(409, 'conflict', {
+    ok: false,
+    conflict: 'player_status_unknown',
+    verificationFailure: 'timeout',
+    playersOnline: null,
+    playerNames: [],
+    players: [],
+    message: 'DST could not verify whether players are online. The query timed out.',
+  })
+}
+
+describe('OnlinePlayerGuardModal', () => {
+  it('defaults focus to safe cancel, explains the risk, and cancels with Escape', async () => {
+    const user = userEvent.setup()
+    const nativeConfirm = vi.spyOn(window, 'confirm')
+    const operation = vi.fn(async () => { throw unknownConflict() })
+    render(<Harness operation={operation} />)
+
+    const launch = screen.getByRole('button', { name: 'Run guarded action' })
+    await user.click(launch)
+
+    expect(await screen.findByRole('alertdialog', { name: 'Player verification failed' })).toBeInTheDocument()
+    expect(screen.getByText('Verification timed out')).toBeInTheDocument()
+    expect(screen.getByText(/Connected players may still be online/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus()
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.getByText('cancelled')).toBeInTheDocument())
+    expect(operation).toHaveBeenCalledTimes(1)
+    expect(launch).toHaveFocus()
+    expect(nativeConfirm).not.toHaveBeenCalled()
+  })
+
+  it('runs the forced retry only from the explicit destructive action', async () => {
+    const user = userEvent.setup()
+    const operation = vi.fn(async (force: boolean) => {
+      if (!force) throw unknownConflict()
+      return 'completed'
+    })
+    render(<Harness operation={operation} />)
+
+    await user.click(screen.getByRole('button', { name: 'Run guarded action' }))
+    const continueButton = await screen.findByRole('button', {
+      name: 'Continue without verification',
+    })
+    await user.click(continueButton)
+
+    await waitFor(() => expect(screen.getByText('completed')).toBeInTheDocument())
+    expect(operation.mock.calls).toEqual([[false], [true]])
+  })
+
+  it('keeps keyboard focus inside the modal', async () => {
+    const user = userEvent.setup()
+    const operation = vi.fn(async () => { throw unknownConflict() })
+    render(<Harness operation={operation} />)
+
+    await user.click(screen.getByRole('button', { name: 'Run guarded action' }))
+    const continueButton = await screen.findByRole('button', {
+      name: 'Continue without verification',
+    })
+    continueButton.focus()
+    await user.tab()
+
+    expect(screen.getByRole('button', { name: 'Cancel and close' })).toHaveFocus()
+  })
+})


### PR DESCRIPTION
## Summary

- Return an explicit empty JSON roster when no players are online instead of misclassifying PostgreSQL `NULL`/blank output as a missing response.
- Keep disruptive actions fail-closed while distinguishing unavailable context, no response, timeout, server error, and invalid response in API details and WARN logs.
- Replace the browser-native player guard prompt with an accessible DST modal that defaults focus to Cancel, traps/restores focus, supports Escape/backdrop cancellation, and requires an explicit destructive continuation.

## Related issue

Phase 2 follow-up after #782.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (menu option removed/renamed, config key changed, etc.)
- [ ] Docs only
- [ ] Chore / CI / refactor

## Testing

- [x] `Parse-validated` the script (no syntax errors)
- [ ] PSScriptAnalyzer is clean (`Invoke-ScriptAnalyzer -Path .\dune-server.ps1`)
- [ ] Ran end-to-end against a real Dune server VM
- [x] Tested affected menu option(s): Commands > Stop All player-safety modal at desktop and 390px touch widths
- [x] Full Pester suite: 1,265 passed
- [x] Focused Vitest suite: 7 passed
- [x] Web UI lint, production build, and TypeScript checks
- [x] Full installer build

## Changelog

- [x] I added an entry to `CHANGELOG.md` under `[Unreleased]`

## Screenshots / output

The modal was checked in-browser at desktop and 390×844 layouts. Cancel is initially focused; the destructive action is explicitly labeled **Continue without verification**. No release version was stamped or published.