### PR TITLE
Prepare v15.0.0 Phase 2 test candidate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,8 +10,8 @@ body:
 
         This issue tracker is for **bugs in this tool's code** — the desktop
         app (Server Health, Commands, PowerShell, Game Config, Gameplay Admin,
-        Maps — DD Atlas / Live state / Lifecycle, Solo Mode, Database, Sietches,
-        Sponsors & Credits, Settings, Setup
+        Maps — DD Atlas / Live state / Lifecycle, Shared Inventory Explorer,
+        Solo Mode, Database, Sietches, Sponsors & Credits, Settings, Setup
         Wizard), the PowerShell script (`dune-server.ps1`), the `.bat`
         launcher, and the installer (`DuneServerSetup.exe`).
 
@@ -38,6 +38,9 @@ body:
         > `game-server-logs.txt` also carries the database pods' logs. The
         > bundle also includes `world-restart-state.json` when available,
         > recording restart/rollback steps and recovery-lock state. The
+        > row-free `inventory-explorer.txt` probe checks the same read-only
+        > player and storage inventory paths without including item, owner,
+        > container, or database identifiers. The
         > `manifest.txt` lists what's inside, leads with any health finding, and
         > records any sanitization warnings. For Maps Live state reports,
         > `maps-platform.txt` adds row-free cache integrity, structural
@@ -85,7 +88,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-test9"
+      placeholder: "v15.0.0-phase2-test1"
     validations:
       required: true
 
@@ -120,6 +123,7 @@ body:
         - Web portal — Gameplay Admin — Overview — Welcome back (returning-player package / days away / announce)
         - Web portal — Gameplay Admin — Market / Market Bot
         - Web portal — Gameplay Admin — Players
+        - Web portal — Shared Inventory Explorer (Players / Bases / Vehicles / Economy — search / refresh / load more / item details / owning entity link)
         - Web portal — Gameplay Admin — Players — Specs (Set level / Apply level rewards / Repair Pattern / Max / Reset)
         - Web portal — Gameplay Admin — Players — Give Item / Give Package / Give Vehicle Kit / Grant Cosmetic / All House Swatches / Max Augment Attributes / Variant (incl. "Allow overflow")
         - Web portal — Gameplay Admin — Players — Cheat Scripts / Dev-Perf Scripts (Live)
@@ -175,8 +179,8 @@ body:
     id: menu_option
     attributes:
       label: Specific page / button / command
