### PR TITLE
Add safe dungeon difficulty normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ here cover everything those tags shipped.
   Pages and whole sections can be hidden without changing top navigation or route
   access, protected destinations stay visible, and Reset restores visibility and
   order.
+- Added a guarded Players control that normalizes historical dungeon completion
+  difficulty above 50, with a verified rollback backup and battlegroup restart.
 
 ### Fixed
 

--- a/app/data/platform-route-policies.json
+++ b/app/data/platform-route-policies.json
@@ -75,6 +75,7 @@
     "http POST /api/gameplay/players/journey/reset": "destructive",
     "http POST /api/gameplay/players/journey/wipe": "destructive",
     "http POST /api/gameplay/players/wipe-codex": "destructive",
+    "http POST /api/gameplay/players/normalize-dungeon-difficulty": "destructive",
     "http DELETE /api/gameplay/item-packages": "reversible-write",
     "http DELETE /api/setup/hyperv-lan/credential": "reversible-write"
     ,"http POST /api/gameplay/vehicles/deletions": "reversible-write"
@@ -119,6 +120,7 @@
     "http POST /api/gameplay/players/journey/reset": "player.manage.destructive",
     "http POST /api/gameplay/players/journey/wipe": "player.manage.destructive",
     "http POST /api/gameplay/players/wipe-codex": "player.manage.destructive",
+    "http POST /api/gameplay/players/normalize-dungeon-difficulty": "player.manage.destructive",
     "http DELETE /api/remote-access/portal-accounts/{id}": "platform.access.destructive",
     "http POST /api/public-ip/apply": "settings.connectivity.manage",
     "http POST /api/public-ip/datacenter-id": "settings.connectivity.manage",
@@ -150,7 +152,7 @@
     { "source": "FlsToken.ps1", "capabilityId": "settings.connectivity", "routeCount": 3, "sha256": "5dbda64c9121b306d6d6f3487aef4e6f630a73beba73d0067baa14373237f2bb" },
     { "source": "GameConfig.ps1", "capabilityId": "settings.game-server", "routeCount": 26, "sha256": "5864b52d958ef8dceeabb527268f413806b5b29b086f450b423359b34d7396ce" },
     { "source": "Gameplay.ps1", "capabilityId": "economy.market", "routeCount": 22, "sha256": "757d3fd58fe70e88c5ccc91b9549e8f9a121b9137c1a2c16cd574c271c46e258" },
-    { "source": "GameplayPlayers.ps1", "capabilityId": "player.manage", "routeCount": 27, "sha256": "4f822fc3645a5196c477810daed318d097c5319fb920a34b8ce8be6ab191d24e" },
+    { "source": "GameplayPlayers.ps1", "capabilityId": "player.manage", "routeCount": 28, "sha256": "7bb0b9d263a45ef642c1321e48c3efff35b80424ff9ecf0a040bccacb3557a46" },
     { "source": "GameplayWorld.ps1", "capabilityId": "base.manage", "routeCount": 12, "sha256": "52bfaeee6658d490bedae03914b525e3272d89ece1dc957d3514dc8ee9a84c30" },
     { "source": "ItemPackages.ps1", "capabilityId": "player.inventory", "routeCount": 3, "sha256": "ed3aac4a943d300002f7aecacb8ecf04619917ee7aa549cde0068e1853e01cf9" },
     { "source": "Landsraad.ps1", "capabilityId": "economy.governance", "routeCount": 9, "sha256": "e78c0dfe1b1f969d781db180f8c73eb3439de9779dd62fde7a8879925ac762f0" },
@@ -161,7 +163,7 @@
     { "source": "Ping.ps1", "capabilityId": "platform.status", "routeCount": 2, "sha256": "67c579421a0597e78028350f74d09ff13ed82d75c113231ed1d9e0cfdda5c73b" },
     { "source": "Platform.ps1", "capabilityId": "platform.capabilities", "routeCount": 2, "sha256": "f38200ccc522826ec54e62f012d064f596b122e3acc45218916f8ffc8f7a0db4" },
     { "source": "PlayersAdmin.ps1", "capabilityId": "player.manage", "routeCount": 7, "sha256": "dc4f7da7eb846e1113f08a7ef04a1eb30878c5d05168c886ba1be4183e83883d" },
-    { "source": "PlayersRead.ps1", "capabilityId": "player.view", "routeCount": 17, "sha256": "28e6db36d3b0f3f5f1ac92358d3eae529fdbb14cb4d069ab5af9378bba377cc0" },
+    { "source": "PlayersRead.ps1", "capabilityId": "player.view", "routeCount": 18, "sha256": "bd67f91e3faf1d6e9a692b3f37aff72b650311a39b209a18abe2e629ea249a80" },
     { "source": "PlayersRmq.ps1", "capabilityId": "player.manage", "routeCount": 10, "sha256": "b789053cad3a7c53140a41a5d4d70ab44354583750380a4d06835898c8010876" },
     { "source": "PlayersWrites.ps1", "capabilityId": "player.manage", "routeCount": 37, "sha256": "655d27fb0a9873e0f7f57babb5cdc2c4e876e18102bfc8bd240aae90584a5662" },
     { "source": "Pods.ps1", "capabilityId": "operation.runtime", "routeCount": 3, "sha256": "86b85eb9a8fbc348525424496d562dd79589f8bf2b68feee0c096004bbdad749" },

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -697,6 +697,186 @@ COMMIT;
     return @{ ok = $true; updated = [int64](ConvertTo-DuneInt $rows[0]['updated_n']) }
 }
 
