### PR TITLE
Fix phantom shared inventory groups and occurrence routing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,7 @@ jobs:
           "DST_TEST_POSTGRES_PSQL=$(Join-Path $bin 'psql.exe')" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           "DST_TEST_POSTGRES_PG_CTL=$(Join-Path $bin 'pg_ctl.exe')" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           "DST_TEST_POSTGRES_DATA=$data" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          'DST_TEST_POSTGRES_DATABASE=dst_inventory' | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           'PGHOST=localhost' | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           'PGPORT=55439' | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           'PGUSER=dst_inventory' | Out-File $env:GITHUB_ENV -Append -Encoding utf8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Shared Inventory Explorer results collapsing into one blank item and
+  occurrence details failing to reach their read-only API route.
+
 ## [15.0.0-phase2-test1] - 2026-09-02
 
 ### Added

--- a/app/data/platform-route-policies.json
+++ b/app/data/platform-route-policies.json
@@ -152,7 +152,7 @@
     { "source": "Gameplay.ps1", "capabilityId": "economy.market", "routeCount": 22, "sha256": "757d3fd58fe70e88c5ccc91b9549e8f9a121b9137c1a2c16cd574c271c46e258" },
     { "source": "GameplayPlayers.ps1", "capabilityId": "player.manage", "routeCount": 27, "sha256": "4f822fc3645a5196c477810daed318d097c5319fb920a34b8ce8be6ab191d24e" },
     { "source": "GameplayWorld.ps1", "capabilityId": "base.manage", "routeCount": 12, "sha256": "52bfaeee6658d490bedae03914b525e3272d89ece1dc957d3514dc8ee9a84c30" },
-    { "source": "Inventory.ps1", "capabilityId": "inventory.read", "routeCount": 2, "sha256": "6f55a9a618b3b5447e160dbd1a40015c0afb68b9e18b810daaee0cfb55aa7268" },
+    { "source": "Inventory.ps1", "capabilityId": "inventory.read", "routeCount": 3, "sha256": "47c43cf9f4b06b0ab008924af54cd0ad716fe969dabcdba10c46dc78898ea3ad" },
     { "source": "ItemPackages.ps1", "capabilityId": "player.inventory", "routeCount": 3, "sha256": "ed3aac4a943d300002f7aecacb8ecf04619917ee7aa549cde0068e1853e01cf9" },
     { "source": "Landsraad.ps1", "capabilityId": "economy.governance", "routeCount": 9, "sha256": "e78c0dfe1b1f969d781db180f8c73eb3439de9779dd62fde7a8879925ac762f0" },
     { "source": "Links.ps1", "capabilityId": "platform.status", "routeCount": 1, "sha256": "175305c4d511463c37a3c0c2484bf7178044f72d42fe444c2eec1733ef876a47" },

--- a/app/lib/Db-Postgres.ps1
+++ b/app/lib/Db-Postgres.ps1
@@ -70,7 +70,13 @@ function Get-V6DbPort {
 }
 
 function Invoke-V6Ssh {
-    param([string]$Ip, [string]$Cmd, [int]$TimeoutSec = 30, [string]$StdinData)
+    param(
+        [string]$Ip,
+        [string]$Cmd,
+        [int]$TimeoutSec = 30,
+        [string]$StdinData,
+        [switch]$SeparateStreams
+    )
     # Strip CRs from the command — here-strings in CRLF-saved .ps1 files
     # preserve \r, which breaks bash (commands appear as "head -1\r" etc).
     if ($Cmd) { $Cmd = $Cmd -replace "`r","" }
@@ -162,6 +168,9 @@ function Invoke-V6Ssh {
             # visible (vs. the silent `$null`/empty failure mode that
             # produced the misleading "kubectl patch may have failed:"
             # toast in the v10.1.13 incident).
+            if ($SeparateStreams) {
+                return @{ stdout = ''; stderr = "ssh timed out after ${TimeoutSec}s"; exitCode = -1 }
+            }
             return "ERROR: ssh timed out after ${TimeoutSec}s"
         }
         # The process exited within the deadline, but that is NOT enough to
@@ -176,16 +185,37 @@ function Invoke-V6Ssh {
         [void]$proc.WaitForExit()
         $drainMs = 5000
         $outDone = $false
+        $errDone = $false
         try { $outDone = $outTask.Wait($drainMs) } catch { $outDone = $true }  # faulted reader = no more output
-        try { [void]$errTask.Wait($drainMs) } catch {}                          # discarded — mirrors prior `2>$null`
+        try { $errDone = $errTask.Wait($drainMs) } catch { $errDone = $true }
         if (-not $outDone) {
             if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
                 Write-DuneLog "Invoke-V6Ssh: stdout drain to $Ip did not finish within ${drainMs}ms after exit (pipe held open by a grandchild?); abandoning reader" 'WARN'
             }
+            if ($SeparateStreams) {
+                return @{ stdout = ''; stderr = 'ssh output drain timed out'; exitCode = -1 }
+            }
             return "ERROR: ssh output drain timed out"
         }
+        if ($SeparateStreams -and -not $errDone) {
+            if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+                Write-DuneLog "Invoke-V6Ssh: stderr drain to $Ip did not finish within ${drainMs}ms after exit; abandoning reader" 'WARN'
+            }
+            return @{ stdout = ''; stderr = 'ssh error drain timed out'; exitCode = -1 }
+        }
         $text = $null
+        $errorText = $null
         try { $text = $outTask.Result } catch { $text = $null }
+        if ($SeparateStreams -and $errDone) {
+            try { $errorText = $errTask.Result } catch { $errorText = $null }
+        }
+        if ($SeparateStreams) {
+            return @{
+                stdout = if ($text) { $text.TrimEnd("`r", "`n") } else { '' }
+                stderr = if ($errorText) { $errorText.TrimEnd("`r", "`n") } else { '' }
+                exitCode = [int]$proc.ExitCode
+            }
+        }
         if ([string]::IsNullOrEmpty($text)) { return }
         # Emit one pipeline item per stdout line — matches the original
         # `& ssh ...` capture semantics so existing callers keep working.

--- a/app/server/lib/Database.ps1
+++ b/app/server/lib/Database.ps1
@@ -134,9 +134,6 @@ function ConvertFrom-DunePsqlCsv {
             message = "Unexpected psql diagnostic in CSV output: $([string]$firstFiltered[0])"
         }
     }
