### PR TITLE
Group shared inventory explorer items

### DIFF
--- a/app/data/platform-route-policies.json
+++ b/app/data/platform-route-policies.json
@@ -152,7 +152,7 @@
     { "source": "Gameplay.ps1", "capabilityId": "economy.market", "routeCount": 22, "sha256": "757d3fd58fe70e88c5ccc91b9549e8f9a121b9137c1a2c16cd574c271c46e258" },
     { "source": "GameplayPlayers.ps1", "capabilityId": "player.manage", "routeCount": 27, "sha256": "4f822fc3645a5196c477810daed318d097c5319fb920a34b8ce8be6ab191d24e" },
     { "source": "GameplayWorld.ps1", "capabilityId": "base.manage", "routeCount": 12, "sha256": "52bfaeee6658d490bedae03914b525e3272d89ece1dc957d3514dc8ee9a84c30" },
-    { "source": "Inventory.ps1", "capabilityId": "inventory.read", "routeCount": 1, "sha256": "6152c83c4eade7ec711473a482be9c47d64ba61dcc180e033251bc00d2183544" },
+    { "source": "Inventory.ps1", "capabilityId": "inventory.read", "routeCount": 2, "sha256": "6f55a9a618b3b5447e160dbd1a40015c0afb68b9e18b810daaee0cfb55aa7268" },
     { "source": "ItemPackages.ps1", "capabilityId": "player.inventory", "routeCount": 3, "sha256": "ed3aac4a943d300002f7aecacb8ecf04619917ee7aa549cde0068e1853e01cf9" },
     { "source": "Landsraad.ps1", "capabilityId": "economy.governance", "routeCount": 9, "sha256": "e78c0dfe1b1f969d781db180f8c73eb3439de9779dd62fde7a8879925ac762f0" },
     { "source": "Links.ps1", "capabilityId": "platform.status", "routeCount": 1, "sha256": "175305c4d511463c37a3c0c2484bf7178044f72d42fe444c2eec1733ef876a47" },

--- a/app/server/HttpServer.ps1
+++ b/app/server/HttpServer.ps1
@@ -169,7 +169,8 @@ function Test-DunePortalOwnerOrAdminPath {
         (
             $Path -eq '/api/v1/maps' -or
             $Path.StartsWith('/api/v1/maps/') -or
-            $Path -eq '/api/v1/inventory/items'
+            $Path -eq '/api/v1/inventory/items' -or
+            $Path.StartsWith('/api/v1/inventory/items/')
         )
     )
 }

