### PR TITLE
Fix grouped inventory SQL aliases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,54 @@ jobs:
           & icacls.exe $output /grant:r "${env:USERNAME}:(OI)(CI)RX" /T /Q
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Start disposable PostgreSQL fixture
+        shell: pwsh
+        run: |
+          $bin = $env:PGBIN
+          if (-not $bin -or -not (Test-Path (Join-Path $bin 'initdb.exe'))) {
+              $bin = Get-ChildItem "$env:ProgramFiles\PostgreSQL" -Directory -ErrorAction SilentlyContinue |
+                  Sort-Object Name -Descending |
+                  ForEach-Object { Join-Path $_.FullName 'bin' } |
+                  Where-Object { Test-Path (Join-Path $_ 'initdb.exe') } |
+                  Select-Object -First 1
+          }
+          if (-not $bin) { throw 'PostgreSQL server binaries are unavailable on this runner.' }
+
+          $data = Join-Path $env:RUNNER_TEMP 'dst-inventory-postgres'
+          $log = Join-Path $env:RUNNER_TEMP 'dst-inventory-postgres.log'
+          $passwordFile = Join-Path $env:RUNNER_TEMP 'dst-inventory-postgres.pw'
+          $superPassword = "$([guid]::NewGuid().ToString('N'))aA1!"
+          $rolePassword = "$([guid]::NewGuid().ToString('N'))bB2!"
+          Set-Content -LiteralPath $passwordFile -Value $superPassword -NoNewline
+          try {
+              & (Join-Path $bin 'initdb.exe') -D $data -A scram-sha-256 -U postgres `
+                  "--pwfile=$passwordFile" --no-locale --encoding=UTF8
+              $initExit = $LASTEXITCODE
+          } finally {
+              Remove-Item -LiteralPath $passwordFile -Force -ErrorAction SilentlyContinue
+          }
+          if ($initExit -ne 0) { exit $initExit }
+          & (Join-Path $bin 'pg_ctl.exe') -D $data -l $log -o '-p 55439' start
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          $env:PGPASSWORD = $superPassword
+          & (Join-Path $bin 'psql.exe') -h localhost -p 55439 -U postgres -d postgres `
+              -v ON_ERROR_STOP=1 -c "CREATE ROLE dst_inventory LOGIN PASSWORD '$rolePassword' NOSUPERUSER NOCREATEDB NOCREATEROLE;"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & (Join-Path $bin 'psql.exe') -h localhost -p 55439 -U postgres -d postgres `
+              -v ON_ERROR_STOP=1 -c 'CREATE DATABASE dst_inventory OWNER dst_inventory;'
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Remove-Item Env:\PGPASSWORD
+
+          "DST_TEST_POSTGRES_PSQL=$(Join-Path $bin 'psql.exe')" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "DST_TEST_POSTGRES_PG_CTL=$(Join-Path $bin 'pg_ctl.exe')" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "DST_TEST_POSTGRES_DATA=$data" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          'PGHOST=localhost' | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          'PGPORT=55439' | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          'PGUSER=dst_inventory' | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          'PGDATABASE=dst_inventory' | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "PGPASSWORD=$rolePassword" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+
       - name: Run Pester suite
         shell: pwsh
         run: |
@@ -152,6 +200,15 @@ jobs:
           Write-Host $stdout.Result
           if ($stderr.Result) { Write-Host $stderr.Result }
           exit $process.ExitCode
+
+      - name: Stop disposable PostgreSQL fixture
+        if: always()
+        shell: pwsh
+        run: |
+          if ($env:DST_TEST_POSTGRES_PG_CTL -and (Test-Path $env:DST_TEST_POSTGRES_PG_CTL) -and
+              $env:DST_TEST_POSTGRES_DATA -and (Test-Path $env:DST_TEST_POSTGRES_DATA)) {
+              & $env:DST_TEST_POSTGRES_PG_CTL -D $env:DST_TEST_POSTGRES_DATA -m fast stop
+          }
 
       - name: Upload test results
         if: always()

--- a/app/server/lib/InventoryExplorer.ps1
+++ b/app/server/lib/InventoryExplorer.ps1
@@ -432,22 +432,22 @@ function Resolve-DuneInventoryGroupSort {
         param([string]$Value)
         $sort = if ($Value) { $Value.Trim().ToLowerInvariant() } else { 'name-asc' }
         $map = @{
-            'name-asc' = @{ sql='sort_name ASC, template_id ASC'; primary='sort_name'; type='text'; direction='asc' }
-            'name-desc' = @{ sql='sort_name DESC, template_id ASC'; primary='sort_name'; type='text'; direction='desc' }
-            'quantity-desc' = @{ sql='total_quantity DESC, sort_name ASC, template_id ASC'; primary='total_quantity'; type='number'; direction='desc' }
-            'quantity-asc' = @{ sql='total_quantity ASC, sort_name ASC, template_id ASC'; primary='total_quantity'; type='number'; direction='asc' }
-            'unit-volume-desc' = @{ sql='unit_volume DESC NULLS LAST, sort_name ASC, template_id ASC'; primary='unit_volume'; type='number'; direction='desc' }
-            'unit-volume-asc' = @{ sql='unit_volume ASC NULLS LAST, sort_name ASC, template_id ASC'; primary='unit_volume'; type='number'; direction='asc' }
-            'total-volume-desc' = @{ sql='total_volume DESC NULLS LAST, sort_name ASC, template_id ASC'; primary='total_volume'; type='number'; direction='desc' }
-            'total-volume-asc' = @{ sql='total_volume ASC NULLS LAST, sort_name ASC, template_id ASC'; primary='total_volume'; type='number'; direction='asc' }
-            'tier-desc' = @{ sql='item_tier DESC NULLS LAST, sort_name ASC, template_id ASC'; primary='item_tier'; type='number'; direction='desc' }
-            'tier-asc' = @{ sql='item_tier ASC NULLS LAST, sort_name ASC, template_id ASC'; primary='item_tier'; type='number'; direction='asc' }
-            'quality-desc' = @{ sql='quality_max DESC, quality_min DESC, sort_name ASC, template_id ASC'; primary='quality_max'; secondary='quality_min'; type='number'; direction='desc' }
-            'quality-asc' = @{ sql='quality_max ASC, quality_min ASC, sort_name ASC, template_id ASC'; primary='quality_max'; secondary='quality_min'; type='number'; direction='asc' }
-            'occurrences-desc' = @{ sql='occurrence_count DESC, sort_name ASC, template_id ASC'; primary='occurrence_count'; type='number'; direction='desc' }
-            'occurrences-asc' = @{ sql='occurrence_count ASC, sort_name ASC, template_id ASC'; primary='occurrence_count'; type='number'; direction='asc' }
-            'locations-desc' = @{ sql='location_count DESC, sort_name ASC, template_id ASC'; primary='location_count'; type='number'; direction='desc' }
-            'locations-asc' = @{ sql='location_count ASC, sort_name ASC, template_id ASC'; primary='location_count'; type='number'; direction='asc' }
+            'name-asc' = @{ sql='grouped.sort_name ASC, grouped.template_id ASC'; primary='sort_name'; type='text'; direction='asc' }
+            'name-desc' = @{ sql='grouped.sort_name DESC, grouped.template_id ASC'; primary='sort_name'; type='text'; direction='desc' }
+            'quantity-desc' = @{ sql='grouped.total_quantity DESC, grouped.sort_name ASC, grouped.template_id ASC'; primary='total_quantity'; type='number'; direction='desc' }
+            'quantity-asc' = @{ sql='grouped.total_quantity ASC, grouped.sort_name ASC, grouped.template_id ASC'; primary='total_quantity'; type='number'; direction='asc' }
+            'unit-volume-desc' = @{ sql='grouped.unit_volume DESC NULLS LAST, grouped.sort_name ASC, grouped.template_id ASC'; primary='unit_volume'; type='number'; direction='desc' }
+            'unit-volume-asc' = @{ sql='grouped.unit_volume ASC NULLS LAST, grouped.sort_name ASC, grouped.template_id ASC'; primary='unit_volume'; type='number'; direction='asc' }
+            'total-volume-desc' = @{ sql='grouped.total_volume DESC NULLS LAST, grouped.sort_name ASC, grouped.template_id ASC'; primary='total_volume'; type='number'; direction='desc' }
+            'total-volume-asc' = @{ sql='grouped.total_volume ASC NULLS LAST, grouped.sort_name ASC, grouped.template_id ASC'; primary='total_volume'; type='number'; direction='asc' }
+            'tier-desc' = @{ sql='grouped.item_tier DESC NULLS LAST, grouped.sort_name ASC, grouped.template_id ASC'; primary='item_tier'; type='number'; direction='desc' }
+            'tier-asc' = @{ sql='grouped.item_tier ASC NULLS LAST, grouped.sort_name ASC, grouped.template_id ASC'; primary='item_tier'; type='number'; direction='asc' }
+            'quality-desc' = @{ sql='grouped.quality_max DESC, grouped.quality_min DESC, grouped.sort_name ASC, grouped.template_id ASC'; primary='quality_max'; secondary='quality_min'; type='number'; direction='desc' }
+            'quality-asc' = @{ sql='grouped.quality_max ASC, grouped.quality_min ASC, grouped.sort_name ASC, grouped.template_id ASC'; primary='quality_max'; secondary='quality_min'; type='number'; direction='asc' }
+            'occurrences-desc' = @{ sql='grouped.occurrence_count DESC, grouped.sort_name ASC, grouped.template_id ASC'; primary='occurrence_count'; type='number'; direction='desc' }
+            'occurrences-asc' = @{ sql='grouped.occurrence_count ASC, grouped.sort_name ASC, grouped.template_id ASC'; primary='occurrence_count'; type='number'; direction='asc' }
+            'locations-desc' = @{ sql='grouped.location_count DESC, grouped.sort_name ASC, grouped.template_id ASC'; primary='location_count'; type='number'; direction='desc' }
+            'locations-asc' = @{ sql='grouped.location_count ASC, grouped.sort_name ASC, grouped.template_id ASC'; primary='location_count'; type='number'; direction='asc' }
         }
         if (-not $map.ContainsKey($sort)) { return @{ ok = $false; error = "Unsupported inventory sort '$sort'." } }
         return @{
@@ -460,14 +460,14 @@ function Resolve-DuneInventoryOccurrenceSort {
         param([string]$Value)
         $sort = if ($Value) { $Value.Trim().ToLowerInvariant() } else { 'player-asc' }
         $map = @{
-            'player-asc' = @{ sql='lower(player_name) ASC NULLS LAST, item_id ASC'; primary='lower(player_name)'; type='text'; direction='asc' }
-            'player-desc' = @{ sql='lower(player_name) DESC NULLS LAST, item_id ASC'; primary='lower(player_name)'; type='text'; direction='desc' }
-            'location-asc' = @{ sql='lower(entity_label) ASC NULLS LAST, item_id ASC'; primary='lower(entity_label)'; type='text'; direction='asc' }
-            'location-desc' = @{ sql='lower(entity_label) DESC NULLS LAST, item_id ASC'; primary='lower(entity_label)'; type='text'; direction='desc' }
-            'quantity-desc' = @{ sql='stack_size DESC NULLS LAST, item_id ASC'; primary='stack_size'; type='number'; direction='desc' }
-            'quantity-asc' = @{ sql='stack_size ASC NULLS LAST, item_id ASC'; primary='stack_size'; type='number'; direction='asc' }
-            'quality-desc' = @{ sql='quality_level DESC NULLS LAST, item_id ASC'; primary='quality_level'; type='number'; direction='desc' }
-            'quality-asc' = @{ sql='quality_level ASC NULLS LAST, item_id ASC'; primary='quality_level'; type='number'; direction='asc' }
+            'player-asc' = @{ sql='lower(r.player_name) ASC NULLS LAST, r.item_id ASC'; primary='lower(r.player_name)'; type='text'; direction='asc' }
+            'player-desc' = @{ sql='lower(r.player_name) DESC NULLS LAST, r.item_id ASC'; primary='lower(r.player_name)'; type='text'; direction='desc' }
+            'location-asc' = @{ sql='lower(r.entity_label) ASC NULLS LAST, r.item_id ASC'; primary='lower(r.entity_label)'; type='text'; direction='asc' }
+            'location-desc' = @{ sql='lower(r.entity_label) DESC NULLS LAST, r.item_id ASC'; primary='lower(r.entity_label)'; type='text'; direction='desc' }
+            'quantity-desc' = @{ sql='r.stack_size DESC NULLS LAST, r.item_id ASC'; primary='r.stack_size'; type='number'; direction='desc' }
+            'quantity-asc' = @{ sql='r.stack_size ASC NULLS LAST, r.item_id ASC'; primary='r.stack_size'; type='number'; direction='asc' }
+            'quality-desc' = @{ sql='r.quality_level DESC NULLS LAST, r.item_id ASC'; primary='r.quality_level'; type='number'; direction='desc' }
+            'quality-asc' = @{ sql='r.quality_level ASC NULLS LAST, r.item_id ASC'; primary='r.quality_level'; type='number'; direction='asc' }
         }
         if (-not $map.ContainsKey($sort)) { return @{ ok = $false; error = "Unsupported occurrence sort '$sort'." } }
         return @{ ok = $true; value = $sort; sql = $map[$sort].sql; primary = $map[$sort].primary; type = $map[$sort].type; direction = $map[$sort].direction }
@@ -917,24 +917,24 @@ player_facets AS (
     FROM searched_rows WHERE player_id IS NOT NULL AND player_id > 0 GROUP BY player_id
 ),
 grouped AS (
-    SELECT lower(trim(template_id)) AS group_key, MIN(template_id) AS template_id,
-           SUM(stack_size)::bigint AS total_quantity, COUNT(*)::bigint AS occurrence_count,
-           COUNT(DISTINCT entity_type || ':' || entity_id::text)::bigint AS location_count,
-           MIN(quality_level)::integer AS quality_min, MAX(quality_level)::integer AS quality_max,
-           MIN(COALESCE(meta.value->>'name', template_id)) AS sort_name,
+    SELECT lower(trim(r.template_id)) AS group_key, MIN(r.template_id) AS template_id,
+           SUM(r.stack_size)::bigint AS total_quantity, COUNT(*)::bigint AS occurrence_count,
+           COUNT(DISTINCT r.entity_type || ':' || r.entity_id::text)::bigint AS location_count,
+           MIN(r.quality_level)::integer AS quality_min, MAX(r.quality_level)::integer AS quality_max,
+           MIN(COALESCE(meta.value->>'name', r.template_id)) AS sort_name,
            MAX((meta.value->>'tier')::integer) AS item_tier,
            MAX((meta.value->>'volume')::double precision) AS unit_volume,
-           MAX((meta.value->>'volume')::double precision) * SUM(stack_size)::double precision AS total_volume
-    FROM searched_rows CROSS JOIN _dst_parameters p
-    LEFT JOIN LATERAL jsonb_each(p.catalog_metadata::jsonb) meta ON meta.key = lower(trim(searched_rows.template_id))
-    WHERE (p.player_id = 0 OR searched_rows.player_id = p.player_id)
-      AND (p.location_type = '' OR (searched_rows.entity_type = p.location_type AND searched_rows.entity_id = p.location_id))
-    GROUP BY lower(trim(template_id))
+           MAX((meta.value->>'volume')::double precision) * SUM(r.stack_size)::double precision AS total_volume
+    FROM searched_rows r CROSS JOIN _dst_parameters p
+    LEFT JOIN LATERAL jsonb_each(p.catalog_metadata::jsonb) meta ON meta.key = lower(trim(r.template_id))
+    WHERE (p.player_id = 0 OR r.player_id = p.player_id)
+      AND (p.location_type = '' OR (r.entity_type = p.location_type AND r.entity_id = p.location_id))
+    GROUP BY lower(trim(r.template_id))
 )
-SELECT 'group'::text AS row_kind, group_key, template_id, total_quantity, occurrence_count,
-       location_count, quality_min, quality_max, NULL::bigint AS player_id, NULL::text AS player_name,
-       sort_name, COALESCE(($primary)::text, '') AS sort_value,
-       $(if ($sortSpec.secondary) { "COALESCE(($([string]$sortSpec.secondary))::text, '')" } else { "''::text" }) AS sort_secondary
+SELECT 'group'::text AS row_kind, grouped.group_key, grouped.template_id, grouped.total_quantity, grouped.occurrence_count,
+       grouped.location_count, grouped.quality_min, grouped.quality_max, NULL::bigint AS player_id, NULL::text AS player_name,
+       grouped.sort_name, COALESCE((grouped.$primary)::text, '') AS sort_value,
+       $(if ($sortSpec.secondary) { "COALESCE((grouped.$([string]$sortSpec.secondary))::text, '')" } else { "''::text" }) AS sort_secondary
 FROM grouped CROSS JOIN _dst_parameters p
 WHERE $pageWhere
 ORDER BY $($sortSpec.sql) LIMIT (SELECT row_limit FROM _dst_parameters)
@@ -966,12 +966,12 @@ ORDER BY player_name, player_id LIMIT 50000
     $locationSql = @"
 WITH $cte,
 search_locations AS (
-    SELECT entity_type, entity_id, MAX(CASE WHEN entity_type = 'player' THEN 'Backpack' ELSE entity_label END) AS entity_label,
-           MAX(owner_name) AS owner_name, MAX(player_id)::bigint AS player_id, MAX(player_name) AS player_name,
+    SELECT r.entity_type, r.entity_id, MAX(CASE WHEN r.entity_type = 'player' THEN 'Backpack' ELSE r.entity_label END) AS entity_label,
+           MAX(r.owner_name) AS owner_name, MAX(r.player_id)::bigint AS player_id, MAX(r.player_name) AS player_name,
            COUNT(*)::bigint AS occurrence_count
-    FROM searched_rows CROSS JOIN _dst_parameters p
-    WHERE (p.player_id = 0 OR searched_rows.player_id = p.player_id)
-    GROUP BY entity_type, entity_id
+    FROM searched_rows r CROSS JOIN _dst_parameters p
+    WHERE (p.player_id = 0 OR r.player_id = p.player_id)
+    GROUP BY r.entity_type, r.entity_id
 ),
 active_location AS (
     SELECT r.entity_type, r.entity_id, MAX(CASE WHEN r.entity_type = 'player' THEN 'Backpack' ELSE r.entity_label END) AS entity_label,
@@ -1118,20 +1118,20 @@ function Invoke-DuneInventoryOccurrencesLive {
     $primary = [string]$sortSpec.primary
     $comparison = if ($sortSpec.direction -eq 'asc') { '>' } else { '<' }
     if ($sortSpec.type -eq 'text') {
-        $pageWhere = "(p.after_item_id = 0 OR $primary $comparison p.after_sort_value OR ($primary = p.after_sort_value AND item_id > p.after_item_id))"
+        $pageWhere = "(p.after_item_id = 0 OR $primary $comparison p.after_sort_value OR ($primary = p.after_sort_value AND r.item_id > p.after_item_id))"
     } else {
-        $pageWhere = "(p.after_item_id = 0 OR $primary IS NULL OR $primary $comparison p.after_sort_value::double precision OR ($primary = p.after_sort_value::double precision AND item_id > p.after_item_id))"
+        $pageWhere = "(p.after_item_id = 0 OR $primary IS NULL OR $primary $comparison p.after_sort_value::double precision OR ($primary = p.after_sort_value::double precision AND r.item_id > p.after_item_id))"
     }
     $cte = Get-DuneInventoryFilteredCteSql
     $sql = @"
 WITH $cte
-SELECT item_id, template_id, stack_size, quality_level, durability, max_durability,
-       water_amount, water_type, inventory_id, inventory_type, entity_type, entity_id,
-       entity_label, owner_name, map, entity_class, player_id, player_name
-FROM searched_rows CROSS JOIN _dst_parameters p
-WHERE lower(trim(template_id)) = lower(trim(p.template_id))
-  AND (p.player_id = 0 OR searched_rows.player_id = p.player_id)
-  AND (p.location_type = '' OR (searched_rows.entity_type = p.location_type AND searched_rows.entity_id = p.location_id))
+SELECT r.item_id, r.template_id, r.stack_size, r.quality_level, r.durability, r.max_durability,
+       r.water_amount, r.water_type, r.inventory_id, r.inventory_type, r.entity_type, r.entity_id,
+       r.entity_label, r.owner_name, r.map, r.entity_class, r.player_id, r.player_name
+FROM searched_rows r CROSS JOIN _dst_parameters p
+WHERE lower(trim(r.template_id)) = lower(trim(p.template_id))
+  AND (p.player_id = 0 OR r.player_id = p.player_id)
+  AND (p.location_type = '' OR (r.entity_type = p.location_type AND r.entity_id = p.location_id))
   AND $pageWhere
 ORDER BY $($sortSpec.sql) LIMIT (SELECT row_limit FROM _dst_parameters)
 "@
@@ -1146,8 +1146,8 @@ ORDER BY $($sortSpec.sql) LIMIT (SELECT row_limit FROM _dst_parameters)
     $facetSql = @"
 WITH $cte,
 template_rows AS (
-    SELECT searched_rows.* FROM searched_rows CROSS JOIN _dst_parameters p
-    WHERE lower(trim(template_id)) = lower(trim(p.template_id))
+    SELECT r.* FROM searched_rows r CROSS JOIN _dst_parameters p
+    WHERE lower(trim(r.template_id)) = lower(trim(p.template_id))
 )
 SELECT player_id, MAX(player_name) AS player_name, COUNT(*)::bigint AS occurrence_count
 FROM template_rows WHERE player_id IS NOT NULL AND player_id > 0
@@ -1160,15 +1160,15 @@ GROUP BY player_id ORDER BY player_name, player_id LIMIT 500
     $locationSql = @"
 WITH $cte,
 template_rows AS (
-    SELECT searched_rows.* FROM searched_rows CROSS JOIN _dst_parameters p
-    WHERE lower(trim(template_id)) = lower(trim(p.template_id))
+    SELECT r.* FROM searched_rows r CROSS JOIN _dst_parameters p
+    WHERE lower(trim(r.template_id)) = lower(trim(p.template_id))
 )
-SELECT entity_type, entity_id, MAX(CASE WHEN entity_type = 'player' THEN 'Backpack' ELSE entity_label END) AS entity_label,
-       MAX(owner_name) AS owner_name, MAX(player_id)::bigint AS player_id, MAX(player_name) AS player_name,
+SELECT t.entity_type, t.entity_id, MAX(CASE WHEN t.entity_type = 'player' THEN 'Backpack' ELSE t.entity_label END) AS entity_label,
+       MAX(t.owner_name) AS owner_name, MAX(t.player_id)::bigint AS player_id, MAX(t.player_name) AS player_name,
        COUNT(*)::bigint AS occurrence_count
-FROM template_rows CROSS JOIN _dst_parameters p
-WHERE (p.player_id = 0 OR template_rows.player_id = p.player_id)
-GROUP BY entity_type, entity_id ORDER BY entity_type, entity_label, entity_id LIMIT 1000
+FROM template_rows t CROSS JOIN _dst_parameters p
+WHERE (p.player_id = 0 OR t.player_id = p.player_id)
+GROUP BY t.entity_type, t.entity_id ORDER BY t.entity_type, entity_label, t.entity_id LIMIT 1000
 "@
     $locationResult = Invoke-DuneSqlQuery -Ip $Ip `
         -Sql (New-DuneInventoryParameterizedSql -Sql $locationSql -Parameters $binding.values -ParameterTypes $binding.types) `

--- a/tests/InventoryExplorer.Tests.ps1
+++ b/tests/InventoryExplorer.Tests.ps1
@@ -11,10 +11,69 @@ BeforeAll {
         $script:DuneInventoryDbContextCalls += 1
         return $script:DuneInventoryDbContextResult
     }
+    function global:Get-DuneInventoryLiveSqlVariants {
+        $captured = [Collections.Generic.List[string]]::new()
+        $existing = Get-Command Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+        $originalNames = $script:DuneGameplayItemNames
+        $originalRules = $script:DuneGameplayItemRules
+        $script:DuneGameplayItemNames = @{ Copper = 'Copper' }
+        $script:DuneGameplayItemRules = @{}
+        function global:Invoke-DuneSqlQuery {
+            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec, [switch]$Bulk)
+            $captured.Add([string]$Sql)
+            return @{ ok = $true; columns = @(); rows = @() }
+        }
+        try {
+            $groupSorts = @(
+                'name-asc', 'name-desc', 'quantity-asc', 'quantity-desc',
+                'unit-volume-asc', 'unit-volume-desc', 'total-volume-asc', 'total-volume-desc',
+                'tier-asc', 'tier-desc', 'quality-asc', 'quality-desc',
+                'occurrences-asc', 'occurrences-desc', 'locations-asc', 'locations-desc'
+            )
+            foreach ($sort in $groupSorts) {
+                $result = Invoke-DuneInventoryGroupedLive -Ip 'fixture' -Query '[' `
+                    -EntityTypes @('player', 'storage') -PlayerId 20001 `
+                    -LocationType storage -LocationId 50001 -Sort $sort -Limit 2
+                if (-not $result.ok) { throw "Grouped SQL generation failed for $sort." }
+                $result = Invoke-DuneInventoryGroupedLive -Ip 'fixture' -Query '[' `
+                    -EntityTypes @('player', 'storage') -PlayerId 20001 `
+                    -LocationType storage -LocationId 50001 -Sort $sort `
+                    -AfterSortValue '1' -AfterSortSecondary '0' `
+                    -AfterSortName 'copper' -AfterTemplateId 'Copper' -Limit 2
+                if (-not $result.ok) { throw "Grouped cursor SQL generation failed for $sort." }
+            }
+
+            $occurrenceSorts = @(
+                'player-asc', 'player-desc', 'location-asc', 'location-desc',
+                'quantity-asc', 'quantity-desc', 'quality-asc', 'quality-desc'
+            )
+            foreach ($sort in $occurrenceSorts) {
+                $result = Invoke-DuneInventoryOccurrencesLive -Ip 'fixture' -TemplateId 'Copper' `
+                    -EntityTypes @('player', 'storage') -PlayerId 20001 `
+                    -LocationType storage -LocationId 50001 -Sort $sort -Limit 2
+                if (-not $result.ok) { throw "Occurrence SQL generation failed for $sort." }
+                $result = Invoke-DuneInventoryOccurrencesLive -Ip 'fixture' -TemplateId 'Copper' `
+                    -EntityTypes @('player', 'storage') -PlayerId 20001 `
+                    -LocationType storage -LocationId 50001 -Sort $sort `
+                    -AfterSortValue '1' -AfterItemId 42 -Limit 2
+                if (-not $result.ok) { throw "Occurrence cursor SQL generation failed for $sort." }
+            }
+        } finally {
+            $script:DuneGameplayItemNames = $originalNames
+            $script:DuneGameplayItemRules = $originalRules
+            if ($existing -and $existing.CommandType -eq 'Function') {
+                Set-Item Function:\global:Invoke-DuneSqlQuery -Value $existing.ScriptBlock
+            } else {
+                Remove-Item Function:\global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+            }
+        }
+        return @($captured)
+    }
 }
 
 AfterAll {
     Remove-Item Function:\global:Get-DuneDbContext -ErrorAction SilentlyContinue
+    Remove-Item Function:\global:Get-DuneInventoryLiveSqlVariants -ErrorAction SilentlyContinue
 }
 
 Describe 'Shared Inventory Explorer read model' -Tag 'Pure' {
@@ -381,11 +440,76 @@ Describe 'Shared Inventory Explorer read model' -Tag 'Pure' {
     }
 
     It 'rejects unknown grouped and occurrence sort values and maps allowed sorts to static SQL' {
-        (Resolve-DuneInventoryGroupSort -Value 'name-asc').sql | Should -Be 'sort_name ASC, template_id ASC'
-        (Resolve-DuneInventoryGroupSort -Value 'quality-desc').sql | Should -Match '^quality_max DESC, quality_min DESC'
-        (Resolve-DuneInventoryOccurrenceSort -Value 'location-asc').sql | Should -Match '^lower\(entity_label\) ASC NULLS LAST'
+        (Resolve-DuneInventoryGroupSort -Value 'name-asc').sql | Should -Be 'grouped.sort_name ASC, grouped.template_id ASC'
+        (Resolve-DuneInventoryGroupSort -Value 'quality-desc').sql | Should -Match '^grouped\.quality_max DESC, grouped\.quality_min DESC'
+        (Resolve-DuneInventoryOccurrenceSort -Value 'location-asc').sql | Should -Match '^lower\(r\.entity_label\) ASC NULLS LAST'
         (Resolve-DuneInventoryGroupSort -Value 'name-asc; DROP TABLE dune.items').ok | Should -BeFalse
         (Resolve-DuneInventoryOccurrenceSort -Value 'item_id DESC').ok | Should -BeFalse
+    }
+
+    It 'qualifies every colliding joined-scope column in all live grouped and occurrence variants' {
+        $queries = @(Get-DuneInventoryLiveSqlVariants)
+
+        $queries.Count | Should -Be 176
+        $defaultGrouped = $queries[0]
+        $defaultGrouped | Should -Match 'SELECT lower\(trim\(r\.template_id\)\) AS group_key'
+        $defaultGrouped | Should -Match 'grouped\.template_id'
+        $defaultGrouped | Should -Match 'ORDER BY grouped\.sort_name ASC, grouped\.template_id ASC'
+        $joinedSql = $queries -join "`n"
+        $joinedSql | Should -Not -Match 'lower\(trim\(template_id\)\)'
+        $joinedSql | Should -Not -Match 'FROM searched_rows CROSS JOIN _dst_parameters'
+        $joinedSql | Should -Not -Match 'FROM template_rows CROSS JOIN _dst_parameters'
+        $joinedSql | Should -Not -Match 'SELECT item_id, template_id, stack_size'
+        $joinedSql | Should -Match 'FROM searched_rows r CROSS JOIN _dst_parameters p'
+        $joinedSql | Should -Match 'FROM template_rows t CROSS JOIN _dst_parameters p'
+
+        $groupQueries = @($queries | Where-Object { $_ -match '(?m)^grouped AS \(' })
+        $groupQueries.Count | Should -Be 32
+        foreach ($sql in $groupQueries) {
+            $sql | Should -Not -Match 'MIN\(template_id\)'
+            $sql | Should -Not -Match 'GROUP BY lower\(trim\(template_id\)\)'
+            $sql | Should -Match 'ORDER BY grouped\.'
+        }
+
+        $occurrenceQueries = @($queries | Where-Object { $_ -match '(?m)^SELECT r\.item_id, r\.template_id' })
+        $occurrenceQueries.Count | Should -Be 16
+        foreach ($sql in $occurrenceQueries) {
+            $sql | Should -Match 'r\.player_id'
+            $sql | Should -Match 'r\.item_id > p\.after_item_id|p\.after_item_id = 0'
+            $sql | Should -Match 'ORDER BY (?:lower\(r\.|r\.)'
+        }
+    }
+
+    It 'executes every generated live query against a disposable PostgreSQL schema' `
+        -Skip:(-not $env:DST_TEST_POSTGRES_PSQL) {
+        $queries = @(Get-DuneInventoryLiveSqlVariants)
+        $fixture = @"
+\set ON_ERROR_STOP on
+BEGIN;
+CREATE SCHEMA dune;
+CREATE TABLE dune.items (
+    id bigint, template_id text, stack_size integer, quality_level integer,
+    stats jsonb, inventory_id bigint
+);
+CREATE TABLE dune.inventories (id bigint, inventory_type integer, actor_id bigint);
+CREATE TABLE dune.player_state (player_pawn_id bigint, character_name text, account_id bigint);
+CREATE TABLE dune.actors (id bigint, map text, owner_account_id bigint);
+CREATE TABLE dune.placeables (
+    id bigint, building_type text, is_hologram boolean, owner_entity_id bigint
+);
+CREATE TABLE dune.permission_actor (actor_id bigint, actor_name text);
+CREATE TABLE dune.actor_fgl_entities (actor_id bigint, entity_id bigint);
+CREATE TABLE dune.permission_actor_rank (
+    permission_actor_id bigint, player_id bigint, rank integer
+);
+"@
+        $scriptPath = Join-Path $TestDrive 'inventory-explorer-postgres.sql'
+        $sql = $fixture + "`n" + (($queries | ForEach-Object { "$_;"} ) -join "`n") + "`nROLLBACK;"
+        Set-Content -LiteralPath $scriptPath -Value $sql -Encoding utf8
+
+        & $env:DST_TEST_POSTGRES_PSQL -X -q -f $scriptPath 2>&1 | Out-String | Write-Verbose
+
+        $LASTEXITCODE | Should -Be 0
     }
 
     It 'binds inventory SQL values through encoded parameters instead of interpolating caller input' {
@@ -483,7 +607,7 @@ ORDER BY $($sort.sql)
 
         $sql | Should -Match 'SUM\(stack_size\)'
         $sql | Should -Match 'COUNT\(DISTINCT entity_type'
-        $sql | Should -Match 'total_volume DESC NULLS LAST, sort_name ASC, template_id ASC'
+        $sql | Should -Match 'grouped\.total_volume DESC NULLS LAST, grouped\.sort_name ASC, grouped\.template_id ASC'
         $sql | Should -Match "r\.template_id !~\* 'Emote\|Gesture'"
     }
 


### PR DESCRIPTION
## Summary
- qualify grouped inventory columns across aggregation, sort, keyset cursor, facets, and output scopes
- qualify occurrence page and facet columns that collide with parameter CTE fields
- add exhaustive generated-SQL coverage for all grouped and occurrence sorts/cursors, plus disposable PostgreSQL execution coverage

## Root cause
PR #789 cross-joined `_dst_parameters` (which includes `template_id` and `player_id`) with inventory row/group scopes while leaving those same column names unqualified. PostgreSQL therefore rejected the default Name A-Z query before returning a page.

## Validation
- exact default All players / All locations / Name A-Z query executes on PostgreSQL 18
- all 176 generated grouped/occurrence query statements execute against an overlapping-column PostgreSQL fixture
- 1,310 backend Pester tests pass
- Shared Inventory Explorer rendered tests pass (10/10)
- production WebUI build passes
- PowerShell parse, encoding, diff, gitleaks, private-reference, and prohibited-path checks pass
- independent re-review found no significant issues

Fixes the live runtime regression introduced by #789. This PR intentionally does not merge or publish anything.