-      description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug? For tray behavior, include left-click vs double-click vs right-click Open, whether the taskbar button returned, and whether the restored window was invisible, off-screen, or unexpectedly small. For Browser Portal authentication, include login vs forced change vs local Settings administration, whether account mode was enabled, transport (Funnel or Cloudflare), and HTTP status only—never include usernames, passwords, cookies, tokens, account IDs, hashes, or salts. For the DST updater, include Update Banner vs Settings, the visible TEST number before/after, and the exact verification message; attach fresh diagnostics so the sanitized relaunch, Inno, and installed-identity logs are included. For Maps Live state, include whether the preview disclosure and tab were present, the freshness label, active-field count, source error code, and whether the host is Windows or Linux—never include raw database rows or private marker data. For Sidebar customization, include the page or section label, whether it was hidden or shown individually or by section, pointer vs keyboard input, and whether the layout was migrated, reset, or reopened in the same browser. For Sponsors & Credits, include the affected supporter name, Notes from Duke message, or support link. For the responsive Game Servers card, include viewport width, the affected pod name, and whether Phase / Ready / Players / Age were visible. For in-game commands, include the exact `!command`, chat channel, monitoring interval, cooldown, whether any broadcast appeared, and whether it used the character name. For shared teleport destinations, include direct Save location vs Arm live capture, whether the player paused about five seconds, and whether they teleported on foot or from a vehicle seat. For scheduled Funcom updates, include the scheduled time, whether Apply available Funcom server updates was enabled, installed/latest build IDs, and the last schedule result. For Reboot All, include the visible phase and whether an on-demand-map repair ran. For World Restart, include the failed progress step, whether rollback ran automatically, whether every player was offline, and whether the Roll back last restart button remains available. For Specs > Apply level, include the track, before/after level, and before/after unspent skill points. For Repair Pattern, include whether the player was fully offline, whether Pattern Upgrading became purchasable after login, and whether Grade 2-5 schematic recipes appeared after the in-game purchase. For Apply Quick Preset, include the exact preset and the first journey research/crafting objective still active afterward. For Full Delete, include whether the deleted character owned or co-owned the affected object and whether Claim Ownership appears—never include account, actor, or permission IDs. For Reset Journey, include whether the post-NPE story restarted at Find the Fremen, which starter-class tree was reset, and how many skill points were refunded. For DD Atlas, include the selected seed, POI type, displayed sector(s), and a current reference screenshot or link when possible. For an Experimental Lab control, include its exact CVar or INI key, source/risk badge, file and section, and whether local Engine.ini management was enabled. For Solo Mode, include the adapter, wrapper/schema status, whether the game was fully closed, and the exact action. PTC Import Base Blueprint is intentionally disabled before save access; report only if the UI/backend allows the action or changes a save. After deleting/recreating a character, state whether PTC was fully restarted before creation. For Enable All Skills, state whether Bindu Sprint remained learnable. For a database migration, name the failing step.
-      placeholder: "e.g. Sidebar > Customize navigation > hide Operations, Sponsors & Credits > Notes from Duke, Maps > Live state > snapshot-missing, or Settings > Remote Device Access > Verify owner login"
+      description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug? For tray behavior, include left-click vs double-click vs right-click Open, whether the taskbar button returned, and whether the restored window was invisible, off-screen, or unexpectedly small. For Browser Portal authentication, include login vs forced change vs local Settings administration, whether account mode was enabled, transport (Funnel or Cloudflare), and HTTP status only—never include usernames, passwords, cookies, tokens, account IDs, hashes, or salts. For the DST updater, include Update Banner vs Settings, the visible TEST number before/after, and the exact verification message; attach fresh diagnostics so the sanitized relaunch, Inno, and installed-identity logs are included. For Maps Live state, include whether the preview disclosure and tab were present, the freshness label, active-field count, source error code, and whether the host is Windows or Linux—never include raw database rows or private marker data. For Shared Inventory Explorer, include the workspace (Players, Bases, Vehicles, or Economy), Search vs Refresh vs Load more vs item details vs owning-entity link, whether the view was global or scoped, the query text if it contains no private names, the Live database/Demo inventory source badge, freshness label, and exact visible error—never include owner, character, container, item, inventory, actor, or account identifiers. For Sidebar customization, include the page or section label, whether it was hidden or shown individually or by section, pointer vs keyboard input, and whether the layout was migrated, reset, or reopened in the same browser. For Sponsors & Credits, include the affected supporter name, Notes from Duke message, or support link. For the responsive Game Servers card, include viewport width, the affected pod name, and whether Phase / Ready / Players / Age were visible. For in-game commands, include the exact `!command`, chat channel, monitoring interval, cooldown, whether any broadcast appeared, and whether it used the character name. For shared teleport destinations, include direct Save location vs Arm live capture, whether the player paused about five seconds, and whether they teleported on foot or from a vehicle seat. For scheduled Funcom updates, include the scheduled time, whether Apply available Funcom server updates was enabled, installed/latest build IDs, and the last schedule result. For Reboot All, include the visible phase and whether an on-demand-map repair ran. For World Restart, include the failed progress step, whether rollback ran automatically, whether every player was offline, and whether the Roll back last restart button remains available. For Specs > Apply level, include the track, before/after level, and before/after unspent skill points. For Repair Pattern, include whether the player was fully offline, whether Pattern Upgrading became purchasable after login, and whether Grade 2-5 schematic recipes appeared after the in-game purchase. For Apply Quick Preset, include the exact preset and the first journey research/crafting objective still active afterward. For Full Delete, include whether the deleted character owned or co-owned the affected object and whether Claim Ownership appears—never include account, actor, or permission IDs. For Reset Journey, include whether the post-NPE story restarted at Find the Fremen, which starter-class tree was reset, and how many skill points were refunded. For DD Atlas, include the selected seed, POI type, displayed sector(s), and a current reference screenshot or link when possible. For an Experimental Lab control, include its exact CVar or INI key, source/risk badge, file and section, and whether local Engine.ini management was enabled. For Solo Mode, include the adapter, wrapper/schema status, whether the game was fully closed, and the exact action. PTC Import Base Blueprint is intentionally disabled before save access; report only if the UI/backend allows the action or changes a save. After deleting/recreating a character, state whether PTC was fully restarted before creation. For Enable All Skills, state whether Bindu Sprint remained learnable. For a database migration, name the failing step.
+      placeholder: "e.g. Economy > Inventory > Search > Inventory database read failed, Sidebar > Customize navigation > hide Operations, or Maps > Live state > snapshot-missing"
     validations:
       required: true
 