--- a/app/server/lib/InventoryExplorer.ps1
+++ b/app/server/lib/InventoryExplorer.ps1
@@ -475,7 +475,9 @@ function Resolve-DuneInventoryOccurrenceSort {
 function Test-DuneInventoryVisibleItem {
     param([Parameter(Mandatory)]$Item)
     $templateId = [string]$Item.templateId
-    return [string]$Item.kind -ne 'emote' -and $templateId -notmatch '(?i)(^|_)Emote(_|$)|Gesture'
+    $rule = Get-DuneGameplayItemRule -TemplateId $templateId
+    if ([string]$rule.category) { return $true }
+    return [string]$Item.kind -ne 'emote' -and $templateId -notmatch '(?i)Emote|Gesture'
 }
 
 function New-DuneInventoryParameterizedSql {
@@ -515,12 +517,17 @@ function Get-DuneInventoryCatalogIdsJson {
 function Get-DuneInventoryCatalogMetadataJson {
     Initialize-DuneGameplayItemData
     $metadata = [ordered]@{}
-    foreach ($id in @($script:DuneGameplayItemRules.Keys | Sort-Object)) {
-        $rule = Get-DuneGameplayItemRule -TemplateId $id
+    $catalogIds = @(
+        @($script:DuneGameplayItemNames.Keys) + @($script:DuneGameplayItemRules.Keys) |
+            Sort-Object -Unique
+    )
+    foreach ($id in $catalogIds) {
+        $hasRule = $script:DuneGameplayItemRules.ContainsKey($id)
+        $rule = if ($hasRule) { Get-DuneGameplayItemRule -TemplateId $id } else { $null }
         $metadata[([string]$id).ToLowerInvariant()] = [ordered]@{
             name = Get-DuneGameplayItemName -TemplateId $id
-            tier = if ($null -ne $rule.tier) { [int]$rule.tier } else { $null }
-            volume = if ($null -ne $rule.volume) { [double]$rule.volume } else { $null }
+            tier = if ($hasRule -and $null -ne $rule.tier) { [int]$rule.tier } else { $null }
+            volume = if ($hasRule -and $null -ne $rule.volume) { [double]$rule.volume } else { $null }
         }
     }
     return ($metadata | ConvertTo-Json -Compress -Depth 4)
@@ -587,7 +594,10 @@ visible_rows AS (
     FROM inventory_rows r CROSS JOIN _dst_parameters p
     WHERE r.entity_type = ANY(string_to_array(p.entity_types, ','))
       AND (p.scope_type = '' OR (r.entity_type = p.scope_type AND r.entity_id = p.scope_id))
-      AND r.template_id !~* '(^|_)Emote(_|$)|Gesture'
+      AND (
+          r.template_id IN (SELECT jsonb_array_elements_text(p.catalog_ids::jsonb))
+          OR r.template_id !~* 'Emote|Gesture'
+      )
 ),
 searched_rows AS (
     SELECT r.*
@@ -755,6 +765,32 @@ function Get-DuneInventoryGroupedDemo {
                 playerName = [string]$first.player.name; occurrenceCount = $_.Count
             }
         } | Sort-Object type, label, id)
+    if ($PlayerId -and -not @($facets | Where-Object { [long]$_.id -eq $PlayerId }).Count) {
+        $activePlayerRows = @($visibleBase | Where-Object { [long]$_.player.id -eq $PlayerId })
+        if ($activePlayerRows.Count) {
+            $facets += [ordered]@{
+                id = $PlayerId; name = [string]$activePlayerRows[0].player.name
+                occurrenceCount = $activePlayerRows.Count
+            }
+        }
+    }
+    if ($LocationType -and -not @($locations | Where-Object {
+        [string]$_.type -eq $LocationType -and [long]$_.id -eq $LocationId
+    }).Count) {
+        $activeLocationRows = @($visibleBase | Where-Object {
+            (-not $PlayerId -or [long]$_.player.id -eq $PlayerId) -and
+            [string]$_.entity.type -eq $LocationType -and [long]$_.entity.id -eq $LocationId
+        })
+        if ($activeLocationRows.Count) {
+            $first = $activeLocationRows[0]
+            $locations += [ordered]@{
+                type = [string]$first.entity.type; id = [long]$first.entity.id
+                label = if ([string]$first.entity.type -eq 'player') { 'Backpack' } else { [string]$first.entity.label }
+                owner = [string]$first.entity.owner; playerId = [long]$first.player.id
+                playerName = [string]$first.player.name; occurrenceCount = $activeLocationRows.Count
+            }
+        }
+    }
     $filtered = @($base | Where-Object {
         (-not $PlayerId -or [long]$_.player.id -eq $PlayerId) -and
         (-not $LocationType -or ([string]$_.entity.type -eq $LocationType -and [long]$_.entity.id -eq $LocationId))
@@ -908,24 +944,51 @@ ORDER BY $($sortSpec.sql) LIMIT (SELECT row_limit FROM _dst_parameters)
     if (-not $groupResult.ok) { return @{ ok = $false; error = $groupResult.error } }
 
     $facetSql = @"
-WITH $cte
-SELECT 'player'::text AS row_kind, NULL::text AS group_key, NULL::text AS template_id,
-       NULL::bigint AS total_quantity, COUNT(*)::bigint AS occurrence_count, NULL::bigint AS location_count,
-       NULL::integer AS quality_min, NULL::integer AS quality_max, player_id, MAX(player_name) AS player_name
-FROM searched_rows WHERE player_id IS NOT NULL AND player_id > 0
-GROUP BY player_id ORDER BY player_name, player_id LIMIT 50000
+WITH $cte,
+search_facets AS (
+    SELECT player_id, MAX(player_name) AS player_name, COUNT(*)::bigint AS occurrence_count
+    FROM searched_rows WHERE player_id IS NOT NULL AND player_id > 0 GROUP BY player_id
+),
+active_facet AS (
+    SELECT r.player_id, MAX(r.player_name) AS player_name, COUNT(*)::bigint AS occurrence_count
+    FROM visible_rows r CROSS JOIN _dst_parameters p
+    WHERE p.player_id > 0 AND r.player_id = p.player_id GROUP BY r.player_id
+)
+SELECT player_id, player_name, occurrence_count FROM search_facets
+UNION ALL
+SELECT a.player_id, a.player_name, a.occurrence_count FROM active_facet a
+WHERE NOT EXISTS (SELECT 1 FROM search_facets s WHERE s.player_id = a.player_id)
+ORDER BY player_name, player_id LIMIT 50000
 "@
     $effectiveFacetSql = New-DuneInventoryParameterizedSql -Sql $facetSql -Parameters $binding.values -ParameterTypes $binding.types
     $facetResult = Invoke-DuneSqlQuery -Ip $Ip -Sql $effectiveFacetSql -ReadOnly $true -MaxRows 50000 -TimeoutSec 45 -Bulk
     if (-not $facetResult.ok) { return @{ ok = $false; error = $facetResult.error } }
     $locationSql = @"
-WITH $cte
-SELECT entity_type, entity_id, MAX(CASE WHEN entity_type = 'player' THEN 'Backpack' ELSE entity_label END) AS entity_label,
-       MAX(owner_name) AS owner_name, MAX(player_id)::bigint AS player_id, MAX(player_name) AS player_name,
-       COUNT(*)::bigint AS occurrence_count
-FROM searched_rows CROSS JOIN _dst_parameters p
-WHERE (p.player_id = 0 OR searched_rows.player_id = p.player_id)
-GROUP BY entity_type, entity_id ORDER BY entity_type, entity_label, entity_id LIMIT 50000
+WITH $cte,
+search_locations AS (
+    SELECT entity_type, entity_id, MAX(CASE WHEN entity_type = 'player' THEN 'Backpack' ELSE entity_label END) AS entity_label,
+           MAX(owner_name) AS owner_name, MAX(player_id)::bigint AS player_id, MAX(player_name) AS player_name,
+           COUNT(*)::bigint AS occurrence_count
+    FROM searched_rows CROSS JOIN _dst_parameters p
+    WHERE (p.player_id = 0 OR searched_rows.player_id = p.player_id)
+    GROUP BY entity_type, entity_id
+),
+active_location AS (
+    SELECT r.entity_type, r.entity_id, MAX(CASE WHEN r.entity_type = 'player' THEN 'Backpack' ELSE r.entity_label END) AS entity_label,
+           MAX(r.owner_name) AS owner_name, MAX(r.player_id)::bigint AS player_id, MAX(r.player_name) AS player_name,
+           COUNT(*)::bigint AS occurrence_count
+    FROM visible_rows r CROSS JOIN _dst_parameters p
+    WHERE p.location_type <> '' AND r.entity_type = p.location_type AND r.entity_id = p.location_id
+      AND (p.player_id = 0 OR r.player_id = p.player_id)
+    GROUP BY r.entity_type, r.entity_id
+)
+SELECT * FROM search_locations
+UNION ALL
+SELECT a.* FROM active_location a
+WHERE NOT EXISTS (
+    SELECT 1 FROM search_locations s WHERE s.entity_type = a.entity_type AND s.entity_id = a.entity_id
+)
+ORDER BY entity_type, entity_label, entity_id LIMIT 50000
 "@
     $effectiveLocationSql = New-DuneInventoryParameterizedSql -Sql $locationSql -Parameters $binding.values -ParameterTypes $binding.types
     $locationResult = Invoke-DuneSqlQuery -Ip $Ip -Sql $effectiveLocationSql -ReadOnly $true -MaxRows 50000 -TimeoutSec 45 -Bulk

--- a/app/server/lib/InventoryExplorer.ps1
+++ b/app/server/lib/InventoryExplorer.ps1
@@ -4,6 +4,8 @@
 $script:DuneInventoryDefaultLimit = 100
 $script:DuneInventoryMaxLimit = 500
 $script:DuneInventoryCursorGeneration = 'inventory-v1'
+$script:DuneInventoryGroupedCursorGeneration = 'inventory-groups-v1'
+$script:DuneInventoryOccurrenceCursorGeneration = 'inventory-occurrences-v1'
 
 function Get-DuneInventoryLimit {
     param([string]$Value)
@@ -414,4 +416,677 @@ function Invoke-DuneInventoryRequestedPage {
         return @{ ok = $false; status = 503; error = "Inventory database read failed: $([string]$live.error)" }
     }
     return @{ ok = $true; source = 'live'; mode = 'live'; items = @($live.items) }
+}
+
+function Resolve-DuneInventoryPlayerId {
+    param([bool]$HasPlayerId, [string]$Value)
+    if (-not $HasPlayerId) { return @{ ok = $true; playerId = 0L } }
+    $playerId = 0L
+    if (-not [Int64]::TryParse($Value, [ref]$playerId) -or $playerId -le 0) {
+        return @{ ok = $false; error = 'player_id must be a positive integer.' }
+    }
+    return @{ ok = $true; playerId = $playerId }
+}
+
+function Resolve-DuneInventoryGroupSort {
+        param([string]$Value)
+        $sort = if ($Value) { $Value.Trim().ToLowerInvariant() } else { 'name-asc' }
+        $map = @{
+            'name-asc' = @{ sql='sort_name ASC, template_id ASC'; primary='sort_name'; type='text'; direction='asc' }
+            'name-desc' = @{ sql='sort_name DESC, template_id ASC'; primary='sort_name'; type='text'; direction='desc' }
+            'quantity-desc' = @{ sql='total_quantity DESC, sort_name ASC, template_id ASC'; primary='total_quantity'; type='number'; direction='desc' }
+            'quantity-asc' = @{ sql='total_quantity ASC, sort_name ASC, template_id ASC'; primary='total_quantity'; type='number'; direction='asc' }
+            'unit-volume-desc' = @{ sql='unit_volume DESC NULLS LAST, sort_name ASC, template_id ASC'; primary='unit_volume'; type='number'; direction='desc' }
+            'unit-volume-asc' = @{ sql='unit_volume ASC NULLS LAST, sort_name ASC, template_id ASC'; primary='unit_volume'; type='number'; direction='asc' }
+            'total-volume-desc' = @{ sql='total_volume DESC NULLS LAST, sort_name ASC, template_id ASC'; primary='total_volume'; type='number'; direction='desc' }
+            'total-volume-asc' = @{ sql='total_volume ASC NULLS LAST, sort_name ASC, template_id ASC'; primary='total_volume'; type='number'; direction='asc' }
+            'tier-desc' = @{ sql='item_tier DESC NULLS LAST, sort_name ASC, template_id ASC'; primary='item_tier'; type='number'; direction='desc' }
+            'tier-asc' = @{ sql='item_tier ASC NULLS LAST, sort_name ASC, template_id ASC'; primary='item_tier'; type='number'; direction='asc' }
+            'quality-desc' = @{ sql='quality_max DESC, quality_min DESC, sort_name ASC, template_id ASC'; primary='quality_max'; secondary='quality_min'; type='number'; direction='desc' }
+            'quality-asc' = @{ sql='quality_max ASC, quality_min ASC, sort_name ASC, template_id ASC'; primary='quality_max'; secondary='quality_min'; type='number'; direction='asc' }
+            'occurrences-desc' = @{ sql='occurrence_count DESC, sort_name ASC, template_id ASC'; primary='occurrence_count'; type='number'; direction='desc' }
+            'occurrences-asc' = @{ sql='occurrence_count ASC, sort_name ASC, template_id ASC'; primary='occurrence_count'; type='number'; direction='asc' }
+            'locations-desc' = @{ sql='location_count DESC, sort_name ASC, template_id ASC'; primary='location_count'; type='number'; direction='desc' }
+            'locations-asc' = @{ sql='location_count ASC, sort_name ASC, template_id ASC'; primary='location_count'; type='number'; direction='asc' }
+        }
+        if (-not $map.ContainsKey($sort)) { return @{ ok = $false; error = "Unsupported inventory sort '$sort'." } }
+        return @{
+            ok = $true; value = $sort; sql = $map[$sort].sql; primary = $map[$sort].primary
+            secondary = [string]$map[$sort].secondary; type = $map[$sort].type; direction = $map[$sort].direction
+        }
+    }
+
+function Resolve-DuneInventoryOccurrenceSort {
+        param([string]$Value)
+        $sort = if ($Value) { $Value.Trim().ToLowerInvariant() } else { 'player-asc' }
+        $map = @{
+            'player-asc' = @{ sql='lower(player_name) ASC NULLS LAST, item_id ASC'; primary='lower(player_name)'; type='text'; direction='asc' }
+            'player-desc' = @{ sql='lower(player_name) DESC NULLS LAST, item_id ASC'; primary='lower(player_name)'; type='text'; direction='desc' }
+            'location-asc' = @{ sql='lower(entity_label) ASC NULLS LAST, item_id ASC'; primary='lower(entity_label)'; type='text'; direction='asc' }
+            'location-desc' = @{ sql='lower(entity_label) DESC NULLS LAST, item_id ASC'; primary='lower(entity_label)'; type='text'; direction='desc' }
+            'quantity-desc' = @{ sql='stack_size DESC NULLS LAST, item_id ASC'; primary='stack_size'; type='number'; direction='desc' }
+            'quantity-asc' = @{ sql='stack_size ASC NULLS LAST, item_id ASC'; primary='stack_size'; type='number'; direction='asc' }
+            'quality-desc' = @{ sql='quality_level DESC NULLS LAST, item_id ASC'; primary='quality_level'; type='number'; direction='desc' }
+            'quality-asc' = @{ sql='quality_level ASC NULLS LAST, item_id ASC'; primary='quality_level'; type='number'; direction='asc' }
+        }
+        if (-not $map.ContainsKey($sort)) { return @{ ok = $false; error = "Unsupported occurrence sort '$sort'." } }
+        return @{ ok = $true; value = $sort; sql = $map[$sort].sql; primary = $map[$sort].primary; type = $map[$sort].type; direction = $map[$sort].direction }
+    }
+function Test-DuneInventoryVisibleItem {
+    param([Parameter(Mandatory)]$Item)
+    $templateId = [string]$Item.templateId
+    return [string]$Item.kind -ne 'emote' -and $templateId -notmatch '(?i)(^|_)Emote(_|$)|Gesture'
+}
+
+function New-DuneInventoryParameterizedSql {
+    param(
+        [Parameter(Mandatory)][string]$Sql,
+        [Parameter(Mandatory)][hashtable]$Parameters,
+        [Parameter(Mandatory)][hashtable]$ParameterTypes
+    )
+    $token = '/*__DST_PARAMETERS__*/'
+    if (-not $Sql.Contains($token)) { throw "Parameterized inventory SQL is missing the $token token." }
+    $allowedTypes = @('text', 'integer', 'bigint', 'boolean')
+    $payload = [ordered]@{}
+    $definitions = @()
+    foreach ($name in @($Parameters.Keys | Sort-Object)) {
+        if ([string]$name -notmatch '^[a-z][a-z0-9_]*$') { throw "Invalid inventory SQL parameter name '$name'." }
+        if (-not $ParameterTypes.ContainsKey($name)) { throw "Inventory SQL parameter '$name' has no declared PostgreSQL type." }
+        $type = ([string]$ParameterTypes[$name]).ToLowerInvariant()
+        if ($allowedTypes -notcontains $type) { throw "Inventory SQL parameter '$name' uses unsupported PostgreSQL type '$type'." }
+        $payload[$name] = $Parameters[$name]
+        $definitions += '"' + $name + '" ' + $type
+    }
+    $json = $payload | ConvertTo-Json -Compress -Depth 5
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+    $cte = "_dst_parameters AS (SELECT * FROM jsonb_to_record(convert_from(decode('$encoded', 'base64'), 'UTF8')::jsonb) AS p($($definitions -join ', ')))"
+    return $Sql.Replace($token, $cte)
+}
+
+function Get-DuneInventoryCatalogIdsJson {
+    Initialize-DuneGameplayItemData
+    $ids = @($script:DuneGameplayItemRules.Keys | Where-Object {
+        [string](Get-DuneGameplayItemRule -TemplateId $_).category
+    } | Sort-Object -Unique)
+    if ($ids.Count -eq 0) { return '[]' }
+    return (ConvertTo-Json -InputObject $ids -Compress)
+}
+
+function Get-DuneInventoryCatalogMetadataJson {
+    Initialize-DuneGameplayItemData
+    $metadata = [ordered]@{}
+    foreach ($id in @($script:DuneGameplayItemRules.Keys | Sort-Object)) {
+        $rule = Get-DuneGameplayItemRule -TemplateId $id
+        $metadata[([string]$id).ToLowerInvariant()] = [ordered]@{
+            name = Get-DuneGameplayItemName -TemplateId $id
+            tier = if ($null -ne $rule.tier) { [int]$rule.tier } else { $null }
+            volume = if ($null -ne $rule.volume) { [double]$rule.volume } else { $null }
+        }
+    }
+    return ($metadata | ConvertTo-Json -Compress -Depth 4)
+}
+
+function Get-DuneInventoryMetadataMatchesJson {
+    param([string]$Query)
+    $ids = @(Get-DuneInventoryMetadataMatches -Query $Query)
+    if ($ids.Count -eq 0) { return '[]' }
+    return (ConvertTo-Json -InputObject $ids -Compress)
+}
+
+function Get-DuneInventoryFilteredCteSql {
+    $storageClassSql = Get-DuneInventoryStorageClassSql
+    return @"
+/*__DST_PARAMETERS__*/,
+inventory_rows AS (
+    SELECT i.id::bigint AS item_id, i.template_id, i.stack_size,
+           COALESCE(i.quality_level, 0) AS quality_level,
+           COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'), 'N/A') AS durability,
+           COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability'), 'N/A') AS max_durability,
+           COALESCE((i.stats->'FFillableItemStats'->1->>'CurrentAmount'), 'N/A') AS water_amount,
+           COALESCE((i.stats->'FFillableItemStats'->1->>'FillableType'), '') AS water_type,
+           inv.id::bigint AS inventory_id, inv.inventory_type,
+           'player'::text AS entity_type, ps.player_pawn_id::bigint AS entity_id,
+           ps.player_pawn_id::bigint AS player_id, COALESCE(ps.character_name, '') AS player_name,
+           COALESCE(ps.character_name, '') AS entity_label, COALESCE(ps.character_name, '') AS owner_name,
+           COALESCE(a.map, '') AS map, ''::text AS entity_class
+    FROM dune.items i
+    JOIN dune.inventories inv ON inv.id = i.inventory_id
+    JOIN dune.player_state ps ON ps.player_pawn_id = inv.actor_id
+    LEFT JOIN dune.actors a ON a.id = ps.player_pawn_id
+    UNION ALL
+    SELECT i.id::bigint AS item_id, i.template_id, i.stack_size,
+           COALESCE(i.quality_level, 0) AS quality_level,
+           COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'), 'N/A') AS durability,
+           COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability'), 'N/A') AS max_durability,
+           COALESCE((i.stats->'FFillableItemStats'->1->>'CurrentAmount'), 'N/A') AS water_amount,
+           COALESCE((i.stats->'FFillableItemStats'->1->>'FillableType'), '') AS water_type,
+           inv.id::bigint AS inventory_id, inv.inventory_type,
+           'storage'::text AS entity_type, p.id::bigint AS entity_id,
+           owner.player_pawn_id::bigint AS player_id, COALESCE(owner.character_name, '') AS player_name,
+           COALESCE(NULLIF((SELECT MAX(CASE WHEN pa.actor_name NOT LIKE '##%' AND pa.actor_name <> 'None' THEN pa.actor_name END)
+               FROM dune.permission_actor pa WHERE pa.actor_id = p.id), ''), NULLIF(($storageClassSql), ''), 'Storage container') AS entity_label,
+           COALESCE(owner.character_name, '') AS owner_name, COALESCE(a.map, '') AS map,
+           COALESCE(p.building_type, '') AS entity_class
+    FROM dune.items i
+    JOIN dune.inventories inv ON inv.id = i.inventory_id AND inv.inventory_type = 4
+    JOIN dune.placeables p ON p.id = inv.actor_id
+    LEFT JOIN dune.actors a ON a.id = p.id
+    LEFT JOIN LATERAL (
+        SELECT ps.player_pawn_id, ps.character_name
+        FROM dune.actor_fgl_entities afe
+        JOIN dune.permission_actor_rank par ON par.permission_actor_id = afe.actor_id
+        JOIN dune.actors player_a ON player_a.id = par.player_id
+        JOIN dune.player_state ps ON ps.account_id = player_a.owner_account_id
+        WHERE afe.entity_id = p.owner_entity_id
+        ORDER BY par.rank ASC, ps.character_name ASC, ps.player_pawn_id ASC LIMIT 1
+    ) owner ON true
+    WHERE p.is_hologram = false AND p.owner_entity_id IS NOT NULL AND p.owner_entity_id <> 0
+),
+visible_rows AS (
+    SELECT r.*
+    FROM inventory_rows r CROSS JOIN _dst_parameters p
+    WHERE r.entity_type = ANY(string_to_array(p.entity_types, ','))
+      AND (p.scope_type = '' OR (r.entity_type = p.scope_type AND r.entity_id = p.scope_id))
+      AND r.template_id !~* '(^|_)Emote(_|$)|Gesture'
+),
+searched_rows AS (
+    SELECT r.*
+    FROM visible_rows r CROSS JOIN _dst_parameters p
+    WHERE p.query = ''
+       OR strpos(lower(COALESCE(r.template_id, '')), lower(p.query)) > 0
+       OR strpos(lower(COALESCE(r.entity_label, '')), lower(p.query)) > 0
+       OR strpos(lower(COALESCE(r.owner_name, '')), lower(p.query)) > 0
+       OR strpos(lower(COALESCE(r.map, '')), lower(p.query)) > 0
+       OR strpos(lower(COALESCE(r.entity_type, '')), lower(p.query)) > 0
+       OR strpos(lower(CASE WHEN r.entity_type = 'storage' THEN 'container storage' ELSE 'player character' END), lower(p.query)) > 0
+       OR r.template_id IN (SELECT jsonb_array_elements_text(p.metadata_ids::jsonb))
+)
+"@
+}
+
+function Get-DuneInventoryQueryParameters {
+    param(
+        [string]$Query,
+        [string[]]$EntityTypes,
+        [string]$ScopeType = '',
+        [long]$ScopeId = 0,
+        [long]$PlayerId = 0,
+        [string]$LocationType = '',
+        [long]$LocationId = 0,
+        [string]$AfterGroupKey = '',
+        [long]$AfterItemId = 0,
+        [string]$TemplateId = '',
+        [string]$AfterSortValue = '',
+        [string]$AfterSortSecondary = '',
+        [string]$AfterSortName = '',
+        [string]$AfterTemplateId = '',
+        [int]$Limit = 101
+    )
+    return @{
+        values = @{
+            query = $Query.Trim()
+            entity_types = ($EntityTypes -join ',')
+            scope_type = $ScopeType
+            scope_id = $ScopeId
+            player_id = $PlayerId
+            location_type = $LocationType
+            location_id = $LocationId
+            after_group_key = $AfterGroupKey
+            after_item_id = $AfterItemId
+            template_id = $TemplateId
+            row_limit = $Limit
+            after_sort_value = $AfterSortValue
+            after_sort_secondary = $AfterSortSecondary
+            after_sort_name = $AfterSortName
+            after_template_id = $AfterTemplateId
+            catalog_ids = Get-DuneInventoryCatalogIdsJson
+            catalog_metadata = Get-DuneInventoryCatalogMetadataJson
+            metadata_ids = Get-DuneInventoryMetadataMatchesJson -Query $Query
+        }
+        types = @{
+            query = 'text'; entity_types = 'text'; scope_type = 'text'; scope_id = 'bigint'
+            player_id = 'bigint'; after_group_key = 'text'; after_item_id = 'bigint'
+            location_type = 'text'; location_id = 'bigint'
+            template_id = 'text'; row_limit = 'integer'; after_sort_value = 'text'
+            after_sort_secondary = 'text'; after_sort_name = 'text'; after_template_id = 'text'
+            catalog_ids = 'text'; catalog_metadata = 'text'; metadata_ids = 'text'
+        }
+    }
+}
+
+function ConvertTo-DuneInventoryPlayerFacet {
+    param([Parameter(Mandatory)]$Row)
+    return [ordered]@{
+        id = ConvertTo-DuneInt $Row['player_id']
+        name = [string]$Row['player_name']
+        occurrenceCount = ConvertTo-DuneInt $Row['occurrence_count']
+    }
+}
+
+function ConvertTo-DuneInventoryGroup {
+    param([Parameter(Mandatory)]$Row)
+    $templateId = [string]$Row['template_id']
+    $rule = Get-DuneGameplayItemRule -TemplateId $templateId
+    $qualityMin = ConvertTo-DuneInt $Row['quality_min']
+    $qualityMax = ConvertTo-DuneInt $Row['quality_max']
+    return [ordered]@{
+        groupKey = [string]$Row['group_key']
+        templateId = $templateId
+        displayName = Get-DuneGameplayItemName -TemplateId $templateId
+        totalQuantity = ConvertTo-DuneInt $Row['total_quantity']
+        occurrenceCount = ConvertTo-DuneInt $Row['occurrence_count']
+        locationCount = ConvertTo-DuneInt $Row['location_count']
+        quality = [ordered]@{ min = $qualityMin; max = $qualityMax; mixed = $qualityMin -ne $qualityMax }
+        cursor = [ordered]@{
+            sortValue = [string]$Row['sort_value']
+            sortSecondary = [string]$Row['sort_secondary']
+            sortName = [string]$Row['sort_name']
+            templateId = $templateId
+        }
+        metadata = [ordered]@{
+            category = [string]$rule.category; tier = [int]$rule.tier; rarity = [string]$rule.rarity
+            icon = [string]$rule.icon; stackMaximum = [int]$rule.stack_max; volume = [double]$rule.volume
+            vendorPrice = [int]$rule.vendor_price; isGradeable = [bool]$rule.is_gradeable
+        }
+    }
+}
+
+function Select-DuneInventoryDemoFiltered {
+    param(
+        [object[]]$Items,
+        [string]$Query,
+        [string[]]$EntityTypes,
+        [string]$ScopeType = '',
+        [long]$ScopeId = 0,
+        [long]$PlayerId = 0,
+        [string]$LocationType = '',
+        [long]$LocationId = 0
+    )
+    return @(Select-DuneInventoryDemoItems -Items $Items -Query $Query -EntityTypes $EntityTypes `
+        -ScopeType $ScopeType -ScopeId $ScopeId -Limit $script:DuneInventoryMaxLimit | Where-Object {
+        (Test-DuneInventoryVisibleItem -Item $_) -and
+        (-not $PlayerId -or [long]$_.player.id -eq $PlayerId) -and
+        (-not $LocationType -or ([string]$_.entity.type -eq $LocationType -and [long]$_.entity.id -eq $LocationId))
+    })
+}
+
+function Get-DuneInventoryDemoPlayerId {
+    param([Parameter(Mandatory)]$Item)
+    if ($Item.PSObject.Properties.Name -contains 'player' -and $Item.player) { return [long]$Item.player.id }
+    if ([string]$Item.entity.type -eq 'player') { return [long]$Item.entity.id }
+    $owner = [string]$Item.entity.owner
+    $player = @(Get-DunePlayersDemo | Where-Object { [string]$_.name -eq $owner } | Select-Object -First 1)
+    return if ($player.Count) { [long]$player[0].id } else { 0L }
+}
+
+function Add-DuneInventoryDemoPlayer {
+    param([Parameter(Mandatory)]$Item)
+    $playerId = Get-DuneInventoryDemoPlayerId -Item $Item
+    $playerName = if ([string]$Item.entity.type -eq 'player') { [string]$Item.entity.label } else { [string]$Item.entity.owner }
+    $Item['player'] = [ordered]@{ id = $playerId; name = $playerName }
+    return $Item
+}
+
+function Get-DuneInventoryGroupedDemo {
+    param(
+        [string]$Query, [string[]]$EntityTypes, [string]$ScopeType = '', [long]$ScopeId = 0,
+        [long]$PlayerId = 0, [string]$LocationType = '', [long]$LocationId = 0,
+        [string]$Sort = 'name-asc', [string]$AfterTemplateId = '', [int]$Limit = 101
+    )
+    $all = @(Get-DuneInventoryDemoItems | ForEach-Object { Add-DuneInventoryDemoPlayer -Item $_ })
+    $base = @(Select-DuneInventoryDemoFiltered -Items $all -Query $Query -EntityTypes $EntityTypes `
+        -ScopeType $ScopeType -ScopeId $ScopeId)
+    $facets = @($base | Where-Object { [long]$_.player.id -gt 0 } | Group-Object { [long]$_.player.id } | ForEach-Object {
+        [ordered]@{ id = [long]$_.Name; name = [string]$_.Group[0].player.name; occurrenceCount = $_.Count }
+    } | Sort-Object name, id)
+    $locations = @($base | Where-Object { (-not $PlayerId -or [long]$_.player.id -eq $PlayerId) } |
+        Group-Object { "$($_.entity.type):$($_.entity.id)" } | ForEach-Object {
+            $first = $_.Group[0]
+            [ordered]@{
+                type = [string]$first.entity.type; id = [long]$first.entity.id
+                label = if ([string]$first.entity.type -eq 'player') { 'Backpack' } else { [string]$first.entity.label }
+                owner = [string]$first.entity.owner; playerId = [long]$first.player.id
+                playerName = [string]$first.player.name; occurrenceCount = $_.Count
+            }
+        } | Sort-Object type, label, id)
+    $filtered = @($base | Where-Object {
+        (-not $PlayerId -or [long]$_.player.id -eq $PlayerId) -and
+        (-not $LocationType -or ([string]$_.entity.type -eq $LocationType -and [long]$_.entity.id -eq $LocationId))
+    })
+    $groups = @($filtered | Group-Object { ([string]$_.templateId).Trim().ToLowerInvariant() } | ForEach-Object {
+        $rows = @($_.Group)
+        $first = $rows[0]
+        $qualities = @($rows | ForEach-Object { [int]$_.quality })
+        $group = [ordered]@{
+            groupKey = [string]$_.Name; templateId = [string]$first.templateId
+            displayName = [string]$first.displayName
+            totalQuantity = [long](($rows | Measure-Object quantity -Sum).Sum)
+            occurrenceCount = $rows.Count
+            locationCount = @($rows | ForEach-Object { "$($_.entity.type):$($_.entity.id)" } | Sort-Object -Unique).Count
+            quality = [ordered]@{ min = ($qualities | Measure-Object -Minimum).Minimum; max = ($qualities | Measure-Object -Maximum).Maximum; mixed = (($qualities | Sort-Object -Unique).Count -gt 1) }
+            metadata = $first.metadata
+        }
+        $group
+    })
+    $sortSpec = Resolve-DuneInventoryGroupSort -Value $Sort
+    $descending = $Sort.EndsWith('-desc')
+    $primary = switch -Wildcard ($Sort) {
+        'name-*' { 'displayName' }
+        'quantity-*' { 'totalQuantity' }
+        'unit-volume-*' { { $_.metadata.volume } }
+        'total-volume-*' { { [double]$_.metadata.volume * [long]$_.totalQuantity } }
+        'tier-*' { { $_.metadata.tier } }
+        'quality-*' { { $_.quality.max } }
+        'occurrences-*' { 'occurrenceCount' }
+        'locations-*' { 'locationCount' }
+    }
+    $sortedGroups = @($groups | Sort-Object -Property @(
+        @{ Expression = $primary; Descending = $descending },
+        @{ Expression = 'displayName'; Descending = $false },
+        @{ Expression = 'templateId'; Descending = $false }
+    ))
+    $skip = 0
+    if ($AfterTemplateId) {
+        for ($index = 0; $index -lt $sortedGroups.Count; $index++) {
+            if ([string]$sortedGroups[$index].templateId -eq $AfterTemplateId) {
+                $skip = $index + 1
+                break
+            }
+        }
+    }
+    $groups = @($sortedGroups | Select-Object -Skip $skip -First $Limit)
+    foreach ($group in $groups) {
+        $sortValue = switch -Wildcard ($Sort) {
+            'name-*' { [string]$group.displayName }
+            'quantity-*' { [string]$group.totalQuantity }
+            'unit-volume-*' { [string]$group.metadata.volume }
+            'total-volume-*' { [string]([double]$group.metadata.volume * [long]$group.totalQuantity) }
+            'tier-*' { [string]$group.metadata.tier }
+            'quality-*' { [string]$group.quality.max }
+            'occurrences-*' { [string]$group.occurrenceCount }
+            'locations-*' { [string]$group.locationCount }
+        }
+        $sortSecondary = if ($Sort -like 'quality-*') { [string]$group.quality.min } else { '' }
+        $group['cursor'] = [ordered]@{
+            sortValue = $sortValue; sortSecondary = $sortSecondary
+            sortName = [string]$group.displayName; templateId = [string]$group.templateId
+        }
+    }
+    return @{ ok = $true; source = 'static'; groups = $groups; players = $facets; locations = $locations }
+}
+
+function Invoke-DuneInventoryGroupedLive {
+    param(
+        [string]$Ip, [string]$Query, [string[]]$EntityTypes, [string]$ScopeType = '', [long]$ScopeId = 0,
+        [long]$PlayerId = 0, [string]$LocationType = '', [long]$LocationId = 0,
+        [string]$Sort = 'name-asc', [string]$AfterSortValue = '', [string]$AfterSortSecondary = '',
+        [string]$AfterSortName = '',
+        [string]$AfterTemplateId = '', [int]$Limit = 101
+    )
+    $binding = Get-DuneInventoryQueryParameters -Query $Query -EntityTypes $EntityTypes -ScopeType $ScopeType `
+        -ScopeId $ScopeId -PlayerId $PlayerId -LocationType $LocationType -LocationId $LocationId `
+        -AfterSortValue $AfterSortValue -AfterSortSecondary $AfterSortSecondary `
+        -AfterSortName $AfterSortName -AfterTemplateId $AfterTemplateId -Limit $Limit
+    $sortSpec = Resolve-DuneInventoryGroupSort -Value $Sort
+    if (-not $sortSpec.ok) { return @{ ok = $false; error = $sortSpec.error } }
+    $cte = Get-DuneInventoryFilteredCteSql
+    $primary = [string]$sortSpec.primary
+    if ($sortSpec.type -eq 'text') {
+        $comparison = if ($sortSpec.direction -eq 'asc') { '>' } else { '<' }
+        $pageWhere = "(p.after_template_id = '' OR grouped.$primary $comparison p.after_sort_value OR (grouped.$primary = p.after_sort_value AND grouped.template_id > p.after_template_id))"
+    } else {
+        $comparison = if ($sortSpec.direction -eq 'asc') { '>' } else { '<' }
+        if ($sortSpec.secondary) {
+            $secondary = [string]$sortSpec.secondary
+            $pageWhere = @"
+(p.after_template_id = '' OR
+ (p.after_sort_value = '' AND grouped.$primary IS NULL AND (grouped.sort_name > p.after_sort_name OR (grouped.sort_name = p.after_sort_name AND grouped.template_id > p.after_template_id))) OR
+ (p.after_sort_value <> '' AND (
+   grouped.$primary IS NULL OR grouped.$primary $comparison p.after_sort_value::double precision OR
+   (grouped.$primary = p.after_sort_value::double precision AND (
+     grouped.$secondary $comparison p.after_sort_secondary::double precision OR
+     (grouped.$secondary = p.after_sort_secondary::double precision AND (grouped.sort_name > p.after_sort_name OR (grouped.sort_name = p.after_sort_name AND grouped.template_id > p.after_template_id)))
+   ))
+ )))
+"@
+        } else {
+            $pageWhere = @"
+(p.after_template_id = '' OR
+ (p.after_sort_value = '' AND grouped.$primary IS NULL AND (grouped.sort_name > p.after_sort_name OR (grouped.sort_name = p.after_sort_name AND grouped.template_id > p.after_template_id))) OR
+ (p.after_sort_value <> '' AND (
+   grouped.$primary IS NULL OR grouped.$primary $comparison p.after_sort_value::double precision OR
+   (grouped.$primary = p.after_sort_value::double precision AND (grouped.sort_name > p.after_sort_name OR (grouped.sort_name = p.after_sort_name AND grouped.template_id > p.after_template_id)))
+ )))
+"@
+        }
+    }
+    $sql = @"
+WITH $cte,
+player_facets AS (
+    SELECT player_id, MAX(player_name) AS player_name, COUNT(*)::bigint AS occurrence_count
+    FROM searched_rows WHERE player_id IS NOT NULL AND player_id > 0 GROUP BY player_id
+),
+grouped AS (
+    SELECT lower(trim(template_id)) AS group_key, MIN(template_id) AS template_id,
+           SUM(stack_size)::bigint AS total_quantity, COUNT(*)::bigint AS occurrence_count,
+           COUNT(DISTINCT entity_type || ':' || entity_id::text)::bigint AS location_count,
+           MIN(quality_level)::integer AS quality_min, MAX(quality_level)::integer AS quality_max,
+           MIN(COALESCE(meta.value->>'name', template_id)) AS sort_name,
+           MAX((meta.value->>'tier')::integer) AS item_tier,
+           MAX((meta.value->>'volume')::double precision) AS unit_volume,
+           MAX((meta.value->>'volume')::double precision) * SUM(stack_size)::double precision AS total_volume
+    FROM searched_rows CROSS JOIN _dst_parameters p
+    LEFT JOIN LATERAL jsonb_each(p.catalog_metadata::jsonb) meta ON meta.key = lower(trim(searched_rows.template_id))
+    WHERE (p.player_id = 0 OR searched_rows.player_id = p.player_id)
+      AND (p.location_type = '' OR (searched_rows.entity_type = p.location_type AND searched_rows.entity_id = p.location_id))
+    GROUP BY lower(trim(template_id))
+)
+SELECT 'group'::text AS row_kind, group_key, template_id, total_quantity, occurrence_count,
+       location_count, quality_min, quality_max, NULL::bigint AS player_id, NULL::text AS player_name,
+       sort_name, COALESCE(($primary)::text, '') AS sort_value,
+       $(if ($sortSpec.secondary) { "COALESCE(($([string]$sortSpec.secondary))::text, '')" } else { "''::text" }) AS sort_secondary
+FROM grouped CROSS JOIN _dst_parameters p
+WHERE $pageWhere
+ORDER BY $($sortSpec.sql) LIMIT (SELECT row_limit FROM _dst_parameters)
+"@
+    $effectiveSql = New-DuneInventoryParameterizedSql -Sql $sql -Parameters $binding.values -ParameterTypes $binding.types
+    $groupResult = Invoke-DuneSqlQuery -Ip $Ip -Sql $effectiveSql -ReadOnly $true -MaxRows $Limit -TimeoutSec 45 -Bulk
+    if (-not $groupResult.ok) { return @{ ok = $false; error = $groupResult.error } }
+
+    $facetSql = @"
+WITH $cte
+SELECT 'player'::text AS row_kind, NULL::text AS group_key, NULL::text AS template_id,
+       NULL::bigint AS total_quantity, COUNT(*)::bigint AS occurrence_count, NULL::bigint AS location_count,
+       NULL::integer AS quality_min, NULL::integer AS quality_max, player_id, MAX(player_name) AS player_name
+FROM searched_rows WHERE player_id IS NOT NULL AND player_id > 0
+GROUP BY player_id ORDER BY player_name, player_id LIMIT 50000
+"@
+    $effectiveFacetSql = New-DuneInventoryParameterizedSql -Sql $facetSql -Parameters $binding.values -ParameterTypes $binding.types
+    $facetResult = Invoke-DuneSqlQuery -Ip $Ip -Sql $effectiveFacetSql -ReadOnly $true -MaxRows 50000 -TimeoutSec 45 -Bulk
+    if (-not $facetResult.ok) { return @{ ok = $false; error = $facetResult.error } }
+    $locationSql = @"
+WITH $cte
+SELECT entity_type, entity_id, MAX(CASE WHEN entity_type = 'player' THEN 'Backpack' ELSE entity_label END) AS entity_label,
+       MAX(owner_name) AS owner_name, MAX(player_id)::bigint AS player_id, MAX(player_name) AS player_name,
+       COUNT(*)::bigint AS occurrence_count
+FROM searched_rows CROSS JOIN _dst_parameters p
+WHERE (p.player_id = 0 OR searched_rows.player_id = p.player_id)
+GROUP BY entity_type, entity_id ORDER BY entity_type, entity_label, entity_id LIMIT 50000
+"@
+    $effectiveLocationSql = New-DuneInventoryParameterizedSql -Sql $locationSql -Parameters $binding.values -ParameterTypes $binding.types
+    $locationResult = Invoke-DuneSqlQuery -Ip $Ip -Sql $effectiveLocationSql -ReadOnly $true -MaxRows 50000 -TimeoutSec 45 -Bulk
+    if (-not $locationResult.ok) { return @{ ok = $false; error = $locationResult.error } }
+    return @{
+        ok = $true
+        groups = @(ConvertTo-DuneRowMaps -Result $groupResult | ForEach-Object { ConvertTo-DuneInventoryGroup -Row $_ })
+        players = @(ConvertTo-DuneRowMaps -Result $facetResult | ForEach-Object { ConvertTo-DuneInventoryPlayerFacet -Row $_ })
+        locations = @(ConvertTo-DuneRowMaps -Result $locationResult | ForEach-Object {
+            [ordered]@{
+                type = [string]$_['entity_type']; id = ConvertTo-DuneInt $_['entity_id']
+                label = [string]$_['entity_label']; owner = [string]$_['owner_name']
+                playerId = ConvertTo-DuneInt $_['player_id']; playerName = [string]$_['player_name']
+                occurrenceCount = ConvertTo-DuneInt $_['occurrence_count']
+            }
+        })
+    }
+}
+
+function Invoke-DuneInventoryGroupedPage {
+    param(
+        [ValidateSet('live', 'demo')][string]$Mode, [string]$Query, [string[]]$EntityTypes,
+        [string]$ScopeType = '', [long]$ScopeId = 0, [long]$PlayerId = 0,
+        [string]$LocationType = '', [long]$LocationId = 0,
+        [string]$Sort = 'name-asc', [string]$AfterSortValue = '', [string]$AfterSortSecondary = '',
+        [string]$AfterSortName = '',
+        [string]$AfterTemplateId = '', [int]$Limit = 101
+    )
+    if ($Mode -eq 'demo') {
+        return Get-DuneInventoryGroupedDemo -Query $Query -EntityTypes $EntityTypes -ScopeType $ScopeType `
+            -ScopeId $ScopeId -PlayerId $PlayerId -LocationType $LocationType -LocationId $LocationId `
+            -Sort $Sort -AfterTemplateId $AfterTemplateId -Limit $Limit
+    }
+    $context = Get-DuneDbContext
+    if (-not $context.ok) { return @{ ok = $false; status = 503; error = "Inventory database unavailable: $([string]$context.message)" } }
+    $result = Invoke-DuneInventoryGroupedLive -Ip $context.ip -Query $Query -EntityTypes $EntityTypes `
+        -ScopeType $ScopeType -ScopeId $ScopeId -PlayerId $PlayerId -LocationType $LocationType `
+        -LocationId $LocationId -Sort $Sort -AfterSortValue $AfterSortValue `
+        -AfterSortSecondary $AfterSortSecondary -AfterSortName $AfterSortName `
+        -AfterTemplateId $AfterTemplateId -Limit $Limit
+    if (-not $result.ok) { return @{ ok = $false; status = 503; error = "Inventory database read failed: $([string]$result.error)" } }
+    $result.source = 'live'
+    return $result
+}
+
+function Get-DuneInventoryOccurrencesDemo {
+    param(
+        [string]$TemplateId, [string[]]$EntityTypes, [string]$ScopeType = '', [long]$ScopeId = 0,
+        [long]$PlayerId = 0, [string]$LocationType = '', [long]$LocationId = 0,
+        [string]$Sort = 'player-asc', [long]$AfterItemId = 0, [int]$Limit = 51
+    )
+    $all = @(Get-DuneInventoryDemoItems | ForEach-Object { Add-DuneInventoryDemoPlayer -Item $_ })
+    $base = @(Select-DuneInventoryDemoFiltered -Items $all -EntityTypes $EntityTypes -ScopeType $ScopeType `
+        -ScopeId $ScopeId | Where-Object {
+        [string]::Equals([string]$_.templateId, $TemplateId, [StringComparison]::OrdinalIgnoreCase)
+    })
+    $players = @($base | Where-Object { [long]$_.player.id -gt 0 } | Group-Object { [long]$_.player.id } | ForEach-Object {
+        [ordered]@{ id = [long]$_.Name; name = [string]$_.Group[0].player.name; occurrenceCount = $_.Count }
+    } | Sort-Object name, id)
+    $locations = @($base | Where-Object { -not $PlayerId -or [long]$_.player.id -eq $PlayerId } |
+        Group-Object { "$($_.entity.type):$($_.entity.id)" } | ForEach-Object {
+            $first = $_.Group[0]
+            [ordered]@{
+                type = [string]$first.entity.type; id = [long]$first.entity.id
+                label = if ([string]$first.entity.type -eq 'player') { 'Backpack' } else { [string]$first.entity.label }
+                owner = [string]$first.entity.owner; playerId = [long]$first.player.id
+                playerName = [string]$first.player.name; occurrenceCount = $_.Count
+            }
+        } | Sort-Object type, label, id)
+    $items = @($base | Where-Object {
+        (-not $PlayerId -or [long]$_.player.id -eq $PlayerId) -and
+        (-not $LocationType -or ([string]$_.entity.type -eq $LocationType -and [long]$_.entity.id -eq $LocationId))
+    })
+    $descending = $Sort.EndsWith('-desc')
+    $primary = switch -Wildcard ($Sort) {
+        'player-*' { { $_.player.name } }
+        'location-*' { { $_.entity.label } }
+        'quantity-*' { 'quantity' }
+        'quality-*' { 'quality' }
+    }
+    $sortedItems = @($items | Sort-Object -Property @(
+        @{ Expression = $primary; Descending = $descending },
+        @{ Expression = 'id'; Descending = $false }
+    ))
+    $skip = 0
+    if ($AfterItemId) {
+        for ($index = 0; $index -lt $sortedItems.Count; $index++) {
+            if ([long]$sortedItems[$index].id -eq $AfterItemId) { $skip = $index + 1; break }
+        }
+    }
+    $items = @($sortedItems | Select-Object -Skip $skip -First $Limit)
+    foreach ($item in $items) { $item.entity.workspacePath = "$($item.entity.workspacePath)&demo=1" }
+    return @{ ok = $true; source = 'static'; items = $items; players = $players; locations = $locations }
+}
+
+function Invoke-DuneInventoryOccurrencesLive {
+    param(
+        [string]$Ip, [string]$TemplateId, [string[]]$EntityTypes, [string]$ScopeType = '', [long]$ScopeId = 0,
+        [long]$PlayerId = 0, [string]$LocationType = '', [long]$LocationId = 0,
+        [string]$Sort = 'player-asc', [string]$AfterSortValue = '', [long]$AfterItemId = 0, [int]$Limit = 51
+    )
+    $binding = Get-DuneInventoryQueryParameters -EntityTypes $EntityTypes -ScopeType $ScopeType -ScopeId $ScopeId `
+        -PlayerId $PlayerId -LocationType $LocationType -LocationId $LocationId `
+        -AfterSortValue $AfterSortValue -AfterItemId $AfterItemId -TemplateId $TemplateId -Limit $Limit
+    $sortSpec = Resolve-DuneInventoryOccurrenceSort -Value $Sort
+    if (-not $sortSpec.ok) { return @{ ok = $false; error = $sortSpec.error } }
+    $primary = [string]$sortSpec.primary
+    $comparison = if ($sortSpec.direction -eq 'asc') { '>' } else { '<' }
+    if ($sortSpec.type -eq 'text') {
+        $pageWhere = "(p.after_item_id = 0 OR $primary $comparison p.after_sort_value OR ($primary = p.after_sort_value AND item_id > p.after_item_id))"
+    } else {
+        $pageWhere = "(p.after_item_id = 0 OR $primary IS NULL OR $primary $comparison p.after_sort_value::double precision OR ($primary = p.after_sort_value::double precision AND item_id > p.after_item_id))"
+    }
+    $cte = Get-DuneInventoryFilteredCteSql
+    $sql = @"
+WITH $cte
+SELECT item_id, template_id, stack_size, quality_level, durability, max_durability,
+       water_amount, water_type, inventory_id, inventory_type, entity_type, entity_id,
+       entity_label, owner_name, map, entity_class, player_id, player_name
+FROM searched_rows CROSS JOIN _dst_parameters p
+WHERE lower(trim(template_id)) = lower(trim(p.template_id))
+  AND (p.player_id = 0 OR searched_rows.player_id = p.player_id)
+  AND (p.location_type = '' OR (searched_rows.entity_type = p.location_type AND searched_rows.entity_id = p.location_id))
+  AND $pageWhere
+ORDER BY $($sortSpec.sql) LIMIT (SELECT row_limit FROM _dst_parameters) OFFSET (SELECT row_offset FROM _dst_parameters)
+"@
+    $effectiveSql = New-DuneInventoryParameterizedSql -Sql $sql -Parameters $binding.values -ParameterTypes $binding.types
+    $result = Invoke-DuneSqlQuery -Ip $Ip -Sql $effectiveSql -ReadOnly $true -MaxRows $Limit -TimeoutSec 45 -Bulk
+    if (-not $result.ok) { return @{ ok = $false; error = $result.error } }
+    $items = @(ConvertTo-DuneRowMaps -Result $result | ForEach-Object {
+        $item = ConvertTo-DuneInventoryItem -Row $_
+        $item['player'] = [ordered]@{ id = ConvertTo-DuneInt $_['player_id']; name = [string]$_['player_name'] }
+        $item
+    } | Where-Object { Test-DuneInventoryVisibleItem -Item $_ })
+    $facetSql = @"
+WITH $cte,
+template_rows AS (
+    SELECT searched_rows.* FROM searched_rows CROSS JOIN _dst_parameters p
+    WHERE lower(trim(template_id)) = lower(trim(p.template_id))
+)
+SELECT player_id, MAX(player_name) AS player_name, COUNT(*)::bigint AS occurrence_count
+FROM template_rows WHERE player_id IS NOT NULL AND player_id > 0
+GROUP BY player_id ORDER BY player_name, player_id LIMIT 500
+"@
+    $facetResult = Invoke-DuneSqlQuery -Ip $Ip `
+        -Sql (New-DuneInventoryParameterizedSql -Sql $facetSql -Parameters $binding.values -ParameterTypes $binding.types) `
+        -ReadOnly $true -MaxRows 500 -TimeoutSec 45 -Bulk
+    if (-not $facetResult.ok) { return @{ ok = $false; error = $facetResult.error } }
+    $locationSql = @"
+WITH $cte,
+template_rows AS (
+    SELECT searched_rows.* FROM searched_rows CROSS JOIN _dst_parameters p
+    WHERE lower(trim(template_id)) = lower(trim(p.template_id))
+)
+SELECT entity_type, entity_id, MAX(CASE WHEN entity_type = 'player' THEN 'Backpack' ELSE entity_label END) AS entity_label,
+       MAX(owner_name) AS owner_name, MAX(player_id)::bigint AS player_id, MAX(player_name) AS player_name,
+       COUNT(*)::bigint AS occurrence_count
+FROM template_rows CROSS JOIN _dst_parameters p
+WHERE (p.player_id = 0 OR template_rows.player_id = p.player_id)
+GROUP BY entity_type, entity_id ORDER BY entity_type, entity_label, entity_id LIMIT 1000
+"@
+    $locationResult = Invoke-DuneSqlQuery -Ip $Ip `
+        -Sql (New-DuneInventoryParameterizedSql -Sql $locationSql -Parameters $binding.values -ParameterTypes $binding.types) `
+        -ReadOnly $true -MaxRows 1000 -TimeoutSec 45 -Bulk
+    if (-not $locationResult.ok) { return @{ ok = $false; error = $locationResult.error } }
+    return @{
+        ok = $true; items = $items
+        players = @(ConvertTo-DuneRowMaps -Result $facetResult | ForEach-Object { ConvertTo-DuneInventoryPlayerFacet -Row $_ })
+        locations = @(ConvertTo-DuneRowMaps -Result $locationResult | ForEach-Object {
+            [ordered]@{
+                type = [string]$_['entity_type']; id = ConvertTo-DuneInt $_['entity_id']
+                label = [string]$_['entity_label']; owner = [string]$_['owner_name']
+                playerId = ConvertTo-DuneInt $_['player_id']; playerName = [string]$_['player_name']
+                occurrenceCount = ConvertTo-DuneInt $_['occurrence_count']
+            }
+        })
+    }
 }

--- a/app/server/lib/InventoryExplorer.ps1
+++ b/app/server/lib/InventoryExplorer.ps1
@@ -663,6 +663,11 @@ function ConvertTo-DuneInventoryPlayerFacet {
     }
 }
 
+function ConvertTo-DuneInventoryBoolean {
+    param($Value)
+    return $Value -eq $true -or [string]$Value -in @('1', 't', 'true')
+}
+
 function ConvertTo-DuneInventoryGroup {
     param([Parameter(Mandatory)]$Row)
     $templateId = [string]$Row['template_id']
@@ -734,8 +739,9 @@ function Get-DuneInventoryGroupedDemo {
         [string]$Sort = 'name-asc', [string]$AfterTemplateId = '', [int]$Limit = 101
     )
     $all = @(Get-DuneInventoryDemoItems | ForEach-Object { Add-DuneInventoryDemoPlayer -Item $_ })
-    $base = @(Select-DuneInventoryDemoFiltered -Items $all -Query $Query -EntityTypes $EntityTypes `
+    $visibleBase = @(Select-DuneInventoryDemoFiltered -Items $all -EntityTypes $EntityTypes `
         -ScopeType $ScopeType -ScopeId $ScopeId)
+    $base = @(Select-DuneInventoryDemoFiltered -Items $visibleBase -Query $Query -EntityTypes $EntityTypes)
     $facets = @($base | Where-Object { [long]$_.player.id -gt 0 } | Group-Object { [long]$_.player.id } | ForEach-Object {
         [ordered]@{ id = [long]$_.Name; name = [string]$_.Group[0].player.name; occurrenceCount = $_.Count }
     } | Sort-Object name, id)
@@ -812,7 +818,15 @@ function Get-DuneInventoryGroupedDemo {
             sortName = [string]$group.displayName; templateId = [string]$group.templateId
         }
     }
-    return @{ ok = $true; source = 'static'; groups = $groups; players = $facets; locations = $locations }
+    $selectedPlayerValid = -not $PlayerId -or @($visibleBase | Where-Object { [long]$_.player.id -eq $PlayerId }).Count -gt 0
+    $selectedLocationValid = -not $LocationType -or @($visibleBase | Where-Object {
+        (-not $PlayerId -or [long]$_.player.id -eq $PlayerId) -and
+        [string]$_.entity.type -eq $LocationType -and [long]$_.entity.id -eq $LocationId
+    }).Count -gt 0
+    return @{
+        ok = $true; source = 'static'; groups = $groups; players = $facets; locations = $locations
+        selectedPlayerValid = $selectedPlayerValid; selectedLocationValid = $selectedLocationValid
+    }
 }
 
 function Invoke-DuneInventoryGroupedLive {
@@ -916,6 +930,24 @@ GROUP BY entity_type, entity_id ORDER BY entity_type, entity_label, entity_id LI
     $effectiveLocationSql = New-DuneInventoryParameterizedSql -Sql $locationSql -Parameters $binding.values -ParameterTypes $binding.types
     $locationResult = Invoke-DuneSqlQuery -Ip $Ip -Sql $effectiveLocationSql -ReadOnly $true -MaxRows 50000 -TimeoutSec 45 -Bulk
     if (-not $locationResult.ok) { return @{ ok = $false; error = $locationResult.error } }
+    $validitySql = @"
+WITH $cte
+SELECT
+    (p.player_id = 0 OR EXISTS (
+        SELECT 1 FROM visible_rows r WHERE r.player_id = p.player_id
+    )) AS player_valid,
+    (p.location_type = '' OR EXISTS (
+        SELECT 1 FROM visible_rows r
+        WHERE (p.player_id = 0 OR r.player_id = p.player_id)
+          AND r.entity_type = p.location_type AND r.entity_id = p.location_id
+    )) AS location_valid
+FROM _dst_parameters p
+"@
+    $validityResult = Invoke-DuneSqlQuery -Ip $Ip `
+        -Sql (New-DuneInventoryParameterizedSql -Sql $validitySql -Parameters $binding.values -ParameterTypes $binding.types) `
+        -ReadOnly $true -MaxRows 1 -TimeoutSec 45 -Bulk
+    if (-not $validityResult.ok) { return @{ ok = $false; error = $validityResult.error } }
+    $validity = @(ConvertTo-DuneRowMaps -Result $validityResult)[0]
     return @{
         ok = $true
         groups = @(ConvertTo-DuneRowMaps -Result $groupResult | ForEach-Object { ConvertTo-DuneInventoryGroup -Row $_ })
@@ -928,6 +960,8 @@ GROUP BY entity_type, entity_id ORDER BY entity_type, entity_label, entity_id LI
                 occurrenceCount = ConvertTo-DuneInt $_['occurrence_count']
             }
         })
+        selectedPlayerValid = ConvertTo-DuneInventoryBoolean $validity['player_valid']
+        selectedLocationValid = ConvertTo-DuneInventoryBoolean $validity['location_valid']
     }
 }
 