-    # Some psql builds/configurations append a human-readable row-count footer
-    # even in CSV mode. It is transport metadata, never a database row.
-    $filtered = @($filtered | Where-Object { $_ -notmatch '^\(\d+ rows?\)$' })
     # If no lines, nothing to parse
     if (-not $filtered) {
         return @{ ok = $true; columns = @(); rows = @(); rowCount = 0; truncated = $false; message = '' }

--- a/app/server/lib/Database.ps1
+++ b/app/server/lib/Database.ps1
@@ -149,47 +149,48 @@ function ConvertFrom-DunePsqlCsv {
     if ($filtered.Count -eq 1 -and $first -notmatch ',' -and $first -match '^(INSERT|UPDATE|DELETE|SELECT|MERGE|CREATE|DROP|ALTER|TRUNCATE|GRANT|REVOKE|COPY|VACUUM|ANALYZE)\b') {
         return @{ ok = $true; columns = @(); rows = @(); rowCount = 0; truncated = $false; message = $first }
     }
-    # CSV path — try to parse using PowerShell's CSV reader
+    # CSV path — TextFieldParser preserves explicit empty fields and rejects
+    # short/long records, unlike ConvertFrom-Csv which turns both missing and
+    # explicitly empty trailing fields into indistinguishable null values.
     try {
         $csvText = ($filtered -join "`n")
-        $parsed = $csvText | ConvertFrom-Csv
-        if (-not $parsed) {
-            return @{ ok = $true; columns = @(); rows = @(); rowCount = 0; truncated = $false; message = '' }
+        if (-not ('Microsoft.VisualBasic.FileIO.TextFieldParser' -as [type])) {
+            Add-Type -AssemblyName Microsoft.VisualBasic -ErrorAction Stop
         }
-        # Force to array (single-row results come back as a single PSCustomObject)
-        $parsedArr = @($parsed)
-        $cols = @($parsedArr[0].PSObject.Properties.Name)
+        # Windows PowerShell 5.1's TextFieldParser does not return a final
+        # header-only record unless the input ends with a line terminator.
+        $reader = [IO.StringReader]::new("$csvText`n")
+        $parser = [Microsoft.VisualBasic.FileIO.TextFieldParser]::new($reader)
+        $parser.TextFieldType = [Microsoft.VisualBasic.FileIO.FieldType]::Delimited
+        $parser.SetDelimiters(',')
+        $parser.HasFieldsEnclosedInQuotes = $true
+        $cols = @($parser.ReadFields())
         if ($cols.Count -eq 0 -or @($cols | Where-Object { [string]::IsNullOrWhiteSpace([string]$_) }).Count -gt 0) {
             throw 'CSV output has a missing or blank column header.'
         }
         if (@($cols | Sort-Object -Unique).Count -ne $cols.Count) {
             throw 'CSV output has duplicate column headers.'
         }
-        foreach ($obj in $parsedArr) {
-            foreach ($col in $cols) {
-                if ($null -eq $obj.PSObject.Properties[$col].Value) {
-                    throw "CSV output row has fewer fields than the '$col' column header."
-                }
-            }
-        }
         $truncated = $false
-        if ($parsedArr.Count -gt $MaxRows) {
-            $parsedArr = $parsedArr[0..($MaxRows - 1)]
-            $truncated = $true
-        }
         $rows = [System.Collections.Generic.List[object]]::new()
-        foreach ($obj in $parsedArr) {
-            $row = New-Object object[] $cols.Count
-            for ($i = 0; $i -lt $cols.Count; $i++) {
-                $row[$i] = $obj.($cols[$i])
+        while (-not $parser.EndOfData) {
+            $fields = $parser.ReadFields()
+            if ($null -eq $fields) { break }
+            $row = @($fields)
+            if ($row.Count -ne $cols.Count) {
+                throw "CSV output row has $($row.Count) fields but the header has $($cols.Count)."
             }
-            [void]$rows.Add($row)
+            if ($rows.Count -lt $MaxRows) {
+                [void]$rows.Add([object[]]$row)
+            } else {
+                $truncated = $true
+            }
         }
         return @{
             ok        = $true
             columns   = $cols
             rows      = $rows.ToArray()
-            rowCount  = $parsedArr.Count
+            rowCount  = $rows.Count
             truncated = $truncated
             message   = ''
         }
@@ -202,6 +203,9 @@ function ConvertFrom-DunePsqlCsv {
             truncated = $false
             message   = "Parse error: $($_.Exception.Message)"
         }
+    } finally {
+        if ($parser) { $parser.Dispose() }
+        if ($reader) { $reader.Dispose() }
     }
 }
 

--- a/app/server/lib/Database.ps1
+++ b/app/server/lib/Database.ps1
@@ -33,13 +33,18 @@ function Invoke-DuneSqlRaw {
         [string]$Ip,
         [string]$Sql,
         [int]$TimeoutSec = 30,
-        [switch]$Csv
+        [switch]$Csv,
+        [switch]$Detailed
     )
     $pod = Find-V6DbPod -Ip $Ip
     $port = Get-V6DbPort
     $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Sql))
     $flags = if ($Csv) { '-X --csv' } else { '-X -A' }
-    $cmd = "echo $b64 | base64 -d | sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p $port -v ON_ERROR_STOP=1 $flags 2>&1"
+    $redirect = if ($Detailed) { '' } else { ' 2>&1' }
+    $cmd = "echo $b64 | base64 -d | sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p $port -v ON_ERROR_STOP=1 $flags$redirect"
+    if ($Detailed) {
+        return Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec -SeparateStreams
+    }
     $out = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec
     return ($out -join "`n")
 }
@@ -55,7 +60,8 @@ function Invoke-DuneSqlRawStdin {
         [string]$Ip,
         [string]$Sql,
         [int]$TimeoutSec = 30,
-        [switch]$Csv
+        [switch]$Csv,
+        [switch]$Detailed
     )
     $pod = Find-V6DbPod -Ip $Ip
     $port = Get-V6DbPort
@@ -64,7 +70,11 @@ function Invoke-DuneSqlRawStdin {
     # Remote cmd reads base64 bytes off OUR stdin (which Invoke-V6Ssh writes
     # via -StdinData), decodes them, and feeds the SQL into psql. Total
     # remote command length is < 200 chars regardless of payload size.
-    $cmd = "base64 -d | sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p $port -v ON_ERROR_STOP=1 $flags 2>&1"
+    $redirect = if ($Detailed) { '' } else { ' 2>&1' }
+    $cmd = "base64 -d | sudo kubectl exec -i -n $($pod.ns) $($pod.name) -- psql -U dune -d dune -p $port -v ON_ERROR_STOP=1 $flags$redirect"
+    if ($Detailed) {
+        return Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec -StdinData $b64 -SeparateStreams
+    }
     $out = Invoke-V6Ssh -Ip $Ip -Cmd $cmd -TimeoutSec $TimeoutSec -StdinData $b64
     return ($out -join "`n")
 }
@@ -109,16 +119,27 @@ function Get-DunePsqlErrorMessage {
 function ConvertFrom-DunePsqlCsv {
     param([string]$Output, [int]$MaxRows)
     if (-not $Output) {
-        return @{ columns = @(); rows = @(); rowCount = 0; truncated = $false; message = '' }
+        return @{ ok = $true; columns = @(); rows = @(); rowCount = 0; truncated = $false; message = '' }
     }
     $lines = ($Output -split "`r?`n")
     # Strip transaction wrappers if present (BEGIN/ROLLBACK psql tags)
     $filtered = $lines | Where-Object {
         $_ -notmatch '^(BEGIN|COMMIT|ROLLBACK|SET|SAVEPOINT|RELEASE)$' -and $_ -ne ''
     }
+    $firstFiltered = @($filtered | Select-Object -First 1)
+    if ($firstFiltered.Count -and
+        [string]$firstFiltered[0] -match '^(?:psql:|WARNING:|NOTICE:|DETAIL:|HINT:|CONTEXT:)') {
+        return @{
+            ok = $false; columns = @(); rows = @(); rowCount = 0; truncated = $false
+            message = "Unexpected psql diagnostic in CSV output: $([string]$firstFiltered[0])"
+        }
+    }
+    # Some psql builds/configurations append a human-readable row-count footer
+    # even in CSV mode. It is transport metadata, never a database row.
+    $filtered = @($filtered | Where-Object { $_ -notmatch '^\(\d+ rows?\)$' })
     # If no lines, nothing to parse
     if (-not $filtered) {
-        return @{ columns = @(); rows = @(); rowCount = 0; truncated = $false; message = '' }
+        return @{ ok = $true; columns = @(); rows = @(); rowCount = 0; truncated = $false; message = '' }
     }
     # Command-tag-only outputs: "UPDATE 5", "INSERT 0 3", "DELETE 12", "CREATE TABLE"
     # These have no commas in the trivial case and look like a single word + numbers.
@@ -126,18 +147,31 @@ function ConvertFrom-DunePsqlCsv {
     # known command-tag prefix, treat the whole thing as a message.
     $first = ($filtered | Select-Object -First 1)
     if ($filtered.Count -eq 1 -and $first -notmatch ',' -and $first -match '^(INSERT|UPDATE|DELETE|SELECT|MERGE|CREATE|DROP|ALTER|TRUNCATE|GRANT|REVOKE|COPY|VACUUM|ANALYZE)\b') {
-        return @{ columns = @(); rows = @(); rowCount = 0; truncated = $false; message = $first }
+        return @{ ok = $true; columns = @(); rows = @(); rowCount = 0; truncated = $false; message = $first }
     }
     # CSV path — try to parse using PowerShell's CSV reader
     try {
         $csvText = ($filtered -join "`n")
         $parsed = $csvText | ConvertFrom-Csv
         if (-not $parsed) {
-            return @{ columns = @(); rows = @(); rowCount = 0; truncated = $false; message = '' }
+            return @{ ok = $true; columns = @(); rows = @(); rowCount = 0; truncated = $false; message = '' }
         }
         # Force to array (single-row results come back as a single PSCustomObject)
         $parsedArr = @($parsed)
         $cols = @($parsedArr[0].PSObject.Properties.Name)
+        if ($cols.Count -eq 0 -or @($cols | Where-Object { [string]::IsNullOrWhiteSpace([string]$_) }).Count -gt 0) {
+            throw 'CSV output has a missing or blank column header.'
+        }
+        if (@($cols | Sort-Object -Unique).Count -ne $cols.Count) {
+            throw 'CSV output has duplicate column headers.'
+        }
+        foreach ($obj in $parsedArr) {
+            foreach ($col in $cols) {
+                if ($null -eq $obj.PSObject.Properties[$col].Value) {
+                    throw "CSV output row has fewer fields than the '$col' column header."
+                }
+            }
+        }
         $truncated = $false
         if ($parsedArr.Count -gt $MaxRows) {
             $parsedArr = $parsedArr[0..($MaxRows - 1)]
@@ -152,6 +186,7 @@ function ConvertFrom-DunePsqlCsv {
             [void]$rows.Add($row)
         }
         return @{
+            ok        = $true
             columns   = $cols
             rows      = $rows.ToArray()
             rowCount  = $parsedArr.Count
@@ -160,6 +195,7 @@ function ConvertFrom-DunePsqlCsv {
         }
     } catch {
         return @{
+            ok        = $false
             columns   = @()
             rows      = @()
             rowCount  = 0
@@ -193,11 +229,25 @@ function Invoke-DuneSqlQuery {
     # don't fail with "The filename or extension is too long". Use for
     # multi-statement transactions like the Seed Market chunked inserts.
     if ($Bulk) {
-        $raw = Invoke-DuneSqlRawStdin -Ip $Ip -Sql $effective -TimeoutSec $TimeoutSec -Csv
+        $transport = Invoke-DuneSqlRawStdin -Ip $Ip -Sql $effective -TimeoutSec $TimeoutSec -Csv -Detailed
     } else {
-        $raw = Invoke-DuneSqlRaw -Ip $Ip -Sql $effective -TimeoutSec $TimeoutSec -Csv
+        $transport = Invoke-DuneSqlRaw -Ip $Ip -Sql $effective -TimeoutSec $TimeoutSec -Csv -Detailed
     }
     $durationMs = [int](([DateTime]::UtcNow - $start).TotalMilliseconds)
+    $raw = [string]$transport.stdout
+    $stderr = [string]$transport.stderr
+
+    if ([int]$transport.exitCode -ne 0 -or $stderr) {
+        $diagnostic = if ($stderr) { $stderr } else { "psql transport exited with code $([int]$transport.exitCode)." }
+        return @{
+            ok = $false
+            error = Get-DunePsqlErrorMessage -Output $diagnostic
+            raw = $raw
+            stderr = $stderr
+            durationMs = $durationMs
+            readOnly = $ReadOnly
+        }
+    }
 
     if (Test-DunePsqlError -Output $raw) {
         return @{
@@ -210,6 +260,15 @@ function Invoke-DuneSqlQuery {
     }
 
     $parsed = ConvertFrom-DunePsqlCsv -Output $raw -MaxRows $MaxRows
+    if (-not $parsed.ok) {
+        return @{
+            ok = $false
+            error = $parsed.message
+            raw = $raw
+            durationMs = $durationMs
+            readOnly = $ReadOnly
+        }
+    }
     return @{
         ok         = $true
         columns    = $parsed.columns

--- a/app/server/lib/InventoryExplorer.ps1
+++ b/app/server/lib/InventoryExplorer.ps1
@@ -228,6 +228,7 @@ LIMIT $Limit;
 
 function ConvertTo-DuneInventoryItem {
     param([Parameter(Mandatory)]$Row)
+    Assert-DuneInventoryDatabaseRow -Row $Row -Kind item
     $templateId = [string]$Row['template_id']
     $rule = Get-DuneGameplayItemRule -TemplateId $templateId
     $entityType = [string]$Row['entity_type']
@@ -666,6 +667,7 @@ function Get-DuneInventoryQueryParameters {
 
 function ConvertTo-DuneInventoryPlayerFacet {
     param([Parameter(Mandatory)]$Row)
+    Assert-DuneInventoryDatabaseRow -Row $Row -Kind playerFacet
     return [ordered]@{
         id = ConvertTo-DuneInt $Row['player_id']
         name = [string]$Row['player_name']
@@ -678,8 +680,70 @@ function ConvertTo-DuneInventoryBoolean {
     return $Value -eq $true -or [string]$Value -in @('1', 't', 'true')
 }
 
+function Assert-DuneInventoryDatabaseRow {
+    param(
+        [Parameter(Mandatory)]$Row,
+        [Parameter(Mandatory)]
+        [ValidateSet('item', 'group', 'playerFacet', 'locationFacet', 'validity')]
+        [string]$Kind
+    )
+    if ($Row -isnot [Collections.IDictionary]) {
+        throw "Malformed inventory database $Kind row: expected a name-keyed row."
+    }
+
+    $requiredText = switch ($Kind) {
+        'item' { @('template_id', 'entity_type') }
+        'group' { @('group_key', 'template_id', 'sort_name') }
+        'playerFacet' { @('player_name') }
+        'locationFacet' { @('entity_type', 'entity_label') }
+        default { @('player_valid', 'location_valid') }
+    }
+    foreach ($name in $requiredText) {
+        if (-not $Row.Contains($name) -or [string]::IsNullOrWhiteSpace([string]$Row[$name])) {
+            throw "Malformed inventory database $Kind row: '$name' is missing or blank."
+        }
+    }
+
+    $requiredPositive = switch ($Kind) {
+        'item' { @('item_id', 'inventory_id', 'entity_id') }
+        'playerFacet' { @('player_id') }
+        'locationFacet' { @('entity_id') }
+        default { @() }
+    }
+    foreach ($name in $requiredPositive) {
+        $value = 0L
+        if (-not $Row.Contains($name) -or
+            -not [Int64]::TryParse([string]$Row[$name], [ref]$value) -or $value -le 0) {
+            throw "Malformed inventory database $Kind row: '$name' must be a positive integer."
+        }
+    }
+
+    $requiredNonNegative = switch ($Kind) {
+        'item' { @('stack_size', 'quality_level', 'inventory_type') }
+        'group' { @('total_quantity', 'occurrence_count', 'location_count', 'quality_min', 'quality_max') }
+        'playerFacet' { @('occurrence_count') }
+        'locationFacet' { @('occurrence_count') }
+        default { @() }
+    }
+    foreach ($name in $requiredNonNegative) {
+        $value = 0L
+        if (-not $Row.Contains($name) -or
+            -not [Int64]::TryParse([string]$Row[$name], [ref]$value) -or $value -lt 0) {
+            throw "Malformed inventory database $Kind row: '$name' must be a non-negative integer."
+        }
+    }
+
+    if ($Kind -eq 'item' -and [string]$Row['entity_type'] -notin @('player', 'storage')) {
+        throw "Malformed inventory database item row: 'entity_type' is unsupported."
+    }
+    if ($Kind -eq 'locationFacet' -and [string]$Row['entity_type'] -notin @('player', 'storage')) {
+        throw "Malformed inventory database locationFacet row: 'entity_type' is unsupported."
+    }
+}
+
 function ConvertTo-DuneInventoryGroup {
     param([Parameter(Mandatory)]$Row)
+    Assert-DuneInventoryDatabaseRow -Row $Row -Kind group
     $templateId = [string]$Row['template_id']
     $rule = Get-DuneGameplayItemRule -TemplateId $templateId
     $qualityMin = ConvertTo-DuneInt $Row['quality_min']
@@ -703,6 +767,17 @@ function ConvertTo-DuneInventoryGroup {
             icon = [string]$rule.icon; stackMaximum = [int]$rule.stack_max; volume = [double]$rule.volume
             vendorPrice = [int]$rule.vendor_price; isGradeable = [bool]$rule.is_gradeable
         }
+    }
+}
+
+function ConvertTo-DuneInventoryLocationFacet {
+    param([Parameter(Mandatory)]$Row)
+    Assert-DuneInventoryDatabaseRow -Row $Row -Kind locationFacet
+    return [ordered]@{
+        type = [string]$Row['entity_type']; id = ConvertTo-DuneInt $Row['entity_id']
+        label = [string]$Row['entity_label']; owner = [string]$Row['owner_name']
+        playerId = ConvertTo-DuneInt $Row['player_id']; playerName = [string]$Row['player_name']
+        occurrenceCount = ConvertTo-DuneInt $Row['occurrence_count']
     }
 }
 
@@ -731,7 +806,8 @@ function Get-DuneInventoryDemoPlayerId {
     if ([string]$Item.entity.type -eq 'player') { return [long]$Item.entity.id }
     $owner = [string]$Item.entity.owner
     $player = @(Get-DunePlayersDemo | Where-Object { [string]$_.name -eq $owner } | Select-Object -First 1)
-    return if ($player.Count) { [long]$player[0].id } else { 0L }
+    if ($player.Count) { return [long]$player[0].id }
+    return 0L
 }
 
 function Add-DuneInventoryDemoPlayer {
@@ -1010,19 +1086,30 @@ FROM _dst_parameters p
         -Sql (New-DuneInventoryParameterizedSql -Sql $validitySql -Parameters $binding.values -ParameterTypes $binding.types) `
         -ReadOnly $true -MaxRows 1 -TimeoutSec 45 -Bulk
     if (-not $validityResult.ok) { return @{ ok = $false; error = $validityResult.error } }
-    $validity = @(ConvertTo-DuneRowMaps -Result $validityResult)[0]
+    try {
+        $validityRows = ConvertTo-DuneRowMaps -Result $validityResult
+        if ($validityRows.Count -ne 1) {
+            throw "Malformed inventory database validity result: expected one row, received $($validityRows.Count)."
+        }
+        $validity = $validityRows[0]
+        Assert-DuneInventoryDatabaseRow -Row $validity -Kind validity
+        $groups = @(foreach ($row in (ConvertTo-DuneRowMaps -Result $groupResult)) {
+            ConvertTo-DuneInventoryGroup -Row $row
+        })
+        $players = @(foreach ($row in (ConvertTo-DuneRowMaps -Result $facetResult)) {
+            ConvertTo-DuneInventoryPlayerFacet -Row $row
+        })
+        $locations = @(foreach ($row in (ConvertTo-DuneRowMaps -Result $locationResult)) {
+            ConvertTo-DuneInventoryLocationFacet -Row $row
+        })
+    } catch {
+        return @{ ok = $false; error = $_.Exception.Message }
+    }
     return @{
         ok = $true
-        groups = @(ConvertTo-DuneRowMaps -Result $groupResult | ForEach-Object { ConvertTo-DuneInventoryGroup -Row $_ })
-        players = @(ConvertTo-DuneRowMaps -Result $facetResult | ForEach-Object { ConvertTo-DuneInventoryPlayerFacet -Row $_ })
-        locations = @(ConvertTo-DuneRowMaps -Result $locationResult | ForEach-Object {
-            [ordered]@{
-                type = [string]$_['entity_type']; id = ConvertTo-DuneInt $_['entity_id']
-                label = [string]$_['entity_label']; owner = [string]$_['owner_name']
-                playerId = ConvertTo-DuneInt $_['player_id']; playerName = [string]$_['player_name']
-                occurrenceCount = ConvertTo-DuneInt $_['occurrence_count']
-            }
-        })
+        groups = $groups
+        players = $players
+        locations = $locations
         selectedPlayerValid = ConvertTo-DuneInventoryBoolean $validity['player_valid']
         selectedLocationValid = ConvertTo-DuneInventoryBoolean $validity['location_valid']
     }
@@ -1138,11 +1225,27 @@ ORDER BY $($sortSpec.sql) LIMIT (SELECT row_limit FROM _dst_parameters)
     $effectiveSql = New-DuneInventoryParameterizedSql -Sql $sql -Parameters $binding.values -ParameterTypes $binding.types
     $result = Invoke-DuneSqlQuery -Ip $Ip -Sql $effectiveSql -ReadOnly $true -MaxRows $Limit -TimeoutSec 45 -Bulk
     if (-not $result.ok) { return @{ ok = $false; error = $result.error } }
-    $items = @(ConvertTo-DuneRowMaps -Result $result | ForEach-Object {
-        $item = ConvertTo-DuneInventoryItem -Row $_
-        $item['player'] = [ordered]@{ id = ConvertTo-DuneInt $_['player_id']; name = [string]$_['player_name'] }
-        $item
-    } | Where-Object { Test-DuneInventoryVisibleItem -Item $_ })
+    try {
+        $items = @(foreach ($row in (ConvertTo-DuneRowMaps -Result $result)) {
+            $item = ConvertTo-DuneInventoryItem -Row $row
+            $playerIdValue = ConvertTo-DuneInt $row['player_id']
+            $playerName = [string]$row['player_name']
+            $hasPlayerId = $playerIdValue -gt 0
+            $hasPlayerName = -not [string]::IsNullOrWhiteSpace($playerName)
+            if ([string]$item.entity.type -eq 'player' -and (-not $hasPlayerId -or -not $hasPlayerName)) {
+                throw "Malformed inventory database item row: player identity is missing."
+            }
+            if ([string]$item.entity.type -eq 'storage' -and $hasPlayerId -ne $hasPlayerName) {
+                throw "Malformed inventory database item row: storage player identity is incomplete."
+            }
+            if ($hasPlayerId) {
+                $item['player'] = [ordered]@{ id = $playerIdValue; name = $playerName }
+            }
+            if (Test-DuneInventoryVisibleItem -Item $item) { $item }
+        })
+    } catch {
+        return @{ ok = $false; error = $_.Exception.Message }
+    }
     $facetSql = @"
 WITH $cte,
 template_rows AS (
@@ -1174,16 +1277,15 @@ GROUP BY t.entity_type, t.entity_id ORDER BY t.entity_type, entity_label, t.enti
         -Sql (New-DuneInventoryParameterizedSql -Sql $locationSql -Parameters $binding.values -ParameterTypes $binding.types) `
         -ReadOnly $true -MaxRows 1000 -TimeoutSec 45 -Bulk
     if (-not $locationResult.ok) { return @{ ok = $false; error = $locationResult.error } }
-    return @{
-        ok = $true; items = $items
-        players = @(ConvertTo-DuneRowMaps -Result $facetResult | ForEach-Object { ConvertTo-DuneInventoryPlayerFacet -Row $_ })
-        locations = @(ConvertTo-DuneRowMaps -Result $locationResult | ForEach-Object {
-            [ordered]@{
-                type = [string]$_['entity_type']; id = ConvertTo-DuneInt $_['entity_id']
-                label = [string]$_['entity_label']; owner = [string]$_['owner_name']
-                playerId = ConvertTo-DuneInt $_['player_id']; playerName = [string]$_['player_name']
-                occurrenceCount = ConvertTo-DuneInt $_['occurrence_count']
-            }
+    try {
+        $players = @(foreach ($row in (ConvertTo-DuneRowMaps -Result $facetResult)) {
+            ConvertTo-DuneInventoryPlayerFacet -Row $row
         })
+        $locations = @(foreach ($row in (ConvertTo-DuneRowMaps -Result $locationResult)) {
+            ConvertTo-DuneInventoryLocationFacet -Row $row
+        })
+    } catch {
+        return @{ ok = $false; error = $_.Exception.Message }
     }
+    return @{ ok = $true; items = $items; players = $players; locations = $locations }
 }

--- a/app/server/routes/Inventory.ps1
+++ b/app/server/routes/Inventory.ps1
@@ -195,12 +195,16 @@ Register-DuneRoute -Method GET -Path '/api/v1/inventory/items' -Handler {
     }
 }
 
-# GET /api/v1/inventory/items/{templateId}/occurrences
+# GET /api/v1/inventory/items/occurrences?template_id={templateId}
 # Lazy, bounded occurrence detail for a grouped inventory item.
-Register-DuneRoute -Method GET -Path '/api/v1/inventory/items/{templateId}/occurrences' -Handler {
+$script:DuneInventoryOccurrencesHandler = {
     param($req, $res, $routeParams, $body)
     try {
-        $templateId = [Uri]::UnescapeDataString([string]$routeParams.templateId).Trim()
+        $templateId = if ([string]$routeParams.templateId) {
+            [Uri]::UnescapeDataString([string]$routeParams.templateId).Trim()
+        } else {
+            (Get-DuneQ $req 'template_id').Trim()
+        }
         if (-not $templateId -or $templateId.Length -gt 240 -or $templateId -notmatch '^[A-Za-z0-9_.:/-]+$') {
             Write-DuneError -Response $res -Status 400 -Message 'templateId is invalid.'
             return
@@ -267,6 +271,7 @@ Register-DuneRoute -Method GET -Path '/api/v1/inventory/items/{templateId}/occur
                 return
             }
         }
+
         $requestedMode = Resolve-DuneInventoryRequestedMode `
             -DemoRequested (Test-DuneDemoRequested $req) -CursorMode $cursorMode
         if (-not $requestedMode.ok) {
@@ -339,3 +344,7 @@ Register-DuneRoute -Method GET -Path '/api/v1/inventory/items/{templateId}/occur
         Write-DuneError -Response $res -Status 500 -Message "Inventory occurrence search failed: $($_.Exception.Message)"
     }
 }
+
+Register-DuneRoute -Method GET -Path '/api/v1/inventory/items/occurrences' -Handler $script:DuneInventoryOccurrencesHandler
+# Compatibility for the first grouped-explorer client build.
+Register-DuneRoute -Method GET -Path '/api/v1/inventory/items/{templateId}/occurrences' -Handler $script:DuneInventoryOccurrencesHandler

--- a/tests/InventoryExplorer.Tests.ps1
+++ b/tests/InventoryExplorer.Tests.ps1
@@ -548,7 +548,7 @@ Describe 'Shared Inventory Explorer read model' -Tag 'Pure' {
     }
 
     It 'executes every generated live query against a disposable PostgreSQL schema' `
-        -Skip:(-not $env:DST_TEST_POSTGRES_PSQL) {
+        -Skip:(-not $env:DST_TEST_POSTGRES_PSQL -or -not $env:DST_TEST_POSTGRES_DATABASE) {
         $queries = @(Get-DuneInventoryLiveSqlVariants)
         $fixture = @"
 \set ON_ERROR_STOP on
@@ -610,13 +610,22 @@ INSERT INTO dune.items (id, template_id, stack_size, quality_level, stats, inven
         $sql = $fixture + "`n" + (($queries | ForEach-Object { "$_;"} ) -join "`n") + "`nROLLBACK;"
         Set-Content -LiteralPath $scriptPath -Value $sql -Encoding utf8
 
-        & $env:DST_TEST_POSTGRES_PSQL -X -q -f $scriptPath 2>&1 | Out-String | Write-Verbose
+        & $env:DST_TEST_POSTGRES_PSQL -X -q -d $env:DST_TEST_POSTGRES_DATABASE -f $scriptPath 2>&1 |
+            Out-String | Write-Verbose
 
         $LASTEXITCODE | Should -Be 0
     }
 
     It 'returns seeded PostgreSQL groups and occurrences through production conversion semantics' `
-        -Skip:(-not $env:DST_TEST_POSTGRES_PSQL) {
+        -Skip:(-not $env:DST_TEST_POSTGRES_PSQL -or -not $env:DST_TEST_POSTGRES_DATABASE) {
+        if ($env:DST_TEST_POSTGRES_DATABASE -notmatch '^dst_inventory(?:_[A-Za-z0-9_-]+)?$') {
+            throw 'DST_TEST_POSTGRES_DATABASE must name an explicit disposable dst_inventory database.'
+        }
+        $databaseName = (& $env:DST_TEST_POSTGRES_PSQL -X -q -A -t `
+            -d $env:DST_TEST_POSTGRES_DATABASE -c 'SELECT current_database();' 2>&1 | Out-String).Trim()
+        if ($LASTEXITCODE -ne 0 -or $databaseName -ne $env:DST_TEST_POSTGRES_DATABASE) {
+            throw 'The configured disposable PostgreSQL database could not be verified.'
+        }
         $setupPath = Join-Path $TestDrive 'inventory-semantic-setup.sql'
         $setup = @"
 \set ON_ERROR_STOP on
@@ -665,7 +674,8 @@ INSERT INTO dune.items (id, template_id, stack_size, quality_level, stats, inven
     (7, 'HarkSandbike_MeshCustomization', 2, 0, '{}'::jsonb, 60002);
 "@
         Set-Content -LiteralPath $setupPath -Value $setup -Encoding utf8
-        & $env:DST_TEST_POSTGRES_PSQL -X -q -f $setupPath 2>&1 | Out-String | Write-Verbose
+        & $env:DST_TEST_POSTGRES_PSQL -X -q -d $env:DST_TEST_POSTGRES_DATABASE -f $setupPath 2>&1 |
+            Out-String | Write-Verbose
         $LASTEXITCODE | Should -Be 0
 
         $existing = Get-Command Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
@@ -678,7 +688,8 @@ INSERT INTO dune.items (id, template_id, stack_size, quality_level, stats, inven
             $queryPath = Join-Path $TestDrive "inventory-semantic-$($script:InventorySemanticQueryIndex).sql"
             $effective = if ($ReadOnly) { Wrap-DuneReadOnlySql -Sql $Sql } else { $Sql }
             Set-Content -LiteralPath $queryPath -Value $effective -Encoding utf8
-            $raw = (& $env:DST_TEST_POSTGRES_PSQL -X --csv -v ON_ERROR_STOP=1 -f $queryPath 2>&1) -join "`n"
+            $raw = (& $env:DST_TEST_POSTGRES_PSQL -X --csv -v ON_ERROR_STOP=1 `
+                -d $env:DST_TEST_POSTGRES_DATABASE -f $queryPath 2>&1) -join "`n"
             if ($LASTEXITCODE -ne 0 -or (Test-DunePsqlError -Output $raw)) {
                 return @{ ok = $false; error = (Get-DunePsqlErrorMessage -Output $raw) }
             }
@@ -793,7 +804,8 @@ INSERT INTO dune.items (id, template_id, stack_size, quality_level, stats, inven
             } else {
                 Remove-Item Function:\global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
             }
-            & $env:DST_TEST_POSTGRES_PSQL -X -q -c 'DROP SCHEMA IF EXISTS dune CASCADE;' 2>&1 | Out-Null
+            & $env:DST_TEST_POSTGRES_PSQL -X -q -d $env:DST_TEST_POSTGRES_DATABASE `
+                -c 'DROP SCHEMA IF EXISTS dune CASCADE;' 2>&1 | Out-Null
         }
     }
 

--- a/tests/InventoryExplorer.Tests.ps1
+++ b/tests/InventoryExplorer.Tests.ps1
@@ -765,7 +765,8 @@ INSERT INTO dune.items (id, template_id, stack_size, quality_level, stats, inven
                 $occurrences.ok | Should -BeTrue -Because ([string]$occurrences.error)
                 @($occurrences.items).Count | Should -Be 4
                 @($occurrences.items | Where-Object { -not $_.templateId -or -not $_.player.name }).Count | Should -Be 0
-                (($occurrences.items | Measure-Object quantity -Sum).Sum) | Should -Be 36
+                (($occurrences.items | ForEach-Object { [long]$_['quantity'] } |
+                    Measure-Object -Sum).Sum) | Should -Be 36
 
                 $firstOccurrencePage = Invoke-DuneInventoryOccurrencesLive -Ip fixture -TemplateId Copper `
                     -EntityTypes @('player', 'storage') -Sort $sort -Limit 1

--- a/tests/InventoryExplorer.Tests.ps1
+++ b/tests/InventoryExplorer.Tests.ps1
@@ -1,5 +1,6 @@
 BeforeAll {
     . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'Database.ps1'
     Import-DstLib 'ApiContract.ps1'
     Import-DstLib 'Gameplay.ps1'
     Import-DstLib 'GameplayPlayers.ps1'
@@ -21,6 +22,13 @@ BeforeAll {
         function global:Invoke-DuneSqlQuery {
             param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec, [switch]$Bulk)
             $captured.Add([string]$Sql)
+            if ($Sql -match 'AS player_valid') {
+                return @{
+                    ok = $true
+                    columns = @('player_valid', 'location_valid')
+                    rows = @(,@('t', 't'))
+                }
+            }
             return @{ ok = $true; columns = @(); rows = @() }
         }
         try {
@@ -34,13 +42,13 @@ BeforeAll {
                 $result = Invoke-DuneInventoryGroupedLive -Ip 'fixture' -Query '[' `
                     -EntityTypes @('player', 'storage') -PlayerId 20001 `
                     -LocationType storage -LocationId 50001 -Sort $sort -Limit 2
-                if (-not $result.ok) { throw "Grouped SQL generation failed for $sort." }
+                if (-not $result.ok) { throw "Grouped SQL generation failed for $sort`: $([string]$result.error)" }
                 $result = Invoke-DuneInventoryGroupedLive -Ip 'fixture' -Query '[' `
                     -EntityTypes @('player', 'storage') -PlayerId 20001 `
                     -LocationType storage -LocationId 50001 -Sort $sort `
                     -AfterSortValue '1' -AfterSortSecondary '0' `
                     -AfterSortName 'copper' -AfterTemplateId 'Copper' -Limit 2
-                if (-not $result.ok) { throw "Grouped cursor SQL generation failed for $sort." }
+                if (-not $result.ok) { throw "Grouped cursor SQL generation failed for $sort`: $([string]$result.error)" }
             }
 
             $occurrenceSorts = @(
@@ -124,6 +132,65 @@ Describe 'Shared Inventory Explorer read model' -Tag 'Pure' {
         $item.entity.owner | Should -Be 'Stilgar'
         $item.entity.workspacePath | Should -Be '/bases?view=inventory&scope_type=storage&scope_id=50001'
         $item.metadata.Keys | Should -Contain 'category'
+    }
+
+    It 'rejects malformed grouped and occurrence rows instead of emitting blank DTOs' {
+        {
+            ConvertTo-DuneInventoryGroup -Row @{
+                group_key = ''; template_id = ''; total_quantity = $null
+            }
+        } | Should -Throw '*Malformed inventory database group row*'
+        {
+            ConvertTo-DuneInventoryItem -Row @{
+                item_id = ''; template_id = ''; entity_type = ''
+            }
+        } | Should -Throw '*Malformed inventory database item row*'
+    }
+
+    It 'allows storage occurrences whose owner player cannot be proven' {
+        $originalRules = $script:DuneGameplayItemRules
+        try {
+            $script:DuneGameplayItemRules = @{ Copper = @{ category = 'Resources' } }
+            $script:UnownedStorageRow = @{
+                item_id = '42'; template_id = 'Copper'; stack_size = '3'; quality_level = '0'
+                durability = 'N/A'; max_durability = 'N/A'; water_amount = 'N/A'; water_type = ''
+                inventory_id = '60001'; inventory_type = '4'; entity_type = 'storage'; entity_id = '50001'
+                entity_label = 'Unclaimed cache'; owner_name = ''; map = ''; entity_class = 'BP_Cache_C'
+                player_id = ''; player_name = ''
+            }
+            function global:Invoke-DuneSqlQuery {
+                param($Ip, $Sql)
+                if ($Sql -match 'SELECT r\.item_id') {
+                    $row = $script:UnownedStorageRow
+                    return @{
+                        ok = $true
+                        columns = @($row.Keys)
+                        rows = @(,(@($row.Keys | ForEach-Object { $row[$_] })))
+                    }
+                }
+                if ($Sql -match 'SELECT t\.entity_type') {
+                    return @{
+                        ok = $true
+                        columns = @('entity_type','entity_id','entity_label','owner_name','player_id','player_name','occurrence_count')
+                        rows = @(,@('storage','50001','Unclaimed cache','','','','1'))
+                    }
+                }
+                return @{
+                    ok = $true
+                    columns = @('player_id','player_name','occurrence_count')
+                    rows = @()
+                }
+            }
+            $result = Invoke-DuneInventoryOccurrencesLive -Ip fixture -TemplateId Copper `
+                -EntityTypes @('storage') -Limit 10
+            $result.ok | Should -BeTrue -Because ([string]$result.error)
+            @($result.items).Count | Should -Be 1
+            $result.items[0].Contains('player') | Should -BeFalse
+        } finally {
+            $script:DuneGameplayItemRules = $originalRules
+            Remove-Variable -Name UnownedStorageRow -Scope Script -ErrorAction SilentlyContinue
+            Remove-Item Function:\global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+        }
     }
 
     It 'normalizes unnamed live storage labels while preserving the raw class' {
@@ -502,6 +569,42 @@ CREATE TABLE dune.actor_fgl_entities (actor_id bigint, entity_id bigint);
 CREATE TABLE dune.permission_actor_rank (
     permission_actor_id bigint, player_id bigint, rank integer
 );
+INSERT INTO dune.actors (id, map, owner_account_id) VALUES
+    (20001, 'Hagga Basin', 30001),
+    (20002, 'Hagga Basin', 30002),
+    (20003, 'Deep Desert', 30003),
+    (50001, 'Hagga Basin', NULL),
+    (50002, 'Deep Desert', NULL);
+INSERT INTO dune.player_state (player_pawn_id, character_name, account_id) VALUES
+    (20001, 'Coastal', 30001),
+    (20002, 'Chani', 30002),
+    (20003, 'Stilgar', 30003);
+INSERT INTO dune.inventories (id, inventory_type, actor_id) VALUES
+    (60001, 0, 20001),
+    (60002, 0, 20002),
+    (60003, 0, 20003),
+    (61001, 4, 50001),
+    (61002, 4, 50002);
+INSERT INTO dune.placeables (id, building_type, is_hologram, owner_entity_id) VALUES
+    (50001, 'BP_GenericContainer_C', false, 90001),
+    (50002, 'Developer_StorageContainer_Placeable', false, 90002);
+INSERT INTO dune.permission_actor (actor_id, actor_name) VALUES
+    (50001, 'Copper Vault'),
+    (50002, 'Named Reserve');
+INSERT INTO dune.actor_fgl_entities (actor_id, entity_id) VALUES
+    (70001, 90001),
+    (70002, 90002);
+INSERT INTO dune.permission_actor_rank (permission_actor_id, player_id, rank) VALUES
+    (70001, 20003, 1),
+    (70002, 20001, 1);
+INSERT INTO dune.items (id, template_id, stack_size, quality_level, stats, inventory_id) VALUES
+    (1, 'Copper', 5, 0, '{}'::jsonb, 60001),
+    (2, 'Copper', 7, 2, '{}'::jsonb, 60002),
+    (3, 'Copper', 11, 1, '{}'::jsonb, 61001),
+    (4, 'Copper', 13, 3, '{}'::jsonb, 61002),
+    (5, 'Iron', 4, 1, '{}'::jsonb, 60003),
+    (6, 'D_TestEmote', 1, 0, '{}'::jsonb, 60001),
+    (7, 'HarkSandbike_MeshCustomization', 2, 0, '{}'::jsonb, 60002);
 "@
         $scriptPath = Join-Path $TestDrive 'inventory-explorer-postgres.sql'
         $sql = $fixture + "`n" + (($queries | ForEach-Object { "$_;"} ) -join "`n") + "`nROLLBACK;"
@@ -510,6 +613,188 @@ CREATE TABLE dune.permission_actor_rank (
         & $env:DST_TEST_POSTGRES_PSQL -X -q -f $scriptPath 2>&1 | Out-String | Write-Verbose
 
         $LASTEXITCODE | Should -Be 0
+    }
+
+    It 'returns seeded PostgreSQL groups and occurrences through production conversion semantics' `
+        -Skip:(-not $env:DST_TEST_POSTGRES_PSQL) {
+        $setupPath = Join-Path $TestDrive 'inventory-semantic-setup.sql'
+        $setup = @"
+\set ON_ERROR_STOP on
+DROP SCHEMA IF EXISTS dune CASCADE;
+CREATE SCHEMA dune;
+CREATE TABLE dune.items (
+    id bigint, template_id text, stack_size integer, quality_level integer,
+    stats jsonb, inventory_id bigint
+);
+CREATE TABLE dune.inventories (id bigint, inventory_type integer, actor_id bigint);
+CREATE TABLE dune.player_state (player_pawn_id bigint, character_name text, account_id bigint);
+CREATE TABLE dune.actors (id bigint, map text, owner_account_id bigint);
+CREATE TABLE dune.placeables (
+    id bigint, building_type text, is_hologram boolean, owner_entity_id bigint
+);
+CREATE TABLE dune.permission_actor (actor_id bigint, actor_name text);
+CREATE TABLE dune.actor_fgl_entities (actor_id bigint, entity_id bigint);
+CREATE TABLE dune.permission_actor_rank (
+    permission_actor_id bigint, player_id bigint, rank integer
+);
+INSERT INTO dune.actors (id, map, owner_account_id) VALUES
+    (20001, 'Hagga Basin', 30001), (20002, 'Hagga Basin', 30002),
+    (20003, 'Deep Desert', 30003), (50001, 'Hagga Basin', NULL),
+    (50002, 'Deep Desert', NULL);
+INSERT INTO dune.player_state (player_pawn_id, character_name, account_id) VALUES
+    (20001, 'Coastal', 30001), (20002, 'Chani', 30002), (20003, 'Stilgar', 30003);
+INSERT INTO dune.inventories (id, inventory_type, actor_id) VALUES
+    (60001, 0, 20001), (60002, 0, 20002), (60003, 0, 20003),
+    (61001, 4, 50001), (61002, 4, 50002);
+INSERT INTO dune.placeables (id, building_type, is_hologram, owner_entity_id) VALUES
+    (50001, 'BP_GenericContainer_C', false, 90001),
+    (50002, 'Developer_StorageContainer_Placeable', false, 90002);
+INSERT INTO dune.permission_actor (actor_id, actor_name) VALUES
+    (50001, 'Copper Vault'), (50002, 'Named Reserve');
+INSERT INTO dune.actor_fgl_entities (actor_id, entity_id) VALUES
+    (70001, 90001), (70002, 90002);
+INSERT INTO dune.permission_actor_rank (permission_actor_id, player_id, rank) VALUES
+    (70001, 20003, 1), (70002, 20001, 1);
+INSERT INTO dune.items (id, template_id, stack_size, quality_level, stats, inventory_id) VALUES
+    (1, 'Copper', 5, 0, '{}'::jsonb, 60001),
+    (2, 'Copper', 7, 2, '{}'::jsonb, 60002),
+    (3, 'Copper', 11, 1, '{}'::jsonb, 61001),
+    (4, 'Copper', 13, 3, '{}'::jsonb, 61002),
+    (5, 'Iron', 4, 1, '{}'::jsonb, 60003),
+    (6, 'D_TestEmote', 1, 0, '{}'::jsonb, 60001),
+    (7, 'HarkSandbike_MeshCustomization', 2, 0, '{}'::jsonb, 60002);
+"@
+        Set-Content -LiteralPath $setupPath -Value $setup -Encoding utf8
+        & $env:DST_TEST_POSTGRES_PSQL -X -q -f $setupPath 2>&1 | Out-String | Write-Verbose
+        $LASTEXITCODE | Should -Be 0
+
+        $existing = Get-Command Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+        $originalNames = $script:DuneGameplayItemNames
+        $originalRules = $script:DuneGameplayItemRules
+        $script:InventorySemanticQueryIndex = 0
+        function global:Invoke-DuneSqlQuery {
+            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec, [switch]$Bulk)
+            $script:InventorySemanticQueryIndex += 1
+            $queryPath = Join-Path $TestDrive "inventory-semantic-$($script:InventorySemanticQueryIndex).sql"
+            $effective = if ($ReadOnly) { Wrap-DuneReadOnlySql -Sql $Sql } else { $Sql }
+            Set-Content -LiteralPath $queryPath -Value $effective -Encoding utf8
+            $raw = (& $env:DST_TEST_POSTGRES_PSQL -X --csv -v ON_ERROR_STOP=1 -f $queryPath 2>&1) -join "`n"
+            if ($LASTEXITCODE -ne 0 -or (Test-DunePsqlError -Output $raw)) {
+                return @{ ok = $false; error = (Get-DunePsqlErrorMessage -Output $raw) }
+            }
+            $parsed = ConvertFrom-DunePsqlCsv -Output $raw -MaxRows $MaxRows
+            if (-not $parsed.ok) {
+                return @{ ok = $false; error = $parsed.message }
+            }
+            return @{
+                ok = $true; columns = $parsed.columns; rows = $parsed.rows
+                rowCount = $parsed.rowCount; truncated = $parsed.truncated
+            }
+        }
+        try {
+            $script:DuneGameplayItemNames = @{
+                Copper = 'Copper'
+                Iron = 'Iron'
+                HarkSandbike_MeshCustomization = 'Harkonnen Sandbike Mesh'
+            }
+            $script:DuneGameplayItemRules = @{
+                Copper = @{ category='Resources'; tier=1; rarity='Common'; icon=''; stack_max=100; volume=0.1; vendor_price=1; is_gradeable=$false }
+                Iron = @{ category='Resources'; tier=2; rarity='Common'; icon=''; stack_max=100; volume=0.2; vendor_price=2; is_gradeable=$false }
+            }
+            foreach ($sort in @(
+                'name-asc', 'name-desc', 'quantity-asc', 'quantity-desc',
+                'unit-volume-asc', 'unit-volume-desc', 'total-volume-asc', 'total-volume-desc',
+                'tier-asc', 'tier-desc', 'quality-asc', 'quality-desc',
+                'occurrences-asc', 'occurrences-desc', 'locations-asc', 'locations-desc'
+            )) {
+                $grouped = Invoke-DuneInventoryGroupedLive -Ip fixture -EntityTypes @('player', 'storage') -Sort $sort -Limit 20
+                $grouped.ok | Should -BeTrue -Because ([string]$grouped.error)
+                @($grouped.groups | Where-Object { -not $_.templateId -or -not $_.displayName }).Count | Should -Be 0
+                $copper = @($grouped.groups | Where-Object templateId -eq 'Copper')[0]
+                $copper.displayName | Should -Be 'Copper'
+                $copper.totalQuantity | Should -Be 36
+                $copper.occurrenceCount | Should -Be 4
+                $copper.locationCount | Should -Be 4
+                $copper.quality.min | Should -Be 0
+                $copper.quality.max | Should -Be 3
+                $copper.quality.mixed | Should -BeTrue
+                @($grouped.groups | Where-Object templateId -eq 'D_TestEmote').Count | Should -Be 0
+                @($grouped.groups | Where-Object templateId -eq 'HarkSandbike_MeshCustomization').Count | Should -Be 1
+                @($grouped.players).Count | Should -Be 3
+                @($grouped.locations | Where-Object label -eq 'Copper Vault').Count | Should -Be 1
+
+                $firstPage = Invoke-DuneInventoryGroupedLive -Ip fixture -EntityTypes @('player', 'storage') `
+                    -Sort $sort -Limit 1
+                $first = $firstPage.groups[0]
+                $nextPage = Invoke-DuneInventoryGroupedLive -Ip fixture -EntityTypes @('player', 'storage') `
+                    -Sort $sort -AfterSortValue $first.cursor.sortValue `
+                    -AfterSortSecondary $first.cursor.sortSecondary -AfterSortName $first.cursor.sortName `
+                    -AfterTemplateId $first.templateId -Limit 1
+                $nextPage.ok | Should -BeTrue -Because ([string]$nextPage.error)
+                $nextPage.groups[0].templateId | Should -Not -Be $first.templateId
+            }
+
+            $storage = Invoke-DuneInventoryGroupedLive -Ip fixture -EntityTypes @('player', 'storage') `
+                -PlayerId 20003 -LocationType storage -LocationId 50001 -Limit 20
+            $storage.groups[0].templateId | Should -Be 'Copper'
+            $storage.groups[0].totalQuantity | Should -Be 11
+            $playerOnly = Invoke-DuneInventoryGroupedLive -Ip fixture -EntityTypes @('player') -Limit 20
+            @($playerOnly.groups | Where-Object templateId -eq 'Copper')[0].totalQuantity | Should -Be 12
+            $namesOnly = Invoke-DuneInventoryGroupedLive -Ip fixture -Query 'Harkonnen Sandbike Mesh' `
+                -EntityTypes @('player', 'storage') -Limit 20
+            @($namesOnly.groups).Count | Should -Be 1
+            $namesOnly.groups[0].templateId | Should -Be 'HarkSandbike_MeshCustomization'
+
+            foreach ($sort in @(
+                'player-asc', 'player-desc', 'location-asc', 'location-desc',
+                'quantity-asc', 'quantity-desc', 'quality-asc', 'quality-desc'
+            )) {
+                $occurrences = Invoke-DuneInventoryOccurrencesLive -Ip fixture -TemplateId Copper `
+                    -EntityTypes @('player', 'storage') -Sort $sort -Limit 20
+                $occurrences.ok | Should -BeTrue -Because ([string]$occurrences.error)
+                @($occurrences.items).Count | Should -Be 4
+                @($occurrences.items | Where-Object { -not $_.templateId -or -not $_.player.name }).Count | Should -Be 0
+                (($occurrences.items | Measure-Object quantity -Sum).Sum) | Should -Be 36
+
+                $firstOccurrencePage = Invoke-DuneInventoryOccurrencesLive -Ip fixture -TemplateId Copper `
+                    -EntityTypes @('player', 'storage') -Sort $sort -Limit 1
+                $firstOccurrence = $firstOccurrencePage.items[0]
+                $afterSortValue = switch -Wildcard ($sort) {
+                    'player-*' { [string]$firstOccurrence.player.name }
+                    'location-*' { [string]$firstOccurrence.entity.label }
+                    'quantity-*' { [string]$firstOccurrence.quantity }
+                    'quality-*' { [string]$firstOccurrence.quality }
+                }
+                $nextOccurrencePage = Invoke-DuneInventoryOccurrencesLive -Ip fixture -TemplateId Copper `
+                    -EntityTypes @('player', 'storage') -Sort $sort `
+                    -AfterSortValue $afterSortValue.ToLowerInvariant() -AfterItemId $firstOccurrence.id -Limit 1
+                $nextOccurrencePage.ok | Should -BeTrue -Because ([string]$nextOccurrencePage.error)
+                $nextOccurrencePage.items[0].id | Should -Not -Be $firstOccurrence.id
+            }
+            $filteredOccurrences = Invoke-DuneInventoryOccurrencesLive -Ip fixture -TemplateId Copper `
+                -EntityTypes @('player', 'storage') -PlayerId 20003 `
+                -LocationType storage -LocationId 50001 -Limit 20
+            @($filteredOccurrences.items).Count | Should -Be 1
+            $filteredOccurrences.items[0].quantity | Should -Be 11
+
+            $empty = Invoke-DuneInventoryGroupedLive -Ip fixture -Query 'does-not-exist' `
+                -EntityTypes @('player', 'storage') -Sort name-asc -Limit 20
+            $empty.ok | Should -BeTrue
+            @($empty.groups).Count | Should -Be 0
+            $emptyOccurrence = Invoke-DuneInventoryOccurrencesLive -Ip fixture -TemplateId Missing `
+                -EntityTypes @('player', 'storage') -Limit 20
+            $emptyOccurrence.ok | Should -BeTrue
+            @($emptyOccurrence.items).Count | Should -Be 0
+        } finally {
+            $script:DuneGameplayItemNames = $originalNames
+            $script:DuneGameplayItemRules = $originalRules
+            if ($existing -and $existing.CommandType -eq 'Function') {
+                Set-Item Function:\global:Invoke-DuneSqlQuery -Value $existing.ScriptBlock
+            } else {
+                Remove-Item Function:\global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+            }
+            & $env:DST_TEST_POSTGRES_PSQL -X -q -c 'DROP SCHEMA IF EXISTS dune CASCADE;' 2>&1 | Out-Null
+        }
     }
 
     It 'binds inventory SQL values through encoded parameters instead of interpolating caller input' {
@@ -614,6 +899,7 @@ ORDER BY $($sort.sql)
     It 'registers a GET-only v1 route without mutation vocabulary' {
         $source = Get-Content (Join-Path (Get-DstRepoRoot) 'app\server\routes\Inventory.ps1') -Raw
         $source | Should -Match "Register-DuneRoute -Method GET -Path '/api/v1/inventory/items'"
+        $source | Should -Match "Register-DuneRoute -Method GET -Path '/api/v1/inventory/items/occurrences'"
         $source | Should -Match "Register-DuneRoute -Method GET -Path '/api/v1/inventory/items/\{templateId\}/occurrences'"
         $source | Should -Not -Match 'Register-DuneRoute -Method (POST|PUT|PATCH|DELETE)'
         $source | Should -Not -Match '(?i)give-item|delete-item|repair-item'

--- a/tests/InventoryRoutes.Tests.ps1
+++ b/tests/InventoryRoutes.Tests.ps1
@@ -101,7 +101,7 @@ Describe 'Inventory production router integration' {
             $parsed = ConvertFrom-DunePsqlCsv `
                 -Output "a,b`n1,2`nWARNING: late warning" -MaxRows 100
             $parsed.ok | Should -BeFalse
-            $parsed.message | Should -Match 'fewer fields'
+            $parsed.message | Should -Match 'fields but the header has'
             @($parsed.rows).Count | Should -Be 0
         }
 

--- a/tests/InventoryRoutes.Tests.ps1
+++ b/tests/InventoryRoutes.Tests.ps1
@@ -1,0 +1,177 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Register-DstStubs
+    $repo = Get-DstRepoRoot
+    . (Join-Path $repo 'app\server\HttpServer.ps1')
+    Import-DstLib 'Database.ps1'
+    Import-DstLib 'ApiContract.ps1'
+    Import-DstLib 'RequestPrincipal.ps1'
+    Import-DstLib 'Gameplay.ps1'
+    Import-DstLib 'GameplayPlayers.ps1'
+    Import-DstLib 'GameplayWorld.ps1'
+    Import-DstLib 'InventoryExplorer.ps1'
+
+    function global:Test-DunePortalAccountModeEnabled { return $false }
+    function global:Test-DuneToken { return $true }
+    function global:Get-DuneCapabilitiesForPrincipal {
+        return @([pscustomobject]@{ id = 'inventory.read' })
+    }
+    function New-InventoryRouteResponse {
+        return [pscustomobject]@{
+            StatusCode = 0
+            ContentType = ''
+            ContentLength64 = 0L
+            Headers = @{}
+            OutputStream = [IO.MemoryStream]::new()
+        }
+    }
+    function Invoke-InventoryRouteRequest {
+        param([string]$Path, [hashtable]$Query)
+        $queryString = [Collections.Specialized.NameValueCollection]::new()
+        foreach ($entry in $Query.GetEnumerator()) {
+            $queryString.Add([string]$entry.Key, [string]$entry.Value)
+        }
+        $suffix = if ($Query.Count) {
+            '?' + (($Query.GetEnumerator() | ForEach-Object {
+                "$([Uri]::EscapeDataString([string]$_.Key))=$([Uri]::EscapeDataString([string]$_.Value))"
+            }) -join '&')
+        } else { '' }
+        $request = [pscustomobject]@{
+            Url = [uri]("http://127.0.0.1$Path$suffix")
+            HttpMethod = 'GET'
+            IsWebSocketRequest = $false
+            HasEntityBody = $false
+            Headers = @{}
+            QueryString = $queryString
+            RemoteEndPoint = [pscustomobject]@{ Address = [Net.IPAddress]::Loopback }
+        }
+        $response = New-InventoryRouteResponse
+        Invoke-DuneContext -Ctx ([pscustomobject]@{ Request = $request; Response = $response })
+        $json = [Text.Encoding]::UTF8.GetString($response.OutputStream.ToArray())
+        return @{ response = $response; body = ($json | ConvertFrom-Json) }
+    }
+}
+
+AfterAll {
+    Remove-Item Function:\global:Test-DunePortalAccountModeEnabled -ErrorAction SilentlyContinue
+    Remove-Item Function:\global:Test-DuneToken -ErrorAction SilentlyContinue
+    Remove-Item Function:\global:Get-DuneCapabilitiesForPrincipal -ErrorAction SilentlyContinue
+}
+
+Describe 'Inventory production router integration' {
+    BeforeEach {
+        $script:DuneRoutes = [Collections.Generic.List[object]]::new()
+        $script:DuneWsRoutes = [Collections.Generic.List[object]]::new()
+        $script:DuneToken = ''
+        $script:DuneApiPoolEnabled = $false
+        . (Join-Path (Get-DstRepoRoot) 'app\server\routes\Gameplay.ps1')
+        . (Join-Path (Get-DstRepoRoot) 'app\server\routes\Inventory.ps1')
+    }
+
+    Describe 'Inventory PostgreSQL CSV conversion contract' {
+        It 'returns zero rows for header-only and explicit zero-row output' {
+            foreach ($raw in @(
+                "BEGIN`ngroup_key,template_id,total_quantity`nROLLBACK",
+                "BEGIN`ngroup_key,template_id,total_quantity`n(0 rows)`nROLLBACK"
+            )) {
+                $parsed = ConvertFrom-DunePsqlCsv -Output $raw -MaxRows 100
+                $parsed.ok | Should -BeTrue
+                $parsed.rowCount | Should -Be 0
+                @($parsed.rows).Count | Should -Be 0
+            }
+        }
+
+        It 'fails closed on psql diagnostics instead of parsing them as rows' {
+            $parsed = ConvertFrom-DunePsqlCsv `
+                -Output "psql: warning: fixture`ngroup_key,template_id`ncopper,Copper" -MaxRows 100
+            $parsed.ok | Should -BeFalse
+            $parsed.message | Should -Match 'Unexpected psql diagnostic'
+            @($parsed.rows).Count | Should -Be 0
+        }
+
+        It 'does not confuse a diagnostic-shaped CSV value with transport diagnostics' {
+            $parsed = ConvertFrom-DunePsqlCsv `
+                -Output "message`nNOTICE: maintenance starts at 8" -MaxRows 100
+            $parsed.ok | Should -BeTrue
+            $parsed.rowCount | Should -Be 1
+            $parsed.rows[0][0] | Should -Be 'NOTICE: maintenance starts at 8'
+        }
+
+        It 'rejects a late merged diagnostic that has fewer fields than the CSV header' {
+            $parsed = ConvertFrom-DunePsqlCsv `
+                -Output "a,b`n1,2`nWARNING: late warning" -MaxRows 100
+            $parsed.ok | Should -BeFalse
+            $parsed.message | Should -Match 'fewer fields'
+            @($parsed.rows).Count | Should -Be 0
+        }
+
+        It 'keeps psql stderr separate from CSV stdout and fails the SQL result' {
+            Mock Invoke-DuneSqlRaw {
+                @{ stdout = "a,b`n1,2"; stderr = 'WARNING: late,warning'; exitCode = 0 }
+            }
+            $result = Invoke-DuneSqlQuery -Ip fixture -Sql 'SELECT 1' -ReadOnly $true -MaxRows 10
+            $result.ok | Should -BeFalse
+            $result.error | Should -Match 'WARNING'
+            $result.stderr | Should -Match 'late,warning'
+        }
+
+        It 'preserves empty and multi-row semantics under Windows PowerShell 5.1' -Skip:($env:OS -ne 'Windows_NT') {
+            $repo = (Get-DstRepoRoot).Replace("'", "''")
+            $command = @"
+. '$repo\app\server\lib\Database.ps1'
+. '$repo\app\server\lib\Gameplay.ps1'
+`$empty = ConvertFrom-DunePsqlCsv -Output "BEGIN``na,b``n(0 rows)``nROLLBACK" -MaxRows 10
+if (-not `$empty.ok -or `$empty.rowCount -ne 0) { throw 'PS5.1 empty CSV semantics failed.' }
+`$parsed = ConvertFrom-DunePsqlCsv -Output "a,b``n1,2``n3,4" -MaxRows 10
+`$maps = ConvertTo-DuneRowMaps -Result @{ ok=`$true; columns=`$parsed.columns; rows=`$parsed.rows }
+if (`$maps.Count -ne 2 -or [string]`$maps[1]['b'] -ne '4') { throw 'PS5.1 row-map semantics failed.' }
+"@
+            & powershell.exe -NoProfile -ExecutionPolicy Bypass -Command $command
+            $LASTEXITCODE | Should -Be 0
+        }
+    }
+
+    It 'dispatches a grouped item click through the canonical v1 occurrence route' {
+        $grouped = Invoke-InventoryRouteRequest -Path '/api/v1/inventory/items' -Query @{
+            grouped = '1'; demo = '1'; types = 'player,storage'; sort = 'name-asc'
+        }
+        $grouped.response.StatusCode | Should -Be 200 -Because ([string]$grouped.body.error)
+        $group = @($grouped.body.data.groups | Where-Object {
+            -not [string]::IsNullOrWhiteSpace([string]$_.templateId)
+        })[0]
+        $group | Should -Not -BeNullOrEmpty
+        @($grouped.body.data.groups | Where-Object {
+            [string]::IsNullOrWhiteSpace([string]$_.templateId) -or
+            [string]::IsNullOrWhiteSpace([string]$_.displayName)
+        }).Count | Should -Be 0
+
+        $occurrence = Invoke-InventoryRouteRequest -Path '/api/v1/inventory/items/occurrences' -Query @{
+            template_id = [string]$group.templateId
+            demo = '1'
+            types = 'player,storage'
+            sort = 'player-asc'
+        }
+        $occurrence.response.StatusCode | Should -Be 200 -Because ([string]$occurrence.body.error)
+        $occurrence.body.data.templateId | Should -Be $group.templateId
+        @($occurrence.body.data.items).Count | Should -BeGreaterThan 0
+        @($occurrence.body.data.items | Where-Object {
+            [string]::IsNullOrWhiteSpace([string]$_.templateId)
+        }).Count | Should -Be 0
+    }
+
+    It 'keeps the template-path occurrence route compatible with existing clients' {
+        $result = Invoke-InventoryRouteRequest -Path '/api/v1/inventory/items/Spice_Melange/occurrences' -Query @{
+            demo = '1'; types = 'player,storage'
+        }
+        $result.response.StatusCode | Should -Be 200 -Because ([string]$result.body.error)
+        $result.body.data.templateId | Should -Be 'Spice_Melange'
+    }
+
+    It 'ships the inventory route and read model through the recursive server package source' {
+        $repo = Get-DstRepoRoot
+        Test-Path (Join-Path $repo 'app\server\routes\Inventory.ps1') | Should -BeTrue
+        Test-Path (Join-Path $repo 'app\server\lib\InventoryExplorer.ps1') | Should -BeTrue
+        $installer = Get-Content (Join-Path $repo 'app\installer\DuneServer.iss') -Raw
+        $installer | Should -Match 'Source: "\.\.\\server\\\*"; DestDir: "\{app\}\\server"; Flags: ignoreversion recursesubdirs'
+    }
+}

--- a/tests/InventoryRoutes.Tests.ps1
+++ b/tests/InventoryRoutes.Tests.ps1
@@ -70,10 +70,7 @@ Describe 'Inventory production router integration' {
 
     Describe 'Inventory PostgreSQL CSV conversion contract' {
         It 'returns zero rows for header-only and explicit zero-row output' {
-            foreach ($raw in @(
-                "BEGIN`ngroup_key,template_id,total_quantity`nROLLBACK",
-                "BEGIN`ngroup_key,template_id,total_quantity`n(0 rows)`nROLLBACK"
-            )) {
+            foreach ($raw in @("BEGIN`ngroup_key,template_id,total_quantity`nROLLBACK")) {
                 $parsed = ConvertFrom-DunePsqlCsv -Output $raw -MaxRows 100
                 $parsed.ok | Should -BeTrue
                 $parsed.rowCount | Should -Be 0
@@ -95,6 +92,13 @@ Describe 'Inventory production router integration' {
             $parsed.ok | Should -BeTrue
             $parsed.rowCount | Should -Be 1
             $parsed.rows[0][0] | Should -Be 'NOTICE: maintenance starts at 8'
+        }
+
+        It 'preserves data values that resemble a psql row-count footer' {
+            $parsed = ConvertFrom-DunePsqlCsv -Output "value`n(1 row)" -MaxRows 100
+            $parsed.ok | Should -BeTrue
+            $parsed.rowCount | Should -Be 1
+            $parsed.rows[0][0] | Should -Be '(1 row)'
         }
 
         It 'rejects a late merged diagnostic that has fewer fields than the CSV header' {
@@ -120,7 +124,7 @@ Describe 'Inventory production router integration' {
             $command = @"
 . '$repo\app\server\lib\Database.ps1'
 . '$repo\app\server\lib\Gameplay.ps1'
-`$empty = ConvertFrom-DunePsqlCsv -Output "BEGIN``na,b``n(0 rows)``nROLLBACK" -MaxRows 10
+`$empty = ConvertFrom-DunePsqlCsv -Output "BEGIN``na,b``nROLLBACK" -MaxRows 10
 if (-not `$empty.ok -or `$empty.rowCount -ne 0) { throw 'PS5.1 empty CSV semantics failed.' }
 `$parsed = ConvertFrom-DunePsqlCsv -Output "a,b``n1,2``n3,4" -MaxRows 10
 `$maps = ConvertTo-DuneRowMaps -Result @{ ok=`$true; columns=`$parsed.columns; rows=`$parsed.rows }

--- a/tests/PlatformBaseline.Tests.ps1
+++ b/tests/PlatformBaseline.Tests.ps1
@@ -153,10 +153,19 @@ Describe 'Direct game database source-call cost model' -Tag 'Baseline' {
 
         function Get-V6DbPort { return 15432 }
         function Invoke-V6Ssh {
-            param([string] $Ip, [string] $Cmd, [int] $TimeoutSec, [string] $StdinData)
+            param(
+                [string] $Ip,
+                [string] $Cmd,
+                [int] $TimeoutSec,
+                [string] $StdinData,
+                [switch] $SeparateStreams
+            )
             $script:platformTransportCalls.Add($Cmd)
             if ($Cmd -match 'kubectl get pods') {
                 return 'fixture-ns fixture-db-dbdepl-sts-0 1/1 Running 0 1m'
+            }
+            if ($SeparateStreams) {
+                return @{ stdout = "value`n1"; stderr = ''; exitCode = 0 }
             }
             return @('value', '1')
         }
@@ -175,7 +184,7 @@ Describe 'Direct game database source-call cost model' -Tag 'Baseline' {
         foreach ($command in $queryCalls) {
             $match = [regex]::Match(
                 $command,
-                '^echo (?<sql>[A-Za-z0-9+/=]+) \| base64 -d \| sudo kubectl exec -i -n fixture-ns fixture-db-dbdepl-sts-0 -- psql -U dune -d dune -p 15432 -v ON_ERROR_STOP=1 -X --csv 2>&1$'
+                '^echo (?<sql>[A-Za-z0-9+/=]+) \| base64 -d \| sudo kubectl exec -i -n fixture-ns fixture-db-dbdepl-sts-0 -- psql -U dune -d dune -p 15432 -v ON_ERROR_STOP=1 -X --csv$'
             )
             $match.Success | Should -BeTrue
             $effectiveSql = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($match.Groups['sql'].Value))

--- a/tests/PlatformContracts.Tests.ps1
+++ b/tests/PlatformContracts.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'Complete route classification' {
     It 'classifies the exact registered HTTP and WebSocket inventory' {
         $records = @(Get-PlatformRouteRecords)
         $manifest = Get-DuneRoutePolicyManifest
-        $records.Count | Should -Be 357
+        $records.Count | Should -Be 358
         $sources = @($records.SourceFile | Sort-Object -Unique)
         @($manifest.groups.source | Sort-Object) | Should -Be $sources
 
@@ -318,7 +318,7 @@ $result = @{
         $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
         $resultLine = @($output | Where-Object { [string]$_ -like 'ROUTE_RESULT:*' })[-1]
         $result = ([string]$resultLine).Substring('ROUTE_RESULT:'.Length) | ConvertFrom-Json
-        $result.total | Should -Be 357
+        $result.total | Should -Be 358
         $result.unclassified | Should -Be 0
         $result.incompatible | Should -Be 0
         $result.podsCleanup | Should -Be 1

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -509,7 +509,8 @@ export function getSharedInventory(query: SharedInventoryQuery = {}) {
 
 export function getSharedInventoryOccurrences(query: SharedInventoryOccurrencesQuery) {
   return api<SharedInventoryOccurrencesResponse>(
-    `/api/v1/inventory/items/${encodeURIComponent(query.templateId)}/occurrences${qs({
+    `/api/v1/inventory/items/occurrences${qs({
+      template_id: query.templateId,
       types: query.types?.join(','),
       scope_type: query.scopeType,
       scope_id: query.scopeId,

--- a/webui/src/components/inventory/SharedInventoryExplorer.tsx
+++ b/webui/src/components/inventory/SharedInventoryExplorer.tsx
@@ -68,6 +68,31 @@ function parsePositiveId(value: string | null) {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined
 }
 
+function assertInventoryGroups(groups: SharedInventoryGroup[]) {
+  const malformed = groups.find(group => (
+    !group.groupKey?.trim()
+    || !group.templateId?.trim()
+    || !group.displayName?.trim()
+    || !Number.isFinite(group.totalQuantity)
+    || !Number.isFinite(group.occurrenceCount)
+    || !Number.isFinite(group.locationCount)
+  ))
+  if (malformed) throw new Error('Inventory response contained a malformed grouped item. Refresh after updating the backend.')
+}
+
+function assertInventoryOccurrences(items: SharedInventoryItem[]) {
+  const malformed = items.find(item => (
+    !Number.isSafeInteger(item.id)
+    || item.id <= 0
+    || !item.templateId?.trim()
+    || !item.displayName?.trim()
+    || !item.entity?.type
+    || !Number.isSafeInteger(item.entity.id)
+    || item.entity.id <= 0
+  ))
+  if (malformed) throw new Error('Inventory response contained a malformed item occurrence. Refresh after updating the backend.')
+}
+
 function setUrlFilters(changes: Record<string, string | undefined>) {
   const params = new URLSearchParams(window.location.search)
   Object.entries(changes).forEach(([key, value]) => {
@@ -192,6 +217,7 @@ export function SharedInventoryExplorer({
         sort, limit: 100, cursor, demo,
       })
       if (version !== requestVersion.current) return
+      assertInventoryGroups(result.data.groups)
       setResponse(result)
       setGroups(existing => append ? [...existing, ...result.data.groups] : result.data.groups)
       setLoadedIdentity(requestIdentity)
@@ -399,6 +425,7 @@ function OccurrencePanel({
         locationType: location?.type, locationId: location?.id, sort, limit: 50, cursor, demo,
       })
       if (request !== version.current) return
+      assertInventoryOccurrences(result.data.items)
       setItems(current => append ? [...current, ...result.data.items] : result.data.items)
       setNextCursor(result.page.nextCursor)
       setPanelPlayers(current => {

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -84,7 +84,7 @@ describe('Phase A — currency / progression writes', () => {
       demo: true,
     })
     expect(last().url).toBe(
-      '/api/v1/inventory/items/Copper%2FBar/occurrences?types=player%2Cstorage&player_id=20001&location_type=player&location_id=20001&sort=quality-desc&limit=50&cursor=next.occurrence&demo=1',
+      '/api/v1/inventory/items/occurrences?template_id=Copper%2FBar&types=player%2Cstorage&player_id=20001&location_type=player&location_id=20001&sort=quality-desc&limit=50&cursor=next.occurrence&demo=1',
     )
     expect(last().method).toBeUndefined()
   })

--- a/webui/tests/sharedInventoryExplorer.test.tsx
+++ b/webui/tests/sharedInventoryExplorer.test.tsx
@@ -131,6 +131,27 @@ describe('Shared Inventory Explorer grouped catalog', () => {
     expect(inventoryApi).toHaveBeenCalledWith(expect.objectContaining({ playerId: undefined, locationId: undefined, sort: 'name-asc' }))
   })
 
+  it('surfaces malformed grouped rows instead of rendering a phantom slot', async () => {
+    inventoryApi.mockResolvedValue({
+      ...fixture,
+      data: {
+        ...fixture.data,
+        groups: [{
+          ...copperGroup,
+          groupKey: '',
+          templateId: '',
+          displayName: '',
+          totalQuantity: 0,
+          occurrenceCount: 0,
+          locationCount: 0,
+        }],
+      },
+    })
+    renderExplorer()
+    expect(await screen.findByText(/malformed grouped item/)).toBeInTheDocument()
+    expect(screen.queryByRole('list', { name: 'Inventory results' })).not.toBeInTheDocument()
+  })
+
   it('keeps duplicate player and storage names visibly distinct without raw IDs', async () => {
     renderExplorer()
     await screen.findByText('Copper')
@@ -205,6 +226,21 @@ describe('Shared Inventory Explorer grouped catalog', () => {
     expect(within(occurrencePlayer).getByRole('option', { name: 'Coastal (2)' })).toBeInTheDocument()
     await user.selectOptions(screen.getByRole('combobox', { name: 'Sort occurrences' }), 'quality-desc')
     await waitFor(() => expect(occurrenceApi).toHaveBeenLastCalledWith(expect.objectContaining({ sort: 'quality-desc' })))
+  })
+
+  it('surfaces malformed occurrence rows instead of rendering blank details', async () => {
+    occurrenceApi.mockResolvedValue({
+      ...occurrenceFixture,
+      data: {
+        ...occurrenceFixture.data,
+        items: [{ ...occurrence, id: 0, templateId: '', displayName: '' }],
+      },
+    })
+    const user = userEvent.setup()
+    renderExplorer()
+    await user.click(await screen.findByRole('button', { name: /Copper/ }))
+    expect(await screen.findByText(/malformed item occurrence/)).toBeInTheDocument()
+    expect(screen.queryByRole('list', { name: 'Item occurrences' })).not.toBeInTheDocument()
   })
 
   it('keeps proven active popup filters visible when the occurrence result is empty', async () => {


### PR DESCRIPTION
## Summary
- fix grouped SQL row conversion so real row arrays are enumerated instead of serialized as one null-valued phantom group
- reject malformed grouped/occurrence DTO rows and keep `psql` stderr separate from CSV stdout
- register and classify `/api/v1/inventory/items/occurrences`, retain compatibility with the template-path endpoint, and use the canonical route from the WebUI
- add production-router grouped-click-to-occurrence coverage and seeded PostgreSQL semantic assertions across sorts, filters, cursors, facets, metadata, emote exclusion, paging, and empty results

## Validation
- full backend Pester: 1,321 passed, 2 skipped; isolated platform cache rerun: 24 passed
- full WebUI Vitest: 328 passed
- WebUI build/typecheck and full installer build
- wide and 390px rendered grouped-to-occurrence smoke
- PowerShell 5.1 parser seam, parse/BOM/diff checks, staged gitleaks scan, and prohibited-path scan

Base: `e4e1d52e90e342cf6bf7ebd5ddfac921de763797`