+if (-not $script:DuneMaintenanceLockPath) {
+    $script:DuneMaintenanceLockPath = '/tmp/dst-battlegroup-maintenance.lock'
+}
+
+function Enter-DuneVmMaintenanceLock {
+    param(
+        [string]$Ip,
+        [ValidateRange(60, 3600)][int]$LeaseTimeoutSec = 1200
+    )
+
+    if (-not (Get-Command Invoke-DuneBackupShell -ErrorAction SilentlyContinue)) {
+        return @{ ok = $false; error = 'VM maintenance lock helper is unavailable.' }
+    }
+
+    $token = [guid]::NewGuid().ToString('N')
+    $workPath = "/tmp/dst-maintenance-$token"
+    $holder = @'
+#!/bin/bash
+set -u
+LOCK="$1"
+WORK="$2"
+LEASE_TIMEOUT="$3"
+STATUS="$WORK/status"
+PIDFILE="$WORK/pid"
+exec 9>"$LOCK" || { echo error > "$STATUS"; exit 70; }
+if ! flock -n 9; then
+  echo busy > "$STATUS"
+  exit 73
+fi
+echo "$$" > "$PIDFILE"
+echo acquired > "$STATUS"
+while [ -f "$WORK/lease" ]; do
+  MODIFIED=$(stat -c %Y "$WORK/lease" 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  if [ "$MODIFIED" -le 0 ] || [ $((NOW - MODIFIED)) -ge "$LEASE_TIMEOUT" ]; then
+    break
+  fi
+  sleep 2
+done
+rm -rf "$WORK"
+'@
+    $holderB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($holder))
+    $script = @"
+set -u
+WORK='$workPath'
+mkdir -m 700 "`$WORK" || { echo '__DST_MAINTENANCE_LOCK_ERROR:workspace'; exit 70; }
+touch "`$WORK/lease"
+printf '%s' '$holderB64' | base64 -d > "`$WORK/holder.sh"
+chmod 700 "`$WORK/holder.sh"
+nohup sudo "`$WORK/holder.sh" '$script:DuneMaintenanceLockPath' "`$WORK" '$LeaseTimeoutSec' >/dev/null 2>&1 &
+for _ in `$(seq 1 50); do
+  STATUS=`$(cat "`$WORK/status" 2>/dev/null || true)
+  if [ "`$STATUS" = acquired ]; then
+    PID=`$(cat "`$WORK/pid" 2>/dev/null || true)
+    case "`$PID" in ''|*[!0-9]*) echo '__DST_MAINTENANCE_LOCK_ERROR:pid'; rm -f "`$WORK/lease"; exit 71 ;; esac
+    FD_TARGET=`$(sudo readlink "/proc/`$PID/fd/9" 2>/dev/null || true)
+    if [ "`$FD_TARGET" = '$script:DuneMaintenanceLockPath' ] &&
+       sudo awk -v expected="`$PID" '`$1 == "lock:" && `$3 == "FLOCK" && `$5 == "WRITE" && `$6 == expected { found=1 } END { exit !found }' "/proc/`$PID/fdinfo/9" 2>/dev/null; then
+      echo "__DST_MAINTENANCE_LOCK_ACQUIRED:$token|`$PID"
+      exit 0
+    fi
+    echo '__DST_MAINTENANCE_LOCK_ERROR:ownership'
+    rm -f "`$WORK/lease"
+    exit 72
+  fi
+  if [ "`$STATUS" = busy ]; then
+    sudo rm -rf "`$WORK"
+    echo '__DST_MAINTENANCE_LOCK_BUSY'
+    exit 73
+  fi
+  if [ "`$STATUS" = error ]; then
+    sudo rm -rf "`$WORK"
+    echo '__DST_MAINTENANCE_LOCK_ERROR:holder'
+    exit 74
+  fi
+  sleep 0.1
+done
+rm -f "`$WORK/lease"
+echo '__DST_MAINTENANCE_LOCK_ERROR:acquire-timeout'
+exit 75
+"@
+    try {
+        $result = Invoke-DuneBackupShell -Ip $Ip -Script $script -TimeoutSec 20
+    } catch {
+        return @{ ok = $false; error = "VM maintenance lock acquisition failed: $($_.Exception.Message)" }
+    }
+    $out = if ($null -eq $result) { '' } else { [string]$result.out }
+    $match = [regex]::Match($out, '__DST_MAINTENANCE_LOCK_ACQUIRED:([a-f0-9]{32})\|(\d+)')
+    if ($null -ne $result -and [int]$result.rc -eq 0 -and $match.Success -and $match.Groups[1].Value -eq $token) {
+        return @{
+            ok = $true
+            token = $token
+            pid = [int64]$match.Groups[2].Value
+            workPath = $workPath
+            leaseTimeoutSec = $LeaseTimeoutSec
+        }
+    }
+    if ($out -match '__DST_MAINTENANCE_LOCK_BUSY') {
+        return @{ ok = $false; busy = $true; error = 'VM maintenance is already running.' }
+    }
+    return @{ ok = $false; error = 'VM maintenance lock ownership could not be verified.' }
+}
+
+function Update-DuneVmMaintenanceLock {
+    param(
+        [string]$Ip,
+        [Parameter(Mandatory)]$Lease
+    )
+
+    $token = [string]$Lease.token
+    $holderPid = [int64]$Lease.pid
+    $workPath = [string]$Lease.workPath
+    if ($token -notmatch '^[a-f0-9]{32}$' -or $holderPid -le 0 -or $workPath -ne "/tmp/dst-maintenance-$token") {
+        return @{ ok = $false; error = 'VM maintenance lock lease is invalid.' }
+    }
+    $script = @"
+set -u
+WORK='$workPath'
+EXPECTED_PID='$holderPid'
+[ "`$(cat "`$WORK/status" 2>/dev/null || true)" = acquired ] || { echo '__DST_MAINTENANCE_LOCK_UNHEALTHY:status'; exit 76; }
+[ "`$(cat "`$WORK/pid" 2>/dev/null || true)" = "`$EXPECTED_PID" ] || { echo '__DST_MAINTENANCE_LOCK_UNHEALTHY:owner'; exit 77; }
+[ "`$(sudo readlink "/proc/`$EXPECTED_PID/fd/9" 2>/dev/null || true)" = '$script:DuneMaintenanceLockPath' ] || { echo '__DST_MAINTENANCE_LOCK_UNHEALTHY:descriptor'; exit 78; }
+sudo awk -v expected="`$EXPECTED_PID" '`$1 == "lock:" && `$3 == "FLOCK" && `$5 == "WRITE" && `$6 == expected { found=1 } END { exit !found }' "/proc/`$EXPECTED_PID/fdinfo/9" 2>/dev/null || { echo '__DST_MAINTENANCE_LOCK_UNHEALTHY:flock'; exit 78; }
+touch "`$WORK/lease" || { echo '__DST_MAINTENANCE_LOCK_UNHEALTHY:heartbeat'; exit 79; }
+sudo awk -v expected="`$EXPECTED_PID" '`$1 == "lock:" && `$3 == "FLOCK" && `$5 == "WRITE" && `$6 == expected { found=1 } END { exit !found }' "/proc/`$EXPECTED_PID/fdinfo/9" 2>/dev/null || { echo '__DST_MAINTENANCE_LOCK_UNHEALTHY:flock'; exit 78; }
+echo '__DST_MAINTENANCE_LOCK_HEALTHY'
+"@
+    try {
+        $result = Invoke-DuneBackupShell -Ip $Ip -Script $script -TimeoutSec 20
+    } catch {
+        return @{ ok = $false; error = "VM maintenance lock health check failed: $($_.Exception.Message)" }
+    }
+    if ($null -ne $result -and [int]$result.rc -eq 0 -and [string]$result.out -match '__DST_MAINTENANCE_LOCK_HEALTHY') {
+        return @{ ok = $true }
+    }
+    return @{ ok = $false; error = 'VM maintenance lock ownership is no longer verifiable.' }
+}
+
+function Exit-DuneVmMaintenanceLock {
+    param(
+        [string]$Ip,
+        [Parameter(Mandatory)]$Lease
+    )
+
+    $token = [string]$Lease.token
+    $holderPid = [int64]$Lease.pid
+    $workPath = [string]$Lease.workPath
+    if ($token -notmatch '^[a-f0-9]{32}$' -or $holderPid -le 0 -or $workPath -ne "/tmp/dst-maintenance-$token") {
+        return @{ ok = $false; error = 'VM maintenance lock lease is invalid and could not be released.' }
+    }
+    $script = @"
+set -u
+WORK='$workPath'
+EXPECTED_PID='$holderPid'
+rm -f "`$WORK/lease"
+for _ in `$(seq 1 15); do
+  if ! sudo kill -0 "`$EXPECTED_PID" 2>/dev/null; then
+    sudo rm -rf "`$WORK"
+    echo '__DST_MAINTENANCE_LOCK_RELEASED'
+    exit 0
+  fi
+  sleep 1
+done
+echo '__DST_MAINTENANCE_LOCK_RELEASE_ERROR:holder-still-running'
+exit 80
+"@
+    try {
+        $result = Invoke-DuneBackupShell -Ip $Ip -Script $script -TimeoutSec 25
+    } catch {
+        return @{ ok = $false; error = "VM maintenance lock release failed: $($_.Exception.Message)" }
+    }
+    if ($null -ne $result -and [int]$result.rc -eq 0 -and [string]$result.out -match '__DST_MAINTENANCE_LOCK_RELEASED') {
+        return @{ ok = $true }
+    }
+    return @{
+        ok = $false
+        error = "VM maintenance lock release could not be verified. Its bounded lease expires within $([int]$Lease.leaseTimeoutSec) seconds."
+    }
+}
+
 function Wait-DuneDungeonBattlegroupPodsStopped {
     param(
         [string]$Ip,
@@ -779,14 +959,15 @@ function Invoke-DuneNormalizeDungeonDifficulty {
         }
     }
 
-    $backup = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'backup'
-    if (-not $backup.ok) {
+    $maintenanceLock = Enter-DuneVmMaintenanceLock -Ip $Ip
+    if (-not $maintenanceLock.ok) {
         return @{
             ok = $false; noOp = $false; changed = $false; verified = $false; restarted = $false
-            updated = 0; backupPath = ''; error = "No changes made because the safety backup failed verification. $($backup.error)"
+            updated = 0; backupPath = ''; error = "No changes made because the VM maintenance lock was not acquired. $($maintenanceLock.error)"
         }
     }
 
+    $backup = $null
     $stopAttempted = $false
     $write = $null
     $after = $null
@@ -794,60 +975,141 @@ function Invoke-DuneNormalizeDungeonDifficulty {
     $verified = $false
     $noOpAfterStop = $false
     $start = $null
+    $lockRelease = $null
+    $maintenanceLockHeld = $true
     try {
-        $stopAttempted = $true
-        $stop = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'stop'
-        if (-not $stop.ok) {
-            $operationError = "No dungeon rows changed because the battlegroup did not stop cleanly. $($stop.error)"
-        } else {
+        $lockHealth = Update-DuneVmMaintenanceLock -Ip $Ip -Lease $maintenanceLock
+        if (-not $lockHealth.ok) {
+            $operationError = "No dungeon rows changed because VM maintenance lock ownership was not verifiable. $($lockHealth.error)"
+        }
+
+        if (-not $operationError) {
+            $backup = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'backup'
+            if (-not $backup.ok) {
+                $operationError = "No changes made because the safety backup failed verification. $($backup.error)"
+            }
+        }
+
+        if (-not $operationError) {
+            $lockHealth = Update-DuneVmMaintenanceLock -Ip $Ip -Lease $maintenanceLock
+            if (-not $lockHealth.ok) {
+                $operationError = "No dungeon rows changed because VM maintenance lock ownership was not verifiable before stop. $($lockHealth.error)"
+            }
+        }
+
+        if (-not $operationError) {
+            $stopAttempted = $true
+            $stop = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'stop'
+            if (-not $stop.ok) {
+                $operationError = "No dungeon rows changed because the battlegroup did not stop cleanly. $($stop.error)"
+            }
+        }
+
+        if (-not $operationError) {
             $podDrain = Wait-DuneDungeonBattlegroupPodsStopped -Ip $Ip
             if (-not $podDrain.ok) {
                 $operationError = "No dungeon rows changed because battlegroup shutdown could not be verified. $($podDrain.error)"
+            }
+        }
+
+        if (-not $operationError) {
+            $lockHealth = Update-DuneVmMaintenanceLock -Ip $Ip -Lease $maintenanceLock
+            if (-not $lockHealth.ok) {
+                $operationError = "No dungeon rows changed because VM maintenance lock ownership was not verifiable after shutdown. $($lockHealth.error)"
+            }
+        }
+
+        if (-not $operationError) {
+            $stoppedSummary = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
+            if (-not $stoppedSummary.ok) {
+                $operationError = "No dungeon rows changed because the stopped-state summary failed. $($stoppedSummary.error)"
+            } elseif ($stoppedSummary.aboveTarget -eq 0) {
+                $after = $stoppedSummary
+                $verified = $true
+                $noOpAfterStop = $true
             } else {
-                $stoppedSummary = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
-                if (-not $stoppedSummary.ok) {
-                    $operationError = "No dungeon rows changed because the stopped-state summary failed. $($stoppedSummary.error)"
-                } elseif ($stoppedSummary.aboveTarget -eq 0) {
-                    $after = $stoppedSummary
-                    $verified = $true
-                    $noOpAfterStop = $true
+                $stoppedBackup = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'backup'
+                if (-not $stoppedBackup.ok) {
+                    $operationError = "No dungeon rows changed because the stopped-state rollback backup failed verification. $($stoppedBackup.error)"
                 } else {
-                    $stoppedBackup = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'backup'
-                    if (-not $stoppedBackup.ok) {
-                        $operationError = "No dungeon rows changed because the stopped-state rollback backup failed verification. $($stoppedBackup.error)"
-                    } else {
-                        $backup = $stoppedBackup
-                        $before = $stoppedSummary
-                        $write = Set-DuneDungeonDifficultyTarget -Ip $Ip
-                        if (-not $write.ok) {
-                            $operationError = $write.error
-                        } else {
-                            $after = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
-                            if (-not $after.ok) {
-                                $operationError = "Dungeon difficulty changed, but post-write verification failed. $($after.error)"
-                            } elseif ($after.total -ne $before.total) {
-                                $operationError = "Post-write verification failed: completion row count changed from $($before.total) to $($after.total)."
-                            } elseif ($write.updated -ne $before.aboveTarget) {
-                                $operationError = "Post-write verification failed: expected $($before.aboveTarget) updated rows but PostgreSQL reported $($write.updated)."
-                            } elseif ($after.aboveTarget -ne 0 -or ($null -ne $after.maximum -and $after.maximum -gt 50)) {
-                                $operationError = "Post-write verification failed: $($after.aboveTarget) completion row(s) remain above 50."
-                            } else {
-                                $verified = $true
-                            }
-                        }
-                    }
+                    $backup = $stoppedBackup
+                    $before = $stoppedSummary
+                }
+            }
+        }
+
+        if (-not $operationError -and -not $noOpAfterStop) {
+            $lockHealth = Update-DuneVmMaintenanceLock -Ip $Ip -Lease $maintenanceLock
+            if (-not $lockHealth.ok) {
+                $operationError = "No dungeon rows changed because VM maintenance lock ownership was not verifiable before the database write. $($lockHealth.error)"
+            }
+        }
+
+        if (-not $operationError -and -not $noOpAfterStop) {
+            $write = Set-DuneDungeonDifficultyTarget -Ip $Ip
+            if (-not $write.ok) {
+                $operationError = $write.error
+            } else {
+                $after = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
+                if (-not $after.ok) {
+                    $operationError = "Dungeon difficulty changed, but post-write verification failed. $($after.error)"
+                } elseif ($after.total -ne $before.total) {
+                    $operationError = "Post-write verification failed: completion row count changed from $($before.total) to $($after.total)."
+                } elseif ($write.updated -ne $before.aboveTarget) {
+                    $operationError = "Post-write verification failed: expected $($before.aboveTarget) updated rows but PostgreSQL reported $($write.updated)."
+                } elseif ($after.aboveTarget -ne 0 -or ($null -ne $after.maximum -and $after.maximum -gt 50)) {
+                    $operationError = "Post-write verification failed: $($after.aboveTarget) completion row(s) remain above 50."
+                } else {
+                    $verified = $true
                 }
             }
         }
     } catch {
         $operationError = "Dungeon difficulty operation failed: $($_.Exception.Message)"
     } finally {
-        if ($stopAttempted) {
-            $start = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'start'
+        try {
+            if ($stopAttempted) {
+                $lockHealth = Update-DuneVmMaintenanceLock -Ip $Ip -Lease $maintenanceLock
+                if (-not $lockHealth.ok) {
+                    $lockRelease = Exit-DuneVmMaintenanceLock -Ip $Ip -Lease $maintenanceLock
+                    $maintenanceLockHeld = $false
+                    if ($lockRelease.ok) {
+                        $replacementLock = Enter-DuneVmMaintenanceLock -Ip $Ip
+                        if ($replacementLock.ok) {
+                            $maintenanceLock = $replacementLock
+                            $maintenanceLockHeld = $true
+                            $lockRelease = $null
+                        } else {
+                            $healthError = "VM maintenance lock ownership was lost before recovery start and the lock could not be reacquired. $($replacementLock.error)"
+                            $operationError = if ($operationError) { "$operationError $healthError" } else { $healthError }
+                        }
+                    } else {
+                        $healthError = "VM maintenance lock ownership was not verifiable before recovery start and the uncertain lease could not be released. $($lockHealth.error) $($lockRelease.error)"
+                        $operationError = if ($operationError) { "$operationError $healthError" } else { $healthError }
+                    }
+                }
+                if ($maintenanceLockHeld) {
+                    try {
+                        $start = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'start'
+                    } catch {
+                        $start = @{ ok = $false; error = "Battlegroup start failed: $($_.Exception.Message)" }
+                    }
+                }
+            }
+        } finally {
+            if ($maintenanceLockHeld) {
+                $lockRelease = Exit-DuneVmMaintenanceLock -Ip $Ip -Lease $maintenanceLock
+                $maintenanceLockHeld = $false
+            }
         }
     }
 
-    if ($null -eq $start -or -not $start.ok) {
+    if ($null -eq $lockRelease -or -not $lockRelease.ok) {
+        $releaseError = if ($null -eq $lockRelease) { 'VM maintenance lock release was not attempted.' } else { $lockRelease.error }
+        $operationError = if ($operationError) { "$operationError $releaseError" } else { $releaseError }
+    }
+
+    if ($stopAttempted -and ($null -eq $start -or -not $start.ok)) {
         $startError = if ($null -eq $start) { 'Battlegroup start was not launched.' } else { $start.error }
         $prefix = if ($operationError) { "$operationError " } elseif ($write -and $write.ok) { "Dungeon difficulty changed, but " } else { "No dungeon rows changed, but " }
         return @{
@@ -861,12 +1123,13 @@ function Invoke-DuneNormalizeDungeonDifficulty {
         }
     }
     if ($operationError) {
+        $recoveryMessage = if ($stopAttempted) { ' The battlegroup start command was launched.' } else { '' }
         return @{
             ok = $false; noOp = $false
             changed = [bool]($write -and $write.ok)
             verified = $verified
-            restarted = $true
-            error = "$operationError The battlegroup start command was launched."
+            restarted = [bool]$stopAttempted
+            error = "$operationError$recoveryMessage"
             backupPath = $backup.backupPath
             updated = if ($write -and $write.ok) { $write.updated } else { 0 }
         }

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -616,6 +616,222 @@ function Invoke-DuneFillPlayerBaseWater {
     }
 }
 
+function Invoke-DuneDungeonDifficultyBgCommand {
+    param(
+        [string]$Ip,
+        [Parameter(Mandatory)][ValidateSet('backup','stop','start')][string]$Command
+    )
+    if (-not (Get-Command Invoke-DuneBackupShell -ErrorAction SilentlyContinue)) {
+        return @{ ok = $false; error = 'Battlegroup shell helper is unavailable.' }
+    }
+
+    $timeout = if ($Command -eq 'backup') { 900 } elseif ($Command -eq 'stop') { 600 } else { 900 }
+    $script = "/home/dune/.dune/bin/battlegroup $Command"
+    if ($Command -eq 'backup') {
+        $stamp = [datetime]::UtcNow.ToString('yyyyMMdd-HHmmss')
+        $nonce = [guid]::NewGuid().ToString('N').Substring(0, 8)
+        $name = "dst-dungeon-difficulty-$stamp-$nonce"
+        $script = @"
+set -e
+OUT=`$(/home/dune/.dune/bin/battlegroup backup '$name' 2>&1)
+printf '%s\n' "`$OUT"
+FILE=`$(printf '%s\n' "`$OUT" | sed -n 's/^Backup file (on this host):[[:space:]]*//p' | tail -1)
+[ -n "`$FILE" ] && [ -s "`$FILE" ] || { echo '__DST_DUNGEON_BACKUP_ERROR:Backup file was not created or is empty.'; exit 20; }
+SIZE=`$(wc -c < "`$FILE")
+[ "`$SIZE" -gt 1024 ] || { echo '__DST_DUNGEON_BACKUP_ERROR:Backup file is too small.'; exit 21; }
+echo "__DST_DUNGEON_BACKUP:`$FILE|`$SIZE"
+"@
+    }
+
+    try {
+        $result = Invoke-DuneBackupShell -Ip $Ip -Script $script -TimeoutSec $timeout
+    } catch {
+        return @{ ok = $false; error = "Battlegroup $Command failed: $($_.Exception.Message)" }
+    }
+    if ($null -eq $result -or [int]$result.rc -ne 0) {
+        $rc = if ($null -eq $result) { -1 } else { [int]$result.rc }
+        $out = if ($null -eq $result) { '' } else { ([string]$result.out).Trim() }
+        return @{ ok = $false; error = "Battlegroup $Command exited $rc. $out".Trim() }
+    }
+
+    $out = ([string]$result.out).Trim()
+    if ($Command -eq 'backup') {
+        $match = [regex]::Match($out, '__DST_DUNGEON_BACKUP:([^|]+)\|(\d+)')
+        if (-not $match.Success) {
+            return @{ ok = $false; error = 'Battlegroup backup completed without a verifiable backup file.' }
+        }
+        return @{
+            ok         = $true
+            command    = $Command
+            output     = $out
+            backupPath = $match.Groups[1].Value
+            backupSize = [int64]$match.Groups[2].Value
+        }
+    }
+    return @{ ok = $true; command = $Command; output = $out }
+}
+
+function Set-DuneDungeonDifficultyTarget {
+    param([string]$Ip)
+
+    $sql = @'
+BEGIN;
+WITH updated AS (
+  UPDATE dune.dungeon_completion
+  SET difficulty = 50
+  WHERE difficulty > 50
+  RETURNING completion_id
+)
+SELECT COUNT(*)::text AS updated_n
+FROM updated;
+COMMIT;
+'@
+    $result = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 60
+    if (-not $result.ok) {
+        return @{ ok = $false; error = "Dungeon difficulty write failed: $($result.error)" }
+    }
+    $rows = ConvertTo-DuneRowMaps -Result $result
+    if ($rows.Count -ne 1 -or $null -eq $rows[0]['updated_n'] -or [string]$rows[0]['updated_n'] -notmatch '^\d+$') {
+        return @{ ok = $false; error = 'Dungeon difficulty write returned no verified affected-row count.' }
+    }
+    return @{ ok = $true; updated = [int64](ConvertTo-DuneInt $rows[0]['updated_n']) }
+}
+
+function Invoke-DuneNormalizeDungeonDifficulty {
+    param([string]$Ip)
+
+    $before = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
+    if (-not $before.ok) { return $before }
+    if ($before.aboveTarget -eq 0) {
+        return @{
+            ok              = $true
+            noOp            = $true
+            changed         = $false
+            verified        = $true
+            restarted       = $false
+            updated         = 0
+            backupPath      = ''
+            summary         = $before
+            message         = 'Dungeon difficulty is already normalized. No backup or battlegroup stop was needed.'
+        }
+    }
+
+    $backup = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'backup'
+    if (-not $backup.ok) {
+        return @{
+            ok = $false; noOp = $false; changed = $false; verified = $false; restarted = $false
+            updated = 0; backupPath = ''; error = "No changes made because the safety backup failed verification. $($backup.error)"
+        }
+    }
+
+    $stopAttempted = $false
+    $write = $null
+    $after = $null
+    $operationError = ''
+    $verified = $false
+    $noOpAfterStop = $false
+    $start = $null
+    try {
+        $stopAttempted = $true
+        $stop = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'stop'
+        if (-not $stop.ok) {
+            $operationError = "No dungeon rows changed because the battlegroup did not stop cleanly. $($stop.error)"
+        } else {
+            $stoppedSummary = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
+            if (-not $stoppedSummary.ok) {
+                $operationError = "No dungeon rows changed because the stopped-state summary failed. $($stoppedSummary.error)"
+            } elseif ($stoppedSummary.aboveTarget -eq 0) {
+                $after = $stoppedSummary
+                $verified = $true
+                $noOpAfterStop = $true
+            } else {
+                $stoppedBackup = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'backup'
+                if (-not $stoppedBackup.ok) {
+                    $operationError = "No dungeon rows changed because the stopped-state rollback backup failed verification. $($stoppedBackup.error)"
+                } else {
+                    $backup = $stoppedBackup
+                    $before = $stoppedSummary
+                    $write = Set-DuneDungeonDifficultyTarget -Ip $Ip
+                    if (-not $write.ok) {
+                        $operationError = $write.error
+                    } else {
+                        $after = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
+                        if (-not $after.ok) {
+                            $operationError = "Dungeon difficulty changed, but post-write verification failed. $($after.error)"
+                        } elseif ($after.total -ne $before.total) {
+                            $operationError = "Post-write verification failed: completion row count changed from $($before.total) to $($after.total)."
+                        } elseif ($write.updated -ne $before.aboveTarget) {
+                            $operationError = "Post-write verification failed: expected $($before.aboveTarget) updated rows but PostgreSQL reported $($write.updated)."
+                        } elseif ($after.aboveTarget -ne 0 -or ($null -ne $after.maximum -and $after.maximum -gt 50)) {
+                            $operationError = "Post-write verification failed: $($after.aboveTarget) completion row(s) remain above 50."
+                        } else {
+                            $verified = $true
+                        }
+                    }
+                }
+            }
+        }
+    } catch {
+        $operationError = "Dungeon difficulty operation failed: $($_.Exception.Message)"
+    } finally {
+        if ($stopAttempted) {
+            $start = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'start'
+        }
+    }
+
+    if ($null -eq $start -or -not $start.ok) {
+        $startError = if ($null -eq $start) { 'Battlegroup start was not launched.' } else { $start.error }
+        $prefix = if ($operationError) { "$operationError " } elseif ($write -and $write.ok) { "Dungeon difficulty changed, but " } else { "No dungeon rows changed, but " }
+        return @{
+            ok = $false; noOp = $false
+            changed = [bool]($write -and $write.ok)
+            verified = $verified
+            restarted = $false
+            error = "$prefix$startError Start the battlegroup manually."
+            backupPath = $backup.backupPath
+            updated = if ($write -and $write.ok) { $write.updated } else { 0 }
+        }
+    }
+    if ($operationError) {
+        return @{
+            ok = $false; noOp = $false
+            changed = [bool]($write -and $write.ok)
+            verified = $verified
+            restarted = $true
+            error = "$operationError The battlegroup start command was launched."
+            backupPath = $backup.backupPath
+            updated = if ($write -and $write.ok) { $write.updated } else { 0 }
+        }
+    }
+    if ($noOpAfterStop) {
+        return @{
+            ok = $true
+            noOp = $true
+            changed = $false
+            verified = $true
+            restarted = $true
+            updated = 0
+            backupPath = $backup.backupPath
+            backupSize = $backup.backupSize
+            summary = $after
+            message = 'Dungeon difficulty became normalized before the write. No database rows changed; safety backup verified and battlegroup start launched.'
+        }
+    }
+
+    return @{
+        ok = $true
+        noOp = $false
+        changed = $true
+        verified = $true
+        restarted = $true
+        updated = $write.updated
+        backupPath = $backup.backupPath
+        backupSize = $backup.backupSize
+        summary = $after
+        message = "Normalized $($write.updated) dungeon completion row(s) to difficulty 50. Safety backup verified; battlegroup start launched."
+    }
+}
+
 
 
 # ----- Character XP table (verbatim from db.go) ----------------------------

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -697,6 +697,69 @@ COMMIT;
     return @{ ok = $true; updated = [int64](ConvertTo-DuneInt $rows[0]['updated_n']) }
 }
 
+function Wait-DuneDungeonBattlegroupPodsStopped {
+    param(
+        [string]$Ip,
+        [ValidateRange(1, 1800)][int]$TimeoutSec = 360,
+        [ValidateRange(1, 60)][int]$PollSec = 5
+    )
+
+    if (-not (Get-Command Invoke-DuneBackupShell -ErrorAction SilentlyContinue)) {
+        return @{ ok = $false; error = 'Battlegroup pod-count helper is unavailable.' }
+    }
+
+    $script = @'
+DEADLINE=$(( $(date +%s) + __TIMEOUT__ ))
+while :; do
+  PODS=$(sudo k3s kubectl get pods -A --no-headers -o custom-columns=NAME:.metadata.name,PHASE:.status.phase 2>&1)
+  RC=$?
+  if [ "$RC" -ne 0 ]; then
+    echo "__DST_DUNGEON_POD_ERROR:kubectl exited $RC: $PODS"
+    exit 20
+  fi
+  COUNT=$(printf '%s\n' "$PODS" | awk '$1 ~ /(^|-)(sg|mq|sgw|tr|bgd)-/ && $2 != "Succeeded" && $2 != "Failed" { count++ } END { print count+0 }')
+  case "$COUNT" in
+    ''|*[!0-9]*) echo "__DST_DUNGEON_POD_ERROR:active pod count was indeterminate"; exit 21 ;;
+  esac
+  if [ "$COUNT" -eq 0 ]; then
+    echo "__DST_DUNGEON_PODS_STOPPED:0"
+    exit 0
+  fi
+  if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+    echo "__DST_DUNGEON_POD_TIMEOUT:$COUNT"
+    exit 22
+  fi
+  sleep __POLL__
+done
+'@
+    $script = $script.Replace('__TIMEOUT__', [string]$TimeoutSec).Replace('__POLL__', [string]$PollSec)
+
+    try {
+        $result = Invoke-DuneBackupShell -Ip $Ip -Script $script -TimeoutSec ($TimeoutSec + 30)
+    } catch {
+        return @{ ok = $false; error = "Active battlegroup pod verification failed: $($_.Exception.Message)" }
+    }
+
+    $out = if ($null -eq $result) { '' } else { ([string]$result.out).Trim() }
+    if ($null -ne $result -and [int]$result.rc -eq 0 -and $out -match '__DST_DUNGEON_PODS_STOPPED:0') {
+        return @{ ok = $true; activePodCount = 0 }
+    }
+    $timeoutMatch = [regex]::Match($out, '__DST_DUNGEON_POD_TIMEOUT:(\d+)')
+    if ($timeoutMatch.Success) {
+        return @{
+            ok = $false
+            activePodCount = [int]$timeoutMatch.Groups[1].Value
+            error = "Timed out after ${TimeoutSec}s waiting for active battlegroup pods to terminate; $($timeoutMatch.Groups[1].Value) remain."
+        }
+    }
+    $errorMatch = [regex]::Match($out, '__DST_DUNGEON_POD_ERROR:([^\r\n]+)')
+    if ($errorMatch.Success) {
+        return @{ ok = $false; error = "Active battlegroup pod count was not verifiable: $($errorMatch.Groups[1].Value)" }
+    }
+    $rc = if ($null -eq $result) { -1 } else { [int]$result.rc }
+    return @{ ok = $false; error = "Active battlegroup pod count was not verifiable (exit $rc)." }
+}
+
 function Invoke-DuneNormalizeDungeonDifficulty {
     param([string]$Ip)
 
@@ -737,35 +800,40 @@ function Invoke-DuneNormalizeDungeonDifficulty {
         if (-not $stop.ok) {
             $operationError = "No dungeon rows changed because the battlegroup did not stop cleanly. $($stop.error)"
         } else {
-            $stoppedSummary = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
-            if (-not $stoppedSummary.ok) {
-                $operationError = "No dungeon rows changed because the stopped-state summary failed. $($stoppedSummary.error)"
-            } elseif ($stoppedSummary.aboveTarget -eq 0) {
-                $after = $stoppedSummary
-                $verified = $true
-                $noOpAfterStop = $true
+            $podDrain = Wait-DuneDungeonBattlegroupPodsStopped -Ip $Ip
+            if (-not $podDrain.ok) {
+                $operationError = "No dungeon rows changed because battlegroup shutdown could not be verified. $($podDrain.error)"
             } else {
-                $stoppedBackup = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'backup'
-                if (-not $stoppedBackup.ok) {
-                    $operationError = "No dungeon rows changed because the stopped-state rollback backup failed verification. $($stoppedBackup.error)"
+                $stoppedSummary = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
+                if (-not $stoppedSummary.ok) {
+                    $operationError = "No dungeon rows changed because the stopped-state summary failed. $($stoppedSummary.error)"
+                } elseif ($stoppedSummary.aboveTarget -eq 0) {
+                    $after = $stoppedSummary
+                    $verified = $true
+                    $noOpAfterStop = $true
                 } else {
-                    $backup = $stoppedBackup
-                    $before = $stoppedSummary
-                    $write = Set-DuneDungeonDifficultyTarget -Ip $Ip
-                    if (-not $write.ok) {
-                        $operationError = $write.error
+                    $stoppedBackup = Invoke-DuneDungeonDifficultyBgCommand -Ip $Ip -Command 'backup'
+                    if (-not $stoppedBackup.ok) {
+                        $operationError = "No dungeon rows changed because the stopped-state rollback backup failed verification. $($stoppedBackup.error)"
                     } else {
-                        $after = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
-                        if (-not $after.ok) {
-                            $operationError = "Dungeon difficulty changed, but post-write verification failed. $($after.error)"
-                        } elseif ($after.total -ne $before.total) {
-                            $operationError = "Post-write verification failed: completion row count changed from $($before.total) to $($after.total)."
-                        } elseif ($write.updated -ne $before.aboveTarget) {
-                            $operationError = "Post-write verification failed: expected $($before.aboveTarget) updated rows but PostgreSQL reported $($write.updated)."
-                        } elseif ($after.aboveTarget -ne 0 -or ($null -ne $after.maximum -and $after.maximum -gt 50)) {
-                            $operationError = "Post-write verification failed: $($after.aboveTarget) completion row(s) remain above 50."
+                        $backup = $stoppedBackup
+                        $before = $stoppedSummary
+                        $write = Set-DuneDungeonDifficultyTarget -Ip $Ip
+                        if (-not $write.ok) {
+                            $operationError = $write.error
                         } else {
-                            $verified = $true
+                            $after = Get-DuneDungeonDifficultySummaryLive -Ip $Ip
+                            if (-not $after.ok) {
+                                $operationError = "Dungeon difficulty changed, but post-write verification failed. $($after.error)"
+                            } elseif ($after.total -ne $before.total) {
+                                $operationError = "Post-write verification failed: completion row count changed from $($before.total) to $($after.total)."
+                            } elseif ($write.updated -ne $before.aboveTarget) {
+                                $operationError = "Post-write verification failed: expected $($before.aboveTarget) updated rows but PostgreSQL reported $($write.updated)."
+                            } elseif ($after.aboveTarget -ne 0 -or ($null -ne $after.maximum -and $after.maximum -gt 50)) {
+                                $operationError = "Post-write verification failed: $($after.aboveTarget) completion row(s) remain above 50."
+                            } else {
+                                $verified = $true
+                            }
                         }
                     }
                 }

--- a/app/server/lib/PlayersRead.ps1
+++ b/app/server/lib/PlayersRead.ps1
@@ -649,6 +649,49 @@ LIMIT 100;
     return @{ ok = $true; dungeons = $list; total = $list.Count }
 }
 
+function Get-DuneDungeonDifficultySummaryLive {
+    param([string]$Ip)
+
+    $sql = @'
+SELECT COUNT(*)::text AS total_n,
+       COUNT(*) FILTER (WHERE difficulty > 50)::text AS above_target_n,
+       COALESCE(MAX(difficulty), 0)::text AS maximum_difficulty,
+       (
+         SELECT COUNT(DISTINCT dcp.player_id)::text
+         FROM dune.dungeon_completion_players dcp
+         JOIN dune.dungeon_completion affected
+           ON affected.completion_id = dcp.completion_id
+         WHERE affected.difficulty > 50
+       ) AS affected_player_n
+FROM dune.dungeon_completion;
+'@
+    $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 15
+    if (-not $r.ok) {
+        return @{ ok = $false; error = "Dungeon difficulty summary failed: $($r.error)" }
+    }
+    $rows = ConvertTo-DuneRowMaps -Result $r
+    if ($rows.Count -ne 1) {
+        return @{ ok = $false; error = 'Dungeon difficulty summary returned no aggregate row.' }
+    }
+
+    $row = $rows[0]
+    foreach ($column in @('total_n', 'above_target_n', 'maximum_difficulty', 'affected_player_n')) {
+        if ($null -eq $row[$column] -or [string]$row[$column] -notmatch '^\d+$') {
+            return @{ ok = $false; error = "Dungeon difficulty summary returned an invalid $column value." }
+        }
+    }
+
+    $total = [int64](ConvertTo-DuneInt $row['total_n'])
+    return @{
+        ok              = $true
+        total           = $total
+        aboveTarget     = [int64](ConvertTo-DuneInt $row['above_target_n'])
+        maximum         = if ($total -gt 0) { [int](ConvertTo-DuneInt $row['maximum_difficulty']) } else { $null }
+        affectedPlayers = [int64](ConvertTo-DuneInt $row['affected_player_n'])
+        target          = 50
+    }
+}
+
 # ----- §1.9 GET /players/{id}/player-ids ----------------------------------
 function Get-DunePlayerIdsLive {
     param([string]$Ip, [long]$ActorId)

--- a/app/server/lib/RestartSchedule.ps1
+++ b/app/server/lib/RestartSchedule.ps1
@@ -50,6 +50,9 @@ $script:DuneRestartVmLogPath = '/var/log/dst-daily-maintenance.log'
 $script:DuneRestartVmResultPath = '/var/lib/dune-server/daily-maintenance-result'
 $script:DuneRestartVmResultLastPoll = [datetime]::MinValue
 $script:DuneRestartVmResultPollSeconds = 300
+if (-not $script:DuneMaintenanceLockPath) {
+    $script:DuneMaintenanceLockPath = '/tmp/dst-battlegroup-maintenance.lock'
+}
 
 function Get-DuneRestartStatePath {
     $dir = Join-Path $env:LOCALAPPDATA 'DuneServer'
@@ -567,7 +570,10 @@ function Invoke-DuneScheduledRestart {
         return @{ ok = $false; status = $ctx.status; message = $ctx.message }
     }
     try {
-        $r = Invoke-DuneBackupShell -Ip $ctx.ip -Script "touch $script:DuneRestartMarkerPath 2>/dev/null; /home/dune/.dune/bin/battlegroup restart" -TimeoutSec 180
+        $inner = "touch $script:DuneRestartMarkerPath 2>/dev/null; /home/dune/.dune/bin/battlegroup restart"
+        $innerB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($inner))
+        $command = "printf '%s' '$innerB64' | base64 -d | sudo flock -n -E 73 '$script:DuneMaintenanceLockPath' /bin/bash"
+        $r = Invoke-DuneBackupShell -Ip $ctx.ip -Script $command -TimeoutSec 180
     } catch {
         return @{ ok = $false; status = 502; message = "Restart command failed: $($_.Exception.Message)" }
     }
@@ -576,7 +582,8 @@ function Invoke-DuneScheduledRestart {
     return @{
         ok      = $ok
         rc      = $rc
-        message = if ($ok) { 'Scheduled restart issued.' } else { "Restart command exited $rc." }
+        status  = if ($rc -eq 73) { 423 } elseif ($ok) { 200 } else { 502 }
+        message = if ($ok) { 'Scheduled restart issued.' } elseif ($rc -eq 73) { 'VM maintenance is already running.' } else { "Restart command exited $rc." }
         out     = if ($r) { [string]$r.out } else { '' }
     }
 }
@@ -590,14 +597,14 @@ function New-DuneVmDailyMaintenanceScript {
 set -u
 APPLY_UPDATES=$apply
 APPID=$appId
-LOCK=/tmp/dst-daily-maintenance.lock
+LOCK=$script:DuneMaintenanceLockPath
 LOG=$script:DuneRestartVmLogPath
 RESULT=$script:DuneRestartVmResultPath
 mkdir -p /var/lib/dune-server
-if ! mkdir "`$LOCK" 2>/dev/null; then
+exec 9>"`$LOCK"
+if ! flock -n 9; then
   exit 0
 fi
-trap 'rmdir "`$LOCK" 2>/dev/null || true' EXIT INT TERM
 exec >>"`$LOG" 2>&1
 if [ -f /var/lib/dune-server/dst-world-restart-recovery-required ] || find /tmp/dst-world-restart-active -mmin -120 2>/dev/null | grep -q .; then
   echo "=== `$(date -u +%Y-%m-%dT%H:%M:%SZ) scheduled maintenance skipped: World Restart active ==="

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -600,3 +600,30 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/fill-base-water' -H
         Write-DuneError -Response $res -Status 500 -Message "Fill base water failed: $($_.Exception.Message)"
     }
 }
+
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/normalize-dungeon-difficulty' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $confirm = [string](Get-DuneBodyValue -Body $body -Name 'confirm')
+        if ($confirm -cne 'NORMALIZE DUNGEONS') {
+            Write-DuneError -Response $res -Status 400 -Message 'Type NORMALIZE DUNGEONS exactly to continue.'
+            return
+        }
+        if (-not (Test-DuneDisruptiveActionGuard -Req $req -Res $res -Action 'normalizing server-wide dungeon completion difficulty')) { return }
+
+        $ctx = Get-DuneDbContext
+        if (-not $ctx.ok) { Write-DuneError -Response $res -Status 503 -Message $ctx.message; return }
+        try {
+            $result = Invoke-WithDuneLock -Name 'dungeon-difficulty-normalize' -TimeoutSec 1 -Script {
+                Invoke-DuneNormalizeDungeonDifficulty -Ip $ctx.ip
+            }
+        } catch {
+            Write-DuneError -Response $res -Status 409 -Message $_.Exception.Message
+            return
+        }
+        if (-not $result.ok) { Write-DuneJson -Response $res -Status 503 -Body $result; return }
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Normalize dungeon difficulty failed: $($_.Exception.Message)"
+    }
+}

--- a/app/server/routes/PlayersRead.ps1
+++ b/app/server/routes/PlayersRead.ps1
@@ -140,6 +140,28 @@ Register-DuneRoute -Method GET -Path '/api/gameplay/players/dungeons' -Handler {
     }
 }
 
+# GET /api/gameplay/players/dungeon-difficulty-summary
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/dungeon-difficulty-summary' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        if (Test-DuneDemoRequested $req) {
+            Write-DuneJson -Response $res -Body @{
+                ok = $true; total = 0; aboveTarget = 0; maximum = $null
+                affectedPlayers = 0; target = 50; source = 'demo'
+            }
+            return
+        }
+        $ctx = Get-DuneDbContext
+        if (-not $ctx.ok) { Write-DuneError -Response $res -Status 503 -Message $ctx.message; return }
+        $result = Get-DuneDungeonDifficultySummaryLive -Ip $ctx.ip
+        if (-not $result.ok) { Write-DuneError -Response $res -Status 503 -Message $result.error; return }
+        $result['source'] = 'live'
+        Write-DuneJson -Response $res -Body $result
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Dungeon difficulty summary failed: $($_.Exception.Message)"
+    }
+}
+
 # GET /api/gameplay/players/player-ids?actor_id=<id>
 Register-DuneRoute -Method GET -Path '/api/gameplay/players/player-ids' -Handler {
     param($req, $res, $routeParams, $body)

--- a/tests/DungeonDifficulty.Tests.ps1
+++ b/tests/DungeonDifficulty.Tests.ps1
@@ -179,6 +179,74 @@ Describe 'Dungeon battlegroup pod drain verification' {
     }
 }
 
+Describe 'Shared VM maintenance lock lease' {
+    BeforeEach {
+        Mock Get-Command { @{ Name = 'Invoke-DuneBackupShell' } } -ParameterFilter { $Name -eq 'Invoke-DuneBackupShell' }
+    }
+
+    It 'acquires a kernel flock with bounded process-failure expiry' {
+        Mock Invoke-DuneBackupShell {
+            $script:lockAcquireScript = $Script
+            [void]($Script -match '__DST_MAINTENANCE_LOCK_ACQUIRED:([a-f0-9]{32})')
+            @{ rc = 0; out = "__DST_MAINTENANCE_LOCK_ACQUIRED:$($Matches[1])|1234" }
+        }
+
+        $result = Enter-DuneVmMaintenanceLock -Ip '10.0.0.1' -LeaseTimeoutSec 120
+
+        $result.ok | Should -BeTrue
+        $result.pid | Should -Be 1234
+        $encodedHolder = [regex]::Match($script:lockAcquireScript, "printf '%s' '([^']+)' \| base64 -d").Groups[1].Value
+        $decodedHolder = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($encodedHolder))
+        $decodedHolder | Should -Match "flock -n 9"
+        $script:lockAcquireScript | Should -Match "'/tmp/dst-battlegroup-maintenance\.lock'"
+        $script:lockAcquireScript | Should -Match '/proc/\$PID/fdinfo/9'
+        $script:lockAcquireScript | Should -Match '"FLOCK"'
+        $script:lockAcquireScript | Should -Match "'120'"
+    }
+
+    It 'fails closed when another maintenance owner holds the flock' {
+        Mock Invoke-DuneBackupShell { @{ rc = 73; out = '__DST_MAINTENANCE_LOCK_BUSY' } }
+
+        $result = Enter-DuneVmMaintenanceLock -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.busy | Should -BeTrue
+    }
+
+    It 'refreshes only a verified live owner lease' {
+        Mock Invoke-DuneBackupShell {
+            $script:lockHealthScript = $Script
+            @{ rc = 0; out = '__DST_MAINTENANCE_LOCK_HEALTHY' }
+        }
+        $lease = @{ token = ('a' * 32); pid = 1234; workPath = "/tmp/dst-maintenance-$('a' * 32)" }
+
+        $result = Update-DuneVmMaintenanceLock -Ip '10.0.0.1' -Lease $lease
+
+        $result.ok | Should -BeTrue
+        $script:lockHealthScript | Should -Match '/proc/\$EXPECTED_PID/fd/9'
+        $script:lockHealthScript | Should -Match '/proc/\$EXPECTED_PID/fdinfo/9'
+        $script:lockHealthScript | Should -Match '"FLOCK"'
+        $script:lockHealthScript | Should -Match 'touch "\$WORK/lease"'
+    }
+
+    It 'releases by ending the holder and verifies process exit' {
+        Mock Invoke-DuneBackupShell {
+            $script:lockReleaseScript = $Script
+            @{ rc = 0; out = '__DST_MAINTENANCE_LOCK_RELEASED' }
+        }
+        $lease = @{
+            token = ('b' * 32); pid = 1234; workPath = "/tmp/dst-maintenance-$('b' * 32)"
+            leaseTimeoutSec = 1200
+        }
+
+        $result = Exit-DuneVmMaintenanceLock -Ip '10.0.0.1' -Lease $lease
+
+        $result.ok | Should -BeTrue
+        $script:lockReleaseScript | Should -Match 'rm -f "\$WORK/lease"'
+        $script:lockReleaseScript | Should -Match 'kill -0'
+    }
+}
+
 Describe 'Dungeon difficulty normalization workflow' {
     BeforeEach {
         $script:calls = [Collections.Generic.List[string]]::new()
@@ -197,6 +265,21 @@ Describe 'Dungeon difficulty normalization workflow' {
         Mock Wait-DuneDungeonBattlegroupPodsStopped {
             $script:calls.Add('wait-zero')
             @{ ok = $true; activePodCount = 0 }
+        }
+        Mock Enter-DuneVmMaintenanceLock {
+            $script:calls.Add('lock-acquire')
+            @{
+                ok = $true; token = ('a' * 32); pid = 1234
+                workPath = "/tmp/dst-maintenance-$('a' * 32)"; leaseTimeoutSec = 1200
+            }
+        }
+        Mock Update-DuneVmMaintenanceLock {
+            $script:calls.Add('lock-health')
+            @{ ok = $true }
+        }
+        Mock Exit-DuneVmMaintenanceLock {
+            $script:calls.Add('lock-release')
+            @{ ok = $true }
         }
     }
 
@@ -231,7 +314,29 @@ Describe 'Dungeon difficulty normalization workflow' {
         $result.changed | Should -BeTrue
         $result.verified | Should -BeTrue
         $result.restarted | Should -BeTrue
-        @($script:calls) | Should -Be @('summary1', 'backup', 'stop', 'wait-zero', 'summary2', 'backup', 'write', 'summary3', 'start')
+        @($script:calls) | Should -Be @(
+            'summary1', 'lock-acquire', 'lock-health', 'backup', 'lock-health', 'stop',
+            'wait-zero', 'lock-health', 'summary2', 'backup', 'lock-health', 'write',
+            'summary3', 'lock-health', 'start', 'lock-release'
+        )
+    }
+
+    It 'fails before backup, stop, or SQL when the VM flock cannot be acquired' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Enter-DuneVmMaintenanceLock {
+            $script:calls.Add('lock-acquire-failed')
+            @{ ok = $false; busy = $true; error = 'VM maintenance is already running.' }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeFalse
+        $result.error | Should -Match 'maintenance lock was not acquired'
+        @($script:calls) | Should -Be @('lock-acquire-failed')
+        Assert-MockCalled Set-DuneDungeonDifficultyTarget -Times 0
     }
 
     It 'fails before disruption when backup verification fails' {
@@ -248,7 +353,7 @@ Describe 'Dungeon difficulty normalization workflow' {
 
         $result.ok | Should -BeFalse
         $result.changed | Should -BeFalse
-        @($script:calls) | Should -Be @('backup')
+        @($script:calls) | Should -Be @('lock-acquire', 'lock-health', 'backup', 'lock-release')
     }
 
     It 'returns a restarted no-op when no affected rows remain after stop' {
@@ -286,7 +391,10 @@ Describe 'Dungeon difficulty normalization workflow' {
         $result.changed | Should -BeFalse
         $result.restarted | Should -BeTrue
         $result.error | Should -Match 'shutdown could not be verified'
-        @($script:calls) | Should -Be @('backup', 'stop', 'wait-timeout', 'start')
+        @($script:calls) | Should -Be @(
+            'lock-acquire', 'lock-health', 'backup', 'lock-health', 'stop',
+            'wait-timeout', 'lock-health', 'start', 'lock-release'
+        )
         Assert-MockCalled Set-DuneDungeonDifficultyTarget -Times 0
     }
 
@@ -304,7 +412,10 @@ Describe 'Dungeon difficulty normalization workflow' {
         $result.ok | Should -BeFalse
         $result.changed | Should -BeFalse
         $result.restarted | Should -BeTrue
-        @($script:calls) | Should -Be @('backup', 'stop', 'wait-indeterminate', 'start')
+        @($script:calls) | Should -Be @(
+            'lock-acquire', 'lock-health', 'backup', 'lock-health', 'stop',
+            'wait-indeterminate', 'lock-health', 'start', 'lock-release'
+        )
         Assert-MockCalled Set-DuneDungeonDifficultyTarget -Times 0
     }
 
@@ -322,8 +433,149 @@ Describe 'Dungeon difficulty normalization workflow' {
         $result.ok | Should -BeFalse
         $result.changed | Should -BeFalse
         $result.restarted | Should -BeTrue
-        @($script:calls) | Should -Be @('backup', 'stop', 'wait-error', 'start')
+        @($script:calls) | Should -Be @(
+            'lock-acquire', 'lock-health', 'backup', 'lock-health', 'stop',
+            'wait-error', 'lock-health', 'start', 'lock-release'
+        )
         Assert-MockCalled Set-DuneDungeonDifficultyTarget -Times 0
+    }
+
+    It 'releases the VM flock after recovery start when an exception occurs' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Invoke-DuneDungeonDifficultyBgCommand {
+            param($Ip, $Command)
+            $script:calls.Add($Command)
+            if ($Command -eq 'backup') {
+                return @{ ok = $true; backupPath = '/mnt/backups/pre-stop.tar.gz'; backupSize = 2048 }
+            }
+            if ($Command -eq 'stop') { throw 'stop transport failed' }
+            @{ ok = $true; command = $Command }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeFalse
+        @($script:calls) | Should -Be @(
+            'lock-acquire', 'lock-health', 'backup', 'lock-health', 'stop',
+            'lock-health', 'start', 'lock-release'
+        )
+    }
+
+    It 'releases the VM flock when recovery start throws' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Wait-DuneDungeonBattlegroupPodsStopped {
+            $script:calls.Add('wait-timeout')
+            @{ ok = $false; activePodCount = 2; error = 'Timed out waiting; 2 remain.' }
+        }
+        Mock Invoke-DuneDungeonDifficultyBgCommand {
+            param($Ip, $Command)
+            $script:calls.Add($Command)
+            if ($Command -eq 'backup') {
+                return @{ ok = $true; backupPath = '/mnt/backups/pre-stop.tar.gz'; backupSize = 2048 }
+            }
+            if ($Command -eq 'start') { throw 'start transport failed' }
+            @{ ok = $true; command = $Command }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.restarted | Should -BeFalse
+        $result.error | Should -Match 'start transport failed'
+        @($script:calls)[-1] | Should -Be 'lock-release'
+    }
+
+    It 'reacquires the shared flock before recovery start when lease health is lost' {
+        $script:healthCall = 0
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Wait-DuneDungeonBattlegroupPodsStopped {
+            $script:calls.Add('wait-timeout')
+            @{ ok = $false; activePodCount = 2; error = 'Timed out waiting; 2 remain.' }
+        }
+        Mock Update-DuneVmMaintenanceLock {
+            $script:healthCall++
+            $script:calls.Add("lock-health$script:healthCall")
+            if ($script:healthCall -eq 3) {
+                return @{ ok = $false; error = 'lease indeterminate' }
+            }
+            @{ ok = $true }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.restarted | Should -BeTrue
+        @($script:calls) | Should -Be @(
+            'lock-acquire', 'lock-health1', 'backup', 'lock-health2', 'stop',
+            'wait-timeout', 'lock-health3', 'lock-release', 'lock-acquire',
+            'start', 'lock-release'
+        )
+    }
+
+    It 'does not start outside the flock when recovery lock reacquisition fails' {
+        $script:healthCall = 0
+        $script:acquireCall = 0
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Wait-DuneDungeonBattlegroupPodsStopped {
+            @{ ok = $false; activePodCount = 2; error = 'Timed out waiting; 2 remain.' }
+        }
+        Mock Update-DuneVmMaintenanceLock {
+            $script:healthCall++
+            if ($script:healthCall -eq 3) {
+                return @{ ok = $false; error = 'lease indeterminate' }
+            }
+            @{ ok = $true }
+        }
+        Mock Enter-DuneVmMaintenanceLock {
+            $script:acquireCall++
+            if ($script:acquireCall -eq 1) {
+                return @{
+                    ok = $true; token = ('a' * 32); pid = 1234
+                    workPath = "/tmp/dst-maintenance-$('a' * 32)"; leaseTimeoutSec = 1200
+                }
+            }
+            @{ ok = $false; busy = $true; error = 'VM maintenance is already running.' }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.restarted | Should -BeFalse
+        $result.error | Should -Match 'could not be reacquired'
+        Assert-MockCalled Invoke-DuneDungeonDifficultyBgCommand -ParameterFilter { $Command -eq 'start' } -Times 0
+    }
+
+    It 'surfaces lock cleanup failure after a verified write' {
+        $script:summaryCall = 0
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            $script:summaryCall++
+            if ($script:summaryCall -lt 3) {
+                return @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+            }
+            @{ ok = $true; total = 10; aboveTarget = 0; maximum = 50; affectedPlayers = 0; target = 50 }
+        }
+        Mock Exit-DuneVmMaintenanceLock {
+            $script:calls.Add('lock-release-failed')
+            @{ ok = $false; error = 'Lock release could not be verified; bounded lease remains.' }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeTrue
+        $result.verified | Should -BeTrue
+        $result.restarted | Should -BeTrue
+        $result.error | Should -Match 'Lock release could not be verified'
+        $script:calls[-2..-1] | Should -Be @('start', 'lock-release-failed')
     }
 
     It 'restarts without writing when the stopped-state backup fails' {

--- a/tests/DungeonDifficulty.Tests.ps1
+++ b/tests/DungeonDifficulty.Tests.ps1
@@ -118,6 +118,67 @@ Describe 'Dungeon difficulty backup and write helpers' {
     }
 }
 
+Describe 'Dungeon battlegroup pod drain verification' {
+    BeforeEach {
+        Mock Get-Command { @{ Name = 'Invoke-DuneBackupShell' } } -ParameterFilter { $Name -eq 'Invoke-DuneBackupShell' }
+    }
+
+    It 'polls active pod phases until a verified zero count' {
+        Mock Invoke-DuneBackupShell {
+            $script:podWaitScript = $Script
+            @{ rc = 0; out = "__DST_DUNGEON_PODS_STOPPED:0" }
+        }
+
+        $result = Wait-DuneDungeonBattlegroupPodsStopped -Ip '10.0.0.1' -TimeoutSec 30 -PollSec 2
+
+        $result.ok | Should -BeTrue
+        $result.activePodCount | Should -Be 0
+        $script:podWaitScript | Should -Match 'custom-columns=NAME:\.metadata\.name,PHASE:\.status\.phase'
+        $script:podWaitScript | Should -Match '\(\^\|-\)\(sg\|mq\|sgw\|tr\|bgd\)-'
+        $script:podWaitScript | Should -Match '\$2 != "Succeeded" && \$2 != "Failed"'
+        $script:podWaitScript | Should -Match 'sleep 2'
+    }
+
+    It 'recognizes pod families at the start or within generated names' {
+        $familyPattern = '(^|-)(sg|mq|sgw|tr|bgd)-'
+
+        @('mq-game-sts-0', 'server-sg-map-0', 'host-bgd-job-123') | ForEach-Object {
+            $_ | Should -Match $familyPattern
+        }
+        @('postgres-0', 'messagequeue-0') | ForEach-Object {
+            $_ | Should -Not -Match $familyPattern
+        }
+    }
+
+    It 'fails closed with the last active count on timeout' {
+        Mock Invoke-DuneBackupShell { @{ rc = 22; out = '__DST_DUNGEON_POD_TIMEOUT:3' } }
+
+        $result = Wait-DuneDungeonBattlegroupPodsStopped -Ip '10.0.0.1' -TimeoutSec 30
+
+        $result.ok | Should -BeFalse
+        $result.activePodCount | Should -Be 3
+        $result.error | Should -Match 'Timed out after 30s'
+    }
+
+    It 'fails closed when the count is indeterminate' {
+        Mock Invoke-DuneBackupShell { @{ rc = 21; out = '__DST_DUNGEON_POD_ERROR:active pod count was indeterminate' } }
+
+        $result = Wait-DuneDungeonBattlegroupPodsStopped -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'not verifiable'
+    }
+
+    It 'fails closed when the pod-count helper errors without a marker' {
+        Mock Invoke-DuneBackupShell { @{ rc = 255; out = 'ssh failed' } }
+
+        $result = Wait-DuneDungeonBattlegroupPodsStopped -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'not verifiable \(exit 255\)'
+    }
+}
+
 Describe 'Dungeon difficulty normalization workflow' {
     BeforeEach {
         $script:calls = [Collections.Generic.List[string]]::new()
@@ -132,6 +193,10 @@ Describe 'Dungeon difficulty normalization workflow' {
         Mock Set-DuneDungeonDifficultyTarget {
             $script:calls.Add('write')
             @{ ok = $true; updated = 2 }
+        }
+        Mock Wait-DuneDungeonBattlegroupPodsStopped {
+            $script:calls.Add('wait-zero')
+            @{ ok = $true; activePodCount = 0 }
         }
     }
 
@@ -166,7 +231,7 @@ Describe 'Dungeon difficulty normalization workflow' {
         $result.changed | Should -BeTrue
         $result.verified | Should -BeTrue
         $result.restarted | Should -BeTrue
-        @($script:calls) | Should -Be @('summary1', 'backup', 'stop', 'summary2', 'backup', 'write', 'summary3', 'start')
+        @($script:calls) | Should -Be @('summary1', 'backup', 'stop', 'wait-zero', 'summary2', 'backup', 'write', 'summary3', 'start')
     }
 
     It 'fails before disruption when backup verification fails' {
@@ -203,6 +268,61 @@ Describe 'Dungeon difficulty normalization workflow' {
         $result.changed | Should -BeFalse
         $result.verified | Should -BeTrue
         $result.restarted | Should -BeTrue
+        Assert-MockCalled Set-DuneDungeonDifficultyTarget -Times 0
+    }
+
+    It 'never backs up stopped state or writes when active pods remain at timeout' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Wait-DuneDungeonBattlegroupPodsStopped {
+            $script:calls.Add('wait-timeout')
+            @{ ok = $false; activePodCount = 2; error = 'Timed out waiting; 2 remain.' }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeFalse
+        $result.restarted | Should -BeTrue
+        $result.error | Should -Match 'shutdown could not be verified'
+        @($script:calls) | Should -Be @('backup', 'stop', 'wait-timeout', 'start')
+        Assert-MockCalled Set-DuneDungeonDifficultyTarget -Times 0
+    }
+
+    It 'never backs up stopped state or writes when pod count is indeterminate' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Wait-DuneDungeonBattlegroupPodsStopped {
+            $script:calls.Add('wait-indeterminate')
+            @{ ok = $false; error = 'Active pod count was indeterminate.' }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeFalse
+        $result.restarted | Should -BeTrue
+        @($script:calls) | Should -Be @('backup', 'stop', 'wait-indeterminate', 'start')
+        Assert-MockCalled Set-DuneDungeonDifficultyTarget -Times 0
+    }
+
+    It 'never backs up stopped state or writes when pod verification errors' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Wait-DuneDungeonBattlegroupPodsStopped {
+            $script:calls.Add('wait-error')
+            @{ ok = $false; error = 'SSH helper failed.' }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeFalse
+        $result.restarted | Should -BeTrue
+        @($script:calls) | Should -Be @('backup', 'stop', 'wait-error', 'start')
         Assert-MockCalled Set-DuneDungeonDifficultyTarget -Times 0
     }
 

--- a/tests/DungeonDifficulty.Tests.ps1
+++ b/tests/DungeonDifficulty.Tests.ps1
@@ -1,0 +1,351 @@
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    $repo = Split-Path $PSScriptRoot -Parent
+
+    function global:Invoke-DuneSqlQuery {}
+    function global:ConvertTo-DuneRowMaps {}
+    function global:ConvertTo-DuneInt {
+        param($Value)
+        [int64]$Value
+    }
+    function global:Invoke-DuneBackupShell {}
+    function global:Write-DuneJson {}
+    function global:Write-DuneError {}
+    function global:Test-DuneDemoRequested {}
+    function global:Get-DuneDbContext {}
+    function global:Get-DuneBodyValue {}
+    function global:Test-DuneDisruptiveActionGuard {}
+    function global:Invoke-WithDuneLock {}
+    function global:Register-DuneRoute {
+        param([string]$Method, [string]$Path, [scriptblock]$Handler)
+        $script:routes["$Method $Path"] = $Handler
+    }
+
+    . (Join-Path $repo 'app\server\lib\PlayersRead.ps1')
+    . (Join-Path $repo 'app\server\lib\PlayersAdmin.ps1')
+    $script:playersReadSource = Get-Content (Join-Path $repo 'app\server\lib\PlayersRead.ps1') -Raw
+    $script:playersAdminSource = Get-Content (Join-Path $repo 'app\server\lib\PlayersAdmin.ps1') -Raw
+    $script:routes = @{}
+    . (Join-Path $repo 'app\server\routes\PlayersRead.ps1')
+    . (Join-Path $repo 'app\server\routes\GameplayPlayers.ps1')
+}
+
+Describe 'Dungeon difficulty summary' {
+    It 'returns aggregate completion and distinct affected participant counts' {
+        Mock Invoke-DuneSqlQuery { @{ ok = $true } }
+        Mock ConvertTo-DuneRowMaps {
+            ,@(@{
+                total_n = '12'; above_target_n = '3'; maximum_difficulty = '89'; affected_player_n = '5'
+            })
+        }
+
+        $result = Get-DuneDungeonDifficultySummaryLive -Ip '10.0.0.1'
+
+        $result.ok | Should -BeTrue
+        $result.total | Should -Be 12
+        $result.aboveTarget | Should -Be 3
+        $result.maximum | Should -Be 89
+        $result.affectedPlayers | Should -Be 5
+        $result.target | Should -Be 50
+        $script:playersReadSource | Should -Match 'COUNT\(DISTINCT dcp\.player_id\)'
+        $script:playersReadSource | Should -Match 'affected\.difficulty > 50'
+        $script:playersReadSource | Should -Match 'Invoke-DuneSqlQuery -Ip \$Ip -Sql \$sql -ReadOnly \$true'
+    }
+
+    It 'fails closed when the live query fails' {
+        Mock Invoke-DuneSqlQuery { @{ ok = $false; error = 'schema unavailable' } }
+
+        $result = Get-DuneDungeonDifficultySummaryLive -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'schema unavailable'
+    }
+
+    It 'fails closed for a malformed aggregate row' {
+        Mock Invoke-DuneSqlQuery { @{ ok = $true } }
+        Mock ConvertTo-DuneRowMaps { ,@(@{ total_n = '12' }) }
+
+        $result = Get-DuneDungeonDifficultySummaryLive -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'invalid'
+    }
+}
+
+Describe 'Dungeon difficulty backup and write helpers' {
+    It 'verifies and returns the battlegroup backup path and size' {
+        Mock Get-Command { @{ Name = 'Invoke-DuneBackupShell' } } -ParameterFilter { $Name -eq 'Invoke-DuneBackupShell' }
+        Mock Invoke-DuneBackupShell {
+            $script:backupScript = $Script
+            @{ rc = 0; out = "Backup complete`n__DST_DUNGEON_BACKUP:/mnt/backups/dungeon.tar.gz|2048" }
+        }
+
+        $result = Invoke-DuneDungeonDifficultyBgCommand -Ip '10.0.0.1' -Command backup
+
+        $result.ok | Should -BeTrue
+        $result.backupPath | Should -Be '/mnt/backups/dungeon.tar.gz'
+        $result.backupSize | Should -Be 2048
+        $script:backupScript | Should -Match "battlegroup backup 'dst-dungeon-difficulty-"
+        $script:backupScript | Should -Match '\[ "\$SIZE" -gt 1024 \]'
+    }
+
+    It 'rejects backup output without a verified file marker' {
+        Mock Get-Command { @{ Name = 'Invoke-DuneBackupShell' } } -ParameterFilter { $Name -eq 'Invoke-DuneBackupShell' }
+        Mock Invoke-DuneBackupShell { @{ rc = 0; out = 'Backup command returned without a file.' } }
+
+        $result = Invoke-DuneDungeonDifficultyBgCommand -Ip '10.0.0.1' -Command backup
+
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'verifiable backup'
+    }
+
+    It 'uses one transaction scoped only to values above 50' {
+        Mock Invoke-DuneSqlQuery { @{ ok = $true } }
+        Mock ConvertTo-DuneRowMaps { ,@(@{ updated_n = '7' }) }
+
+        $result = Set-DuneDungeonDifficultyTarget -Ip '10.0.0.1'
+
+        $result.ok | Should -BeTrue
+        $result.updated | Should -Be 7
+        $functionSource = [regex]::Match(
+            $script:playersAdminSource,
+            '(?ms)^function Set-DuneDungeonDifficultyTarget \{.*?^}'
+        ).Value
+        $functionSource | Should -Match '(?s)BEGIN;.*UPDATE dune\.dungeon_completion.*SET difficulty = 50.*WHERE difficulty > 50.*COMMIT;'
+        $functionSource | Should -Not -Match 'DELETE'
+        $functionSource | Should -Match 'Invoke-DuneSqlQuery -Ip \$Ip -Sql \$sql -ReadOnly \$false'
+    }
+}
+
+Describe 'Dungeon difficulty normalization workflow' {
+    BeforeEach {
+        $script:calls = [Collections.Generic.List[string]]::new()
+        Mock Invoke-DuneDungeonDifficultyBgCommand {
+            param($Ip, $Command)
+            $script:calls.Add($Command)
+            if ($Command -eq 'backup') {
+                return @{ ok = $true; backupPath = '/mnt/backups/dungeon.tar.gz'; backupSize = 2048 }
+            }
+            @{ ok = $true; command = $Command }
+        }
+        Mock Set-DuneDungeonDifficultyTarget {
+            $script:calls.Add('write')
+            @{ ok = $true; updated = 2 }
+        }
+    }
+
+    It 'returns a verified no-op without backup or battlegroup disruption' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 4; aboveTarget = 0; maximum = 50; affectedPlayers = 0; target = 50 }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeTrue
+        $result.noOp | Should -BeTrue
+        $result.changed | Should -BeFalse
+        $result.verified | Should -BeTrue
+        $script:calls.Count | Should -Be 0
+    }
+
+    It 'orders fresh summary, backup, stop, write, verification, and start' {
+        $script:summaryCall = 0
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            $script:summaryCall++
+            $script:calls.Add("summary$script:summaryCall")
+            if ($script:summaryCall -lt 3) {
+                return @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+            }
+            @{ ok = $true; total = 10; aboveTarget = 0; maximum = 50; affectedPlayers = 0; target = 50 }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeTrue
+        $result.changed | Should -BeTrue
+        $result.verified | Should -BeTrue
+        $result.restarted | Should -BeTrue
+        @($script:calls) | Should -Be @('summary1', 'backup', 'stop', 'summary2', 'backup', 'write', 'summary3', 'start')
+    }
+
+    It 'fails before disruption when backup verification fails' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Invoke-DuneDungeonDifficultyBgCommand {
+            param($Ip, $Command)
+            $script:calls.Add($Command)
+            @{ ok = $false; error = 'backup invalid' }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeFalse
+        @($script:calls) | Should -Be @('backup')
+    }
+
+    It 'returns a restarted no-op when no affected rows remain after stop' {
+        $script:summaryCall = 0
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            $script:summaryCall++
+            if ($script:summaryCall -eq 1) {
+                return @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+            }
+            @{ ok = $true; total = 10; aboveTarget = 0; maximum = 50; affectedPlayers = 0; target = 50 }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeTrue
+        $result.noOp | Should -BeTrue
+        $result.changed | Should -BeFalse
+        $result.verified | Should -BeTrue
+        $result.restarted | Should -BeTrue
+        Assert-MockCalled Set-DuneDungeonDifficultyTarget -Times 0
+    }
+
+    It 'restarts without writing when the stopped-state backup fails' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        $script:backupCall = 0
+        Mock Invoke-DuneDungeonDifficultyBgCommand {
+            param($Ip, $Command)
+            if ($Command -eq 'backup') {
+                $script:backupCall++
+                if ($script:backupCall -eq 2) { return @{ ok = $false; error = 'stopped backup invalid' } }
+                return @{ ok = $true; backupPath = '/mnt/backups/pre-stop.tar.gz'; backupSize = 2048 }
+            }
+            @{ ok = $true; command = $Command }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeFalse
+        $result.restarted | Should -BeTrue
+        $result.backupPath | Should -Be '/mnt/backups/pre-stop.tar.gz'
+        $result.error | Should -Match 'stopped-state rollback backup failed'
+        Assert-MockCalled Set-DuneDungeonDifficultyTarget -Times 0
+    }
+
+    It 'detects incoherent affected counts and restarts' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Set-DuneDungeonDifficultyTarget { @{ ok = $true; updated = 1 } }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeTrue
+        $result.verified | Should -BeFalse
+        $result.restarted | Should -BeTrue
+        $result.error | Should -Match 'expected 2 updated rows'
+        Assert-MockCalled Invoke-DuneDungeonDifficultyBgCommand -Times 1 -ParameterFilter { $Command -eq 'start' }
+    }
+
+    It 'reports verification failure and restarts' {
+        $script:summaryCall = 0
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            $script:summaryCall++
+            if ($script:summaryCall -lt 3) {
+                return @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+            }
+            @{ ok = $true; total = 10; aboveTarget = 1; maximum = 51; affectedPlayers = 1; target = 50 }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeTrue
+        $result.verified | Should -BeFalse
+        $result.restarted | Should -BeTrue
+        $result.error | Should -Match 'remain above 50'
+    }
+
+    It 'restarts when the write fails' {
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+        }
+        Mock Set-DuneDungeonDifficultyTarget { @{ ok = $false; error = 'write failed' } }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeFalse
+        $result.restarted | Should -BeTrue
+        $result.error | Should -Match 'write failed'
+    }
+
+    It 'reports restart failure without hiding a verified write' {
+        $script:summaryCall = 0
+        Mock Get-DuneDungeonDifficultySummaryLive {
+            $script:summaryCall++
+            if ($script:summaryCall -lt 3) {
+                return @{ ok = $true; total = 10; aboveTarget = 2; maximum = 91; affectedPlayers = 3; target = 50 }
+            }
+            @{ ok = $true; total = 10; aboveTarget = 0; maximum = 50; affectedPlayers = 0; target = 50 }
+        }
+        Mock Invoke-DuneDungeonDifficultyBgCommand {
+            param($Ip, $Command)
+            if ($Command -eq 'backup') {
+                return @{ ok = $true; backupPath = '/mnt/backups/dungeon.tar.gz'; backupSize = 2048 }
+            }
+            if ($Command -eq 'start') { return @{ ok = $false; error = 'start failed' } }
+            @{ ok = $true; command = $Command }
+        }
+
+        $result = Invoke-DuneNormalizeDungeonDifficulty -Ip '10.0.0.1'
+
+        $result.ok | Should -BeFalse
+        $result.changed | Should -BeTrue
+        $result.verified | Should -BeTrue
+        $result.restarted | Should -BeFalse
+        $result.error | Should -Match 'start failed'
+    }
+}
+
+Describe 'Dungeon difficulty route safety contracts' {
+    BeforeAll {
+        $script:writeRouteSource = Get-Content (Join-Path $repo 'app\server\routes\GameplayPlayers.ps1') -Raw
+        $script:readRouteSource = Get-Content (Join-Path $repo 'app\server\routes\PlayersRead.ps1') -Raw
+        $script:policy = Get-Content (Join-Path $repo 'app\data\platform-route-policies.json') -Raw | ConvertFrom-Json
+    }
+
+    It 'validates the exact confirmation before invoking the disruptive guard' {
+        $route = [regex]::Match(
+            $script:writeRouteSource,
+            "(?ms)Register-DuneRoute -Method POST -Path '/api/gameplay/players/normalize-dungeon-difficulty'.*?^}"
+        ).Value
+
+        $route | Should -Match "\$confirm -cne 'NORMALIZE DUNGEONS'"
+        $route.IndexOf("`$confirm -cne 'NORMALIZE DUNGEONS'") |
+            Should -BeLessThan $route.IndexOf('Test-DuneDisruptiveActionGuard')
+    }
+
+    It 'uses the normal disruptive guard and dedicated concurrency lock' {
+        $script:writeRouteSource | Should -Match "Test-DuneDisruptiveActionGuard.+normalizing server-wide dungeon completion difficulty"
+        $script:writeRouteSource | Should -Match "Invoke-WithDuneLock -Name 'dungeon-difficulty-normalize' -TimeoutSec 1"
+        $script:writeRouteSource | Should -Match '(?s)Invoke-WithDuneLock.+catch \{.+Write-DuneError -Response \$res -Status 409'
+    }
+
+    It 'classifies the mutation as destructive player management' {
+        $key = 'http POST /api/gameplay/players/normalize-dungeon-difficulty'
+        $script:policy.routeLifecycleOverrides.$key | Should -Be 'destructive'
+        $script:policy.routeCapabilityOverrides.$key | Should -Be 'player.manage.destructive'
+    }
+
+    It 'provides deterministic zero-valued demo data before live DB access' {
+        $route = [regex]::Match(
+            $script:readRouteSource,
+            "(?ms)Register-DuneRoute -Method GET -Path '/api/gameplay/players/dungeon-difficulty-summary'.*?^}"
+        ).Value
+
+        $route | Should -Match 'total = 0; aboveTarget = 0; maximum = \$null'
+        $route | Should -Match "affectedPlayers = 0; target = 50; source = 'demo'"
+        $route.IndexOf('Test-DuneDemoRequested') | Should -BeLessThan $route.IndexOf('Get-DuneDbContext')
+    }
+}

--- a/tests/PlatformContracts.Tests.ps1
+++ b/tests/PlatformContracts.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'Complete route classification' {
     It 'classifies the exact registered HTTP and WebSocket inventory' {
         $records = @(Get-PlatformRouteRecords)
         $manifest = Get-DuneRoutePolicyManifest
-        $records.Count | Should -Be 355
+        $records.Count | Should -Be 357
         $sources = @($records.SourceFile | Sort-Object -Unique)
         @($manifest.groups.source | Sort-Object) | Should -Be $sources
 
@@ -302,7 +302,7 @@ $result = @{
         $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
         $resultLine = @($output | Where-Object { [string]$_ -like 'ROUTE_RESULT:*' })[-1]
         $result = ([string]$resultLine).Substring('ROUTE_RESULT:'.Length) | ConvertFrom-Json
-        $result.total | Should -Be 355
+        $result.total | Should -Be 357
         $result.unclassified | Should -Be 0
         $result.incompatible | Should -Be 0
         $result.podsCleanup | Should -Be 1

--- a/tests/RestartSchedule.Tests.ps1
+++ b/tests/RestartSchedule.Tests.ps1
@@ -53,6 +53,32 @@ Describe 'Scheduled Funcom updates' -Tag 'RestartSchedule' {
         $scriptText | Should -Match '/var/lib/dune-server/dst-world-restart-recovery-required'
     }
 
+    It 'holds the shared kernel flock across scheduled restart or update maintenance' {
+        $scriptText = New-DuneVmDailyMaintenanceScript -ApplyFuncomUpdates $true
+        $playersAdmin = Get-Content (Join-Path (Get-DstRepoRoot) 'app\server\lib\PlayersAdmin.ps1') -Raw
+
+        $scriptText | Should -Match 'LOCK=/tmp/dst-battlegroup-maintenance\.lock'
+        $scriptText | Should -Match 'exec 9>"\$LOCK"'
+        $scriptText | Should -Match 'flock -n 9'
+        $playersAdmin | Should -Match "DuneMaintenanceLockPath = '/tmp/dst-battlegroup-maintenance\.lock'"
+    }
+
+    It 'makes in-process scheduled restart honor the shared flock' {
+        Mock Get-DuneBackupContext { @{ ok = $true; ip = '10.0.0.1' } }
+        Mock Invoke-DuneBackupShell {
+            param($Ip, $Script, $TimeoutSec)
+            $script:scheduledRestartCommand = $Script
+            @{ rc = 73; out = '' }
+        }
+
+        $result = Invoke-DuneScheduledRestart
+
+        $result.ok | Should -BeFalse
+        $result.status | Should -Be 423
+        $result.message | Should -Match 'maintenance is already running'
+        $script:scheduledRestartCommand | Should -Match "flock -n -E 73 '/tmp/dst-battlegroup-maintenance\.lock'"
+    }
+
     It 'renders the explicit unattended-update opt-in into the VM script' {
         (New-DuneVmDailyMaintenanceScript -ApplyFuncomUpdates $true) |
             Should -Match 'APPLY_UPDATES=1'

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -1814,10 +1814,57 @@ export function processVehicleDeletions(confirm: string) {
   )
 }
 
-export interface DungeonRunRow { dungeon_id: string; cleared: boolean; best_time_seconds?: number }
+export interface DungeonRunRow {
+  dungeon_id: string
+  difficulty: string
+  duration_ms: number
+  players_num: number
+  completion_id: number
+}
 export function getPlayerDungeons(id: number, demo?: boolean) {
-  return api<{ ok: boolean; runs: DungeonRunRow[]; source: DataSource }>(
+  return api<{ dungeons: DungeonRunRow[]; total: number; source: DataSource; liveError?: string }>(
     `/api/gameplay/players/dungeons${qs({ player_id: id, demo: demo ? 1 : undefined })}`)
+}
+
+export interface DungeonDifficultySummary {
+  ok: boolean
+  total: number
+  aboveTarget: number
+  maximum: number | null
+  affectedPlayers: number
+  target: 50
+  source: DataSource
+}
+
+export interface NormalizeDungeonDifficultyResult {
+  ok: boolean
+  noOp: boolean
+  changed: boolean
+  verified: boolean
+  restarted: boolean
+  updated: number
+  backupPath: string
+  backupSize?: number
+  summary: DungeonDifficultySummary
+  message: string
+}
+
+export function getDungeonDifficultySummary(demo?: boolean) {
+  return api<DungeonDifficultySummary>(
+    `/api/gameplay/players/dungeon-difficulty-summary${qs({ demo: demo ? 1 : undefined })}`,
+  )
+}
+
+export function normalizeDungeonDifficulty(confirm: string) {
+  return withOnlinePlayerGuard(force =>
+    api<NormalizeDungeonDifficultyResult>(
+      `/api/gameplay/players/normalize-dungeon-difficulty${force ? '?force=true' : ''}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ confirm }),
+      },
+    ),
+  )
 }
 
 export interface PlayerIdsResponse {

--- a/webui/src/components/ConfirmationModal.tsx
+++ b/webui/src/components/ConfirmationModal.tsx
@@ -9,6 +9,7 @@ type Props = {
   onConfirm: () => void
   onCancel: () => void
   children?: ReactNode
+  confirmDisabled?: boolean
 }
 
 export function ConfirmationModal({
@@ -18,6 +19,7 @@ export function ConfirmationModal({
   onConfirm,
   onCancel,
   children,
+  confirmDisabled = false,
 }: Props) {
   const titleId = useId()
   const descriptionId = useId()
@@ -128,6 +130,7 @@ export function ConfirmationModal({
             type="button"
             className="btn-danger min-h-11 justify-center"
             onClick={onConfirm}
+            disabled={confirmDisabled}
           >
             <Icon name="TriangleAlert" size={15} />
             {confirmLabel}

--- a/webui/src/pages/gameplay/PlayersTab.tsx
+++ b/webui/src/pages/gameplay/PlayersTab.tsx
@@ -15,6 +15,7 @@ import {
 } from './players/sections'
 import { CoriolisAdmin } from './players/coriolis'
 import { BaseWaterAdmin } from './players/base-water'
+import { DungeonDifficultyAdmin } from './players/dungeon-difficulty'
 
 type OnlineFilter = '' | 'online' | 'offline'
 
@@ -333,6 +334,13 @@ export function PlayersTab() {
                 <BaseWaterAdmin
                   players={visiblePlayers}
                   canWrite={source === 'live'}
+                  flash={(msg, kind = 'ok') => setFlash({ msg, kind })}
+                />
+              </div>
+              <div className="mt-3">
+                <DungeonDifficultyAdmin
+                  canWrite={source === 'live'}
+                  demo={source === 'demo'}
                   flash={(msg, kind = 'ok') => setFlash({ msg, kind })}
                 />
               </div>

--- a/webui/src/pages/gameplay/players/dungeon-difficulty.tsx
+++ b/webui/src/pages/gameplay/players/dungeon-difficulty.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ApiError } from '../../../api/client'
+import {
+  getDungeonDifficultySummary,
+  normalizeDungeonDifficulty,
+  type DungeonDifficultySummary,
+} from '../../../api/gameplay'
+import { ConfirmationModal } from '../../../components/ConfirmationModal'
+import { Icon } from '../../../components/Icon'
+import { fmtNum } from '../shared'
+
+const CONFIRMATION = 'NORMALIZE DUNGEONS'
+
+type Flash = (msg: string, kind?: 'ok' | 'err') => void
+
+export function DungeonDifficultyAdmin({
+  canWrite,
+  demo,
+  flash,
+}: {
+  canWrite: boolean
+  demo: boolean
+  flash: Flash
+}) {
+  const [summary, setSummary] = useState<DungeonDifficultySummary | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [backupPath, setBackupPath] = useState('')
+  const [confirming, setConfirming] = useState(false)
+  const [typed, setTyped] = useState('')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setSummary(await getDungeonDifficultySummary(demo))
+    } catch (e) {
+      setSummary(null)
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [demo])
+
+  useEffect(() => { void load() }, [load])
+
+  const run = async () => {
+    if (typed !== CONFIRMATION) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await normalizeDungeonDifficulty(typed)
+      setBackupPath(result.backupPath || '')
+      setConfirming(false)
+      setTyped('')
+      flash(result.message)
+      await load()
+    } catch (e) {
+      const body = e instanceof ApiError && e.body && typeof e.body === 'object'
+        ? e.body as { backupPath?: unknown }
+        : null
+      const path = typeof body?.backupPath === 'string' ? body.backupPath : ''
+      setBackupPath(path)
+      setError(e instanceof Error ? e.message : String(e))
+      setConfirming(false)
+      setTyped('')
+      flash(e instanceof Error ? e.message : String(e), 'err')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const affected = summary?.aboveTarget ?? 0
+  const available = summary !== null && summary.source === 'live'
+  const canNormalize = canWrite && available && affected > 0 && !busy
+
+  return (
+    <div className="card p-4 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-text-dim">
+          <Icon name="Gauge" size={13} /> Normalize Dungeon Difficulty
+        </div>
+        <button type="button" className="btn-secondary" onClick={() => { void load() }} disabled={loading || busy}>
+          <Icon name="RefreshCw" size={13} className={loading ? 'animate-spin' : ''} /> Refresh
+        </button>
+      </div>
+
+      <p className="text-xs text-text-dim">
+        Lower historical dungeon completion difficulty values above 50 to exactly 50 across the server.
+        Values at or below 50 are never changed or raised.
+      </p>
+
+      {summary && (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-5" aria-label="Dungeon difficulty summary">
+          <Metric label="Completions" value={summary.total} />
+          <Metric label="Above 50" value={summary.aboveTarget} warning={summary.aboveTarget > 0} />
+          <Metric label="Maximum" value={summary.maximum} />
+          <Metric label="Participants" value={summary.affectedPlayers} />
+          <Metric label="Fixed target" value={summary.target} />
+        </div>
+      )}
+
+      <div className="rounded-lg border border-warning/40 bg-warning/10 p-3 text-xs space-y-1.5">
+        <div className="flex items-center gap-2 font-semibold text-warning">
+          <Icon name="TriangleAlert" size={14} /> Server-wide historical change
+        </div>
+        <p className="text-text-dim">
+          DST verifies a pre-stop backup, stops the battlegroup, then verifies the definitive rollback backup
+          before updating only completion rows above 50. It verifies the result and starts the battlegroup.
+          All connected players are disconnected during the stop.
+        </p>
+      </div>
+
+      {demo && <div className="text-xs text-text-dim">Demo mode is read-only; no server data can be changed.</div>}
+      {error && <div role="alert" className="rounded-lg border border-danger/40 bg-danger/10 p-3 text-xs text-danger break-words">{error}</div>}
+      {backupPath && (
+        <div className="text-xs text-text-dim break-all">
+          Rollback backup: <span className="font-mono text-text">{backupPath}</span>
+        </div>
+      )}
+      {summary && affected === 0 && !loading && (
+        <div className="text-xs text-success">No dungeon completion rows are above 50. Nothing needs changing.</div>
+      )}
+
+      <button
+        type="button"
+        className="btn-danger"
+        disabled={!canNormalize}
+        onClick={() => setConfirming(true)}
+      >
+        <Icon name={busy ? 'Loader2' : 'Gauge'} size={13} className={busy ? 'animate-spin' : ''} />
+        {busy ? 'Backing up, normalizing, and restarting...' : `Normalize ${fmtNum(affected)} completion row${affected === 1 ? '' : 's'}`}
+      </button>
+
+      {confirming && summary && (
+        <ConfirmationModal
+          title="Normalize dungeon difficulty server-wide?"
+          description={`This will lower ${fmtNum(summary.aboveTarget)} historical completion row${summary.aboveTarget === 1 ? '' : 's'} to difficulty 50 and disconnect connected players during the battlegroup stop.`}
+          confirmLabel="Back up and normalize"
+          confirmDisabled={typed !== CONFIRMATION || busy}
+          onConfirm={() => { void run() }}
+          onCancel={() => { if (!busy) { setConfirming(false); setTyped('') } }}
+        >
+          <div className="space-y-3 text-sm">
+            <p className="text-text-muted">
+              A verified safety backup is required before the battlegroup stops, and a definitive rollback
+              backup is verified while it is stopped before any write. No completion is deleted, and no value
+              at or below 50 is changed.
+            </p>
+            <label className="block">
+              <span className="block text-xs text-text-dim mb-1">
+                Type <span className="font-mono text-warning">{CONFIRMATION}</span> to continue
+              </span>
+              <input
+                autoFocus
+                aria-label="Dungeon normalization confirmation"
+                value={typed}
+                onChange={event => setTyped(event.target.value)}
+                className="w-full rounded-lg border border-border bg-surface-2 px-3 py-2 font-mono text-sm text-text"
+              />
+            </label>
+          </div>
+        </ConfirmationModal>
+      )}
+    </div>
+  )
+}
+
+function Metric({ label, value, warning = false }: { label: string; value: number | null; warning?: boolean }) {
+  return (
+    <div className="rounded-lg border border-border bg-surface-2 p-2">
+      <div className="text-[10px] uppercase tracking-wide text-text-dim">{label}</div>
+      <div className={`mt-1 font-mono text-base ${warning ? 'text-warning' : 'text-text'}`}>
+        {value === null ? '-' : fmtNum(value)}
+      </div>
+    </div>
+  )
+}

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -481,6 +481,33 @@ Spice Melange:
     ])
   })
 
+  describe('dungeon difficulty administration', () => {
+    it('loads the server-wide preview and sends the exact confirmation body', async () => {
+      await gp.getDungeonDifficultySummary()
+      expect(last().url).toBe('/api/gameplay/players/dungeon-difficulty-summary')
+
+      await gp.normalizeDungeonDifficulty('NORMALIZE DUNGEONS')
+      expect(last().url).toBe('/api/gameplay/players/normalize-dungeon-difficulty')
+      expect(last().method).toBe('POST')
+      expect(last().body).toEqual({ confirm: 'NORMALIZE DUNGEONS' })
+    })
+
+    it('uses the shipped dungeons response and query contract', async () => {
+      const row: gp.DungeonRunRow = {
+        dungeon_id: 'cave_01',
+        difficulty: '48',
+        duration_ms: 90210,
+        players_num: 3,
+        completion_id: 17,
+      }
+
+      await gp.getPlayerDungeons(42)
+
+      expect(row.completion_id).toBe(17)
+      expect(last().url).toBe('/api/gameplay/players/dungeons?player_id=42')
+    })
+  })
+
   describe('in-game teleport bookmark API', () => {
     it('arms the selected online player location capture', async () => {
       await gp.armChatTeleport('Base Camp', 42)

--- a/webui/tests/components/DungeonDifficultyAdmin.test.tsx
+++ b/webui/tests/components/DungeonDifficultyAdmin.test.tsx
@@ -1,0 +1,176 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError } from '../../src/api/client'
+import {
+  getDungeonDifficultySummary,
+  normalizeDungeonDifficulty,
+  type DungeonDifficultySummary,
+} from '../../src/api/gameplay'
+import { DungeonDifficultyAdmin } from '../../src/pages/gameplay/players/dungeon-difficulty'
+
+vi.mock('../../src/api/gameplay', () => ({
+  getDungeonDifficultySummary: vi.fn(),
+  normalizeDungeonDifficulty: vi.fn(),
+}))
+
+const liveSummary: DungeonDifficultySummary = {
+  ok: true,
+  total: 120,
+  aboveTarget: 8,
+  maximum: 93,
+  affectedPlayers: 14,
+  target: 50,
+  source: 'live',
+}
+
+describe('DungeonDifficultyAdmin', () => {
+  const flash = vi.fn()
+
+  beforeEach(() => {
+    flash.mockReset()
+    vi.mocked(getDungeonDifficultySummary).mockReset()
+    vi.mocked(normalizeDungeonDifficulty).mockReset()
+    vi.mocked(getDungeonDifficultySummary).mockResolvedValue(liveSummary)
+  })
+
+  afterEach(() => cleanup())
+
+  const renderAdmin = (overrides: Partial<{ canWrite: boolean; demo: boolean }> = {}) =>
+    render(
+      <DungeonDifficultyAdmin
+        canWrite={overrides.canWrite ?? true}
+        demo={overrides.demo ?? false}
+        flash={flash}
+      />,
+    )
+
+  it('renders the preview and complete safety boundary', async () => {
+    renderAdmin()
+
+    expect(await screen.findByText('Normalize Dungeon Difficulty')).toBeInTheDocument()
+    for (const value of ['120', '8', '93', '14', '50']) {
+      expect(screen.getByText(value)).toBeInTheDocument()
+    }
+    expect(screen.getByText(/historical dungeon completion difficulty values/i)).toBeInTheDocument()
+    expect(screen.getByText(/never changed or raised/i)).toBeInTheDocument()
+    expect(screen.getByText(/all connected players are disconnected/i)).toBeInTheDocument()
+    expect(screen.getByText(/rollback backup/i)).toBeInTheDocument()
+  })
+
+  it('requires the exact typed confirmation before submitting', async () => {
+    renderAdmin()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Normalize 8 completion rows' }))
+    const dialog = screen.getByRole('alertdialog')
+    const confirmButton = within(dialog).getByRole('button', { name: 'Back up and normalize' })
+    const input = within(dialog).getByLabelText('Dungeon normalization confirmation')
+
+    expect(confirmButton).toBeDisabled()
+    fireEvent.change(input, { target: { value: 'normalize dungeons' } })
+    expect(confirmButton).toBeDisabled()
+    fireEvent.change(input, { target: { value: 'NORMALIZE DUNGEONS' } })
+    expect(confirmButton).toBeEnabled()
+  })
+
+  it('supports cancellation without invoking the mutation', async () => {
+    renderAdmin()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Normalize 8 completion rows' }))
+    fireEvent.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(normalizeDungeonDifficulty).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['demo mode', { demo: true }],
+    ['read-only permissions', { canWrite: false }],
+  ])('disables mutation in %s', async (_name, props) => {
+    vi.mocked(getDungeonDifficultySummary).mockResolvedValue(
+      props.demo ? { ...liveSummary, source: 'demo' } : liveSummary,
+    )
+    renderAdmin(props)
+
+    expect(await screen.findByRole('button', { name: 'Normalize 8 completion rows' })).toBeDisabled()
+  })
+
+  it('disables mutation when no rows need changing', async () => {
+    vi.mocked(getDungeonDifficultySummary).mockResolvedValue({
+      ...liveSummary,
+      aboveTarget: 0,
+      affectedPlayers: 0,
+      maximum: 50,
+    })
+    renderAdmin()
+
+    expect(await screen.findByRole('button', { name: 'Normalize 0 completion rows' })).toBeDisabled()
+    expect(screen.getByText(/nothing needs changing/i)).toBeInTheDocument()
+  })
+
+  it('fails closed when the summary is unavailable and supports retry', async () => {
+    vi.mocked(getDungeonDifficultySummary)
+      .mockRejectedValueOnce(new Error('Dungeon schema unavailable'))
+      .mockResolvedValueOnce(liveSummary)
+    renderAdmin()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Dungeon schema unavailable')
+    expect(screen.getByRole('button', { name: 'Normalize 0 completion rows' })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+    expect(await screen.findByRole('button', { name: 'Normalize 8 completion rows' })).toBeEnabled()
+  })
+
+  it('refreshes after success and shows the rollback backup', async () => {
+    vi.mocked(normalizeDungeonDifficulty).mockResolvedValue({
+      ok: true,
+      noOp: false,
+      changed: true,
+      verified: true,
+      restarted: true,
+      updated: 8,
+      backupPath: '/mnt/backups/dungeon.tar.gz',
+      backupSize: 2048,
+      summary: { ...liveSummary, aboveTarget: 0, maximum: 50, affectedPlayers: 0 },
+      message: 'Normalized 8 dungeon completion rows.',
+    })
+    vi.mocked(getDungeonDifficultySummary)
+      .mockResolvedValueOnce(liveSummary)
+      .mockResolvedValueOnce({ ...liveSummary, aboveTarget: 0, maximum: 50, affectedPlayers: 0 })
+    renderAdmin()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Normalize 8 completion rows' }))
+    const dialog = screen.getByRole('alertdialog')
+    fireEvent.change(within(dialog).getByLabelText('Dungeon normalization confirmation'), {
+      target: { value: 'NORMALIZE DUNGEONS' },
+    })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Back up and normalize' }))
+
+    await waitFor(() => expect(normalizeDungeonDifficulty).toHaveBeenCalledWith('NORMALIZE DUNGEONS'))
+    await waitFor(() => expect(getDungeonDifficultySummary).toHaveBeenCalledTimes(2))
+    expect(flash).toHaveBeenCalledWith('Normalized 8 dungeon completion rows.')
+    expect(screen.getByText('/mnt/backups/dungeon.tar.gz')).toBeInTheDocument()
+  })
+
+  it('keeps backup and recovery details visible after a partial failure', async () => {
+    vi.mocked(normalizeDungeonDifficulty).mockRejectedValue(
+      new ApiError(503, 'Post-write verification failed. The battlegroup start command was launched.', {
+        ok: false,
+        changed: true,
+        verified: false,
+        restarted: true,
+        backupPath: '/mnt/backups/recovery.tar.gz',
+      }),
+    )
+    renderAdmin()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Normalize 8 completion rows' }))
+    const dialog = screen.getByRole('alertdialog')
+    fireEvent.change(within(dialog).getByLabelText('Dungeon normalization confirmation'), {
+      target: { value: 'NORMALIZE DUNGEONS' },
+    })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Back up and normalize' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Post-write verification failed')
+    expect(screen.getByText('/mnt/backups/recovery.tar.gz')).toBeInTheDocument()
+    expect(flash).toHaveBeenCalledWith(expect.stringContaining('battlegroup start command was launched'), 'err')
+  })
+})


### PR DESCRIPTION
## Summary
- add a server-wide dungeon difficulty preview and fixed normalization target of 50
- require destructive-action authorization, exact typed confirmation, serialized execution, verified rollback backups, battlegroup stop/start, scoped transactional SQL, and post-write verification
- add focused backend, route-policy, API, and UI coverage

## Validation
- `Invoke-Pester -Path tests/DungeonDifficulty.Tests.ps1,tests/PlatformContracts.Tests.ps1` (42 passed)
- `npm test -- --run tests/api/gameplay.test.ts tests/components/DungeonDifficultyAdmin.test.tsx` (61 passed)
- `npm run build`
- Impeccable UI detector
- gitleaks commit scan

## Field-test caveat
The fixed `UPDATE dune.dungeon_completion SET difficulty = 50 WHERE difficulty > 50` shape is community-proven, but this integrated workflow still needs end-to-end validation on a server that currently has affected rows.