@@ -1036,7 +1070,7 @@ WHERE lower(trim(template_id)) = lower(trim(p.template_id))
   AND (p.player_id = 0 OR searched_rows.player_id = p.player_id)
   AND (p.location_type = '' OR (searched_rows.entity_type = p.location_type AND searched_rows.entity_id = p.location_id))
   AND $pageWhere
-ORDER BY $($sortSpec.sql) LIMIT (SELECT row_limit FROM _dst_parameters) OFFSET (SELECT row_offset FROM _dst_parameters)
+ORDER BY $($sortSpec.sql) LIMIT (SELECT row_limit FROM _dst_parameters)
 "@
     $effectiveSql = New-DuneInventoryParameterizedSql -Sql $sql -Parameters $binding.values -ParameterTypes $binding.types
     $result = Invoke-DuneSqlQuery -Ip $Ip -Sql $effectiveSql -ReadOnly $true -MaxRows $Limit -TimeoutSec 45 -Bulk

--- a/app/server/routes/Inventory.ps1
+++ b/app/server/routes/Inventory.ps1
@@ -104,13 +104,11 @@ Register-DuneRoute -Method GET -Path '/api/v1/inventory/items' -Handler {
                 Write-DuneError -Response $res -Status ([int]$groupResult.status) -Message ([string]$groupResult.error)
                 return
             }
