### PR TITLE
Redesign shared inventory as compact icon grid

### DIFF
--- a/webui/src/components/inventory/InventoryItemIcon.tsx
+++ b/webui/src/components/inventory/InventoryItemIcon.tsx
@@ -47,7 +47,10 @@ export function extractItemImageUrl(prefix: string) {
 
 async function readBoundedResponse(response: Response) {
   const declaredLength = Number(response.headers.get('content-length'))
-  if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) return null
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) {
+    await response.body?.cancel().catch(() => undefined)
+    return null
+  }
   if (!response.body) return null
 
   const reader = response.body.getReader()

--- a/webui/src/components/inventory/InventoryItemIcon.tsx
+++ b/webui/src/components/inventory/InventoryItemIcon.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useRef, useState } from 'react'
+
+const CDN_ORIGIN = 'https://cdn-hosted.gaming.tools'
+const METADATA_PREFIX = `${CDN_ORIGIN}/dune/data/en/items/`
+const IMAGE_PREFIX = `${CDN_ORIGIN}/dune`
+const MAX_RESPONSE_BYTES = 64 * 1024
+const RANGE_HEADER = 'bytes=0-4095'
+
+const iconCache = new Map<string, Promise<string | null>>()
+const observedElements = new Map<Element, () => void>()
+let sharedObserver: IntersectionObserver | null = null
+
+export function itemSlug(templateId: string) {
+  return encodeURIComponent(templateId.toLowerCase())
+}
+
+export function itemMetadataUrl(templateId: string) {
+  return `${METADATA_PREFIX}${itemSlug(templateId)}.d.json`
+}
+
+export function itemDetailsUrl(templateId: string) {
+  return `https://dune.gaming.tools/items/${itemSlug(templateId)}`
+}
+
+function validatedImageUrl(path: string) {
+  if (!path.startsWith('/images/') || /[\u0000-\u001f\u007f\\?#]/.test(path)) return null
+  try {
+    const segments = path.split('/').map(segment => decodeURIComponent(segment))
+    if (segments.some(segment => segment === '..' || segment === '.')) return null
+    const url = new URL(path, IMAGE_PREFIX)
+    if (url.origin !== CDN_ORIGIN || !url.pathname.startsWith('/images/')) return null
+    return `${IMAGE_PREFIX}${url.pathname}`
+  } catch {
+    return null
+  }
+}
+
+export function extractItemImageUrl(prefix: string) {
+  const match = prefix.match(/"(\/images\/(?:\\["\\/bfnrt]|\\u[0-9a-fA-F]{4}|[^"\\\u0000-\u001f])*)"/)
+  if (!match) return null
+  try {
+    return validatedImageUrl(JSON.parse(`"${match[1]}"`) as string)
+  } catch {
+    return null
+  }
+}
+
+async function readBoundedResponse(response: Response) {
+  const declaredLength = Number(response.headers.get('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) return null
+  if (!response.body) return null
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      total += value.byteLength
+      if (total > MAX_RESPONSE_BYTES) {
+        await reader.cancel()
+        return null
+      }
+      chunks.push(value)
+    }
+  } catch {
+    return null
+  }
+
+  const bytes = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return new TextDecoder().decode(bytes)
+}
+
+async function fetchItemIcon(templateId: string) {
+  if (!templateId.trim()) return null
+  try {
+    const response = await fetch(itemMetadataUrl(templateId), {
+      headers: { Range: RANGE_HEADER },
+    })
+    if (response.status !== 200 && response.status !== 206) return null
+    const prefix = await readBoundedResponse(response)
+    return prefix ? extractItemImageUrl(prefix) : null
+  } catch {
+    return null
+  }
+}
+
+export function resolveItemIcon(templateId: string) {
+  const cacheKey = templateId.toLowerCase()
+  const cached = iconCache.get(cacheKey)
+  if (cached) return cached
+  const pending = fetchItemIcon(templateId)
+  iconCache.set(cacheKey, pending)
+  return pending
+}
+
+export function clearItemIconCacheForTests() {
+  iconCache.clear()
+}
+
+function observeNearViewport(element: Element, onVisible: () => void) {
+  if (typeof IntersectionObserver === 'undefined') return () => undefined
+  if (!sharedObserver) {
+    sharedObserver = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue
+        const callback = observedElements.get(entry.target)
+        if (!callback) continue
+        observedElements.delete(entry.target)
+        sharedObserver?.unobserve(entry.target)
+        callback()
+      }
+    }, { rootMargin: '160px' })
+  }
+  observedElements.set(element, onVisible)
+  sharedObserver.observe(element)
+  return () => {
+    observedElements.delete(element)
+    sharedObserver?.unobserve(element)
+  }
+}
+
+export function InventoryItemIcon({
+  templateId,
+  displayName,
+}: {
+  templateId: string
+  displayName: string
+}) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const [iconUrl, setIconUrl] = useState<string | null>(null)
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    let active = true
+    setIconUrl(null)
+    setFailed(false)
+    const stopObserving = observeNearViewport(host, () => {
+      void resolveItemIcon(templateId).then(url => {
+        if (active) setIconUrl(url)
+      })
+    })
+    return () => {
+      active = false
+      stopObserving()
+    }
+  }, [templateId])
+
+  return (
+    <div ref={hostRef} className="flex min-h-0 flex-1 items-center justify-center overflow-hidden">
+      {iconUrl && !failed ? (
+        <img
+          src={iconUrl}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          className="h-full w-full object-contain p-1"
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        <span
+          aria-hidden="true"
+          title={`${displayName || templateId} icon unavailable`}
+          className="flex h-12 w-12 items-center justify-center rounded-lg border border-border/70 bg-base/40 text-lg font-semibold text-text-dim"
+        >
+          {(displayName || templateId).trim().charAt(0).toUpperCase() || '?'}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/webui/src/components/inventory/InventorySlot.tsx
+++ b/webui/src/components/inventory/InventorySlot.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { SharedInventoryItem } from '../../api/gameplay'
 import { InventoryItemIcon } from './InventoryItemIcon'
@@ -15,6 +15,7 @@ export function InventorySlot({
   onSelect: (item: SharedInventoryItem) => void
 }) {
   const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const tooltipRef = useRef<HTMLDivElement | null>(null)
   const tooltipId = useId()
   const [hovered, setHovered] = useState(false)
   const [hoverSuppressed, setHoverSuppressed] = useState(false)
@@ -28,12 +29,12 @@ export function InventorySlot({
   const placeInfoCard = useCallback(() => {
     const rect = buttonRef.current?.getBoundingClientRect()
     if (!rect) return
-    const width = Math.min(288, window.innerWidth - 16)
-    const estimatedHeight = 184
+    const width = tooltipRef.current?.offsetWidth || Math.min(288, window.innerWidth - 16)
+    const height = tooltipRef.current?.offsetHeight || 0
     const left = Math.min(Math.max(8, rect.left + rect.width / 2 - width / 2), window.innerWidth - width - 8)
-    const top = rect.bottom + estimatedHeight + 8 <= window.innerHeight
+    const top = rect.bottom + height + 8 <= window.innerHeight
       ? rect.bottom + 8
-      : Math.max(8, rect.top - estimatedHeight - 8)
+      : Math.max(8, Math.min(rect.top - height - 8, window.innerHeight - height - 8))
     setPosition({ left, top })
   }, [])
 
@@ -47,12 +48,17 @@ export function InventorySlot({
     return () => document.removeEventListener('focusin', handleFocusIn)
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!showInfo) return
     placeInfoCard()
+    const resizeObserver = typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(placeInfoCard)
+    if (tooltipRef.current) resizeObserver?.observe(tooltipRef.current)
     window.addEventListener('resize', placeInfoCard)
     window.addEventListener('scroll', placeInfoCard, true)
     return () => {
+      resizeObserver?.disconnect()
       window.removeEventListener('resize', placeInfoCard)
       window.removeEventListener('scroll', placeInfoCard, true)
     }
@@ -96,10 +102,11 @@ export function InventorySlot({
 
       {showInfo && createPortal(
         <div
+          ref={tooltipRef}
           id={tooltipId}
           role="tooltip"
           style={{ position: 'fixed', left: position.left, top: position.top, width: 'min(18rem, calc(100vw - 1rem))' }}
-          className="pointer-events-none z-[100] rounded-xl border border-border-bright bg-surface px-3 py-2.5 text-xs shadow-[0_12px_32px_-10px_rgba(0,0,0,0.85)]"
+          className="pointer-events-none z-[100] max-h-[calc(100dvh-1rem)] overflow-hidden rounded-xl border border-border-bright bg-surface px-3 py-2.5 text-xs shadow-[0_12px_32px_-10px_rgba(0,0,0,0.85)]"
         >
           <p className="break-words text-sm font-semibold text-text">{name}</p>
           <p className="mt-0.5 break-all font-mono text-[11px] text-text-muted">{item.templateId}</p>

--- a/webui/src/components/inventory/InventorySlot.tsx
+++ b/webui/src/components/inventory/InventorySlot.tsx
@@ -17,9 +17,10 @@ export function InventorySlot({
   const buttonRef = useRef<HTMLButtonElement | null>(null)
   const tooltipId = useId()
   const [hovered, setHovered] = useState(false)
+  const [hoverSuppressed, setHoverSuppressed] = useState(false)
   const [focused, setFocused] = useState(false)
   const [position, setPosition] = useState({ left: 8, top: 8 })
-  const showInfo = hovered || focused
+  const showInfo = (hovered && !hoverSuppressed) || focused
   const name = item.displayName || item.templateId
   const source = entityTypeLabel(item.entity.type)
   const entity = item.entity.label || `Actor ${item.entity.id}`
@@ -34,6 +35,16 @@ export function InventorySlot({
       ? rect.bottom + 8
       : Math.max(8, rect.top - estimatedHeight - 8)
     setPosition({ left, top })
+  }, [])
+
+  useEffect(() => {
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target
+      if (!(target instanceof Element) || !target.closest('[data-inventory-slot]')) return
+      setHoverSuppressed(target !== buttonRef.current)
+    }
+    document.addEventListener('focusin', handleFocusIn)
+    return () => document.removeEventListener('focusin', handleFocusIn)
   }, [])
 
   useEffect(() => {
@@ -52,14 +63,22 @@ export function InventorySlot({
       <button
         ref={buttonRef}
         type="button"
+        data-inventory-slot
         aria-label={`${name}, quantity ${item.quantity}, quality ${item.quality}, ${source}, ${entity}`}
         aria-describedby={showInfo ? tooltipId : undefined}
         className="group relative flex aspect-square min-h-22 w-full min-w-0 flex-col overflow-hidden rounded-xl border border-border bg-surface/85 text-left shadow-[inset_0_1px_rgba(255,255,255,0.04),0_6px_16px_-12px_rgba(0,0,0,0.9)] transition-[border-color,background-color,transform] duration-150 hover:-translate-y-0.5 hover:border-accent/60 hover:bg-surface-2 focus:outline-none focus-visible:border-ibad focus-visible:ring-2 focus-visible:ring-ibad active:translate-y-0"
-        onMouseEnter={() => setHovered(true)}
+        onMouseEnter={() => {
+          setHoverSuppressed(false)
+          setHovered(true)
+        }}
         onMouseLeave={() => setHovered(false)}
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
-        onClick={() => onSelect(item)}
+        onClick={() => {
+          setHovered(false)
+          setFocused(false)
+          onSelect(item)
+        }}
       >
         <span className="flex w-full items-center justify-between gap-1 px-1.5 pt-1.5">
           <span className="rounded-md border border-info/35 bg-base/90 px-1.5 py-0.5 text-[10px] font-semibold text-info">

--- a/webui/src/components/inventory/InventorySlot.tsx
+++ b/webui/src/components/inventory/InventorySlot.tsx
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { SharedInventoryItem } from '../../api/gameplay'
+import { InventoryItemIcon } from './InventoryItemIcon'
+
+function entityTypeLabel(type: SharedInventoryItem['entity']['type']) {
+  return type === 'player' ? 'Player inventory' : 'Storage container'
+}
+
+export function InventorySlot({
+  item,
+  onSelect,
+}: {
+  item: SharedInventoryItem
+  onSelect: (item: SharedInventoryItem) => void
+}) {
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const tooltipId = useId()
+  const [hovered, setHovered] = useState(false)
+  const [focused, setFocused] = useState(false)
+  const [position, setPosition] = useState({ left: 8, top: 8 })
+  const showInfo = hovered || focused
+  const name = item.displayName || item.templateId
+  const source = entityTypeLabel(item.entity.type)
+  const entity = item.entity.label || `Actor ${item.entity.id}`
+
+  const placeInfoCard = useCallback(() => {
+    const rect = buttonRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const width = Math.min(288, window.innerWidth - 16)
+    const estimatedHeight = 184
+    const left = Math.min(Math.max(8, rect.left + rect.width / 2 - width / 2), window.innerWidth - width - 8)
+    const top = rect.bottom + estimatedHeight + 8 <= window.innerHeight
+      ? rect.bottom + 8
+      : Math.max(8, rect.top - estimatedHeight - 8)
+    setPosition({ left, top })
+  }, [])
+
+  useEffect(() => {
+    if (!showInfo) return
+    placeInfoCard()
+    window.addEventListener('resize', placeInfoCard)
+    window.addEventListener('scroll', placeInfoCard, true)
+    return () => {
+      window.removeEventListener('resize', placeInfoCard)
+      window.removeEventListener('scroll', placeInfoCard, true)
+    }
+  }, [placeInfoCard, showInfo])
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-label={`${name}, quantity ${item.quantity}, quality ${item.quality}, ${source}, ${entity}`}
+        aria-describedby={showInfo ? tooltipId : undefined}
+        className="group relative flex aspect-square min-h-22 w-full min-w-0 flex-col overflow-hidden rounded-xl border border-border bg-surface/85 text-left shadow-[inset_0_1px_rgba(255,255,255,0.04),0_6px_16px_-12px_rgba(0,0,0,0.9)] transition-[border-color,background-color,transform] duration-150 hover:-translate-y-0.5 hover:border-accent/60 hover:bg-surface-2 focus:outline-none focus-visible:border-ibad focus-visible:ring-2 focus-visible:ring-ibad active:translate-y-0"
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        onClick={() => onSelect(item)}
+      >
+        <span className="flex w-full items-center justify-between gap-1 px-1.5 pt-1.5">
+          <span className="rounded-md border border-info/35 bg-base/90 px-1.5 py-0.5 text-[10px] font-semibold text-info">
+            Q{item.quality}
+          </span>
+          <span className="rounded-md border border-accent/45 bg-base/90 px-1.5 py-0.5 text-[11px] font-bold text-accent-bright">
+            x{item.quantity}
+          </span>
+        </span>
+        <InventoryItemIcon templateId={item.templateId} displayName={name} />
+        <span className="w-full truncate border-t border-border/80 bg-base/75 px-2 py-1.5 text-center text-xs font-semibold text-text">
+          {name}
+        </span>
+      </button>
+
+      {showInfo && createPortal(
+        <div
+          id={tooltipId}
+          role="tooltip"
+          style={{ position: 'fixed', left: position.left, top: position.top, width: 'min(18rem, calc(100vw - 1rem))' }}
+          className="pointer-events-none z-[100] rounded-xl border border-border-bright bg-surface px-3 py-2.5 text-xs shadow-[0_12px_32px_-10px_rgba(0,0,0,0.85)]"
+        >
+          <p className="break-words text-sm font-semibold text-text">{name}</p>
+          <p className="mt-0.5 break-all font-mono text-[11px] text-text-muted">{item.templateId}</p>
+          <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+            <dt className="text-text-muted">Quantity</dt><dd className="text-right font-semibold text-text">{item.quantity}</dd>
+            <dt className="text-text-muted">Quality</dt><dd className="text-right font-semibold text-text">{item.quality}</dd>
+            <dt className="text-text-muted">Source</dt><dd className="break-words text-right text-text">{source}</dd>
+            <dt className="text-text-muted">Entity</dt><dd className="break-words text-right text-text">{entity}</dd>
+            {item.entity.owner && <><dt className="text-text-muted">Owner</dt><dd className="break-words text-right text-text">{item.entity.owner}</dd></>}
+          </dl>
+        </div>,
+        document.body,
+      )}
+    </>
+  )
+}

--- a/webui/src/components/inventory/SharedInventoryExplorer.tsx
+++ b/webui/src/components/inventory/SharedInventoryExplorer.tsx
@@ -12,7 +12,7 @@ import { Icon } from '../Icon'
 import { DataState, FreshnessBadge } from '../platform/DataState'
 import { DetailPanel } from '../platform/DetailPanel'
 import { WorkspaceSection } from '../platform/WorkspaceLayout'
-import { itemDetailsUrl } from './InventoryItemIcon'
+import { itemDetailsUrl, resolveItemIcon } from './InventoryItemIcon'
 import { InventorySlot } from './InventorySlot'
 
 function errorMessage(error: unknown) {
@@ -72,6 +72,7 @@ export function SharedInventoryExplorer({
   const [response, setResponse] = useState<SharedInventoryResponse | null>(null)
   const [items, setItems] = useState<SharedInventoryItem[]>([])
   const [selected, setSelected] = useState<SharedInventoryItem | null>(null)
+  const [verifiedDetailsUrl, setVerifiedDetailsUrl] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState('')
@@ -174,6 +175,18 @@ export function SharedInventoryExplorer({
   useEffect(() => () => {
     requestVersion.current += 1
   }, [])
+
+  useEffect(() => {
+    setVerifiedDetailsUrl(null)
+    if (!currentSelection) return
+    let active = true
+    void resolveItemIcon(currentSelection.templateId).then(iconUrl => {
+      if (active && iconUrl) setVerifiedDetailsUrl(itemDetailsUrl(currentSelection.templateId))
+    })
+    return () => {
+      active = false
+    }
+  }, [currentSelection])
 
   const busy = loading || loadingMore
 
@@ -373,15 +386,17 @@ export function SharedInventoryExplorer({
               <Link className="btn-secondary inline-flex min-h-11" to={currentSelection.entity.workspacePath}>
                 Open owning {currentSelection.entity.type === 'player' ? 'player' : 'container'}
               </Link>
-              <a
-                className="btn-ghost inline-flex min-h-11 text-text-muted"
-                href={itemDetailsUrl(currentSelection.templateId)}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                View on dune.gaming.tools
-                <Icon name="ExternalLink" size={14} />
-              </a>
+              {verifiedDetailsUrl && (
+                <a
+                  className="btn-ghost inline-flex min-h-11 text-text-muted"
+                  href={verifiedDetailsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View on dune.gaming.tools
+                  <Icon name="ExternalLink" size={14} />
+                </a>
+              )}
             </div>
           </div>
         )}

--- a/webui/src/components/inventory/SharedInventoryExplorer.tsx
+++ b/webui/src/components/inventory/SharedInventoryExplorer.tsx
@@ -12,6 +12,8 @@ import { Icon } from '../Icon'
 import { DataState, FreshnessBadge } from '../platform/DataState'
 import { DetailPanel } from '../platform/DetailPanel'
 import { WorkspaceSection } from '../platform/WorkspaceLayout'
+import { itemDetailsUrl } from './InventoryItemIcon'
+import { InventorySlot } from './InventorySlot'
 
 function errorMessage(error: unknown) {
   return error instanceof ApiError ? error.message : error instanceof Error ? error.message : String(error)
@@ -318,40 +320,10 @@ export function SharedInventoryExplorer({
 
       {currentItems.length > 0 && (
         <>
-          <ul className="grid min-w-0 grid-cols-1 gap-2 xl:grid-cols-2" aria-label="Inventory results">
+          <ul className="grid min-w-0 grid-cols-[repeat(auto-fill,minmax(min(6.5rem,100%),1fr))] gap-2.5" aria-label="Inventory results">
             {currentItems.map(item => (
               <li key={`${item.entity.type}:${item.id}`} className="min-w-0">
-                <button
-                  type="button"
-                  className="card min-h-11 w-full min-w-0 p-4 text-left hover:border-accent/45 focus:outline-none focus-visible:ring-2 focus-visible:ring-ibad"
-                  onClick={() => setSelected(item)}
-                >
-                  <div className="flex min-w-0 flex-wrap items-start justify-between gap-2">
-                    <div className="min-w-0">
-                      <h3 className="break-words font-semibold text-text">{item.displayName || item.templateId}</h3>
-                      <p className="mt-1 break-all font-mono text-xs text-text-dim">{item.templateId}</p>
-                    </div>
-                    <span className="pill shrink-0 border-border text-text-muted">x{item.quantity}</span>
-                  </div>
-                  <dl className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
-                    <div>
-                      <dt className="text-xs text-text-dim">Source</dt>
-                      <dd className="mt-0.5 break-words text-text">{entityTypeLabel(item.entity.type)}</dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs text-text-dim">Entity</dt>
-                      <dd className="mt-0.5 break-words text-text">{item.entity.label || `Actor ${item.entity.id}`}</dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs text-text-dim">Owner</dt>
-                      <dd className="mt-0.5 break-words text-text">{item.entity.owner || 'Not proven'}</dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs text-text-dim">Map</dt>
-                      <dd className="mt-0.5 break-words text-text">{item.entity.map || 'Not reported'}</dd>
-                    </div>
-                  </dl>
-                </button>
+                <InventorySlot item={item} onSelect={setSelected} />
               </li>
             ))}
           </ul>
@@ -397,9 +369,20 @@ export function SharedInventoryExplorer({
               <div><dt className="text-text-dim">Map</dt><dd className="break-words">{currentSelection.entity.map || 'Not reported'}</dd></div>
               <div><dt className="text-text-dim">Observed</dt><dd>{currentResponse?.freshness.observedAt ? new Date(currentResponse.freshness.observedAt).toLocaleString() : 'Not reported'}</dd></div>
             </dl>
-            <Link className="btn-secondary mt-5 inline-flex min-h-11" to={currentSelection.entity.workspacePath}>
-              Open owning {currentSelection.entity.type === 'player' ? 'player' : 'container'}
-            </Link>
+            <div className="mt-5 flex flex-wrap gap-2">
+              <Link className="btn-secondary inline-flex min-h-11" to={currentSelection.entity.workspacePath}>
+                Open owning {currentSelection.entity.type === 'player' ? 'player' : 'container'}
+              </Link>
+              <a
+                className="btn-ghost inline-flex min-h-11 text-text-muted"
+                href={itemDetailsUrl(currentSelection.templateId)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View on dune.gaming.tools
+                <Icon name="ExternalLink" size={14} />
+              </a>
+            </div>
           </div>
         )}
       </DetailPanel>

--- a/webui/tests/inventoryItemIcon.test.tsx
+++ b/webui/tests/inventoryItemIcon.test.tsx
@@ -1,0 +1,104 @@
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearItemIconCacheForTests,
+  extractItemImageUrl,
+  InventoryItemIcon,
+  itemDetailsUrl,
+  itemMetadataUrl,
+  resolveItemIcon,
+} from '../src/components/inventory/InventoryItemIcon'
+
+let intersectionCallback: IntersectionObserverCallback | null = null
+
+class IntersectionObserverMock implements IntersectionObserver {
+  readonly root = null
+  readonly rootMargin = ''
+  readonly thresholds = []
+
+  constructor(callback: IntersectionObserverCallback) {
+    intersectionCallback = callback
+  }
+
+  disconnect() {}
+  observe() {}
+  takeRecords() { return [] }
+  unobserve() {}
+}
+
+beforeEach(() => {
+  clearItemIconCacheForTests()
+  vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('inventory item icon resolution', () => {
+  it('builds fixed-origin encoded metadata and detail URLs', () => {
+    expect(itemMetadataUrl('HealthPack /../?')).toBe(
+      'https://cdn-hosted.gaming.tools/dune/data/en/items/healthpack%20%2F..%2F%3F.d.json',
+    )
+    expect(itemDetailsUrl('MelangeSpice')).toBe('https://dune.gaming.tools/items/melangespice')
+  })
+
+  it('extracts only safe root-relative image paths', () => {
+    expect(extractItemImageUrl('{"icon":"/images/dune/items/spice.webp"}')).toBe(
+      'https://cdn-hosted.gaming.tools/dune/images/dune/items/spice.webp',
+    )
+    expect(extractItemImageUrl('{"icon":"/images/../private.webp"}')).toBeNull()
+    expect(extractItemImageUrl('{"icon":"/images/%2e%2e/private.webp"}')).toBeNull()
+    expect(extractItemImageUrl('{"icon":"https://evil.example/images/item.webp"}')).toBeNull()
+  })
+
+  it('uses a bounded range request and caches success by lowercased template ID', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      '{"name":"Spice","icon":"/images/dune/items/spice.webp"}',
+      { status: 206, headers: { 'content-length': '58' } },
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(resolveItemIcon('MelangeSpice')).resolves.toContain('/images/dune/items/spice.webp')
+    await expect(resolveItemIcon('melangespice')).resolves.toContain('/images/dune/items/spice.webp')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://cdn-hosted.gaming.tools/dune/data/en/items/melangespice.d.json',
+      { headers: { Range: 'bytes=0-4095' } },
+    )
+  })
+
+  it('caches null for failed and unexpectedly large responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('ignored', {
+      status: 200,
+      headers: { 'content-length': String(65 * 1024) },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(resolveItemIcon('OversizedItem')).resolves.toBeNull()
+    await expect(resolveItemIcon('OversizedItem')).resolves.toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for viewport proximity and falls back without broken image chrome', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 206 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { container } = render(<InventoryItemIcon templateId="UnknownItem" displayName="Unknown item" />)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(container.querySelector('img')).not.toBeInTheDocument()
+    expect(screen.getByTitle('Unknown item icon unavailable')).toBeInTheDocument()
+
+    await act(async () => {
+      intersectionCallback?.([{
+        isIntersecting: true,
+        target: container.firstElementChild as Element,
+      } as IntersectionObserverEntry], {} as IntersectionObserver)
+    })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(container.querySelector('img')).not.toBeInTheDocument()
+  })
+})

--- a/webui/tests/inventoryItemIcon.test.tsx
+++ b/webui/tests/inventoryItemIcon.test.tsx
@@ -71,7 +71,13 @@ describe('inventory item icon resolution', () => {
   })
 
   it('caches null for failed and unexpectedly large responses', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response('ignored', {
+    let cancelled = false
+    const body = new ReadableStream({
+      cancel() {
+        cancelled = true
+      },
+    })
+    const fetchMock = vi.fn().mockResolvedValue(new Response(body, {
       status: 200,
       headers: { 'content-length': String(65 * 1024) },
     }))
@@ -80,6 +86,7 @@ describe('inventory item icon resolution', () => {
     await expect(resolveItemIcon('OversizedItem')).resolves.toBeNull()
     await expect(resolveItemIcon('OversizedItem')).resolves.toBeNull()
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(cancelled).toBe(true)
   })
 
   it('waits for viewport proximity and falls back without broken image chrome', async () => {

--- a/webui/tests/sharedInventoryExplorer.test.tsx
+++ b/webui/tests/sharedInventoryExplorer.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SharedInventoryExplorer } from '../src/components/inventory/SharedInventoryExplorer'
 import { BrowserRouter } from '../src/router'
 
@@ -14,6 +14,7 @@ const capabilityState = vi.hoisted(() => ({
 }))
 
 const inventoryApi = vi.hoisted(() => vi.fn())
+const itemIconResolver = vi.hoisted(() => vi.fn())
 
 vi.mock('../src/hooks/usePlatformCapabilities', () => ({
   usePlatformCapabilities: () => ({
@@ -28,6 +29,11 @@ vi.mock('../src/hooks/usePlatformCapabilities', () => ({
 vi.mock('../src/api/gameplay', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/api/gameplay')>()
   return { ...actual, getSharedInventory: inventoryApi }
+})
+
+vi.mock('../src/components/inventory/InventoryItemIcon', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/components/inventory/InventoryItemIcon')>()
+  return { ...actual, resolveItemIcon: itemIconResolver }
 })
 
 const fixture = {
@@ -98,6 +104,10 @@ function deferred<T>() {
   return { promise, resolve }
 }
 
+beforeEach(() => {
+  itemIconResolver.mockResolvedValue('https://cdn-hosted.gaming.tools/dune/images/dune/items/spice.webp')
+})
+
 afterEach(() => {
   cleanup()
   capabilityState.loading = false
@@ -106,6 +116,7 @@ afterEach(() => {
   capabilityState.enabled = true
   capabilityState.refresh.mockClear()
   inventoryApi.mockReset()
+  itemIconResolver.mockReset()
   window.history.replaceState(null, '', '/')
 })
 
@@ -136,12 +147,29 @@ describe('Shared Inventory Explorer', () => {
 
     await user.click(resultSlot)
     expect(screen.getByRole('dialog', { name: 'Spice Melange' })).toBeInTheDocument()
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Open owning container' }))
       .toHaveAttribute('href', '/bases?view=inventory&scope_type=storage&scope_id=50001')
-    expect(screen.getByRole('link', { name: 'View on dune.gaming.tools' })).toHaveAttribute(
+    expect(await screen.findByRole('link', { name: 'View on dune.gaming.tools' })).toHaveAttribute(
       'href',
       'https://dune.gaming.tools/items/melangespice',
     )
+  })
+
+  it('omits gaming.tools attribution when metadata or icon verification fails', async () => {
+    const user = userEvent.setup()
+    itemIconResolver.mockResolvedValue(null)
+    inventoryApi.mockResolvedValue(fixture)
+    render(
+      <BrowserRouter>
+        <SharedInventoryExplorer entityTypes={['storage']} />
+      </BrowserRouter>,
+    )
+
+    await user.click(await screen.findByRole('button', { name: /Spice Melange/ }))
+    expect(screen.getByRole('dialog', { name: 'Spice Melange' })).toBeInTheDocument()
+    await waitFor(() => expect(itemIconResolver).toHaveBeenCalledWith('MelangeSpice'))
+    expect(screen.queryByRole('link', { name: 'View on dune.gaming.tools' })).not.toBeInTheDocument()
   })
 
   it('submits one typed search and preserves the bounded entity filter', async () => {

--- a/webui/tests/sharedInventoryExplorer.test.tsx
+++ b/webui/tests/sharedInventoryExplorer.test.tsx
@@ -120,16 +120,28 @@ describe('Shared Inventory Explorer', () => {
     )
 
     expect(await screen.findByText('Spice Melange')).toBeInTheDocument()
-    expect(screen.getByText('Spice Vault')).toBeInTheDocument()
-    expect(screen.getByText('Stilgar')).toBeInTheDocument()
+    const resultSlot = screen.getByRole('button', { name: /Spice Melange/ })
+    expect(resultSlot).toHaveAccessibleName(/quantity 12, quality 3, Storage container, Spice Vault/)
+    expect(screen.getByRole('list', { name: 'Inventory results' }).className).toContain('auto-fill')
+    resultSlot.focus()
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Spice Vault')
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Stilgar')
+    resultSlot.blur()
+    await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument())
+    await user.hover(resultSlot)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Spice Vault')
     expect(screen.getByText('Live database')).toHaveAttribute('data-freshness-state', 'fresh')
     expect(screen.getAllByText('Read-only').length).toBeGreaterThan(0)
     expect(screen.queryByRole('button', { name: /give|delete|repair/i })).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /Spice Melange/ }))
+    await user.click(resultSlot)
     expect(screen.getByRole('dialog', { name: 'Spice Melange' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Open owning container' }))
       .toHaveAttribute('href', '/bases?view=inventory&scope_type=storage&scope_id=50001')
+    expect(screen.getByRole('link', { name: 'View on dune.gaming.tools' })).toHaveAttribute(
+      'href',
+      'https://dune.gaming.tools/items/melangespice',
+    )
   })
 
   it('submits one typed search and preserves the bounded entity filter', async () => {

--- a/webui/tests/sharedInventoryExplorer.test.tsx
+++ b/webui/tests/sharedInventoryExplorer.test.tsx
@@ -172,6 +172,40 @@ describe('Shared Inventory Explorer', () => {
     expect(screen.queryByRole('link', { name: 'View on dune.gaming.tools' })).not.toBeInTheDocument()
   })
 
+  it('places the info card using its measured height near the viewport edge', async () => {
+    inventoryApi.mockResolvedValue(fixture)
+    const heightSpy = vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockImplementation(function measuredHeight() {
+        return this.getAttribute('role') === 'tooltip' ? 240 : 0
+      })
+    const widthSpy = vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(288)
+    const viewportSpy = vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)
+    render(
+      <BrowserRouter>
+        <SharedInventoryExplorer entityTypes={['storage']} />
+      </BrowserRouter>,
+    )
+
+    const resultSlot = await screen.findByRole('button', { name: /Spice Melange/ })
+    vi.spyOn(resultSlot, 'getBoundingClientRect').mockReturnValue({
+      x: 100,
+      y: 590,
+      top: 590,
+      right: 210,
+      bottom: 700,
+      left: 100,
+      width: 110,
+      height: 110,
+      toJSON: () => ({}),
+    })
+    resultSlot.focus()
+
+    expect(await screen.findByRole('tooltip')).toHaveStyle({ top: '342px' })
+    heightSpy.mockRestore()
+    widthSpy.mockRestore()
+    viewportSpy.mockRestore()
+  })
+
   it('submits one typed search and preserves the bounded entity filter', async () => {
     const user = userEvent.setup()
     inventoryApi.mockResolvedValue(fixture)


### PR DESCRIPTION
## Summary
- replace tall Shared Inventory Explorer result cards with dense, responsive square inventory slots
- lazily resolve gaming.tools icons through a fixed-origin, bounded, validated, session-cached resolver with graceful placeholders
- expose concise collision-aware hover and keyboard-focus info cards while preserving click/tap detail behavior
- add safe dune.gaming.tools attribution links in the existing detail panel
- preserve read-only search, scoping, provenance, pagination, and request-race behavior

## Validation
- 329 WebUI tests
- WebUI TypeScript/Vite production build and performance budget
- changed-file ESLint
- Impeccable detector
- `git diff --check`
- staged gitleaks scan
- private-reference and prohibited-path scans