@@ -224,6 +228,38 @@ body:
         Changed: Base > Max Building Extensions 5 -> 8; Player Inventory Volume 185 -> 195
         DST shows 195 after reload; in-game still behaves like 185.
         Battlegroup restarted after save? yes
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: inventory_explorer_diag
+    attributes:
+      label: Shared Inventory Explorer — search, scope, freshness, or item details
+      description: |
+        Only fill this in for the read-only **Shared Inventory Explorer** embedded
+        in Players, Bases, Vehicles, and Economy. Attach a fresh diagnostics ZIP;
+        `inventory-explorer.txt` checks the live player/storage read paths with
+        row counts bounded to one and never includes item, owner, container, or
+        database identifiers. Also tell us:
+
+        - Which workspace you opened and whether the view was global or reached
+          through an owning-player/container link.
+        - Search, Refresh, Load more, an item detail card, or Open owning entity.
+        - The query text only if it contains no private character/container names.
+        - The visible source and freshness labels, or unavailable/error message.
+        - Whether retrying or reopening the same workspace changed the result.
+
+        Do not paste owner names, character names, container names, template IDs,
+        or item/inventory/actor/account IDs into this public report.
+        Leave blank if the bug is not about Shared Inventory Explorer.
+      placeholder: |
+        Workspace: Economy > Inventory
+        View: global
+        Action: Search
+        Source/freshness: Live database / Fresh
+        Message: "Inventory database read failed: ..."
+        Retry changed result: no
       render: shell
     validations:
       required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.0-phase2-test1] - 2026-09-02
+
 ### Added
 
 - Added a read-only Shared Inventory Explorer across Players, Bases, Vehicles,

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.0'
+$script:DuneToolVersion = '15.0.0-phase2-test1'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.0',
+    [string]$Version = '15.0.0-phase2-test1',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,
@@ -91,7 +91,10 @@ if (-not (Get-Module -ListAvailable ps2exe)) {
 }
 Import-Module ps2exe -Force
 