-            if ($playerId -gt 0 -and -not @($groupResult.players | Where-Object { [long]$_.id -eq $playerId }).Count) {
+            if ($playerId -gt 0 -and -not [bool]$groupResult.selectedPlayerValid) {
                 Write-DuneError -Response $res -Status 400 -Message 'player_id is not available in the filtered inventory dataset.'
                 return
             }
-            if ($locationType -and -not @($groupResult.locations | Where-Object {
-                [string]$_.type -eq $locationType -and [long]$_.id -eq $locationId
-            }).Count) {
+            if ($locationType -and -not [bool]$groupResult.selectedLocationValid) {
                 Write-DuneError -Response $res -Status 400 -Message 'The selected location is not available for the selected player.'
                 return
             }
@@ -137,6 +135,8 @@ Register-DuneRoute -Method GET -Path '/api/v1/inventory/items' -Handler {
                 query = $query
                 playerId = if ($playerId -gt 0) { $playerId } else { $null }
                 location = if ($locationType) { [ordered]@{ type = $locationType; id = $locationId } } else { $null }
+                selectedPlayerValid = [bool]$groupResult.selectedPlayerValid
+                selectedLocationValid = [bool]$groupResult.selectedLocationValid
                 supportedEntityTypes = @('player', 'storage')
                 unavailableEntityTypes = @('base', 'vehicle')
                 groups = $pageGroups

--- a/app/server/routes/Inventory.ps1
+++ b/app/server/routes/Inventory.ps1
@@ -28,20 +28,57 @@ Register-DuneRoute -Method GET -Path '/api/v1/inventory/items' -Handler {
         }
         $scopeType = [string]$scope.scopeType
         $scopeId = [long]$scope.scopeId
+        $player = Resolve-DuneInventoryPlayerId `
+            -HasPlayerId (Test-DuneInventoryQueryParameterPresent -Request $req -Name 'player_id') `
+            -Value (Get-DuneQ $req 'player_id')
+        if (-not $player.ok) {
+            Write-DuneError -Response $res -Status 400 -Message ([string]$player.error)
+            return
+        }
+        $playerId = [long]$player.playerId
+        $location = Resolve-DuneInventoryScope `
+            -HasScopeType (Test-DuneInventoryQueryParameterPresent -Request $req -Name 'location_type') `
+            -ScopeTypeValue (Get-DuneQ $req 'location_type') `
+            -HasScopeId (Test-DuneInventoryQueryParameterPresent -Request $req -Name 'location_id') `
+            -ScopeIdValue (Get-DuneQ $req 'location_id') -EntityTypes $entityTypes
+        if (-not $location.ok) {
+            Write-DuneError -Response $res -Status 400 -Message (([string]$location.error).Replace('scope_', 'location_'))
+            return
+        }
+        $locationType = [string]$location.scopeType
+        $locationId = [long]$location.scopeId
+        $grouped = (Get-DuneQ $req 'grouped').Trim() -in @('1', 'true', 'yes')
+        $groupSort = Resolve-DuneInventoryGroupSort -Value (Get-DuneQ $req 'sort')
+        if ($grouped -and -not $groupSort.ok) {
+            Write-DuneError -Response $res -Status 400 -Message ([string]$groupSort.error)
+            return
+        }
 
         $limit = Get-DuneInventoryLimit -Value (Get-DuneQ $req 'limit')
         $principal = Get-DuneRouteRequestPrincipal $routeParams
-        $bindingScope = "$scopeType`:$scopeId"
+        $bindingScope = "$scopeType`:$scopeId|player:$playerId|location:$locationType`:$locationId|sort:$([string]$groupSort.value)"
         $afterItemId = 0L
+        $afterSortValue = ''
+        $afterSortSecondary = ''
+        $afterSortName = ''
+        $afterTemplateId = ''
         $cursorMode = ''
         $cursor = (Get-DuneQ $req 'cursor').Trim()
         if ($cursor) {
             try {
                 $cursorPayload = Read-DuneOpaqueCursor -Cursor $cursor -Principal $principal `
                     -MapId 'shared-inventory' -Layers $entityTypes -Bbox $bindingScope `
-                    -Query $query -Generation $script:DuneInventoryCursorGeneration
-                $afterItemId = [long]$cursorPayload.position.itemId
-                if ($afterItemId -le 0) { throw 'Invalid cursor position.' }
+                    -Query $query -Generation $(if ($grouped) { $script:DuneInventoryGroupedCursorGeneration } else { $script:DuneInventoryCursorGeneration })
+                if ($grouped) {
+                    $afterSortValue = [string]$cursorPayload.position.sortValue
+                    $afterSortSecondary = [string]$cursorPayload.position.sortSecondary
+                    $afterSortName = [string]$cursorPayload.position.sortName
+                    $afterTemplateId = [string]$cursorPayload.position.templateId
+                    if (-not $afterTemplateId) { throw 'Invalid cursor position.' }
+                } else {
+                    $afterItemId = [long]$cursorPayload.position.itemId
+                    if ($afterItemId -le 0) { throw 'Invalid cursor position.' }
+                }
                 $cursorMode = [string]$cursorPayload.position.mode
                 if ($cursorMode -notin @('live', 'demo')) { throw 'Invalid cursor source.' }
             } catch {
@@ -54,6 +91,64 @@ Register-DuneRoute -Method GET -Path '/api/v1/inventory/items' -Handler {
         $requestedMode = Resolve-DuneInventoryRequestedMode -DemoRequested $demoRequested -CursorMode $cursorMode
         if (-not $requestedMode.ok) {
             Write-DuneError -Response $res -Status 400 -Message ([string]$requestedMode.error)
+            return
+        }
+        if ($grouped) {
+            $groupResult = Invoke-DuneInventoryGroupedPage -Mode ([string]$requestedMode.mode) `
+                -Query $query -EntityTypes $entityTypes -ScopeType $scopeType -ScopeId $scopeId `
+                -PlayerId $playerId -LocationType $locationType -LocationId $locationId `
+                -Sort ([string]$groupSort.value) -AfterSortValue $afterSortValue `
+                -AfterSortSecondary $afterSortSecondary `
+                -AfterSortName $afterSortName -AfterTemplateId $afterTemplateId -Limit ($limit + 1)
+            if (-not $groupResult.ok) {
+                Write-DuneError -Response $res -Status ([int]$groupResult.status) -Message ([string]$groupResult.error)
+                return
+            }
+            if ($playerId -gt 0 -and -not @($groupResult.players | Where-Object { [long]$_.id -eq $playerId }).Count) {
+                Write-DuneError -Response $res -Status 400 -Message 'player_id is not available in the filtered inventory dataset.'
+                return
+            }
+            if ($locationType -and -not @($groupResult.locations | Where-Object {
+                [string]$_.type -eq $locationType -and [long]$_.id -eq $locationId
+            }).Count) {
+                Write-DuneError -Response $res -Status 400 -Message 'The selected location is not available for the selected player.'
+                return
+            }
+            $groups = @($groupResult.groups)
+            $truncated = $groups.Count -gt $limit
+            $pageGroups = @($groups | Select-Object -First $limit)
+            $nextCursor = ''
+            if ($truncated -and $pageGroups.Count -gt 0) {
+                $nextCursor = New-DuneOpaqueCursor -Principal $principal `
+                    -MapId 'shared-inventory' -Layers $entityTypes -Bbox $bindingScope `
+                    -Query $query -Generation $script:DuneInventoryGroupedCursorGeneration `
+                    -Position ([ordered]@{
+                        sortValue = [string]$pageGroups[-1].cursor.sortValue
+                        sortSecondary = [string]$pageGroups[-1].cursor.sortSecondary
+                        sortName = [string]$pageGroups[-1].cursor.sortName
+                        templateId = [string]$pageGroups[-1].cursor.templateId
+                        mode = [string]$requestedMode.mode
+                    })
+            }
+            $observedAt = (Get-Date).ToUniversalTime().ToString('o')
+            $capabilities = @(Get-DuneCapabilitiesForPrincipal $principal | ForEach-Object { [string]$_.id })
+            $data = [ordered]@{
+                mode = [string]$requestedMode.mode
+                query = $query
+                playerId = if ($playerId -gt 0) { $playerId } else { $null }
+                location = if ($locationType) { [ordered]@{ type = $locationType; id = $locationId } } else { $null }
+                supportedEntityTypes = @('player', 'storage')
+                unavailableEntityTypes = @('base', 'vehicle')
+                groups = $pageGroups
+                players = @($groupResult.players)
+                locations = @($groupResult.locations)
+            }
+            $envelope = New-DuneApiV1Envelope `
+                -RequestId ([string]$routeParams.requestId) -Source ([string]$groupResult.source) `
+                -Freshness (New-DuneApiFreshness -State fresh -ObservedAt $observedAt) `
+                -Capabilities $capabilities -Data $data `
+                -Page (New-DuneApiPage -Limit $limit -NextCursor $nextCursor -Truncated $truncated)
+            Write-DuneJson -Response $res -Body $envelope
             return
         }
         $pageResult = Invoke-DuneInventoryRequestedPage -Mode ([string]$requestedMode.mode) `
@@ -97,5 +192,150 @@ Register-DuneRoute -Method GET -Path '/api/v1/inventory/items' -Handler {
         Write-DuneJson -Response $res -Body $envelope
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Inventory search failed: $($_.Exception.Message)"
+    }
+}
+
+# GET /api/v1/inventory/items/{templateId}/occurrences
+# Lazy, bounded occurrence detail for a grouped inventory item.
+Register-DuneRoute -Method GET -Path '/api/v1/inventory/items/{templateId}/occurrences' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $templateId = [Uri]::UnescapeDataString([string]$routeParams.templateId).Trim()
+        if (-not $templateId -or $templateId.Length -gt 240 -or $templateId -notmatch '^[A-Za-z0-9_.:/-]+$') {
+            Write-DuneError -Response $res -Status 400 -Message 'templateId is invalid.'
+            return
+        }
+        try {
+            $entityTypes = @(Get-DuneInventoryEntityTypes -Value (Get-DuneQ $req 'types'))
+        } catch {
+            Write-DuneError -Response $res -Status 400 -Message $_.Exception.Message
+            return
+        }
+        $scope = Resolve-DuneInventoryScope `
+            -HasScopeType (Test-DuneInventoryQueryParameterPresent -Request $req -Name 'scope_type') `
+            -ScopeTypeValue (Get-DuneQ $req 'scope_type') `
+            -HasScopeId (Test-DuneInventoryQueryParameterPresent -Request $req -Name 'scope_id') `
+            -ScopeIdValue (Get-DuneQ $req 'scope_id') -EntityTypes $entityTypes
+        if (-not $scope.ok) {
+            Write-DuneError -Response $res -Status 400 -Message ([string]$scope.error)
+            return
+        }
+        $player = Resolve-DuneInventoryPlayerId `
+            -HasPlayerId (Test-DuneInventoryQueryParameterPresent -Request $req -Name 'player_id') `
+            -Value (Get-DuneQ $req 'player_id')
+        if (-not $player.ok) {
+            Write-DuneError -Response $res -Status 400 -Message ([string]$player.error)
+            return
+        }
+        $scopeType = [string]$scope.scopeType
+        $scopeId = [long]$scope.scopeId
+        $playerId = [long]$player.playerId
+        $location = Resolve-DuneInventoryScope `
+            -HasScopeType (Test-DuneInventoryQueryParameterPresent -Request $req -Name 'location_type') `
+            -ScopeTypeValue (Get-DuneQ $req 'location_type') `
+            -HasScopeId (Test-DuneInventoryQueryParameterPresent -Request $req -Name 'location_id') `
+            -ScopeIdValue (Get-DuneQ $req 'location_id') -EntityTypes $entityTypes
+        if (-not $location.ok) {
+            Write-DuneError -Response $res -Status 400 -Message (([string]$location.error).Replace('scope_', 'location_'))
+            return
+        }
+        $locationType = [string]$location.scopeType
+        $locationId = [long]$location.scopeId
+        $occurrenceSort = Resolve-DuneInventoryOccurrenceSort -Value (Get-DuneQ $req 'sort')
+        if (-not $occurrenceSort.ok) {
+            Write-DuneError -Response $res -Status 400 -Message ([string]$occurrenceSort.error)
+            return
+        }
+        $limit = [Math]::Min(100, (Get-DuneInventoryLimit -Value (Get-DuneQ $req 'limit')))
+        $principal = Get-DuneRouteRequestPrincipal $routeParams
+        $bindingScope = "$scopeType`:$scopeId|player:$playerId|location:$locationType`:$locationId|sort:$([string]$occurrenceSort.value)"
+        $afterItemId = 0L
+        $afterOccurrenceSortValue = ''
+        $cursorMode = ''
+        $cursor = (Get-DuneQ $req 'cursor').Trim()
+        if ($cursor) {
+            try {
+                $payload = Read-DuneOpaqueCursor -Cursor $cursor -Principal $principal `
+                    -MapId "shared-inventory:$templateId" -Layers $entityTypes -Bbox $bindingScope `
+                    -Generation $script:DuneInventoryOccurrenceCursorGeneration
+                $afterItemId = [long]$payload.position.itemId
+                $afterOccurrenceSortValue = [string]$payload.position.sortValue
+                if ($afterItemId -le 0) { throw 'Invalid cursor position.' }
+                $cursorMode = [string]$payload.position.mode
+            } catch {
+                Write-DuneError -Response $res -Status 400 -Message $_.Exception.Message
+                return
+            }
+        }
+        $requestedMode = Resolve-DuneInventoryRequestedMode `
+            -DemoRequested (Test-DuneDemoRequested $req) -CursorMode $cursorMode
+        if (-not $requestedMode.ok) {
+            Write-DuneError -Response $res -Status 400 -Message ([string]$requestedMode.error)
+            return
+        }
+        if ([string]$requestedMode.mode -eq 'demo') {
+            $result = Get-DuneInventoryOccurrencesDemo -TemplateId $templateId -EntityTypes $entityTypes `
+                -ScopeType $scopeType -ScopeId $scopeId -PlayerId $playerId -LocationType $locationType `
+                -LocationId $locationId -Sort ([string]$occurrenceSort.value) -AfterItemId $afterItemId -Limit ($limit + 1)
+        } else {
+            $context = Get-DuneDbContext
+            if (-not $context.ok) {
+                Write-DuneError -Response $res -Status 503 -Message "Inventory database unavailable: $([string]$context.message)"
+                return
+            }
+            $result = Invoke-DuneInventoryOccurrencesLive -Ip $context.ip -TemplateId $templateId `
+                -EntityTypes $entityTypes -ScopeType $scopeType -ScopeId $scopeId -PlayerId $playerId `
+                -LocationType $locationType -LocationId $locationId -Sort ([string]$occurrenceSort.value) `
+                -AfterSortValue $afterOccurrenceSortValue -AfterItemId $afterItemId -Limit ($limit + 1)
+            $result.source = 'live'
+        }
+        if (-not $result.ok) {
+            Write-DuneError -Response $res -Status 503 -Message "Inventory database read failed: $([string]$result.error)"
+            return
+        }
+        if ($playerId -gt 0 -and -not @($result.players | Where-Object { [long]$_.id -eq $playerId }).Count) {
+            Write-DuneError -Response $res -Status 400 -Message 'player_id is not available for this item.'
+            return
+        }
+        if ($locationType -and -not @($result.locations | Where-Object {
+            [string]$_.type -eq $locationType -and [long]$_.id -eq $locationId
+        }).Count) {
+            Write-DuneError -Response $res -Status 400 -Message 'The selected location is not available for this player and item.'
+            return
+        }
+        $items = @($result.items)
+        $truncated = $items.Count -gt $limit
+        $pageItems = @($items | Select-Object -First $limit)
+        $nextCursor = ''
+        if ($truncated -and $pageItems.Count -gt 0) {
+            $last = $pageItems[-1]
+            $sortValue = switch -Wildcard ([string]$occurrenceSort.value) {
+                'player-*' { [string]$last.player.name }
+                'location-*' { [string]$last.entity.label }
+                'quantity-*' { [string]$last.quantity }
+                'quality-*' { [string]$last.quality }
+            }
+            $nextCursor = New-DuneOpaqueCursor -Principal $principal `
+                -MapId "shared-inventory:$templateId" -Layers $entityTypes -Bbox $bindingScope `
+                -Generation $script:DuneInventoryOccurrenceCursorGeneration `
+                -Position ([ordered]@{ itemId = [long]$last.id; sortValue = $sortValue.ToLowerInvariant(); mode = [string]$requestedMode.mode })
+        }
+        $observedAt = (Get-Date).ToUniversalTime().ToString('o')
+        $envelope = New-DuneApiV1Envelope `
+            -RequestId ([string]$routeParams.requestId) -Source ([string]$result.source) `
+            -Freshness (New-DuneApiFreshness -State fresh -ObservedAt $observedAt) `
+            -Capabilities @(Get-DuneCapabilitiesForPrincipal $principal | ForEach-Object { [string]$_.id }) `
+            -Data ([ordered]@{
+                mode = [string]$requestedMode.mode
+                templateId = $templateId
+                playerId = if ($playerId) { $playerId } else { $null }
+                items = $pageItems
+                players = @($result.players)
+                locations = @($result.locations)
+            }) `
+            -Page (New-DuneApiPage -Limit $limit -NextCursor $nextCursor -Truncated $truncated)
+        Write-DuneJson -Response $res -Body $envelope
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Inventory occurrence search failed: $($_.Exception.Message)"
     }
 }

--- a/tests/InventoryExplorer.Tests.ps1
+++ b/tests/InventoryExplorer.Tests.ps1
@@ -429,6 +429,29 @@ Describe 'Shared Inventory Explorer read model' -Tag 'Pure' {
             -PlayerId 20001 -LocationType storage -LocationId 50001).Count | Should -Be 1
     }
 
+    It 'keeps valid selected facets valid when search has no grouped matches' {
+        $item = [ordered]@{
+            id=1; templateId='Copper'; displayName='Copper'; kind='item'; quantity=5; quality=0
+            metadata=[ordered]@{category='Resources';tier=1;rarity='Common';icon='';stackMaximum=100;volume=0.1;vendorPrice=1;isGradeable=$false}
+            entity=[ordered]@{type='player';id=20001;label='Coastal';owner='Coastal';map='Hagga Basin'}
+        }
+        Mock Get-DuneInventoryDemoItems { @($item) }
+
+        $result = Get-DuneInventoryGroupedDemo -Query 'no match' -EntityTypes @('player') `
+            -PlayerId 20001 -LocationType player -LocationId 20001
+
+        $result.groups.Count | Should -Be 0
+        $result.selectedPlayerValid | Should -BeTrue
+        $result.selectedLocationValid | Should -BeTrue
+    }
+
+    It 'uses keyset-only occurrence SQL and pre-search validity checks' {
+        $source = Get-Content (Join-Path (Get-DstRepoRoot) 'app\server\lib\InventoryExplorer.ps1') -Raw
+        $source | Should -Not -Match 'OFFSET \(SELECT row_offset'
+        $source | Should -Match 'SELECT 1 FROM visible_rows r WHERE r\.player_id = p\.player_id'
+        $source | Should -Match 'r\.entity_type = p\.location_type AND r\.entity_id = p\.location_id'
+    }
+
     It 'builds grouped SQL with authoritative aggregation, null-last metadata sorting, and stable ties' {
         $sort = Resolve-DuneInventoryGroupSort -Value 'total-volume-desc'
         $binding = Get-DuneInventoryQueryParameters -EntityTypes @('player','storage') -Limit 101

--- a/tests/InventoryExplorer.Tests.ps1
+++ b/tests/InventoryExplorer.Tests.ps1
@@ -168,6 +168,17 @@ Describe 'Shared Inventory Explorer read model' -Tag 'Pure' {
         }
     }
 
+    It 'projects names-only catalog entries with null sortable metadata' {
+        $templateId = 'HarkSandbike_MeshCustomization'
+        $metadata = Get-DuneInventoryCatalogMetadataJson | ConvertFrom-Json
+        $entry = $metadata.PSObject.Properties[$templateId.ToLowerInvariant()].Value
+
+        $entry.name | Should -Be (Get-DuneGameplayItemName -TemplateId $templateId)
+        $entry.name | Should -Not -Be $templateId
+        $entry.tier | Should -BeNullOrEmpty
+        $entry.volume | Should -BeNullOrEmpty
+    }
+
     It 'validates entity types and supports exact demo scopes' {
         { Get-DuneInventoryEntityTypes -Value 'player,storage' } | Should -Not -Throw
         { Get-DuneInventoryEntityTypes -Value 'vehicle' } | Should -Throw '*Unsupported inventory entity type*'
@@ -397,7 +408,7 @@ Describe 'Shared Inventory Explorer read model' -Tag 'Pure' {
             entity = [ordered]@{ type='player'; id=20001; label='Coastal'; owner='Coastal'; map='Hagga Basin' }
         }
         $emote = [pscustomobject]@{
-            id = 2; templateId = 'Emote_Wave_01'; displayName = 'Wave'; kind = 'emote'; quantity = 1; quality = 0
+            id = 2; templateId = 'D_TestEmote'; displayName = 'Test emote'; kind = 'emote'; quantity = 1; quality = 0
             metadata = [ordered]@{ category=''; tier=0; rarity=''; icon=''; stackMaximum=0; volume=0; vendorPrice=0; isGradeable=$false }
             player = [ordered]@{ id=20001; name='Coastal' }
             entity = [ordered]@{ type='player'; id=20001; label='Coastal'; owner='Coastal'; map='Hagga Basin' }
@@ -407,6 +418,10 @@ Describe 'Shared Inventory Explorer read model' -Tag 'Pure' {
 
         $result.Count | Should -Be 1
         $result[0].templateId | Should -Be 'Copper'
+
+        $cte = Get-DuneInventoryFilteredCteSql
+        $cte | Should -Match "template_id IN \(SELECT jsonb_array_elements_text\(p\.catalog_ids::jsonb\)\)"
+        $cte | Should -Match "r\.template_id !~\* 'Emote\|Gesture'"
     }
 
     It 'keeps backpack and storage locations separate under the same player filter' {
@@ -469,7 +484,7 @@ ORDER BY $($sort.sql)
         $sql | Should -Match 'SUM\(stack_size\)'
         $sql | Should -Match 'COUNT\(DISTINCT entity_type'
         $sql | Should -Match 'total_volume DESC NULLS LAST, sort_name ASC, template_id ASC'
-        $sql | Should -Match "template_id !~\* '\(\^\|_\)Emote"
+        $sql | Should -Match "r\.template_id !~\* 'Emote\|Gesture'"
     }
 
     It 'registers a GET-only v1 route without mutation vocabulary' {

--- a/tests/InventoryExplorer.Tests.ps1
+++ b/tests/InventoryExplorer.Tests.ps1
@@ -369,9 +369,90 @@ Describe 'Shared Inventory Explorer read model' -Tag 'Pure' {
         }
     }
 
+    It 'rejects unknown grouped and occurrence sort values and maps allowed sorts to static SQL' {
+        (Resolve-DuneInventoryGroupSort -Value 'name-asc').sql | Should -Be 'sort_name ASC, template_id ASC'
+        (Resolve-DuneInventoryGroupSort -Value 'quality-desc').sql | Should -Match '^quality_max DESC, quality_min DESC'
+        (Resolve-DuneInventoryOccurrenceSort -Value 'location-asc').sql | Should -Match '^lower\(entity_label\) ASC NULLS LAST'
+        (Resolve-DuneInventoryGroupSort -Value 'name-asc; DROP TABLE dune.items').ok | Should -BeFalse
+        (Resolve-DuneInventoryOccurrenceSort -Value 'item_id DESC').ok | Should -BeFalse
+    }
+
+    It 'binds inventory SQL values through encoded parameters instead of interpolating caller input' {
+        $binding = Get-DuneInventoryQueryParameters -Query "100%_O'Brien" `
+            -EntityTypes @('player', 'storage') -PlayerId 20001 -LocationType storage -LocationId 50001
+        $sql = New-DuneInventoryParameterizedSql `
+            -Sql 'WITH /*__DST_PARAMETERS__*/ SELECT query FROM _dst_parameters' `
+            -Parameters $binding.values -ParameterTypes $binding.types
+
+        $sql | Should -Match 'jsonb_to_record'
+        $sql | Should -Not -Match "100%_O'Brien"
+        $sql | Should -Not -Match 'DROP TABLE'
+    }
+
+    It 'excludes emotes before demo grouping, facets, counts, and paging' {
+        $visible = [pscustomobject]@{
+            id = 1; templateId = 'Copper'; displayName = 'Copper'; kind = 'item'; quantity = 5; quality = 0
+            metadata = [ordered]@{ category='Resources'; tier=1; rarity='Common'; icon=''; stackMaximum=100; volume=0.1; vendorPrice=1; isGradeable=$false }
+            player = [ordered]@{ id=20001; name='Coastal' }
+            entity = [ordered]@{ type='player'; id=20001; label='Coastal'; owner='Coastal'; map='Hagga Basin' }
+        }
+        $emote = [pscustomobject]@{
+            id = 2; templateId = 'Emote_Wave_01'; displayName = 'Wave'; kind = 'emote'; quantity = 1; quality = 0
+            metadata = [ordered]@{ category=''; tier=0; rarity=''; icon=''; stackMaximum=0; volume=0; vendorPrice=0; isGradeable=$false }
+            player = [ordered]@{ id=20001; name='Coastal' }
+            entity = [ordered]@{ type='player'; id=20001; label='Coastal'; owner='Coastal'; map='Hagga Basin' }
+        }
+
+        $result = @(Select-DuneInventoryDemoFiltered -Items @($visible, $emote) -EntityTypes @('player'))
+
+        $result.Count | Should -Be 1
+        $result[0].templateId | Should -Be 'Copper'
+    }
+
+    It 'keeps backpack and storage locations separate under the same player filter' {
+        $items = @(
+            [pscustomobject]@{
+                id=1; templateId='Copper'; displayName='Copper'; kind='item'; quantity=5; quality=0
+                player=[ordered]@{id=20001;name='Coastal'}
+                entity=[ordered]@{type='player';id=20001;label='Coastal';owner='Coastal';map='Hagga Basin'}
+            },
+            [pscustomobject]@{
+                id=2; templateId='Copper'; displayName='Copper'; kind='item'; quantity=7; quality=0
+                player=[ordered]@{id=20001;name='Coastal'}
+                entity=[ordered]@{type='storage';id=50001;label='Copper box';owner='Coastal';map='Hagga Basin'}
+            }
+        )
+
+        @(Select-DuneInventoryDemoFiltered -Items $items -EntityTypes @('player','storage') `
+            -PlayerId 20001 -LocationType player -LocationId 20001).Count | Should -Be 1
+        @(Select-DuneInventoryDemoFiltered -Items $items -EntityTypes @('player','storage') `
+            -PlayerId 20001 -LocationType storage -LocationId 50001).Count | Should -Be 1
+    }
+
+    It 'builds grouped SQL with authoritative aggregation, null-last metadata sorting, and stable ties' {
+        $sort = Resolve-DuneInventoryGroupSort -Value 'total-volume-desc'
+        $binding = Get-DuneInventoryQueryParameters -EntityTypes @('player','storage') -Limit 101
+        $cte = Get-DuneInventoryFilteredCteSql
+        $sql = New-DuneInventoryParameterizedSql -Sql @"
+WITH $cte
+SELECT lower(trim(template_id)) AS group_key,
+       SUM(stack_size) AS total_quantity,
+       COUNT(*) AS occurrence_count,
+       COUNT(DISTINCT entity_type || ':' || entity_id::text) AS location_count
+FROM searched_rows GROUP BY lower(trim(template_id))
+ORDER BY $($sort.sql)
+"@ -Parameters $binding.values -ParameterTypes $binding.types
+
+        $sql | Should -Match 'SUM\(stack_size\)'
+        $sql | Should -Match 'COUNT\(DISTINCT entity_type'
+        $sql | Should -Match 'total_volume DESC NULLS LAST, sort_name ASC, template_id ASC'
+        $sql | Should -Match "template_id !~\* '\(\^\|_\)Emote"
+    }
+
     It 'registers a GET-only v1 route without mutation vocabulary' {
         $source = Get-Content (Join-Path (Get-DstRepoRoot) 'app\server\routes\Inventory.ps1') -Raw
         $source | Should -Match "Register-DuneRoute -Method GET -Path '/api/v1/inventory/items'"
+        $source | Should -Match "Register-DuneRoute -Method GET -Path '/api/v1/inventory/items/\{templateId\}/occurrences'"
         $source | Should -Not -Match 'Register-DuneRoute -Method (POST|PUT|PATCH|DELETE)'
         $source | Should -Not -Match '(?i)give-item|delete-item|repair-item'
     }

--- a/tests/PlatformContracts.Tests.ps1
+++ b/tests/PlatformContracts.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'Complete route classification' {
     It 'classifies the exact registered HTTP and WebSocket inventory' {
         $records = @(Get-PlatformRouteRecords)
         $manifest = Get-DuneRoutePolicyManifest
-        $records.Count | Should -Be 356
+        $records.Count | Should -Be 357
         $sources = @($records.SourceFile | Sort-Object -Unique)
         @($manifest.groups.source | Sort-Object) | Should -Be $sources
 
@@ -270,6 +270,12 @@ Describe 'Complete route classification' {
         (Test-DuneRoutePrincipalAccess -Route $inventoryRoute -Principal @{
             type = 'portal-account'; role = 'owner'
         }) | Should -BeTrue
+        $occurrenceRoute = @($script:DuneRoutes | Where-Object Path -eq '/api/v1/inventory/items/{templateId}/occurrences')[0]
+        $occurrenceRoute.Classification.capabilityId | Should -Be 'inventory.read'
+        $occurrenceRoute.Classification.currentAccess | Should -Be 'owner-admin'
+        (Test-DuneRoutePrincipalAccess -Route $occurrenceRoute -Principal @{
+            type = 'portal-account'; role = 'member'
+        }) | Should -BeFalse
         @($script:DuneRoutes | Where-Object Path -eq '/api/diagnostics/cleanup-old-images').Classification.capabilityId |
             Should -Be 'operation.diagnostics.manage'
         @($script:DuneRoutes | Where-Object Path -eq '/api/status').Classification.capabilityId |
@@ -312,7 +318,7 @@ $result = @{
         $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
         $resultLine = @($output | Where-Object { [string]$_ -like 'ROUTE_RESULT:*' })[-1]
         $result = ([string]$resultLine).Substring('ROUTE_RESULT:'.Length) | ConvertFrom-Json
-        $result.total | Should -Be 356
+        $result.total | Should -Be 357
         $result.unclassified | Should -Be 0
         $result.incompatible | Should -Be 0
         $result.podsCleanup | Should -Be 1

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -110,6 +110,8 @@ export interface SharedInventoryResponse extends InventoryEnvelope {
     unavailableEntityTypes: Array<'base' | 'vehicle'>
     playerId: number | null
     location: { type: InventoryEntityType; id: number } | null
+    selectedPlayerValid: boolean
+    selectedLocationValid: boolean
     groups: SharedInventoryGroup[]
     players: SharedInventoryPlayerFacet[]
     locations: SharedInventoryLocationFacet[]

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -39,6 +39,10 @@ export interface SharedInventoryItem {
   waterAmount: string
   waterType: string
   metadata: InventoryItemMetadata
+  player?: {
+    id: number
+    name: string
+  }
   entity: {
     type: InventoryEntityType
     id: number
@@ -52,7 +56,38 @@ export interface SharedInventoryItem {
   }
 }
 
-export interface SharedInventoryResponse {
+export interface SharedInventoryPlayerFacet {
+  id: number
+  name: string
+  occurrenceCount: number
+}
+
+export interface SharedInventoryLocationFacet {
+  type: InventoryEntityType
+  id: number
+  label: string
+  owner: string
+  playerId: number
+  playerName: string
+  occurrenceCount: number
+}
+
+export interface SharedInventoryGroup {
+  groupKey: string
+  templateId: string
+  displayName: string
+  totalQuantity: number
+  occurrenceCount: number
+  locationCount: number
+  quality: {
+    min: number
+    max: number
+    mixed: boolean
+  }
+  metadata: InventoryItemMetadata
+}
+
+interface InventoryEnvelope {
   schemaVersion: number
   requestId: string
   generatedAt: string
@@ -65,12 +100,19 @@ export interface SharedInventoryResponse {
     lastErrorCode: string | null
   }
   capabilities: string[]
+}
+
+export interface SharedInventoryResponse extends InventoryEnvelope {
   data: {
     mode: 'live' | 'demo'
     query: string
     supportedEntityTypes: InventoryEntityType[]
     unavailableEntityTypes: Array<'base' | 'vehicle'>
-    items: SharedInventoryItem[]
+    playerId: number | null
+    location: { type: InventoryEntityType; id: number } | null
+    groups: SharedInventoryGroup[]
+    players: SharedInventoryPlayerFacet[]
+    locations: SharedInventoryLocationFacet[]
   }
   page: {
     limit: number
@@ -84,6 +126,52 @@ export interface SharedInventoryQuery {
   types?: InventoryEntityType[]
   scopeType?: InventoryEntityType
   scopeId?: number
+  playerId?: number
+  locationType?: InventoryEntityType
+  locationId?: number
+  sort?: SharedInventorySort
+  limit?: number
+  cursor?: string
+  demo?: boolean
+}
+
+export type SharedInventorySort =
+  | 'name-asc' | 'name-desc'
+  | 'quantity-desc' | 'quantity-asc'
+  | 'unit-volume-desc' | 'unit-volume-asc'
+  | 'total-volume-desc' | 'total-volume-asc'
+  | 'tier-desc' | 'tier-asc'
+  | 'quality-desc' | 'quality-asc'
+  | 'occurrences-desc' | 'occurrences-asc'
+  | 'locations-desc' | 'locations-asc'
+
+export type SharedInventoryOccurrenceSort =
+  | 'player-asc' | 'player-desc'
+  | 'location-asc' | 'location-desc'
+  | 'quantity-desc' | 'quantity-asc'
+  | 'quality-desc' | 'quality-asc'
+
+export interface SharedInventoryOccurrencesResponse extends InventoryEnvelope {
+  data: {
+    mode: 'live' | 'demo'
+    templateId: string
+    playerId: number | null
+    items: SharedInventoryItem[]
+    players: SharedInventoryPlayerFacet[]
+    locations: SharedInventoryLocationFacet[]
+  }
+  page: SharedInventoryResponse['page']
+}
+
+export interface SharedInventoryOccurrencesQuery {
+  templateId: string
+  types?: InventoryEntityType[]
+  scopeType?: InventoryEntityType
+  scopeId?: number
+  playerId?: number
+  locationType?: InventoryEntityType
+  locationId?: number
+  sort?: SharedInventoryOccurrenceSort
   limit?: number
   cursor?: string
   demo?: boolean
@@ -406,10 +494,32 @@ export function getSharedInventory(query: SharedInventoryQuery = {}) {
     types: query.types?.join(','),
     scope_type: query.scopeType,
     scope_id: query.scopeId,
+    player_id: query.playerId,
+    location_type: query.locationType,
+    location_id: query.locationId,
+    sort: query.sort,
+    grouped: 1,
     limit: query.limit,
     cursor: query.cursor,
     demo: query.demo ? 1 : undefined,
   })}`)
+}
+
+export function getSharedInventoryOccurrences(query: SharedInventoryOccurrencesQuery) {
+  return api<SharedInventoryOccurrencesResponse>(
+    `/api/v1/inventory/items/${encodeURIComponent(query.templateId)}/occurrences${qs({
+      types: query.types?.join(','),
+      scope_type: query.scopeType,
+      scope_id: query.scopeId,
+      player_id: query.playerId,
+      location_type: query.locationType,
+      location_id: query.locationId,
+      sort: query.sort,
+      limit: query.limit,
+      cursor: query.cursor,
+      demo: query.demo ? 1 : undefined,
+    })}`,
+  )
 }
 
 export type MarketSortKey =

--- a/webui/src/components/inventory/InventorySlot.tsx
+++ b/webui/src/components/inventory/InventorySlot.tsx
@@ -1,18 +1,14 @@
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import type { SharedInventoryItem } from '../../api/gameplay'
+import type { SharedInventoryGroup } from '../../api/gameplay'
 import { InventoryItemIcon } from './InventoryItemIcon'
-
-function entityTypeLabel(type: SharedInventoryItem['entity']['type']) {
-  return type === 'player' ? 'Player inventory' : 'Storage container'
-}
 
 export function InventorySlot({
   item,
   onSelect,
 }: {
-  item: SharedInventoryItem
-  onSelect: (item: SharedInventoryItem) => void
+  item: SharedInventoryGroup
+  onSelect: (item: SharedInventoryGroup) => void
 }) {
   const buttonRef = useRef<HTMLButtonElement | null>(null)
   const tooltipRef = useRef<HTMLDivElement | null>(null)
@@ -23,8 +19,7 @@ export function InventorySlot({
   const [position, setPosition] = useState({ left: 8, top: 8 })
   const showInfo = (hovered && !hoverSuppressed) || focused
   const name = item.displayName || item.templateId
-  const source = entityTypeLabel(item.entity.type)
-  const entity = item.entity.label || `Actor ${item.entity.id}`
+  const quality = item.quality.mixed ? `${item.quality.min}-${item.quality.max}` : String(item.quality.max)
 
   const placeInfoCard = useCallback(() => {
     const rect = buttonRef.current?.getBoundingClientRect()
@@ -70,7 +65,7 @@ export function InventorySlot({
         ref={buttonRef}
         type="button"
         data-inventory-slot
-        aria-label={`${name}, quantity ${item.quantity}, quality ${item.quality}, ${source}, ${entity}`}
+        aria-label={`${name}, total quantity ${item.totalQuantity}, ${item.occurrenceCount} occurrences across ${item.locationCount} locations, quality ${quality}`}
         aria-describedby={showInfo ? tooltipId : undefined}
         className="group relative flex aspect-square min-h-22 w-full min-w-0 flex-col overflow-hidden rounded-xl border border-border bg-surface/85 text-left shadow-[inset_0_1px_rgba(255,255,255,0.04),0_6px_16px_-12px_rgba(0,0,0,0.9)] transition-[border-color,background-color,transform] duration-150 hover:-translate-y-0.5 hover:border-accent/60 hover:bg-surface-2 focus:outline-none focus-visible:border-ibad focus-visible:ring-2 focus-visible:ring-ibad active:translate-y-0"
         onMouseEnter={() => {
@@ -88,13 +83,16 @@ export function InventorySlot({
       >
         <span className="flex w-full items-center justify-between gap-1 px-1.5 pt-1.5">
           <span className="rounded-md border border-info/35 bg-base/90 px-1.5 py-0.5 text-[10px] font-semibold text-info">
-            Q{item.quality}
+            Q{quality}
           </span>
           <span className="rounded-md border border-accent/45 bg-base/90 px-1.5 py-0.5 text-[11px] font-bold text-accent-bright">
-            x{item.quantity}
+            x{item.totalQuantity}
           </span>
         </span>
         <InventoryItemIcon templateId={item.templateId} displayName={name} />
+        <span className="absolute right-1.5 bottom-7 rounded-md border border-border-bright bg-base/90 px-1.5 py-0.5 text-[10px] font-semibold text-text-muted">
+          {item.locationCount} loc
+        </span>
         <span className="w-full truncate border-t border-border/80 bg-base/75 px-2 py-1.5 text-center text-xs font-semibold text-text">
           {name}
         </span>
@@ -111,11 +109,10 @@ export function InventorySlot({
           <p className="break-words text-sm font-semibold text-text">{name}</p>
           <p className="mt-0.5 break-all font-mono text-[11px] text-text-muted">{item.templateId}</p>
           <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
-            <dt className="text-text-muted">Quantity</dt><dd className="text-right font-semibold text-text">{item.quantity}</dd>
-            <dt className="text-text-muted">Quality</dt><dd className="text-right font-semibold text-text">{item.quality}</dd>
-            <dt className="text-text-muted">Source</dt><dd className="break-words text-right text-text">{source}</dd>
-            <dt className="text-text-muted">Entity</dt><dd className="break-words text-right text-text">{entity}</dd>
-            {item.entity.owner && <><dt className="text-text-muted">Owner</dt><dd className="break-words text-right text-text">{item.entity.owner}</dd></>}
+            <dt className="text-text-muted">Total quantity</dt><dd className="text-right font-semibold text-text">{item.totalQuantity}</dd>
+            <dt className="text-text-muted">Quality</dt><dd className="text-right font-semibold text-text">{quality}</dd>
+            <dt className="text-text-muted">Occurrences</dt><dd className="text-right text-text">{item.occurrenceCount}</dd>
+            <dt className="text-text-muted">Locations</dt><dd className="text-right text-text">{item.locationCount}</dd>
           </dl>
         </div>,
         document.body,

--- a/webui/src/components/inventory/SharedInventoryExplorer.tsx
+++ b/webui/src/components/inventory/SharedInventoryExplorer.tsx
@@ -2,9 +2,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ApiError } from '../../api/client'
 import {
   getSharedInventory,
+  getSharedInventoryOccurrences,
   type InventoryEntityType,
+  type SharedInventoryGroup,
   type SharedInventoryItem,
+  type SharedInventoryLocationFacet,
+  type SharedInventoryOccurrenceSort,
   type SharedInventoryResponse,
+  type SharedInventorySort,
 } from '../../api/gameplay'
 import { usePlatformCapabilities } from '../../hooks/usePlatformCapabilities'
 import { Link, useSearch } from '../../router'
@@ -15,22 +20,80 @@ import { WorkspaceSection } from '../platform/WorkspaceLayout'
 import { itemDetailsUrl, resolveItemIcon } from './InventoryItemIcon'
 import { InventorySlot } from './InventorySlot'
 
+const catalogSorts: Array<{ value: SharedInventorySort; label: string }> = [
+  { value: 'name-asc', label: 'Name A-Z' },
+  { value: 'name-desc', label: 'Name Z-A' },
+  { value: 'quantity-desc', label: 'Total quantity: high to low' },
+  { value: 'quantity-asc', label: 'Total quantity: low to high' },
+  { value: 'unit-volume-desc', label: 'Unit volume: high to low' },
+  { value: 'unit-volume-asc', label: 'Unit volume: low to high' },
+  { value: 'total-volume-desc', label: 'Total volume: high to low' },
+  { value: 'total-volume-asc', label: 'Total volume: low to high' },
+  { value: 'tier-desc', label: 'Tier: high to low' },
+  { value: 'tier-asc', label: 'Tier: low to high' },
+  { value: 'quality-desc', label: 'Quality: high to low' },
+  { value: 'quality-asc', label: 'Quality: low to high' },
+  { value: 'occurrences-desc', label: 'Occurrences: high to low' },
+  { value: 'occurrences-asc', label: 'Occurrences: low to high' },
+  { value: 'locations-desc', label: 'Locations: high to low' },
+  { value: 'locations-asc', label: 'Locations: low to high' },
+]
+
+const occurrenceSorts: Array<{ value: SharedInventoryOccurrenceSort; label: string }> = [
+  { value: 'player-asc', label: 'Player A-Z' },
+  { value: 'player-desc', label: 'Player Z-A' },
+  { value: 'location-asc', label: 'Location A-Z' },
+  { value: 'location-desc', label: 'Location Z-A' },
+  { value: 'quantity-desc', label: 'Quantity: high to low' },
+  { value: 'quantity-asc', label: 'Quantity: low to high' },
+  { value: 'quality-desc', label: 'Quality: high to low' },
+  { value: 'quality-asc', label: 'Quality: low to high' },
+]
+
 function errorMessage(error: unknown) {
   return error instanceof ApiError ? error.message : error instanceof Error ? error.message : String(error)
 }
 
 function entityTypeLabel(type: InventoryEntityType) {
-  return type === 'player' ? 'Player inventory' : 'Storage container'
+  return type === 'player' ? 'Backpack' : 'Storage box'
 }
 
 function valueOrNotReported(value: string) {
   return value && value !== 'N/A' ? value : 'Not reported'
 }
 
+function parsePositiveId(value: string | null) {
+  if (!value || !/^\d+$/.test(value)) return undefined
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined
+}
+
+function setUrlFilters(changes: Record<string, string | undefined>) {
+  const params = new URLSearchParams(window.location.search)
+  Object.entries(changes).forEach(([key, value]) => {
+    if (value) params.set(key, value)
+    else params.delete(key)
+  })
+  const next = `${window.location.pathname}${params.size ? `?${params}` : ''}`
+  window.history.pushState(null, '', next)
+  window.dispatchEvent(new PopStateEvent('popstate'))
+}
+
+function locationValue(location?: { type: InventoryEntityType; id: number } | null) {
+  return location ? `${location.type}:${location.id}` : ''
+}
+
+function locationLabel(location: SharedInventoryLocationFacet, allPlayers: boolean, duplicateOrdinal = 0) {
+  const base = location.type === 'player' ? 'Backpack' : location.label || 'Storage box'
+  const owner = location.playerName || location.owner
+  const owned = allPlayers && owner ? `${base} - ${owner}` : base
+  return duplicateOrdinal > 0 ? `${owned} (${duplicateOrdinal})` : owned
+}
+
 export function SharedInventoryExplorer({
   entityTypes,
   title = 'Shared Inventory Explorer',
-  description = 'Search item names, template IDs, owners, containers, and proven entity types from one read-only view.',
+  description = 'Browse distinct item types across proven player backpacks and storage locations from one read-only view.',
   unavailableReason,
 }: {
   entityTypes: InventoryEntityType[]
@@ -39,40 +102,35 @@ export function SharedInventoryExplorer({
   unavailableReason?: string
 }) {
   const search = useSearch()
-  const searchParams = useMemo(() => new URLSearchParams(search), [search])
-  const hasScopeType = searchParams.has('scope_type')
-  const hasScopeId = searchParams.has('scope_id')
-  const requestedScopeType = searchParams.get('scope_type')
-  const requestedScopeId = searchParams.get('scope_id')
-  const parsedScopeId = Number(requestedScopeId)
+  const params = useMemo(() => new URLSearchParams(search), [search])
+  const requestedScopeType = params.get('scope_type')
+  const requestedScopeId = params.get('scope_id')
+  const parsedScopeId = parsePositiveId(requestedScopeId)
+  const hasScopeType = params.has('scope_type')
+  const hasScopeId = params.has('scope_id')
   const validScopeType = requestedScopeType === 'player' || requestedScopeType === 'storage'
-  const validScopeId = requestedScopeId !== null
-    && /^\d+$/.test(requestedScopeId)
-    && Number.isSafeInteger(parsedScopeId)
-    && parsedScopeId > 0
   const scopeError = hasScopeType !== hasScopeId
     ? 'Both scope_type and scope_id are required for a scoped inventory link.'
     : hasScopeType && (!validScopeType || !entityTypes.includes(requestedScopeType as InventoryEntityType))
       ? 'The requested inventory scope type is not supported in this workspace.'
-      : hasScopeId && !validScopeId
-        ? 'The requested inventory scope ID must be a positive integer.'
-        : ''
-  const scopeType = !scopeError && validScopeType
-    ? requestedScopeType as InventoryEntityType
-    : undefined
-  const scopeId = !scopeError && validScopeId ? parsedScopeId : undefined
-  const demoRequested = ['1', 'true', 'yes'].includes((searchParams.get('demo') ?? '').toLowerCase())
-  const initialQuery = searchParams.get('q') ?? ''
-  const [draftQuery, setDraftQuery] = useState(initialQuery)
-  const [submittedQuery, setSubmittedQuery] = useState(initialQuery)
-  const syncedUrlQuery = useRef(initialQuery)
-  const urlQueryChanged = syncedUrlQuery.current !== initialQuery
-  const currentDraftQuery = urlQueryChanged ? initialQuery : draftQuery
-  const currentSubmittedQuery = urlQueryChanged ? initialQuery : submittedQuery
+      : hasScopeId && !parsedScopeId ? 'The requested inventory scope ID must be a positive integer.' : ''
+  const scopeType = !scopeError && validScopeType ? requestedScopeType as InventoryEntityType : undefined
+  const scopeId = !scopeError ? parsedScopeId : undefined
+  const playerId = parsePositiveId(params.get('player_id'))
+  const requestedLocationType = params.get('location_type')
+  const locationType = requestedLocationType === 'player' || requestedLocationType === 'storage'
+    ? requestedLocationType : undefined
+  const locationId = parsePositiveId(params.get('location_id'))
+  const locationError = params.has('location_type') !== params.has('location_id')
+    || (params.has('location_type') && (!locationType || !locationId))
+  const query = params.get('q') ?? ''
+  const sort = catalogSorts.some(option => option.value === params.get('sort'))
+    ? params.get('sort') as SharedInventorySort : 'name-asc'
+  const demo = ['1', 'true', 'yes'].includes((params.get('demo') ?? '').toLowerCase())
+  const [draftQuery, setDraftQuery] = useState(query)
   const [response, setResponse] = useState<SharedInventoryResponse | null>(null)
-  const [items, setItems] = useState<SharedInventoryItem[]>([])
-  const [selected, setSelected] = useState<SharedInventoryItem | null>(null)
-  const [verifiedDetailsUrl, setVerifiedDetailsUrl] = useState<string | null>(null)
+  const [groups, setGroups] = useState<SharedInventoryGroup[]>([])
+  const [selected, setSelected] = useState<SharedInventoryGroup | null>(null)
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState('')
@@ -82,51 +140,40 @@ export function SharedInventoryExplorer({
   const capabilityReady = capabilities.data !== null
   const canReadInventory = capabilities.hasCapability('inventory.read')
   const requestIdentity = JSON.stringify({
-    query: currentSubmittedQuery.trim(),
-    entityTypes,
-    scopeType: scopeType ?? null,
-    scopeId: scopeId ?? null,
-    source: demoRequested ? 'demo' : 'live',
-    scopeError,
+    query: query.trim(), entityTypes, scopeType, scopeId, playerId, locationType, locationId, sort,
+    source: demo ? 'demo' : 'live', scopeError, locationError,
   })
-  const hasCurrentResult = loadedIdentity === requestIdentity
-  const currentResponse = hasCurrentResult ? response : null
-  const currentItems = hasCurrentResult ? items : []
-  const currentSelection = hasCurrentResult ? selected : null
+  const current = loadedIdentity === requestIdentity ? response : null
+  const currentGroups = loadedIdentity === requestIdentity ? groups : []
 
   const load = useCallback(async (cursor?: string, append = false) => {
-    if (!canReadInventory || unavailableReason || scopeError) return
+    if (!canReadInventory || unavailableReason || scopeError || locationError) return
     const version = ++requestVersion.current
     if (append) setLoadingMore(true)
     else {
       setLoading(true)
       setResponse(null)
-      setItems([])
+      setGroups([])
       setSelected(null)
       setLoadedIdentity('')
     }
     setError('')
     try {
       const result = await getSharedInventory({
-        q: currentSubmittedQuery.trim(),
-        types: entityTypes,
-        scopeType,
-        scopeId,
-        limit: 100,
-        cursor,
-        demo: demoRequested,
+        q: query.trim(), types: entityTypes, scopeType, scopeId, playerId, locationType, locationId,
+        sort, limit: 100, cursor, demo,
       })
       if (version !== requestVersion.current) return
       setResponse(result)
-      setItems(current => append ? [...current, ...result.data.items] : result.data.items)
+      setGroups(existing => append ? [...existing, ...result.data.groups] : result.data.groups)
       setLoadedIdentity(requestIdentity)
-    } catch (loadError) {
+    } catch (reason) {
       if (version !== requestVersion.current) return
       setResponse(null)
-      setItems([])
+      setGroups([])
       setSelected(null)
       setLoadedIdentity('')
-      setError(errorMessage(loadError))
+      setError(errorMessage(reason))
     } finally {
       if (version === requestVersion.current) {
         setLoading(false)
@@ -134,273 +181,292 @@ export function SharedInventoryExplorer({
       }
     }
   }, [
-    canReadInventory,
-    demoRequested,
-    entityTypes,
-    requestIdentity,
-    scopeError,
-    scopeId,
-    scopeType,
-    setError,
-    setItems,
-    setLoadedIdentity,
-    setLoading,
-    setLoadingMore,
-    setResponse,
-    setSelected,
-    currentSubmittedQuery,
-    unavailableReason,
+    canReadInventory, demo, entityTypes, locationError, locationId, locationType, playerId, query,
+    requestIdentity, scopeError, scopeId, scopeType, sort, unavailableReason,
+    setError, setGroups, setLoadedIdentity, setLoading, setLoadingMore, setResponse, setSelected,
   ])
 
-  useEffect(() => {
-    syncedUrlQuery.current = initialQuery
-    setDraftQuery(initialQuery)
-    setSubmittedQuery(initialQuery)
-  }, [initialQuery])
-
+  useEffect(() => setDraftQuery(query), [query])
   useEffect(() => {
     requestVersion.current += 1
     setResponse(null)
-    setItems([])
+    setGroups([])
     setSelected(null)
-    setLoadedIdentity('')
     setError('')
+    setLoadedIdentity('')
     setLoadingMore(false)
   }, [requestIdentity])
-
   useEffect(() => {
-    if (capabilityReady && canReadInventory && !unavailableReason && !scopeError) void load()
-  }, [capabilityReady, canReadInventory, load, scopeError, unavailableReason])
-
-  useEffect(() => () => {
-    requestVersion.current += 1
-  }, [])
-
-  useEffect(() => {
-    setVerifiedDetailsUrl(null)
-    if (!currentSelection) return
-    let active = true
-    void resolveItemIcon(currentSelection.templateId).then(iconUrl => {
-      if (active && iconUrl) setVerifiedDetailsUrl(itemDetailsUrl(currentSelection.templateId))
-    })
-    return () => {
-      active = false
-    }
-  }, [currentSelection])
-
-  const busy = loading || loadingMore
+    if (capabilityReady && canReadInventory && !unavailableReason && !scopeError && !locationError) void load()
+  }, [capabilityReady, canReadInventory, load, locationError, scopeError, unavailableReason])
+  useEffect(() => () => { requestVersion.current += 1 }, [])
 
   if (unavailableReason) {
-    return (
-      <WorkspaceSection id="shared-inventory" title={title} description={description}>
-        <DataState state="unavailable" title="Inventory scope not yet available" message={unavailableReason} />
-      </WorkspaceSection>
-    )
+    return <WorkspaceSection id="shared-inventory" title={title} description={description}><DataState state="unavailable" title="Inventory scope not yet available" message={unavailableReason} /></WorkspaceSection>
   }
-
-  if (scopeError) {
-    return (
-      <WorkspaceSection id="shared-inventory" title={title} description={description}>
-        <DataState state="error" title="Invalid inventory scope" message={scopeError} />
-      </WorkspaceSection>
-    )
+  if (scopeError || locationError) {
+    return <WorkspaceSection id="shared-inventory" title={title} description={description}><DataState state="error" title="Invalid inventory scope" message={scopeError || 'Both location_type and location_id must identify a supported location.'} /></WorkspaceSection>
   }
-
   if (!capabilityReady && capabilities.loading) {
-    return (
-      <WorkspaceSection id="shared-inventory" title={title} description={description}>
-        <DataState state="loading" title="Checking inventory access" />
-      </WorkspaceSection>
-    )
+    return <WorkspaceSection id="shared-inventory" title={title} description={description}><DataState state="loading" title="Checking inventory access" /></WorkspaceSection>
   }
-
   if (!capabilityReady && capabilities.error) {
-    return (
-      <WorkspaceSection id="shared-inventory" title={title} description={description}>
-        <DataState
-          state="error"
-          title="Could not check inventory access"
-          message={capabilities.error}
-          action={(
-            <button className="btn-secondary min-h-11" onClick={() => { void capabilities.refresh() }}>
-              <Icon name="RefreshCw" size={14} />
-              Retry capability check
-            </button>
-          )}
-        />
-      </WorkspaceSection>
-    )
+    return <WorkspaceSection id="shared-inventory" title={title} description={description}><DataState state="error" title="Could not check inventory access" message={capabilities.error} action={<button className="btn-secondary min-h-11" onClick={() => { void capabilities.refresh() }}>Retry capability check</button>} /></WorkspaceSection>
+  }
+  if (capabilityReady && !canReadInventory) {
+    return <WorkspaceSection id="shared-inventory" title={title} description={description}><DataState state="unavailable" title="Shared inventory is not included in this backend" message="Install the matching DST backend build to use the read-only inventory explorer." /></WorkspaceSection>
   }
 
-  if (capabilityReady && !canReadInventory) {
-    return (
-      <WorkspaceSection id="shared-inventory" title={title} description={description}>
-        <DataState
-          state="unavailable"
-          title="Shared inventory is not included in this backend"
-          message="Install the matching DST backend build to use the read-only inventory explorer."
-        />
-      </WorkspaceSection>
-    )
-  }
+  const locationCounts = new Map<string, number>()
+  current?.data.locations.forEach(location => locationCounts.set(location.label, (locationCounts.get(location.label) ?? 0) + 1))
+  const validSelectedLocation = !locationType || current?.data.locations.some(location => location.type === locationType && location.id === locationId)
 
   return (
     <WorkspaceSection id="shared-inventory" title={title} description={description}>
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <span className="pill border-info/40 text-info">Read-only</span>
-        {entityTypes.map(type => (
-          <span key={type} className="pill border-border text-text-muted">{entityTypeLabel(type)}</span>
-        ))}
-        {currentResponse && (
-          <FreshnessBadge
-            state={currentResponse.freshness.state}
-            observedAt={currentResponse.freshness.observedAt}
-            label={currentResponse.data.mode === 'demo' ? 'Demo inventory' : 'Live database'}
-          />
-        )}
+        {entityTypes.map(type => <span key={type} className="pill border-border text-text-muted">{type === 'player' ? 'Player backpacks' : 'Storage boxes'}</span>)}
+        {current && <FreshnessBadge state={current.freshness.state} observedAt={current.freshness.observedAt} label={current.data.mode === 'demo' ? 'Demo inventory' : 'Live database'} />}
       </div>
-
-      {scopeType && scopeId && (
-        <div className="mb-3 rounded-lg border border-info/35 bg-info/10 px-4 py-3 text-sm text-text" role="status">
-          Scoped to {entityTypeLabel(scopeType).toLowerCase()} actor {scopeId}.
-        </div>
-      )}
-
+      {scopeType && scopeId && <div className="mb-3 rounded-lg border border-info/35 bg-info/10 px-4 py-3 text-sm text-text" role="status">Scoped to {entityTypeLabel(scopeType).toLowerCase()} actor {scopeId}.</div>}
       <form
-        className="card mb-4 flex min-w-0 flex-col gap-3 p-4 sm:flex-row sm:items-end"
+        className="card mb-4 grid min-w-0 grid-cols-1 gap-3 p-4 sm:grid-cols-2 xl:grid-cols-[minmax(15rem,1fr)_minmax(10rem,.55fr)_minmax(10rem,.55fr)_minmax(12rem,.7fr)_auto_auto] xl:items-end"
         role="search"
         onSubmit={event => {
           event.preventDefault()
-          if (currentDraftQuery === currentSubmittedQuery) {
-            void load()
-          } else {
-            setItems([])
-            setResponse(null)
-            setSubmittedQuery(currentDraftQuery)
-          }
+          if (draftQuery === query) void load()
+          else setUrlFilters({ q: draftQuery.trim() || undefined })
         }}
       >
-        <label className="min-w-0 flex-1 text-sm font-medium text-text">
+        <label className="min-w-0 text-sm font-medium text-text">
           Search inventory
-          <input
-            className="input mt-1 min-h-11 w-full"
-            value={currentDraftQuery}
-            maxLength={200}
-            placeholder="Item, template ID, owner, container, or entity type"
-            onChange={event => setDraftQuery(event.target.value)}
-          />
+          <input className="input mt-1 min-h-11 w-full" value={draftQuery} maxLength={200} placeholder="Item, owner, or location" onChange={event => setDraftQuery(event.target.value)} />
         </label>
-        <button type="submit" className="btn-primary min-h-11 shrink-0" disabled={busy}>
-          <Icon name="Search" size={15} />
-          Search
-        </button>
-        <button
-          type="button"
-          className="btn-secondary min-h-11 shrink-0"
-          disabled={busy}
-          onClick={() => { void load() }}
-        >
-          <Icon name="RefreshCw" size={14} />
-          Refresh
-        </button>
+        <label className="min-w-0 text-sm font-medium text-text">
+          Player
+          <select
+            aria-label="Player"
+            className="input mt-1 min-h-11 w-full"
+            value={playerId ?? ''}
+            onChange={event => setUrlFilters({ player_id: event.target.value || undefined, location_type: undefined, location_id: undefined })}
+          >
+            <option value="">All players</option>
+            {current?.data.players.map((player, _index, players) => {
+              const duplicate = players.filter(candidate => candidate.name === player.name).length > 1
+              const ordinal = players.filter(candidate => candidate.name === player.name).findIndex(candidate => candidate.id === player.id) + 1
+              return <option key={player.id} value={player.id}>{player.name || 'Unnamed player'}{duplicate ? ` (${ordinal})` : ''}</option>
+            })}
+          </select>
+        </label>
+        <label className="min-w-0 text-sm font-medium text-text">
+          Location
+          <select
+            aria-label="Location"
+            className="input mt-1 min-h-11 w-full"
+            value={validSelectedLocation ? locationValue(locationType && locationId ? { type: locationType, id: locationId } : null) : ''}
+            onChange={event => {
+              const [type, id] = event.target.value.split(':')
+              setUrlFilters({ location_type: type || undefined, location_id: id || undefined })
+            }}
+          >
+            <option value="">All locations</option>
+            {current?.data.locations.map(location => (
+              <option key={`${location.type}:${location.id}`} value={locationValue(location)}>
+                {locationLabel(
+                  location,
+                  !playerId,
+                  (locationCounts.get(location.label) ?? 0) > 1
+                    ? current.data.locations.filter(candidate => candidate.label === location.label).findIndex(candidate => candidate.type === location.type && candidate.id === location.id) + 1
+                    : 0,
+                )}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="min-w-0 text-sm font-medium text-text">
+          Sort by
+          <select aria-label="Sort by" className="input mt-1 min-h-11 w-full" value={sort} onChange={event => setUrlFilters({ sort: event.target.value === 'name-asc' ? undefined : event.target.value })}>
+            {catalogSorts.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+          </select>
+        </label>
+        <button type="submit" className="btn-primary min-h-11" disabled={loading || loadingMore}><Icon name="Search" size={15} />Search</button>
+        <button type="button" className="btn-secondary min-h-11" disabled={loading || loadingMore} onClick={() => { void load() }}><Icon name="RefreshCw" size={14} />Refresh</button>
       </form>
 
-      {currentResponse?.data.mode === 'demo' && (
-        <DataState
-          state="fresh"
-          title="Showing bundled demo inventory"
-          message="Demo mode was explicitly requested; these rows are examples and not live server contents."
-        />
-      )}
-      {error && (
-        <div className="mb-4">
-          <DataState
-            state="error"
-            title="Inventory search failed"
-            message={error}
-            action={<button className="btn-secondary min-h-11" onClick={() => { void load() }}>Retry</button>}
-          />
-        </div>
-      )}
-      {loading && currentItems.length === 0 && !error && <DataState state="loading" title="Loading inventory" />}
-      {!loading && !error && currentResponse && currentItems.length === 0 && (
-        <DataState
-          state="empty"
-          title="No matching inventory items"
-          message="Try a display name, template ID, owner, container name, or another supported entity type."
-        />
-      )}
-
-      {currentItems.length > 0 && (
+      {locationType && current && !validSelectedLocation && <DataState state="error" title="Location does not match this player" message="Choose a location available to the selected player." />}
+      {current?.data.mode === 'demo' && <DataState state="fresh" title="Showing bundled demo inventory" message="Demo mode was explicitly requested; these grouped items are examples and not live server contents." />}
+      {error && <div className="mb-4"><DataState state="error" title="Inventory search failed" message={error} action={<button className="btn-secondary min-h-11" onClick={() => { void load() }}>Retry</button>} /></div>}
+      {loading && currentGroups.length === 0 && !error && <DataState state="loading" title="Loading inventory catalog" />}
+      {!loading && !error && current && currentGroups.length === 0 && <DataState state="empty" title="No matching inventory items" message="Try another item, player, location, or source filter." />}
+      {currentGroups.length > 0 && (
         <>
           <ul className="grid min-w-0 grid-cols-[repeat(auto-fill,minmax(min(6.5rem,100%),1fr))] gap-2.5" aria-label="Inventory results">
-            {currentItems.map(item => (
-              <li key={`${item.entity.type}:${item.id}`} className="min-w-0">
-                <InventorySlot item={item} onSelect={setSelected} />
-              </li>
-            ))}
+            {currentGroups.map(group => <li key={group.groupKey} className="min-w-0"><InventorySlot item={group} onSelect={setSelected} /></li>)}
           </ul>
-          {currentResponse?.page.nextCursor && (
-            <div className="mt-4 flex justify-center">
-              <button
-                className="btn-secondary min-h-11"
-                disabled={loadingMore}
-                onClick={() => { void load(currentResponse.page.nextCursor ?? undefined, true) }}
-              >
-                <Icon name={loadingMore ? 'Loader2' : 'ChevronDown'} size={14} className={loadingMore ? 'animate-spin' : undefined} />
-                {loadingMore ? 'Loading...' : 'Load more'}
-              </button>
-            </div>
-          )}
+          {current?.page.nextCursor && <div className="mt-4 flex justify-center"><button className="btn-secondary min-h-11" disabled={loadingMore} onClick={() => { void load(current.page.nextCursor ?? undefined, true) }}><Icon name={loadingMore ? 'Loader2' : 'ChevronDown'} size={14} className={loadingMore ? 'animate-spin' : undefined} />{loadingMore ? 'Loading...' : 'Load more items'}</button></div>}
         </>
       )}
-
-      <DetailPanel
-        open={currentSelection !== null}
-        title={currentSelection?.displayName || currentSelection?.templateId || 'Inventory item'}
+      <OccurrencePanel
+        group={selected}
+        players={current?.data.players ?? []}
+        locations={current?.data.locations ?? []}
+        initialPlayerId={playerId}
+        initialLocation={locationType && locationId ? { type: locationType, id: locationId } : undefined}
+        entityTypes={entityTypes}
+        scopeType={scopeType}
+        scopeId={scopeId}
+        demo={demo}
         onClose={() => setSelected(null)}
-      >
-        {currentSelection && (
-          <div className="min-w-0">
-            <div className="mb-4 flex flex-wrap gap-2">
-              <span className="pill border-info/40 text-info">Read-only</span>
-              {currentSelection.metadata.category && <span className="pill border-border">{currentSelection.metadata.category}</span>}
-              {currentSelection.metadata.rarity && <span className="pill border-border">{currentSelection.metadata.rarity}</span>}
-              {currentSelection.metadata.tier > 0 && <span className="pill border-border">Tier {currentSelection.metadata.tier}</span>}
-            </div>
-            <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
-              <div><dt className="text-text-dim">Template ID</dt><dd className="break-all font-mono">{currentSelection.templateId}</dd></div>
-              <div><dt className="text-text-dim">Item ID</dt><dd>{currentSelection.id}</dd></div>
-              <div><dt className="text-text-dim">Quantity</dt><dd>{currentSelection.quantity}</dd></div>
-              <div><dt className="text-text-dim">Quality</dt><dd>{currentSelection.quality}</dd></div>
-              <div><dt className="text-text-dim">Durability</dt><dd>{valueOrNotReported(currentSelection.durability)} / {valueOrNotReported(currentSelection.maxDurability)}</dd></div>
-              <div><dt className="text-text-dim">Water</dt><dd>{valueOrNotReported(currentSelection.waterAmount)}{currentSelection.waterType ? ` ${currentSelection.waterType}` : ''}</dd></div>
-              <div><dt className="text-text-dim">Source</dt><dd>{entityTypeLabel(currentSelection.entity.type)}</dd></div>
-              <div><dt className="text-text-dim">Inventory type</dt><dd>{currentSelection.entity.inventoryType}</dd></div>
-              <div><dt className="text-text-dim">Entity</dt><dd className="break-words">{currentSelection.entity.label || `Actor ${currentSelection.entity.id}`}</dd></div>
-              <div><dt className="text-text-dim">Owner</dt><dd className="break-words">{currentSelection.entity.owner || 'Not proven'}</dd></div>
-              <div><dt className="text-text-dim">Map</dt><dd className="break-words">{currentSelection.entity.map || 'Not reported'}</dd></div>
-              <div><dt className="text-text-dim">Observed</dt><dd>{currentResponse?.freshness.observedAt ? new Date(currentResponse.freshness.observedAt).toLocaleString() : 'Not reported'}</dd></div>
-            </dl>
-            <div className="mt-5 flex flex-wrap gap-2">
-              <Link className="btn-secondary inline-flex min-h-11" to={currentSelection.entity.workspacePath}>
-                Open owning {currentSelection.entity.type === 'player' ? 'player' : 'container'}
-              </Link>
-              {verifiedDetailsUrl && (
-                <a
-                  className="btn-ghost inline-flex min-h-11 text-text-muted"
-                  href={verifiedDetailsUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  View on dune.gaming.tools
-                  <Icon name="ExternalLink" size={14} />
-                </a>
-              )}
-            </div>
-          </div>
-        )}
-      </DetailPanel>
+      />
     </WorkspaceSection>
+  )
+}
+
+function OccurrencePanel({
+  group, players, locations, initialPlayerId, initialLocation, entityTypes, scopeType, scopeId, demo, onClose,
+}: {
+  group: SharedInventoryGroup | null
+  players: SharedInventoryResponse['data']['players']
+  locations: SharedInventoryLocationFacet[]
+  initialPlayerId?: number
+  initialLocation?: { type: InventoryEntityType; id: number }
+  entityTypes: InventoryEntityType[]
+  scopeType?: InventoryEntityType
+  scopeId?: number
+  demo: boolean
+  onClose: () => void
+}) {
+  const [playerId, setPlayerId] = useState<number | undefined>(initialPlayerId)
+  const [location, setLocation] = useState(initialLocation)
+  const [sort, setSort] = useState<SharedInventoryOccurrenceSort>('player-asc')
+  const [items, setItems] = useState<SharedInventoryItem[]>([])
+  const [panelPlayers, setPanelPlayers] = useState(players)
+  const [panelLocations, setPanelLocations] = useState(locations)
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [verifiedDetailsUrl, setVerifiedDetailsUrl] = useState<string | null>(null)
+  const version = useRef(0)
+  const initialLocationType = initialLocation?.type
+  const initialLocationId = initialLocation?.id
+  const identity = JSON.stringify({ templateId: group?.templateId, playerId, location, sort, scopeType, scopeId, demo })
+  const filteredLocations = panelLocations.filter(candidate => !playerId || candidate.playerId === playerId)
+
+  const load = useCallback(async (cursor?: string, append = false) => {
+    if (!group) return
+    const request = ++version.current
+    setLoading(true)
+    setError('')
+    if (!append) {
+      setItems([])
+      setNextCursor(null)
+    }
+    try {
+      const result = await getSharedInventoryOccurrences({
+        templateId: group.templateId, types: entityTypes, scopeType, scopeId, playerId,
+        locationType: location?.type, locationId: location?.id, sort, limit: 50, cursor, demo,
+      })
+      if (request !== version.current) return
+      setItems(current => append ? [...current, ...result.data.items] : result.data.items)
+      setNextCursor(result.page.nextCursor)
+      setPanelPlayers(result.data.players)
+      setPanelLocations(result.data.locations)
+    } catch (reason) {
+      if (request === version.current) setError(errorMessage(reason))
+    } finally {
+      if (request === version.current) setLoading(false)
+    }
+  }, [demo, entityTypes, group, location, playerId, scopeId, scopeType, sort])
+
+  useEffect(() => {
+    setPlayerId(initialPlayerId)
+    setLocation(initialLocationType && initialLocationId ? { type: initialLocationType, id: initialLocationId } : undefined)
+    setSort('player-asc')
+    setPanelPlayers(players)
+    setPanelLocations(locations)
+  }, [group?.groupKey, initialLocationId, initialLocationType, initialPlayerId, locations, players])
+  useEffect(() => {
+    version.current += 1
+    setItems([])
+    setNextCursor(null)
+    setError('')
+    if (group) void load()
+  }, [identity, group, load])
+  useEffect(() => {
+    setVerifiedDetailsUrl(null)
+    if (!group) return
+    let active = true
+    void resolveItemIcon(group.templateId).then(icon => {
+      if (active && icon) setVerifiedDetailsUrl(itemDetailsUrl(group.templateId))
+    })
+    return () => { active = false }
+  }, [group])
+
+  return (
+    <DetailPanel open={group !== null} title={group?.displayName || group?.templateId || 'Inventory item'} onClose={onClose}>
+      {group && (
+        <div className="min-w-0">
+          <div className="mb-4 flex flex-wrap gap-2">
+            <span className="pill border-info/40 text-info">Read-only</span>
+            <span className="pill border-border">x{group.totalQuantity} total</span>
+            <span className="pill border-border">{group.occurrenceCount} occurrences</span>
+            <span className="pill border-border">{group.locationCount} locations</span>
+          </div>
+          <p className="mb-4 break-all font-mono text-xs text-text-muted">{group.templateId}</p>
+          <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <label className="text-sm font-medium text-text">Player
+              <select aria-label="Occurrence player" className="input mt-1 min-h-11 w-full" value={playerId ?? ''} onChange={event => {
+                setPlayerId(parsePositiveId(event.target.value))
+                setLocation(undefined)
+              }}>
+                <option value="">All players</option>
+                {panelPlayers.map(player => <option key={player.id} value={player.id}>{player.name || 'Unnamed player'}</option>)}
+              </select>
+            </label>
+            <label className="text-sm font-medium text-text">Location
+              <select aria-label="Occurrence location" className="input mt-1 min-h-11 w-full" value={locationValue(location)} onChange={event => {
+                const [type, id] = event.target.value.split(':')
+                setLocation(type && id ? { type: type as InventoryEntityType, id: Number(id) } : undefined)
+              }}>
+                <option value="">All locations</option>
+                {filteredLocations.map((option, index) => <option key={`${option.type}:${option.id}`} value={locationValue(option)}>{locationLabel(option, !playerId, filteredLocations.filter(candidate => candidate.label === option.label).length > 1 ? index + 1 : 0)}</option>)}
+              </select>
+            </label>
+            <label className="text-sm font-medium text-text">Sort occurrences
+              <select aria-label="Sort occurrences" className="input mt-1 min-h-11 w-full" value={sort} onChange={event => setSort(event.target.value as SharedInventoryOccurrenceSort)}>
+                {occurrenceSorts.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+              </select>
+            </label>
+          </div>
+          {error && <DataState state="error" title="Could not load occurrences" message={error} />}
+          {loading && items.length === 0 && <DataState state="loading" title="Loading occurrences" />}
+          {!loading && !error && items.length === 0 && <DataState state="empty" title="No matching occurrences" message="Try another player or location." />}
+          {items.length > 0 && (
+            <ul className="divide-y divide-border" aria-label="Item occurrences">
+              {items.map(item => (
+                <li key={`${item.entity.type}:${item.id}`} className="py-3 first:pt-0">
+                  <div className="flex min-w-0 items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="truncate font-semibold text-text">{entityTypeLabel(item.entity.type)}: {item.entity.label || `Actor ${item.entity.id}`}</p>
+                      <p className="mt-0.5 truncate text-xs text-text-muted">{item.player?.name || item.entity.owner || 'Owner not proven'} · {item.entity.map || 'Map not reported'}</p>
+                    </div>
+                    <span className="shrink-0 font-semibold text-accent-bright">x{item.quantity}</span>
+                  </div>
+                  <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-4">
+                    <div><dt className="text-text-dim">Quality</dt><dd>{item.quality}</dd></div>
+                    <div><dt className="text-text-dim">Durability</dt><dd>{valueOrNotReported(item.durability)} / {valueOrNotReported(item.maxDurability)}</dd></div>
+                    <div><dt className="text-text-dim">Item</dt><dd>{item.id}</dd></div>
+                    <div><dt className="text-text-dim">Inventory</dt><dd>{item.entity.inventoryType}</dd></div>
+                  </dl>
+                  <Link className="mt-2 inline-flex text-xs font-semibold text-info hover:text-ibad" to={item.entity.workspacePath}>Open {item.entity.type === 'player' ? 'player' : 'container'}</Link>
+                </li>
+              ))}
+            </ul>
+          )}
+          {nextCursor && <button className="btn-secondary mt-4 min-h-11 w-full" disabled={loading} onClick={() => { void load(nextCursor, true) }}>{loading ? 'Loading...' : 'Load more occurrences'}</button>}
+          {verifiedDetailsUrl && <a className="btn-ghost mt-4 inline-flex min-h-11 text-text-muted" href={verifiedDetailsUrl} target="_blank" rel="noopener noreferrer">View on dune.gaming.tools<Icon name="ExternalLink" size={14} /></a>}
+        </div>
+      )}
+    </DetailPanel>
   )
 }

--- a/webui/src/components/inventory/SharedInventoryExplorer.tsx
+++ b/webui/src/components/inventory/SharedInventoryExplorer.tsx
@@ -401,8 +401,18 @@ function OccurrencePanel({
       if (request !== version.current) return
       setItems(current => append ? [...current, ...result.data.items] : result.data.items)
       setNextCursor(result.page.nextCursor)
-      setPanelPlayers(result.data.players)
-      setPanelLocations(result.data.locations)
+      setPanelPlayers(current => {
+        if (!playerId || result.data.players.some(player => player.id === playerId)) return result.data.players
+        const active = current.find(player => player.id === playerId)
+        return active ? [...result.data.players, active] : result.data.players
+      })
+      setPanelLocations(current => {
+        if (!location || result.data.locations.some(candidate => candidate.type === location.type && candidate.id === location.id)) {
+          return result.data.locations
+        }
+        const active = current.find(candidate => candidate.type === location.type && candidate.id === location.id)
+        return active ? [...result.data.locations, active] : result.data.locations
+      })
     } catch (reason) {
       if (request === version.current) setError(errorMessage(reason))
     } finally {

--- a/webui/src/components/inventory/SharedInventoryExplorer.tsx
+++ b/webui/src/components/inventory/SharedInventoryExplorer.tsx
@@ -90,6 +90,24 @@ function locationLabel(location: SharedInventoryLocationFacet, allPlayers: boole
   return duplicateOrdinal > 0 ? `${owned} (${duplicateOrdinal})` : owned
 }
 
+function duplicateOrdinals<T>(items: T[], labelOf: (item: T) => string, keyOf: (item: T) => string) {
+  const counts = new Map<string, number>()
+  const seen = new Map<string, number>()
+  const ordinals = new Map<string, number>()
+  items.forEach(item => {
+    const label = labelOf(item)
+    counts.set(label, (counts.get(label) ?? 0) + 1)
+  })
+  items.forEach(item => {
+    const label = labelOf(item)
+    if ((counts.get(label) ?? 0) < 2) return
+    const ordinal = (seen.get(label) ?? 0) + 1
+    seen.set(label, ordinal)
+    ordinals.set(keyOf(item), ordinal)
+  })
+  return ordinals
+}
+
 export function SharedInventoryExplorer({
   entityTypes,
   title = 'Shared Inventory Explorer',
@@ -116,7 +134,11 @@ export function SharedInventoryExplorer({
       : hasScopeId && !parsedScopeId ? 'The requested inventory scope ID must be a positive integer.' : ''
   const scopeType = !scopeError && validScopeType ? requestedScopeType as InventoryEntityType : undefined
   const scopeId = !scopeError ? parsedScopeId : undefined
-  const playerId = parsePositiveId(params.get('player_id'))
+  const requestedPlayerId = params.get('player_id')
+  const playerId = parsePositiveId(requestedPlayerId)
+  const playerError = params.has('player_id') && !playerId
+    ? 'The requested player ID must be a positive integer.'
+    : ''
   const requestedLocationType = params.get('location_type')
   const locationType = requestedLocationType === 'player' || requestedLocationType === 'storage'
     ? requestedLocationType : undefined
@@ -141,13 +163,19 @@ export function SharedInventoryExplorer({
   const canReadInventory = capabilities.hasCapability('inventory.read')
   const requestIdentity = JSON.stringify({
     query: query.trim(), entityTypes, scopeType, scopeId, playerId, locationType, locationId, sort,
-    source: demo ? 'demo' : 'live', scopeError, locationError,
+    source: demo ? 'demo' : 'live', scopeError, playerError, locationError,
   })
   const current = loadedIdentity === requestIdentity ? response : null
   const currentGroups = loadedIdentity === requestIdentity ? groups : []
+  const playerOrdinals = useMemo(() => duplicateOrdinals(
+    current?.data.players ?? [], player => player.name, player => String(player.id),
+  ), [current])
+  const locationOrdinals = useMemo(() => duplicateOrdinals(
+    current?.data.locations ?? [], location => location.label, location => `${location.type}:${location.id}`,
+  ), [current])
 
   const load = useCallback(async (cursor?: string, append = false) => {
-    if (!canReadInventory || unavailableReason || scopeError || locationError) return
+    if (!canReadInventory || unavailableReason || scopeError || playerError || locationError) return
     const version = ++requestVersion.current
     if (append) setLoadingMore(true)
     else {
@@ -181,7 +209,7 @@ export function SharedInventoryExplorer({
       }
     }
   }, [
-    canReadInventory, demo, entityTypes, locationError, locationId, locationType, playerId, query,
+    canReadInventory, demo, entityTypes, locationError, locationId, locationType, playerError, playerId, query,
     requestIdentity, scopeError, scopeId, scopeType, sort, unavailableReason,
     setError, setGroups, setLoadedIdentity, setLoading, setLoadingMore, setResponse, setSelected,
   ])
@@ -197,15 +225,15 @@ export function SharedInventoryExplorer({
     setLoadingMore(false)
   }, [requestIdentity])
   useEffect(() => {
-    if (capabilityReady && canReadInventory && !unavailableReason && !scopeError && !locationError) void load()
-  }, [capabilityReady, canReadInventory, load, locationError, scopeError, unavailableReason])
+    if (capabilityReady && canReadInventory && !unavailableReason && !scopeError && !playerError && !locationError) void load()
+  }, [capabilityReady, canReadInventory, load, locationError, playerError, scopeError, unavailableReason])
   useEffect(() => () => { requestVersion.current += 1 }, [])
 
   if (unavailableReason) {
     return <WorkspaceSection id="shared-inventory" title={title} description={description}><DataState state="unavailable" title="Inventory scope not yet available" message={unavailableReason} /></WorkspaceSection>
   }
-  if (scopeError || locationError) {
-    return <WorkspaceSection id="shared-inventory" title={title} description={description}><DataState state="error" title="Invalid inventory scope" message={scopeError || 'Both location_type and location_id must identify a supported location.'} /></WorkspaceSection>
+  if (scopeError || playerError || locationError) {
+    return <WorkspaceSection id="shared-inventory" title={title} description={description}><DataState state="error" title="Invalid inventory scope" message={scopeError || playerError || 'Both location_type and location_id must identify a supported location.'} /></WorkspaceSection>
   }
   if (!capabilityReady && capabilities.loading) {
     return <WorkspaceSection id="shared-inventory" title={title} description={description}><DataState state="loading" title="Checking inventory access" /></WorkspaceSection>
@@ -217,9 +245,7 @@ export function SharedInventoryExplorer({
     return <WorkspaceSection id="shared-inventory" title={title} description={description}><DataState state="unavailable" title="Shared inventory is not included in this backend" message="Install the matching DST backend build to use the read-only inventory explorer." /></WorkspaceSection>
   }
 
-  const locationCounts = new Map<string, number>()
-  current?.data.locations.forEach(location => locationCounts.set(location.label, (locationCounts.get(location.label) ?? 0) + 1))
-  const validSelectedLocation = !locationType || current?.data.locations.some(location => location.type === locationType && location.id === locationId)
+  const validSelectedLocation = !locationType || current?.data.selectedLocationValid !== false
 
   return (
     <WorkspaceSection id="shared-inventory" title={title} description={description}>
@@ -251,10 +277,9 @@ export function SharedInventoryExplorer({
             onChange={event => setUrlFilters({ player_id: event.target.value || undefined, location_type: undefined, location_id: undefined })}
           >
             <option value="">All players</option>
-            {current?.data.players.map((player, _index, players) => {
-              const duplicate = players.filter(candidate => candidate.name === player.name).length > 1
-              const ordinal = players.filter(candidate => candidate.name === player.name).findIndex(candidate => candidate.id === player.id) + 1
-              return <option key={player.id} value={player.id}>{player.name || 'Unnamed player'}{duplicate ? ` (${ordinal})` : ''}</option>
+            {current?.data.players.map(player => {
+              const ordinal = playerOrdinals.get(String(player.id))
+              return <option key={player.id} value={player.id}>{player.name || 'Unnamed player'}{ordinal ? ` (${ordinal})` : ''}</option>
             })}
           </select>
         </label>
@@ -275,9 +300,7 @@ export function SharedInventoryExplorer({
                 {locationLabel(
                   location,
                   !playerId,
-                  (locationCounts.get(location.label) ?? 0) > 1
-                    ? current.data.locations.filter(candidate => candidate.label === location.label).findIndex(candidate => candidate.type === location.type && candidate.id === location.id) + 1
-                    : 0,
+                  locationOrdinals.get(`${location.type}:${location.id}`) ?? 0,
                 )}
               </option>
             ))}
@@ -350,7 +373,16 @@ function OccurrencePanel({
   const initialLocationType = initialLocation?.type
   const initialLocationId = initialLocation?.id
   const identity = JSON.stringify({ templateId: group?.templateId, playerId, location, sort, scopeType, scopeId, demo })
-  const filteredLocations = panelLocations.filter(candidate => !playerId || candidate.playerId === playerId)
+  const playerOrdinals = useMemo(() => duplicateOrdinals(
+    panelPlayers, player => player.name, player => String(player.id),
+  ), [panelPlayers])
+  const filteredLocations = useMemo(
+    () => panelLocations.filter(candidate => !playerId || candidate.playerId === playerId),
+    [panelLocations, playerId],
+  )
+  const locationOrdinals = useMemo(() => duplicateOrdinals(
+    filteredLocations, location => location.label, location => `${location.type}:${location.id}`,
+  ), [filteredLocations])
 
   const load = useCallback(async (cursor?: string, append = false) => {
     if (!group) return
@@ -380,7 +412,11 @@ function OccurrencePanel({
 
   useEffect(() => {
     setPlayerId(initialPlayerId)
-    setLocation(initialLocationType && initialLocationId ? { type: initialLocationType, id: initialLocationId } : undefined)
+    setLocation(current => {
+      if (!initialLocationType || !initialLocationId) return undefined
+      if (current?.type === initialLocationType && current.id === initialLocationId) return current
+      return { type: initialLocationType, id: initialLocationId }
+    })
     setSort('player-asc')
     setPanelPlayers(players)
     setPanelLocations(locations)
@@ -420,7 +456,10 @@ function OccurrencePanel({
                 setLocation(undefined)
               }}>
                 <option value="">All players</option>
-                {panelPlayers.map(player => <option key={player.id} value={player.id}>{player.name || 'Unnamed player'}</option>)}
+                {panelPlayers.map(player => {
+                  const ordinal = playerOrdinals.get(String(player.id))
+                  return <option key={player.id} value={player.id}>{player.name || 'Unnamed player'}{ordinal ? ` (${ordinal})` : ''}</option>
+                })}
               </select>
             </label>
             <label className="text-sm font-medium text-text">Location
@@ -429,7 +468,7 @@ function OccurrencePanel({
                 setLocation(type && id ? { type: type as InventoryEntityType, id: Number(id) } : undefined)
               }}>
                 <option value="">All locations</option>
-                {filteredLocations.map((option, index) => <option key={`${option.type}:${option.id}`} value={locationValue(option)}>{locationLabel(option, !playerId, filteredLocations.filter(candidate => candidate.label === option.label).length > 1 ? index + 1 : 0)}</option>)}
+                {filteredLocations.map(option => <option key={`${option.type}:${option.id}`} value={locationValue(option)}>{locationLabel(option, !playerId, locationOrdinals.get(`${option.type}:${option.id}`) ?? 0)}</option>)}
               </select>
             </label>
             <label className="text-sm font-medium text-text">Sort occurrences

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -57,12 +57,34 @@ describe('Phase A — currency / progression writes', () => {
       types: ['player', 'storage'],
       scopeType: 'storage',
       scopeId: 50001,
+      playerId: 20001,
+      locationType: 'storage',
+      locationId: 50001,
+      sort: 'quantity-desc',
       limit: 100,
       cursor: 'next.page',
       demo: true,
     })
     expect(last().url).toBe(
-      '/api/v1/inventory/items?q=spice%20vault&types=player%2Cstorage&scope_type=storage&scope_id=50001&limit=100&cursor=next.page&demo=1',
+      '/api/v1/inventory/items?q=spice%20vault&types=player%2Cstorage&scope_type=storage&scope_id=50001&player_id=20001&location_type=storage&location_id=50001&sort=quantity-desc&grouped=1&limit=100&cursor=next.page&demo=1',
+    )
+    expect(last().method).toBeUndefined()
+  })
+
+  it('builds the bounded grouped occurrence query with inherited filters and sort', async () => {
+    await gp.getSharedInventoryOccurrences({
+      templateId: 'Copper/Bar',
+      types: ['player', 'storage'],
+      playerId: 20001,
+      locationType: 'player',
+      locationId: 20001,
+      sort: 'quality-desc',
+      limit: 50,
+      cursor: 'next.occurrence',
+      demo: true,
+    })
+    expect(last().url).toBe(
+      '/api/v1/inventory/items/Copper%2FBar/occurrences?types=player%2Cstorage&player_id=20001&location_type=player&location_id=20001&sort=quality-desc&limit=50&cursor=next.occurrence&demo=1',
     )
     expect(last().method).toBeUndefined()
   })

--- a/webui/tests/sharedInventoryExplorer.test.tsx
+++ b/webui/tests/sharedInventoryExplorer.test.tsx
@@ -171,8 +171,8 @@ describe('Shared Inventory Explorer grouped catalog', () => {
         playerId: 20001,
         location: { type: 'storage', id: 50001 },
         groups: [],
-        players: [],
-        locations: [],
+        players: [players[0]],
+        locations: [locations[1]],
         selectedPlayerValid: true,
         selectedLocationValid: true,
       },
@@ -180,6 +180,14 @@ describe('Shared Inventory Explorer grouped catalog', () => {
     renderExplorer()
     expect(await screen.findByText('No matching inventory items')).toBeInTheDocument()
     expect(screen.queryByText('Location does not match this player')).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Player' })).toHaveValue('20001')
+    expect(screen.getByRole('option', { name: 'Coastal' })).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Location' })).toHaveValue('storage:50001')
+    expect(screen.getByRole('option', { name: 'Copper box' })).toBeInTheDocument()
+
+    await userEvent.setup().selectOptions(screen.getByRole('combobox', { name: 'Player' }), '')
+    expect(window.location.search).not.toContain('player_id')
+    expect(window.location.search).not.toContain('location_id')
   })
 
   it('opens a lazy occurrence panel with inherited filters and adjustable sorting', async () => {
@@ -197,6 +205,22 @@ describe('Shared Inventory Explorer grouped catalog', () => {
     expect(within(occurrencePlayer).getByRole('option', { name: 'Coastal (2)' })).toBeInTheDocument()
     await user.selectOptions(screen.getByRole('combobox', { name: 'Sort occurrences' }), 'quality-desc')
     await waitFor(() => expect(occurrenceApi).toHaveBeenLastCalledWith(expect.objectContaining({ sort: 'quality-desc' })))
+  })
+
+  it('keeps proven active popup filters visible when the occurrence result is empty', async () => {
+    const user = userEvent.setup()
+    window.history.replaceState(null, '', '/economy?view=inventory&player_id=20001&location_type=storage&location_id=50001')
+    occurrenceApi.mockResolvedValue({
+      ...occurrenceFixture,
+      data: { ...occurrenceFixture.data, playerId: 20001, items: [], players: [], locations: [] },
+    })
+    renderExplorer()
+    await user.click(await screen.findByRole('button', { name: /Copper/ }))
+    expect(await screen.findByText('No matching occurrences')).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Occurrence player' })).toHaveValue('20001')
+    expect(screen.getByRole('combobox', { name: 'Occurrence location' })).toHaveValue('storage:50001')
+    expect(within(screen.getByRole('combobox', { name: 'Occurrence player' })).getByRole('option', { name: 'Coastal' })).toBeInTheDocument()
+    expect(within(screen.getByRole('combobox', { name: 'Occurrence location' })).getByRole('option', { name: 'Copper box' })).toBeInTheDocument()
   })
 
   it('omits gaming.tools attribution when icon verification fails', async () => {

--- a/webui/tests/sharedInventoryExplorer.test.tsx
+++ b/webui/tests/sharedInventoryExplorer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SharedInventoryExplorer } from '../src/components/inventory/SharedInventoryExplorer'
@@ -69,6 +69,8 @@ const fixture = {
     query: '',
     playerId: null,
     location: null,
+    selectedPlayerValid: true,
+    selectedLocationValid: true,
     supportedEntityTypes: ['player', 'storage'],
     unavailableEntityTypes: ['base', 'vehicle'],
     groups: [copperGroup],
@@ -152,6 +154,34 @@ describe('Shared Inventory Explorer grouped catalog', () => {
     expect(window.location.search).toContain('sort=quantity-desc')
   })
 
+  it('fails closed for a malformed player deep link', async () => {
+    window.history.replaceState(null, '', '/economy?view=inventory&player_id=bad')
+    renderExplorer()
+    expect(await screen.findByText('The requested player ID must be a positive integer.')).toBeInTheDocument()
+    expect(inventoryApi).not.toHaveBeenCalled()
+  })
+
+  it('keeps a valid selected location when search returns no facet matches', async () => {
+    window.history.replaceState(null, '', '/economy?view=inventory&q=missing&player_id=20001&location_type=storage&location_id=50001')
+    inventoryApi.mockResolvedValue({
+      ...fixture,
+      data: {
+        ...fixture.data,
+        query: 'missing',
+        playerId: 20001,
+        location: { type: 'storage', id: 50001 },
+        groups: [],
+        players: [],
+        locations: [],
+        selectedPlayerValid: true,
+        selectedLocationValid: true,
+      },
+    })
+    renderExplorer()
+    expect(await screen.findByText('No matching inventory items')).toBeInTheDocument()
+    expect(screen.queryByText('Location does not match this player')).not.toBeInTheDocument()
+  })
+
   it('opens a lazy occurrence panel with inherited filters and adjustable sorting', async () => {
     const user = userEvent.setup()
     window.history.replaceState(null, '', '/economy?view=inventory&player_id=20001&location_type=storage&location_id=50001')
@@ -162,6 +192,9 @@ describe('Shared Inventory Explorer grouped catalog', () => {
       templateId: 'Copper', playerId: 20001, locationType: 'storage', locationId: 50001, sort: 'player-asc',
     })))
     expect(screen.getByRole('list', { name: 'Item occurrences' })).toHaveTextContent('Copper box')
+    const occurrencePlayer = screen.getByRole('combobox', { name: 'Occurrence player' })
+    expect(within(occurrencePlayer).getByRole('option', { name: 'Coastal (1)' })).toBeInTheDocument()
+    expect(within(occurrencePlayer).getByRole('option', { name: 'Coastal (2)' })).toBeInTheDocument()
     await user.selectOptions(screen.getByRole('combobox', { name: 'Sort occurrences' }), 'quality-desc')
     await waitFor(() => expect(occurrenceApi).toHaveBeenLastCalledWith(expect.objectContaining({ sort: 'quality-desc' })))
   })
@@ -172,6 +205,7 @@ describe('Shared Inventory Explorer grouped catalog', () => {
     renderExplorer()
     await user.click(await screen.findByRole('button', { name: /Copper/ }))
     await screen.findByRole('dialog', { name: 'Copper' })
+    await waitFor(() => expect(itemIconResolver).toHaveBeenCalledWith('Copper'))
     expect(screen.queryByRole('link', { name: 'View on dune.gaming.tools' })).not.toBeInTheDocument()
   })
 

--- a/webui/tests/sharedInventoryExplorer.test.tsx
+++ b/webui/tests/sharedInventoryExplorer.test.tsx
@@ -12,8 +12,8 @@ const capabilityState = vi.hoisted(() => ({
   enabled: true,
   refresh: vi.fn(),
 }))
-
 const inventoryApi = vi.hoisted(() => vi.fn())
+const occurrenceApi = vi.hoisted(() => vi.fn())
 const itemIconResolver = vi.hoisted(() => vi.fn())
 
 vi.mock('../src/hooks/usePlatformCapabilities', () => ({
@@ -25,454 +25,177 @@ vi.mock('../src/hooks/usePlatformCapabilities', () => ({
     hasCapability: (id: string) => id === 'inventory.read' && capabilityState.enabled,
   }),
 }))
-
 vi.mock('../src/api/gameplay', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/api/gameplay')>()
-  return { ...actual, getSharedInventory: inventoryApi }
+  return { ...actual, getSharedInventory: inventoryApi, getSharedInventoryOccurrences: occurrenceApi }
 })
-
 vi.mock('../src/components/inventory/InventoryItemIcon', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/components/inventory/InventoryItemIcon')>()
   return { ...actual, resolveItemIcon: itemIconResolver }
 })
 
+const metadata = {
+  category: 'Resources', tier: 2, rarity: 'Common', icon: '', stackMaximum: 100,
+  volume: 0.1, vendorPrice: 5, isGradeable: false,
+}
+const players = [
+  { id: 20001, name: 'Coastal', occurrenceCount: 5 },
+  { id: 20002, name: 'Coastal', occurrenceCount: 2 },
+]
+const locations = [
+  { type: 'player', id: 20001, label: 'Backpack', owner: 'Coastal', playerId: 20001, playerName: 'Coastal', occurrenceCount: 2 },
+  { type: 'storage', id: 50001, label: 'Copper box', owner: 'Coastal', playerId: 20001, playerName: 'Coastal', occurrenceCount: 3 },
+  { type: 'storage', id: 50002, label: 'Copper box', owner: 'Coastal', playerId: 20002, playerName: 'Coastal', occurrenceCount: 2 },
+] as const
+const copperGroup = {
+  groupKey: 'copper',
+  templateId: 'Copper',
+  displayName: 'Copper',
+  totalQuantity: 30,
+  occurrenceCount: 3,
+  locationCount: 3,
+  quality: { min: 0, max: 2, mixed: true },
+  metadata,
+}
 const fixture = {
   schemaVersion: 1,
-  requestId: 'request-1',
+  requestId: 'group-request',
   generatedAt: '2026-09-02T10:00:00Z',
   source: 'live',
-  freshness: {
-    observedAt: '2026-09-02T10:00:00Z',
-    cachedAt: null,
-    ageSeconds: null,
-    state: 'fresh',
-    lastErrorCode: null,
-  },
+  freshness: { observedAt: '2026-09-02T10:00:00Z', cachedAt: null, ageSeconds: null, state: 'fresh', lastErrorCode: null },
   capabilities: ['inventory.read'],
   data: {
     mode: 'live',
     query: '',
+    playerId: null,
+    location: null,
     supportedEntityTypes: ['player', 'storage'],
     unavailableEntityTypes: ['base', 'vehicle'],
-    items: [{
-      id: 42,
-      templateId: 'MelangeSpice',
-      displayName: 'Spice Melange',
-      kind: 'item',
-      quantity: 12,
-      quality: 3,
-      durability: 'N/A',
-      maxDurability: 'N/A',
-      waterAmount: 'N/A',
-      waterType: '',
-      metadata: {
-        category: 'Resources',
-        tier: 2,
-        rarity: 'Common',
-        icon: '',
-        stackMaximum: 100,
-        volume: 0.1,
-        vendorPrice: 5,
-        isGradeable: false,
-      },
-      entity: {
-        type: 'storage',
-        id: 50001,
-        label: 'Spice Vault',
-        owner: 'Stilgar',
-        map: 'Hagga Basin',
-        class: 'SpiceSilo_Placeable',
-        inventoryId: 60001,
-        inventoryType: 4,
-        workspacePath: '/bases?view=inventory&scope_type=storage&scope_id=50001',
-      },
-    }],
+    groups: [copperGroup],
+    players,
+    locations,
   },
   page: { limit: 100, nextCursor: null, truncated: false },
 } as const
+const occurrence = {
+  id: 42, templateId: 'Copper', displayName: 'Copper', kind: 'item', quantity: 10,
+  quality: 2, durability: '80', maxDurability: '100', waterAmount: 'N/A', waterType: '',
+  metadata, player: { id: 20001, name: 'Coastal' },
+  entity: {
+    type: 'storage', id: 50001, label: 'Copper box', owner: 'Coastal', map: 'Hagga Basin',
+    class: 'GenericContainer_Placeable', inventoryId: 60001, inventoryType: 4,
+    workspacePath: '/bases?view=inventory&scope_type=storage&scope_id=50001',
+  },
+} as const
+const occurrenceFixture = {
+  ...fixture,
+  requestId: 'occurrence-request',
+  data: { mode: 'live', templateId: 'Copper', playerId: null, items: [occurrence], players, locations },
+  page: { limit: 50, nextCursor: null, truncated: false },
+} as const
 
-function navigateTo(url: string) {
-  act(() => {
-    window.history.pushState(null, '', url)
-    window.dispatchEvent(new PopStateEvent('popstate'))
-  })
+function renderExplorer() {
+  return render(<BrowserRouter><SharedInventoryExplorer entityTypes={['player', 'storage']} /></BrowserRouter>)
 }
 
 function deferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void
+  let resolve!: (value: T) => void
   const promise = new Promise<T>(done => { resolve = done })
   return { promise, resolve }
 }
 
 beforeEach(() => {
-  itemIconResolver.mockResolvedValue('https://cdn-hosted.gaming.tools/dune/images/dune/items/spice.webp')
+  inventoryApi.mockResolvedValue(fixture)
+  occurrenceApi.mockResolvedValue(occurrenceFixture)
+  itemIconResolver.mockResolvedValue('https://cdn-hosted.gaming.tools/dune/images/dune/items/copper.webp')
 })
 
 afterEach(() => {
   cleanup()
-  capabilityState.loading = false
-  capabilityState.dataPresent = true
-  capabilityState.error = null
-  capabilityState.enabled = true
-  capabilityState.refresh.mockClear()
   inventoryApi.mockReset()
+  occurrenceApi.mockReset()
   itemIconResolver.mockReset()
   window.history.replaceState(null, '', '/')
 })
 
-describe('Shared Inventory Explorer', () => {
-  it('shows live item, owner, source, freshness, and read-only detail without write controls', async () => {
-    const user = userEvent.setup()
-    inventoryApi.mockResolvedValue(fixture)
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['player', 'storage']} />
-      </BrowserRouter>,
-    )
-
-    expect(await screen.findByText('Spice Melange')).toBeInTheDocument()
-    const resultSlot = screen.getByRole('button', { name: /Spice Melange/ })
-    expect(resultSlot).toHaveAccessibleName(/quantity 12, quality 3, Storage container, Spice Vault/)
-    expect(screen.getByRole('list', { name: 'Inventory results' }).className).toContain('auto-fill')
-    resultSlot.focus()
-    expect(await screen.findByRole('tooltip')).toHaveTextContent('Spice Vault')
-    expect(screen.getByRole('tooltip')).toHaveTextContent('Stilgar')
-    resultSlot.blur()
-    await waitFor(() => expect(screen.queryByRole('tooltip')).not.toBeInTheDocument())
-    await user.hover(resultSlot)
-    expect(await screen.findByRole('tooltip')).toHaveTextContent('Spice Vault')
-    expect(screen.getByText('Live database')).toHaveAttribute('data-freshness-state', 'fresh')
-    expect(screen.getAllByText('Read-only').length).toBeGreaterThan(0)
-    expect(screen.queryByRole('button', { name: /give|delete|repair/i })).not.toBeInTheDocument()
-
-    await user.click(resultSlot)
-    expect(screen.getByRole('dialog', { name: 'Spice Melange' })).toBeInTheDocument()
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Open owning container' }))
-      .toHaveAttribute('href', '/bases?view=inventory&scope_type=storage&scope_id=50001')
-    expect(await screen.findByRole('link', { name: 'View on dune.gaming.tools' })).toHaveAttribute(
-      'href',
-      'https://dune.gaming.tools/items/melangespice',
-    )
+describe('Shared Inventory Explorer grouped catalog', () => {
+  it('defaults to all players and locations and renders one aggregate slot', async () => {
+    renderExplorer()
+    const slot = await screen.findByRole('button', { name: /Copper, total quantity 30, 3 occurrences across 3 locations, quality 0-2/ })
+    expect(slot).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Player' })).toHaveValue('')
+    expect(screen.getByRole('combobox', { name: 'Location' })).toHaveValue('')
+    expect(screen.getByText('3 loc')).toBeInTheDocument()
+    expect(inventoryApi).toHaveBeenCalledWith(expect.objectContaining({ playerId: undefined, locationId: undefined, sort: 'name-asc' }))
   })
 
-  it('omits gaming.tools attribution when metadata or icon verification fails', async () => {
+  it('keeps duplicate player and storage names visibly distinct without raw IDs', async () => {
+    renderExplorer()
+    await screen.findByText('Copper')
+    expect(screen.getByRole('option', { name: 'Coastal (1)' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Coastal (2)' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Copper box - Coastal (1)' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Copper box - Coastal (2)' })).toBeInTheDocument()
+    expect(screen.queryByText('50001')).not.toBeInTheDocument()
+  })
+
+  it('writes player, location, and sort filters to URL and clears dependent location on player change', async () => {
+    const user = userEvent.setup()
+    window.history.replaceState(null, '', '/economy?view=inventory&location_type=storage&location_id=50001')
+    renderExplorer()
+    await screen.findByText('Copper')
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Player' }), '20001')
+    expect(window.location.search).toContain('player_id=20001')
+    expect(window.location.search).not.toContain('location_id')
+    await screen.findByText('Copper')
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Sort by' }), 'quantity-desc')
+    expect(window.location.search).toContain('sort=quantity-desc')
+  })
+
+  it('opens a lazy occurrence panel with inherited filters and adjustable sorting', async () => {
+    const user = userEvent.setup()
+    window.history.replaceState(null, '', '/economy?view=inventory&player_id=20001&location_type=storage&location_id=50001')
+    renderExplorer()
+    await user.click(await screen.findByRole('button', { name: /Copper/ }))
+    expect(await screen.findByRole('dialog', { name: 'Copper' })).toBeInTheDocument()
+    await waitFor(() => expect(occurrenceApi).toHaveBeenCalledWith(expect.objectContaining({
+      templateId: 'Copper', playerId: 20001, locationType: 'storage', locationId: 50001, sort: 'player-asc',
+    })))
+    expect(screen.getByRole('list', { name: 'Item occurrences' })).toHaveTextContent('Copper box')
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Sort occurrences' }), 'quality-desc')
+    await waitFor(() => expect(occurrenceApi).toHaveBeenLastCalledWith(expect.objectContaining({ sort: 'quality-desc' })))
+  })
+
+  it('omits gaming.tools attribution when icon verification fails', async () => {
     const user = userEvent.setup()
     itemIconResolver.mockResolvedValue(null)
-    inventoryApi.mockResolvedValue(fixture)
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['storage']} />
-      </BrowserRouter>,
-    )
-
-    await user.click(await screen.findByRole('button', { name: /Spice Melange/ }))
-    expect(screen.getByRole('dialog', { name: 'Spice Melange' })).toBeInTheDocument()
-    await waitFor(() => expect(itemIconResolver).toHaveBeenCalledWith('MelangeSpice'))
+    renderExplorer()
+    await user.click(await screen.findByRole('button', { name: /Copper/ }))
+    await screen.findByRole('dialog', { name: 'Copper' })
     expect(screen.queryByRole('link', { name: 'View on dune.gaming.tools' })).not.toBeInTheDocument()
   })
 
-  it('places the info card using its measured height near the viewport edge', async () => {
-    inventoryApi.mockResolvedValue(fixture)
-    const heightSpy = vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
-      .mockImplementation(function measuredHeight() {
-        return this.getAttribute('role') === 'tooltip' ? 240 : 0
-      })
-    const widthSpy = vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(288)
-    const viewportSpy = vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['storage']} />
-      </BrowserRouter>,
-    )
-
-    const resultSlot = await screen.findByRole('button', { name: /Spice Melange/ })
-    vi.spyOn(resultSlot, 'getBoundingClientRect').mockReturnValue({
-      x: 100,
-      y: 590,
-      top: 590,
-      right: 210,
-      bottom: 700,
-      left: 100,
-      width: 110,
-      height: 110,
-      toJSON: () => ({}),
-    })
-    resultSlot.focus()
-
-    expect(await screen.findByRole('tooltip')).toHaveStyle({ top: '342px' })
-    heightSpy.mockRestore()
-    widthSpy.mockRestore()
-    viewportSpy.mockRestore()
-  })
-
-  it('submits one typed search and preserves the bounded entity filter', async () => {
-    const user = userEvent.setup()
-    inventoryApi.mockResolvedValue(fixture)
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['storage']} />
-      </BrowserRouter>,
-    )
-    await screen.findByText('Spice Melange')
-    await user.clear(screen.getByRole('textbox', { name: 'Search inventory' }))
-    await user.type(screen.getByRole('textbox', { name: 'Search inventory' }), 'vault')
-    await user.click(screen.getByRole('button', { name: 'Search' }))
-
-    await waitFor(() => expect(inventoryApi).toHaveBeenLastCalledWith(expect.objectContaining({
-      q: 'vault',
-      types: ['storage'],
-      limit: 100,
-    })))
-  })
-
-  it('sends a complete valid scope and explicit demo request without broadening', async () => {
-    const user = userEvent.setup()
-    window.history.replaceState(
-      null,
-      '',
-      '/bases?view=inventory&scope_type=storage&scope_id=50001&demo=1',
-    )
-    inventoryApi.mockResolvedValue({
+  it('isolates late grouped responses after URL filter changes', async () => {
+    const late = deferred<typeof fixture>()
+    inventoryApi.mockReset()
+    inventoryApi.mockReturnValueOnce(late.promise).mockResolvedValueOnce({
       ...fixture,
-      source: 'static',
-      data: {
-        ...fixture.data,
-        mode: 'demo',
-        items: [{
-          ...fixture.data.items[0],
-          entity: {
-            ...fixture.data.items[0].entity,
-            workspacePath: '/bases?view=inventory&scope_type=storage&scope_id=50001&demo=1',
-          },
-        }],
-      },
+      data: { ...fixture.data, groups: [{ ...copperGroup, groupKey: 'iron', templateId: 'Iron', displayName: 'Iron' }] },
     })
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['storage']} />
-      </BrowserRouter>,
-    )
-
-    await waitFor(() => expect(inventoryApi).toHaveBeenCalledWith(expect.objectContaining({
-      types: ['storage'],
-      scopeType: 'storage',
-      scopeId: 50001,
-      demo: true,
-    })))
-    expect(screen.getByText('Showing bundled demo inventory')).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: /Spice Melange/ }))
-    expect(screen.getByRole('link', { name: 'Open owning container' }))
-      .toHaveAttribute('href', '/bases?view=inventory&scope_type=storage&scope_id=50001&demo=1')
+    renderExplorer()
+    act(() => {
+      window.history.pushState(null, '', '/economy?view=inventory&q=iron')
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    })
+    expect(await screen.findByText('Iron')).toBeInTheDocument()
+    await act(async () => { late.resolve(fixture); await late.promise })
+    expect(screen.queryByText('Copper')).not.toBeInTheDocument()
   })
 
-  it('renders vehicle cargo as honestly unavailable without calling inventory APIs', () => {
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer
-          entityTypes={[]}
-          title="Vehicle cargo"
-          unavailableReason="No proven vehicle cargo join."
-        />
-      </BrowserRouter>,
-    )
-
-    expect(screen.getByText('Inventory scope not yet available')).toBeInTheDocument()
-    expect(screen.getByText('No proven vehicle cargo join.')).toBeInTheDocument()
-    expect(inventoryApi).not.toHaveBeenCalled()
-  })
-
-  it('fails closed when the capability is not advertised', () => {
-    capabilityState.enabled = false
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['player']} />
-      </BrowserRouter>,
-    )
-
-    expect(screen.getByText('Shared inventory is not included in this backend')).toBeInTheDocument()
-    expect(inventoryApi).not.toHaveBeenCalled()
-  })
-
-  it.each([
-    '/players?view=inventory&scope_type=player',
-    '/players?view=inventory&scope_id=20001',
-    '/players?view=inventory&scope_type=player&scope_id=bad',
-    '/players?view=inventory&scope_type=player&scope_id=0',
-    '/players?view=inventory&scope_type=player&scope_id=-1',
-  ])('does not broaden invalid scoped URL %s', route => {
-    window.history.replaceState(null, '', route)
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['player']} />
-      </BrowserRouter>,
-    )
-
+  it('fails closed for malformed direct location links', () => {
+    window.history.replaceState(null, '', '/economy?view=inventory&location_type=storage')
+    renderExplorer()
     expect(screen.getByText('Invalid inventory scope')).toBeInTheDocument()
     expect(inventoryApi).not.toHaveBeenCalled()
-  })
-
-  it('removes demo rows, metadata, cursor, and selection when a replacement live request fails', async () => {
-    const user = userEvent.setup()
-    window.history.replaceState(null, '', '/bases?view=inventory&demo=1')
-    inventoryApi
-      .mockResolvedValueOnce({
-        ...fixture,
-        source: 'static',
-        data: { ...fixture.data, mode: 'demo' },
-        page: { ...fixture.page, nextCursor: 'demo-cursor', truncated: true },
-      })
-      .mockRejectedValueOnce(new Error('live database unavailable'))
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['storage']} />
-      </BrowserRouter>,
-    )
-
-    await user.click(await screen.findByRole('button', { name: /Spice Melange/ }))
-    expect(screen.getByRole('dialog', { name: 'Spice Melange' })).toBeInTheDocument()
-    expect(screen.getByText('Demo inventory')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument()
-
-    navigateTo('/bases?view=inventory')
-
-    expect(await screen.findByText('Inventory search failed')).toBeInTheDocument()
-    expect(screen.getByText('live database unavailable')).toBeInTheDocument()
-    expect(screen.queryByRole('list', { name: 'Inventory results' })).not.toBeInTheDocument()
-    expect(screen.queryByText('Spice Melange')).not.toBeInTheDocument()
-    expect(screen.queryByText('x12')).not.toBeInTheDocument()
-    expect(screen.queryByText('Showing bundled demo inventory')).not.toBeInTheDocument()
-    expect(screen.queryByText('Demo inventory')).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-  })
-
-  it('removes broader unscoped results when a replacement scoped request fails', async () => {
-    const user = userEvent.setup()
-    window.history.replaceState(null, '', '/bases?view=inventory')
-    inventoryApi
-      .mockResolvedValueOnce({
-        ...fixture,
-        page: { ...fixture.page, nextCursor: 'live-cursor', truncated: true },
-      })
-      .mockRejectedValueOnce(new Error('scoped inventory unavailable'))
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['storage']} />
-      </BrowserRouter>,
-    )
-
-    await user.click(await screen.findByRole('button', { name: /Spice Melange/ }))
-    expect(screen.getByRole('dialog', { name: 'Spice Melange' })).toBeInTheDocument()
-    expect(screen.getByText('Live database')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument()
-
-    navigateTo('/bases?view=inventory&scope_type=storage&scope_id=50001')
-
-    expect(await screen.findByText('Inventory search failed')).toBeInTheDocument()
-    expect(screen.getByText('scoped inventory unavailable')).toBeInTheDocument()
-    expect(screen.getByText('Scoped to storage container actor 50001.')).toBeInTheDocument()
-    expect(screen.queryByRole('list', { name: 'Inventory results' })).not.toBeInTheDocument()
-    expect(screen.queryByText('Spice Melange')).not.toBeInTheDocument()
-    expect(screen.queryByText('x12')).not.toBeInTheDocument()
-    expect(screen.queryByText('Live database')).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-  })
-
-  it('synchronizes URL query navigation and ignores a late response from the prior query', async () => {
-    const user = userEvent.setup()
-    const lateFooPage = deferred<unknown>()
-    const barPage = deferred<unknown>()
-    const fooResponse = {
-      ...fixture,
-      data: { ...fixture.data, query: 'foo' },
-      page: { ...fixture.page, nextCursor: 'foo-cursor', truncated: true },
-    }
-    const barResponse = {
-      ...fixture,
-      data: {
-        ...fixture.data,
-        query: 'bar',
-        items: [{
-          ...fixture.data.items[0],
-          id: 84,
-          templateId: 'BarItem',
-          displayName: 'Bar Result',
-        }],
-      },
-    }
-    window.history.replaceState(null, '', '/bases?view=inventory&q=foo')
-    inventoryApi
-      .mockResolvedValueOnce(fooResponse)
-      .mockReturnValueOnce(lateFooPage.promise)
-      .mockReturnValueOnce(barPage.promise)
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['storage']} />
-      </BrowserRouter>,
-    )
-
-    await user.click(await screen.findByRole('button', { name: /Spice Melange/ }))
-    expect(screen.getByRole('dialog', { name: 'Spice Melange' })).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'Load more' }))
-    await waitFor(() => expect(inventoryApi).toHaveBeenLastCalledWith(expect.objectContaining({
-      q: 'foo',
-      cursor: 'foo-cursor',
-    })))
-
-    navigateTo('/bases?view=inventory&q=bar')
-
-    expect(screen.getByRole('textbox', { name: 'Search inventory' })).toHaveValue('bar')
-    expect(screen.queryByText('Spice Melange')).not.toBeInTheDocument()
-    expect(screen.queryByText('Live database')).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-    await waitFor(() => expect(inventoryApi).toHaveBeenLastCalledWith(expect.objectContaining({
-      q: 'bar',
-      cursor: undefined,
-    })))
-
-    await act(async () => {
-      barPage.resolve(barResponse)
-      await barPage.promise
-    })
-    expect(await screen.findByText('Bar Result')).toBeInTheDocument()
-
-    await act(async () => {
-      lateFooPage.resolve(fooResponse)
-      await lateFooPage.promise
-    })
-    expect(screen.getByText('Bar Result')).toBeInTheDocument()
-    expect(screen.queryByText('Spice Melange')).not.toBeInTheDocument()
-  })
-
-  it('synchronizes and requests an explicitly cleared URL query', async () => {
-    const clearPage = deferred<unknown>()
-    window.history.replaceState(null, '', '/bases?view=inventory&q=bar')
-    inventoryApi
-      .mockResolvedValueOnce({ ...fixture, data: { ...fixture.data, query: 'bar' } })
-      .mockReturnValueOnce(clearPage.promise)
-    render(
-      <BrowserRouter>
-        <SharedInventoryExplorer entityTypes={['storage']} />
-      </BrowserRouter>,
-    )
-    expect(await screen.findByText('Spice Melange')).toBeInTheDocument()
-
-    navigateTo('/bases?view=inventory')
-
-    expect(screen.getByRole('textbox', { name: 'Search inventory' })).toHaveValue('')
-    expect(screen.queryByText('Spice Melange')).not.toBeInTheDocument()
-    await waitFor(() => expect(inventoryApi).toHaveBeenLastCalledWith(expect.objectContaining({
-      q: '',
-      cursor: undefined,
-    })))
-
-    await act(async () => {
-      clearPage.resolve(fixture)
-      await clearPage.promise
-    })
-    expect(await screen.findByText('Spice Melange')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- group Shared Inventory Explorer results authoritatively by exact normalized template ID, with aggregate quantity, occurrence/location counts, mixed-quality ranges, and backend keyset sorting/pagination
- exclude emotes before live/demo facets, grouping, counts, pages, and occurrence detail
- add URL-synchronized Player and dependent Location filters that distinguish Backpack from named storage, including duplicate-label disambiguation and stale-state isolation
- lazily load bounded, sortable grouped-item occurrences in the existing side panel with inherited and adjustable Player/Location filters
- preserve the existing raw inventory response unless callers explicitly request `grouped=1`

## Validation
- full backend Pester suite: 1,306 passed
- full WebUI suite: 323 passed
- focused Shared Inventory/API UI tests: 59 passed
- WebUI build/typecheck/performance and changed-file ESLint passed
- PowerShell parsing, route contract, diff/BOM, Impeccable detector, and changed-content gitleaks/private-reference checks passed
- rendered desktop and 390px narrow QA covered repeated Copper across players/locations, duplicate player names, mixed quality, missing icon, hidden emote, dependent Backpack/storage filters, sorting, and occurrence detail with no horizontal overflow or console errors

This PR intentionally does not publish, release, deploy, merge, or enable auto-merge.