-$verNum = "$Version.0"  # ps2exe wants 4-part version
+if ($Version -notmatch '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-[0-9A-Za-z.-]+)?$') {
+    throw "Version must be SemVer-compatible (got '$Version')."
+}
+$verNum = "$($Matches[1]).$($Matches[2]).$($Matches[3]).0"  # ps2exe wants numeric 4-part version
 
 Write-Host "Compiling DuneServer.exe (v$Version; prerelease=$([bool]$Prerelease); tag=$BuildTag; commit=$BuildCommit)..." -ForegroundColor Cyan
 

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -58,6 +58,12 @@ if (-not (Test-Path $buildHelpers)) { throw "Build helpers not found: $buildHelp
 if (-not (Test-Path $outDir)) { New-Item -ItemType Directory -Force -Path $outDir | Out-Null }
 . $buildHelpers
 
+$versionInfo = Get-DuneVersionInfo -Version $Version
+if ($Prerelease -and -not $versionInfo.IsPrerelease) {
+    throw "Stable version $Version must not use -Prerelease."
+}
+$Prerelease = [bool]$versionInfo.IsPrerelease
+
 if (-not $BuildCommit) {
     $repoRoot = Split-Path -Parent $appRoot
     try { $BuildCommit = (& git -C $repoRoot rev-parse HEAD 2>$null).Trim() } catch { $BuildCommit = '' }
@@ -67,8 +73,8 @@ if ($BuildCommit -and $BuildCommit -notmatch '^[0-9a-f]{7,40}$') {
     throw 'BuildCommit must be a 7-40 character hexadecimal Git commit id.'
 }
 $BuildTag = $BuildTag.Trim()
-if ($BuildTag -and $BuildTag -notmatch '^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
-    throw 'BuildTag must be a release tag such as v14.0.0 or v14.0.0-test6.'
+if ($BuildTag) {
+    Assert-DuneTagPrereleaseConsistency -BuildTag $BuildTag -Prerelease:$Prerelease
 }
 $sourceText = Get-Content -LiteralPath $src -Raw
 $embedded = [ordered]@{
@@ -91,10 +97,7 @@ if (-not (Get-Module -ListAvailable ps2exe)) {
 }
 Import-Module ps2exe -Force
 
-if ($Version -notmatch '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-[0-9A-Za-z.-]+)?$') {
-    throw "Version must be SemVer-compatible (got '$Version')."
-}
-$verNum = "$($Matches[1]).$($Matches[2]).$($Matches[3]).0"  # ps2exe wants numeric 4-part version
+$verNum = $versionInfo.NumericVersion
 
 Write-Host "Compiling DuneServer.exe (v$Version; prerelease=$([bool]$Prerelease); tag=$BuildTag; commit=$BuildCommit)..." -ForegroundColor Cyan
 

--- a/app/build/BuildHelpers.ps1
+++ b/app/build/BuildHelpers.ps1
@@ -41,6 +41,27 @@ function Publish-DuneBuildArtifact {
     }
 }
 
+function Get-DuneVersionInfo {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Version)
+
+    $value = $Version.Trim()
+    $identifier = '(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+    $pattern = "^(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)\.(?<patch>0|[1-9][0-9]*)(?:-(?<pre>$identifier(?:\.$identifier)*))?$"
+    $match = [regex]::Match($value, $pattern)
+    if (-not $match.Success) {
+        throw "Version must be a SemVer-compatible release version without build metadata (got '$Version')."
+    }
+
+    $core = "$($match.Groups['major'].Value).$($match.Groups['minor'].Value).$($match.Groups['patch'].Value)"
+    return [pscustomobject]@{
+        Version = $value
+        CoreVersion = $core
+        NumericVersion = "$core.0"
+        IsPrerelease = $match.Groups['pre'].Success
+    }
+}
+
 function Get-DuneExistingTagCommit {
     [CmdletBinding()]
     param(
@@ -62,7 +83,13 @@ function Test-DunePrereleaseTag {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$BuildTag)
 
-    return $BuildTag.Trim() -match '^v?\d+\.\d+\.\d+-.+$'
+    $tag = $BuildTag.Trim()
+    $version = if ($tag.StartsWith('v', [StringComparison]::OrdinalIgnoreCase)) {
+        $tag.Substring(1)
+    } else {
+        $tag
+    }
+    return [bool](Get-DuneVersionInfo -Version $version).IsPrerelease
 }
 
 function Assert-DuneTagPrereleaseConsistency {
@@ -73,10 +100,11 @@ function Assert-DuneTagPrereleaseConsistency {
     )
 
     $tag = $BuildTag.Trim()
-    if ($tag -notmatch '^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+    try {
+        $tagIsPrerelease = Test-DunePrereleaseTag -BuildTag $tag
+    } catch {
         throw 'BuildTag must be a release tag such as v15.0.0 or v15.0.0-test9.'
     }
-    $tagIsPrerelease = Test-DunePrereleaseTag -BuildTag $tag
     if ($tagIsPrerelease -and -not $Prerelease) {
         throw "Prerelease tag $tag requires -Prerelease."
     }
@@ -98,7 +126,14 @@ function Get-DuneReleaseTagsAtCommit {
     }
     return @($output |
         ForEach-Object { "$_".Trim() } |
-        Where-Object { $_ -match '^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$' } |
+        Where-Object {
+            try {
+                $null = Test-DunePrereleaseTag -BuildTag $_
+                $true
+            } catch {
+                $false
+            }
+        } |
         Sort-Object -Unique)
 }
 
@@ -130,10 +165,6 @@ function Resolve-DuneBuildIdentity {
             }
             throw "Checkout HEAD $headCommit already has release tag $exampleTag, but -BuildTag was omitted. Refusing to embed '(manual)' identity. Run: $example"
         }
-        if ($Prerelease) {
-            throw 'Prerelease installer builds require an existing -BuildTag and an explicit full -BuildCommit.'
-        }
-
         $commit = if ($BuildCommitSpecified) { $BuildCommit.Trim().ToLowerInvariant() } else { $headCommit }
         if ($commit -and $commit -notmatch '^[0-9a-f]{7,40}$') {
             throw 'BuildCommit must be a 7-40 character hexadecimal Git commit id.'
@@ -141,7 +172,7 @@ function Resolve-DuneBuildIdentity {
         return [pscustomobject]@{
             Commit = $commit
             Tag = ''
-            Prerelease = $false
+            Prerelease = [bool]$Prerelease
             HeadCommit = $headCommit
         }
     }
@@ -230,8 +261,6 @@ function Assert-DuneBuildMetadataMatches {
     $commit = $ExpectedCommit.Trim().ToLowerInvariant()
     if ($tag) {
         Assert-DuneTagPrereleaseConsistency -BuildTag $tag -Prerelease:$ExpectedPrerelease
-    } elseif ($ExpectedPrerelease) {
-        throw 'Expected prerelease metadata requires a release tag.'
     }
     $commitPattern = if ($tag) { '^[0-9a-f]{40}$' } else { '^[0-9a-f]{7,40}$' }
     if ($commit -notmatch $commitPattern) {

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.0</Version>
+    <Version>15.0.0-phase2-test1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/Build-Installer.ps1
+++ b/app/installer/Build-Installer.ps1
@@ -101,11 +101,11 @@ Write-Host ''
 # a deliberate intermediate test build), pass `-SkipVersionCheck`.
 # ---------------------------------------------------------------------------
 $versionFiles = @(
-    @{ Path = Join-Path $repoRoot 'dune-server.ps1';                 Pattern = '\$script:ToolVersion\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"';     Label = '$script:ToolVersion' },
-    @{ Path = Join-Path $appRoot  'DuneServer.ps1';                  Pattern = "\`$script:DuneToolVersion\s*=\s*'([0-9]+\.[0-9]+\.[0-9]+)'"; Label = '$script:DuneToolVersion' },
-    @{ Path = Join-Path $appRoot  'build\Build-Exe.ps1';             Pattern = "\[string\]\`$Version\s*=\s*'([0-9]+\.[0-9]+\.[0-9]+)'";     Label = 'Build-Exe.ps1 default $Version' },
-    @{ Path = Join-Path $appRoot  'installer\DuneServer.iss';        Pattern = '#define\s+MyAppVersion\s+"([0-9]+\.[0-9]+\.[0-9]+)"';       Label = 'MyAppVersion' },
-    @{ Path = Join-Path $appRoot  'desktop\DuneShell\DuneShell.csproj'; Pattern = '<Version>([0-9]+\.[0-9]+\.[0-9]+)</Version>';            Label = 'DuneShell <Version>' }
+    @{ Path = Join-Path $repoRoot 'dune-server.ps1';                 Pattern = '\$script:ToolVersion\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)"';     Label = '$script:ToolVersion' },
+    @{ Path = Join-Path $appRoot  'DuneServer.ps1';                  Pattern = "\`$script:DuneToolVersion\s*=\s*'([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)'"; Label = '$script:DuneToolVersion' },
+    @{ Path = Join-Path $appRoot  'build\Build-Exe.ps1';             Pattern = "\[string\]\`$Version\s*=\s*'([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)'";     Label = 'Build-Exe.ps1 default $Version' },
+    @{ Path = Join-Path $appRoot  'installer\DuneServer.iss';        Pattern = '#define\s+MyAppVersion\s+"([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)"';       Label = 'MyAppVersion' },
+    @{ Path = Join-Path $appRoot  'desktop\DuneShell\DuneShell.csproj'; Pattern = '<Version>([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)</Version>';            Label = 'DuneShell <Version>' }
 )
 if (-not $SkipVersionCheck) {
     $stampReport = foreach ($vf in $versionFiles) {

--- a/app/installer/Build-Installer.ps1
+++ b/app/installer/Build-Installer.ps1
@@ -15,8 +15,8 @@ param(
     [switch]$SkipSoloBuild,
     [switch]$SkipPlatformBuild,
     [switch]$SkipVersionCheck,
-    # Explicit artifact identity. Normal release/local builds default stable.
-    # Test candidates must pass -Prerelease; branch names are never inferred.
+    # Explicit artifact identity. The version suffix determines prerelease state;
+    # -Prerelease remains accepted as a consistency guard for release automation.
     [switch]$Prerelease,
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
@@ -49,6 +49,41 @@ $platformExe = Join-Path $appRoot 'tools\DunePlatformStore\bin\Release\net10.0-w
 $buildHelpers = Join-Path $appRoot 'build\BuildHelpers.ps1'
 
 $null = . $buildHelpers
+$versionFiles = @(
+    @{ Path = Join-Path $repoRoot 'dune-server.ps1';                   Pattern = '\$script:ToolVersion\s*=\s*"([^"]+)"';       Label = '$script:ToolVersion' },
+    @{ Path = Join-Path $appRoot  'DuneServer.ps1';                    Pattern = "\`$script:DuneToolVersion\s*=\s*'([^']+)'"; Label = '$script:DuneToolVersion' },
+    @{ Path = Join-Path $appRoot  'build\Build-Exe.ps1';               Pattern = "\[string\]\`$Version\s*=\s*'([^']+)'";      Label = 'Build-Exe.ps1 default $Version' },
+    @{ Path = Join-Path $appRoot  'installer\DuneServer.iss';          Pattern = '#define\s+MyAppVersion\s+"([^"]+)"';         Label = 'MyAppVersion' },
+    @{ Path = Join-Path $appRoot  'desktop\DuneShell\DuneShell.csproj'; Pattern = '<Version>([^<]+)</Version>';                 Label = 'DuneShell <Version>' }
+)
+$stampReport = foreach ($vf in $versionFiles) {
+    if (-not (Test-Path -LiteralPath $vf.Path)) {
+        throw "Version-stamp file not found: $($vf.Path)"
+    }
+
+    $match = Select-String -Path $vf.Path -Pattern $vf.Pattern -List
+    if (-not $match) {
+        throw "Could not find version stamp in $($vf.Path) using pattern: $($vf.Pattern)"
+    }
+    $version = $match.Matches[0].Groups[1].Value
+    try {
+        $versionInfo = Get-DuneVersionInfo -Version $version
+    } catch {
+        throw "$($vf.Label) has an invalid release version: $($_.Exception.Message)"
+    }
+    [pscustomobject]@{
+        File = $vf.Path.Substring($repoRoot.Length + 1)
+        Label = $vf.Label
+        Version = $versionInfo.Version
+        VersionInfo = $versionInfo
+    }
+}
+$installerVersion = ($stampReport | Where-Object Label -eq 'MyAppVersion').VersionInfo
+if ($Prerelease -and -not $installerVersion.IsPrerelease) {
+    throw "Stable version $($installerVersion.Version) must not use -Prerelease."
+}
+$Prerelease = [bool]$installerVersion.IsPrerelease
+
 $repoKey = [Convert]::ToHexString(
     [Security.Cryptography.SHA256]::HashData(
         [Text.Encoding]::UTF8.GetBytes($repoRoot.ToLowerInvariant()))).Substring(0, 16)
@@ -100,29 +135,7 @@ Write-Host ''
 # If the stamps disagree, abort with a clear listing. To override (e.g. for
 # a deliberate intermediate test build), pass `-SkipVersionCheck`.
 # ---------------------------------------------------------------------------
-$versionFiles = @(
-    @{ Path = Join-Path $repoRoot 'dune-server.ps1';                 Pattern = '\$script:ToolVersion\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)"';     Label = '$script:ToolVersion' },
-    @{ Path = Join-Path $appRoot  'DuneServer.ps1';                  Pattern = "\`$script:DuneToolVersion\s*=\s*'([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)'"; Label = '$script:DuneToolVersion' },
-    @{ Path = Join-Path $appRoot  'build\Build-Exe.ps1';             Pattern = "\[string\]\`$Version\s*=\s*'([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)'";     Label = 'Build-Exe.ps1 default $Version' },
-    @{ Path = Join-Path $appRoot  'installer\DuneServer.iss';        Pattern = '#define\s+MyAppVersion\s+"([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)"';       Label = 'MyAppVersion' },
-    @{ Path = Join-Path $appRoot  'desktop\DuneShell\DuneShell.csproj'; Pattern = '<Version>([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)</Version>';            Label = 'DuneShell <Version>' }
-)
 if (-not $SkipVersionCheck) {
-    $stampReport = foreach ($vf in $versionFiles) {
-        if (-not (Test-Path -LiteralPath $vf.Path)) {
-            throw "Version-stamp file not found: $($vf.Path)"
-        }
-
-        $m = Select-String -Path $vf.Path -Pattern $vf.Pattern -List
-        if (-not $m) {
-            throw "Could not find version stamp in $($vf.Path) using pattern: $($vf.Pattern)"
-        }
-        [pscustomobject]@{
-            File    = $vf.Path.Substring($repoRoot.Length + 1)
-            Label   = $vf.Label
-            Version = $m.Matches[0].Groups[1].Value
-        }
-    }
     $distinct = @($stampReport.Version | Sort-Object -Unique)
     Write-Host "Version-stamp check:" -ForegroundColor Cyan
     foreach ($r in $stampReport) {

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -17,7 +17,7 @@
 
 #define MyAppName        "Dune Server Tool"
 #define MyAppVersion "15.0.0-phase2-test1"
-#define MyAppNumericVersion "15.0.0.0"
+#define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,8 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.0"
+#define MyAppVersion "15.0.0-phase2-test1"
+#define MyAppNumericVersion "15.0.0.0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
 #define MyAppExeName     "DuneServer.exe"
@@ -31,7 +32,7 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}/issues
 AppUpdatesURL={#MyAppURL}/releases
-VersionInfoVersion={#MyAppVersion}.0
+VersionInfoVersion={#MyAppNumericVersion}
 DefaultDirName={autopf}\Dune Server Tool
 DefaultGroupName=Dune Server Tool
 DisableProgramGroupPage=no

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -1040,6 +1040,49 @@ done
         $warnings.Add('Gameplay read helpers not loaded - read-path probe skipped.')
     }
 
+    # 6f) Shared Inventory Explorer read-path probe --------------------------
+    # Handled inventory database failures are returned to the UI and are not
+    # written to dune-server.log. Exercise the same read-only projection with a
+    # one-row bound per supported source, recording no rows or identifiers.
+    if ((Get-Command Get-DuneDbContext -ErrorAction SilentlyContinue) -and
+        (Get-Command Invoke-DuneInventorySearchLive -ErrorAction SilentlyContinue)) {
+        try {
+            $inventoryProbe = [System.Collections.Generic.List[string]]::new()
+            $inventoryProbe.Add('# Shared Inventory Explorer read-path probe (row-free and identifier-free)')
+            $inventoryProbe.Add("# Generated $(Get-Date -Format 'o')")
+            $inventoryProbe.Add('# Each source query is read-only and bounded to one row; only success/failure is recorded.')
+            $inventoryProbe.Add('')
+            $inventoryContext = Get-DuneDbContext
+            if (-not $inventoryContext.ok) {
+                $inventoryProbe.Add("DB context: NOT available - $($inventoryContext.message)")
+            } else {
+                $inventoryProbe.Add('DB context: available')
+                foreach ($inventoryType in @('player', 'storage')) {
+                    try {
+                        $inventoryResult = Invoke-DuneInventorySearchLive -Ip $inventoryContext.ip `
+                            -EntityTypes @($inventoryType) -Limit 1
+                        if ($inventoryResult.ok) {
+                            $hasSample = @($inventoryResult.items).Count -gt 0
+                            $inventoryProbe.Add("$inventoryType source: query ok; sample row present: $hasSample")
+                        } else {
+                            $inventoryProbe.Add("$inventoryType source: QUERY FAILED - $($inventoryResult.error)")
+                        }
+                    } catch {
+                        $inventoryProbe.Add("$inventoryType source: PROBE ERROR - $($_.Exception.Message)")
+                    }
+                }
+            }
+            $inventoryText = Invoke-DstRedaction -Text ($inventoryProbe -join "`r`n") @redactArgs
+            $inventoryOut = Join-Path $stageDir 'inventory-explorer.txt'
+            Set-Content -LiteralPath $inventoryOut -Value $inventoryText -Encoding UTF8
+            $included.Add(@{ name = 'inventory-explorer.txt'; bytes = (Get-Item -LiteralPath $inventoryOut).Length })
+        } catch {
+            $warnings.Add("Inventory Explorer read-path probe failed: $($_.Exception.Message)")
+        }
+    } else {
+        $warnings.Add('Inventory Explorer helpers not loaded - read-path probe skipped.')
+    }
+
     # 7) Manifest ------------------------------------------------------------
     $manLines = [System.Collections.Generic.List[string]]::new()
     $manLines.Add("Dune Server Tool diagnostic bundle")
@@ -1087,6 +1130,11 @@ done
     $manLines.Add('gameplay-read-probe.txt re-runs the Players/Bases list queries and records')
     $manLines.Add('COUNTS ONLY (no player names or ids) so "rows but blank detail" bugs are')
     $manLines.Add('triageable; absent when the DB is unreachable (see Warnings).')
+    $manLines.Add('')
+    $manLines.Add('inventory-explorer.txt exercises the same read-only player and storage inventory')
+    $manLines.Add('projections used by Shared Inventory Explorer, bounded to one row per source. It')
+    $manLines.Add('records only source success/failure and whether a sample row exists; no item,')
+    $manLines.Add('owner, container, inventory, actor, account, or database identifiers are included.')
     $manLines.Add('')
     $manLines.Add('vm-memory-pressure.txt probes the VM for the OOMKilled-operators / low-memory')
     $manLines.Add('signature (Funcom controller-manager restart counts + lastState, Postgres pod')

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.0"
+$script:ToolVersion = "15.0.0-phase2-test1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/BuildMetadata.Tests.ps1
+++ b/tests/BuildMetadata.Tests.ps1
@@ -88,6 +88,17 @@ Describe 'Build artifact metadata' {
         $workflow | Should -Not -Match '\$biArgs\s*\+='
     }
 
+    It 'validates release versions and derives numeric resource versions' {
+        $candidate = Get-DuneVersionInfo -Version '15.0.0-phase2-test1'
+
+        $candidate.IsPrerelease | Should -BeTrue
+        $candidate.CoreVersion | Should -BeExactly '15.0.0'
+        $candidate.NumericVersion | Should -BeExactly '15.0.0.0'
+        foreach ($invalid in @('01.2.3', '1.02.3', '1.2.03', '1.2.3-', '1.2.3-.test', '1.2.3-test.', '1.2.3-..', '1.2.3-01')) {
+            { Get-DuneVersionInfo -Version $invalid } | Should -Throw '*SemVer-compatible release version*'
+        }
+    }
+
     It 'publishes through replacement so an installed hardlink is not overwritten' {
         $installed = Join-Path $TestDrive 'installed.exe'
         $destination = Join-Path $TestDrive 'output.exe'
@@ -136,6 +147,17 @@ Describe 'Build artifact metadata' {
 
         $identity.Tag | Should -Be ''
         $identity.Prerelease | Should -BeFalse
+        $identity.Commit | Should -BeExactly $head
+    }
+
+    It 'preserves prerelease identity for an untagged candidate build' {
+        $repo = Join-Path $TestDrive 'untagged-prerelease'
+        $head = New-BuildIdentityTestRepo -Path $repo
+
+        $identity = Resolve-DuneBuildIdentity -RepoRoot $repo -Prerelease
+
+        $identity.Tag | Should -Be ''
+        $identity.Prerelease | Should -BeTrue
         $identity.Commit | Should -BeExactly $head
     }
 
@@ -214,6 +236,24 @@ Describe 'Build artifact metadata' {
                 -Metadata $metadata `
                 -ExpectedTag '' `
                 -ExpectedCommit ('a' * 40)
+        } | Should -Not -Throw
+    }
+
+    It 'accepts matching prerelease manual compiled metadata' {
+        $metadata = [pscustomobject]@{
+            present = $true
+            valid = $true
+            tag = ''
+            commit = 'a' * 40
+            prerelease = $true
+        }
+
+        {
+            $null = Assert-DuneBuildMetadataMatches `
+                -Metadata $metadata `
+                -ExpectedTag '' `
+                -ExpectedCommit ('a' * 40) `
+                -ExpectedPrerelease
         } | Should -Not -Throw
     }
 

--- a/tests/Diagnostics.Tests.ps1
+++ b/tests/Diagnostics.Tests.ps1
@@ -245,6 +245,17 @@ Describe 'Diagnostics route registration' -Tag 'Pure' {
         $source | Should -Not -Match "snapshot\['activeSpice'\]"
     }
 
+    It 'includes an identifier-free Shared Inventory Explorer read probe' {
+        $routeFile = Join-Path (Get-DstRepoRoot) 'app\server\routes\Diagnostics.ps1'
+        $source = Get-Content -LiteralPath $routeFile -Raw
+
+        $source | Should -Match "inventory-explorer\.txt"
+        $source | Should -Match "Invoke-DuneInventorySearchLive"
+        $source | Should -Match '-EntityTypes @\(\$inventoryType\) -Limit 1'
+        $source | Should -Match 'Invoke-DstRedaction -Text \(\$inventoryProbe'
+        $source | Should -Not -Match 'inventoryProbe\.Add\(.+\.(?:id|name|owner|templateId|inventoryId)'
+    }
+
     It 'registers failed database operation cleanup at script scope' {
         $routeFile = Join-Path (Get-DstRepoRoot) 'app\server\routes\Diagnostics.ps1'
         $tokens = $null


### PR DESCRIPTION
## Summary
- stamp all five release-version surfaces for `15.0.0-phase2-test1`
- roll the combined Phase 2 scope into the dated 2026-09-02 changelog entry
- add Shared Inventory Explorer bug-report and identifier-free diagnostic coverage
- support prerelease SemVer labels while preserving numeric Windows resource versions

## Validation
- `Invoke-Pester tests/Diagnostics.Tests.ps1, tests/InventoryExplorer.Tests.ps1` (48 passed)
- `Invoke-Pester tests/BuildMetadata.Tests.ps1` (16 passed)
- `pwsh app/installer/Build-Installer.ps1`
- PowerShell 5.1 parse and UTF-8 BOM preflight
- gitleaks committed-range scan
- prohibited local-only/private-reference scans

Preparation only: keep this PR open and unmerged. Do not tag or publish a release from this PR.