### PR TITLE
Make release artifacts immutable

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -88,7 +88,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-phase2-test2"
+      placeholder: "v15.0.0-phase2-test1.1"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -88,7 +88,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-phase2-test1"
+      placeholder: "v15.0.0-phase2-test2"
     validations:
       required: true
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -134,6 +134,12 @@ A session worktree may not have warm `webui/node_modules` — run `npm ci` in
   Code-only releases break the in-app updater (it gates on an asset being
   present and silently reports "up to date"). After publishing, verify with
   `gh release view vX.Y.Z --json assets`.
+- **Release assets are immutable.** Publish through the
+  `Build & sign installer` workflow with an existing tag at the merged release
+  commit. The workflow builds from that tag, verifies the embedded identity,
+  creates a draft with `DuneServerSetup.exe`, and only then publishes it. Never
+  upload or replace an asset on an existing release; any correction gets a new
+  version and tag so checksums and tester reports remain trustworthy.
 - **Every release, refresh the bug-report issue template.** When a release adds
   or changes user-facing features, update
   `.github/ISSUE_TEMPLATE/bug_report.yml` so bug reports and the log-gathering

--- a/.github/workflows/release-signed.yml
+++ b/.github/workflows/release-signed.yml
@@ -295,11 +295,16 @@ jobs:
         shell: pwsh
         env:
           BUILD_TAG: ${{ inputs.release_tag }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           . '${{ github.workspace }}\app\build\BuildHelpers.ps1'
           $tagCommit = "$(& git rev-parse --verify "refs/tags/$env:BUILD_TAG^{commit}")".Trim().ToLowerInvariant()
           if ($LASTEXITCODE -ne 0 -or $tagCommit -notmatch '^[0-9a-f]{40}$') {
            throw "Could not resolve release tag $env:BUILD_TAG to an immutable commit."
+          }
+          & git merge-base --is-ancestor $tagCommit "refs/remotes/origin/$env:DEFAULT_BRANCH"
+          if ($LASTEXITCODE -ne 0) {
+           throw "Release tag $env:BUILD_TAG does not point to a commit merged into $env:DEFAULT_BRANCH."
           }
           $expectedPrerelease = Test-DunePrereleaseTag -BuildTag $env:BUILD_TAG
           & '${{ github.workspace }}\app\build\Verify-ReleaseArtifact.ps1' `

--- a/.github/workflows/release-signed.yml
+++ b/.github/workflows/release-signed.yml
@@ -29,9 +29,9 @@ name: Build & sign installer
 #       *_EXE and *_INSTALLER to the same slug. Leaving a var blank falls back to
 #       the SignPath project's default artifact configuration.)
 #
-# After that, run this workflow (Actions tab > "Build & sign installer" > Run),
-# optionally passing attach_to_release_tag to replace the asset on an existing
-# GitHub release — which keeps the "DuneServerSetup.exe is the sole asset" rule.
+# After that, run this workflow (Actions tab > "Build & sign installer" > Run).
+# Passing release_tag builds from that immutable tag, creates a draft with the
+# installer attached, then publishes it. Existing releases are never modified.
 #
 # NOTE: SignPath's action is pinned to the v1 major tag below. For a hardened
 # supply chain, pin it to a full commit SHA instead.
@@ -40,8 +40,16 @@ name: Build & sign installer
 on:
   workflow_dispatch:
     inputs:
-      attach_to_release_tag:
-        description: 'Existing release tag to upload the (signed) installer to, e.g. v12.15.1 (blank = just build + upload as a workflow artifact)'
+      release_tag:
+        description: 'Immutable tag for a NEW release, e.g. v15.0.0-phase2-test2 (blank = build a workflow artifact only)'
+        required: false
+        default: ''
+      release_title:
+        description: 'Title for the new release (required when release_tag is set)'
+        required: false
+        default: ''
+      release_notes:
+        description: 'Release notes for the new release (required when release_tag is set)'
         required: false
         default: ''
       skip_version_check:
@@ -56,7 +64,7 @@ on:
         default: false
 
 permissions:
-  contents: write   # needed to upload the asset to an existing release
+  contents: write   # needed to create the release after its asset is ready
 
 jobs:
   build:
@@ -65,15 +73,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.attach_to_release_tag != '' && inputs.attach_to_release_tag || github.ref }}
+          ref: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref }}
           fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.22.2'
           cache: 'npm'
           cache-dependency-path: webui/package-lock.json
+
+      - name: Refuse an existing release
+        if: inputs.release_tag != ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          & gh release view $env:RELEASE_TAG --repo '${{ github.repository }}' --json tagName *> $null
+          if ($LASTEXITCODE -eq 0) {
+            throw "Release $env:RELEASE_TAG already exists. Release assets are immutable; publish a new version instead."
+          }
 
       - name: Setup .NET 10 SDK
         uses: actions/setup-dotnet@v4
@@ -110,7 +130,7 @@ jobs:
       - name: Build raw artifacts (phase A)
         shell: pwsh
         env:
-          BUILD_TAG: ${{ inputs.attach_to_release_tag }}
+          BUILD_TAG: ${{ inputs.release_tag }}
         run: |
           $biArgs = @{ SkipInstaller = $true }
           if ($env:BUILD_TAG) { $biArgs.BuildCommit = (& git rev-parse HEAD).Trim() }
@@ -212,7 +232,7 @@ jobs:
       - name: Build installer (phase B)
         shell: pwsh
         env:
-          BUILD_TAG: ${{ inputs.attach_to_release_tag }}
+          BUILD_TAG: ${{ inputs.release_tag }}
         run: |
           $biArgs = @{
             SkipWebBuild = $true
@@ -271,27 +291,22 @@ jobs:
           }
 
       - name: Verify release artifact identity
-        if: inputs.attach_to_release_tag != ''
+        if: inputs.release_tag != ''
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
-          BUILD_TAG: ${{ inputs.attach_to_release_tag }}
+          BUILD_TAG: ${{ inputs.release_tag }}
         run: |
-          $releaseJson = gh api "repos/${{ github.repository }}/releases/tags/$env:BUILD_TAG"
-          if ($LASTEXITCODE -ne 0) { throw "Could not read GitHub release $env:BUILD_TAG." }
-          $release = $releaseJson | ConvertFrom-Json
-          if ([string]$release.tag_name -cne $env:BUILD_TAG) {
-           throw "GitHub release tag mismatch: requested '$env:BUILD_TAG', API returned '$($release.tag_name)'."
-          }
+          . '${{ github.workspace }}\app\build\BuildHelpers.ps1'
           $tagCommit = "$(& git rev-parse --verify "refs/tags/$env:BUILD_TAG^{commit}")".Trim().ToLowerInvariant()
           if ($LASTEXITCODE -ne 0 -or $tagCommit -notmatch '^[0-9a-f]{40}$') {
            throw "Could not resolve release tag $env:BUILD_TAG to an immutable commit."
           }
+          $expectedPrerelease = Test-DunePrereleaseTag -BuildTag $env:BUILD_TAG
           & '${{ github.workspace }}\app\build\Verify-ReleaseArtifact.ps1' `
            -ExecutablePath '${{ github.workspace }}\app\build\output\DuneServer.exe' `
            -ExpectedTag $env:BUILD_TAG `
            -ExpectedCommit $tagCommit `
-           -ExpectedPrerelease:([bool]$release.prerelease)
+           -ExpectedPrerelease:$expectedPrerelease
 
       - name: Upload installer as workflow artifact
         uses: actions/upload-artifact@v4
@@ -300,16 +315,62 @@ jobs:
           path: app/installer/output/DuneServerSetup.exe
           if-no-files-found: error
 
-      - name: Attach installer to release
-        if: inputs.attach_to_release_tag != ''
-        shell: bash
+      - name: Publish new release with installer
+        if: inputs.release_tag != ''
+        shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TITLE: ${{ inputs.release_title }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
-          set -euo pipefail
-          tag='${{ inputs.attach_to_release_tag }}'
-          echo "Uploading signed installer to release $tag (replacing any existing asset)…"
-          gh release upload "$tag" \
-            "app/installer/output/DuneServerSetup.exe" \
-            --repo "${{ github.repository }}" --clobber
-          echo "Done. Verify the release has DuneServerSetup.exe as its sole asset."
+          if ([string]::IsNullOrWhiteSpace($env:RELEASE_TITLE)) {
+            throw 'release_title is required when release_tag is set.'
+          }
+          if ([string]::IsNullOrWhiteSpace($env:RELEASE_NOTES)) {
+            throw 'release_notes is required when release_tag is set.'
+          }
+
+          & gh release view $env:RELEASE_TAG --repo '${{ github.repository }}' --json tagName *> $null
+          if ($LASTEXITCODE -eq 0) {
+            throw "Release $env:RELEASE_TAG already exists. Release assets are immutable; publish a new version instead."
+          }
+
+          . '${{ github.workspace }}\app\build\BuildHelpers.ps1'
+          $isPrerelease = Test-DunePrereleaseTag -BuildTag $env:RELEASE_TAG
+          $installer = '${{ github.workspace }}\app\installer\output\DuneServerSetup.exe'
+          $createArgs = @(
+            'release', 'create', $env:RELEASE_TAG, $installer,
+            '--repo', '${{ github.repository }}',
+            '--verify-tag',
+            '--draft',
+            '--title', $env:RELEASE_TITLE,
+            '--notes', $env:RELEASE_NOTES
+          )
+          if ($isPrerelease) { $createArgs += '--prerelease' }
+          & gh @createArgs
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not create draft release $env:RELEASE_TAG with its installer."
+          }
+
+          $publishArgs = @(
+            'release', 'edit', $env:RELEASE_TAG,
+            '--repo', '${{ github.repository }}',
+            '--draft=false'
+          )
+          if ($isPrerelease) { $publishArgs += '--prerelease' }
+          & gh @publishArgs
+          if ($LASTEXITCODE -ne 0) {
+            throw "Draft $env:RELEASE_TAG has its installer but could not be published."
+          }
+
+          $release = & gh release view $env:RELEASE_TAG `
+            --repo '${{ github.repository }}' `
+            --json assets,isDraft,tagName | ConvertFrom-Json
+          if ($LASTEXITCODE -ne 0 -or $release.isDraft -or
+              $release.tagName -cne $env:RELEASE_TAG -or
+              @($release.assets).Count -ne 1 -or
+              $release.assets[0].name -cne 'DuneServerSetup.exe') {
+            throw "Published release $env:RELEASE_TAG failed the immutable sole-asset verification."
+          }
+          Write-Host "Published immutable release $env:RELEASE_TAG with DuneServerSetup.exe." -ForegroundColor Green

--- a/.github/workflows/release-signed.yml
+++ b/.github/workflows/release-signed.yml
@@ -41,7 +41,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Immutable tag for a NEW release, e.g. v15.0.0-phase2-test2 (blank = build a workflow artifact only)'
+        description: 'Immutable tag for a NEW release, e.g. v15.0.0-phase2-test1.1 (blank = build a workflow artifact only)'
         required: false
         default: ''
       release_title:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.0-phase2-test2] - 2026-09-02
+
 ### Added
 
 - Added storage-box renaming from Storage administration and the Shared
@@ -23,6 +25,9 @@ here cover everything those tags shipped.
 
 ### Fixed
 
+- Made release artifacts immutable: tagged builds are now verified and attached
+  before a new release is published, and existing release assets cannot be
+  silently replaced.
 - Fixed Shared Inventory Explorer results collapsing into one blank item and
   occurrence details failing to reach their read-only API route.
 - Hardened shared `!tp <destination>` replay against intermittent game-side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
-## [15.0.0-phase2-test2] - 2026-09-02
+## [15.0.0-phase2-test1.1] - 2026-09-02
 
 ### Added
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.0-phase2-test1'
+$script:DuneToolVersion = '15.0.0-phase2-test2'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.0-phase2-test2'
+$script:DuneToolVersion = '15.0.0-phase2-test1.1'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/README.md
+++ b/app/README.md
@@ -81,22 +81,26 @@ Outputs:
 
 ### Releasing a new version
 
-1. Bump `$script:ToolVersion` in `dune-server.ps1`
-2. Bump `$Version` default in `app\build\Build-Exe.ps1` (or pass `-Version` to it)
-3. Bump `MyAppVersion` in `app\installer\DuneServer.iss`
-4. Add a CHANGELOG entry
-5. Run `.\app\installer\Build-Installer.ps1`
-6. Commit, tag, push:
+1. Keep the version stamps synchronized in `dune-server.ps1`,
+   `app\DuneServer.ps1`, `app\build\Build-Exe.ps1`,
+   `app\desktop\DuneShell\DuneShell.csproj`, and
+   `app\installer\DuneServer.iss`.
+2. Add the dated CHANGELOG entry and refresh the bug-report template.
+3. Merge the release change, then create and push an annotated tag at that
+   merged commit:
    ```powershell
-   git tag -a v4.0.x -m "v4.0.x: ..."
-   git push origin main v4.0.x
+   git tag -a vX.Y.Z -m "vX.Y.Z: ..."
+   git push origin vX.Y.Z
    ```
-7. Create GitHub release (substitute the real version — DO NOT leave `X.Y.Z`
-   literal in the title; the releases page renders the title prominently):
-   ```powershell
-   gh release create v10.1.8 --title "10.1.8" --notes-file release-notes.md
-   gh release upload v10.1.8 app\installer\output\DuneServerSetup.exe
-   ```
+4. In GitHub Actions, run **Build & sign installer** with that immutable tag
+   and provide the release title and notes. Set **prerelease_build** for a test
+   tag. The workflow builds from the tag, verifies the embedded tag and commit,
+   attaches `DuneServerSetup.exe` to a new draft, and publishes it.
+5. Verify the published release has `DuneServerSetup.exe` as its sole asset.
+
+The workflow is the only publication path. A local installer build is for
+validation only; do not create a release or upload/replace release assets with
+`gh release`.
 
 ## Regenerating the icon
 

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.0-phase2-test2',
+    [string]$Version = '15.0.0-phase2-test1.1',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.0-phase2-test1',
+    [string]$Version = '15.0.0-phase2-test2',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.0-phase2-test2</Version>
+    <Version>15.0.0-phase2-test1.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.0-phase2-test1</Version>
+    <Version>15.0.0-phase2-test2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.0-phase2-test2"
+#define MyAppVersion "15.0.0-phase2-test1.1"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.0-phase2-test1"
+#define MyAppVersion "15.0.0-phase2-test2"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.0-phase2-test1"
+$script:ToolVersion = "15.0.0-phase2-test2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.0-phase2-test2"
+$script:ToolVersion = "15.0.0-phase2-test1.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/BuildMetadata.Tests.ps1
+++ b/tests/BuildMetadata.Tests.ps1
@@ -75,15 +75,21 @@ Describe 'Build artifact metadata' {
         $exe | Should -Not -Match 'rev-parse --short'
         $exe | Should -Match 'DuneBuildMetadataPresent = \$true'
         $workflow | Should -Match 'prerelease_build'
-        $workflow | Should -Match 'inputs\.attach_to_release_tag.*github\.ref'
+        $workflow | Should -Match 'inputs\.release_tag.*github\.ref'
         $workflow | Should -Match 'fetch-depth:\s*0'
         $workflow | Should -Not -Match 'github\.ref.*Prerelease'
         $workflow | Should -Match '\$biArgs\s*=\s*@\{'
         $workflow | Should -Match '\$biArgs\.BuildTag\s*='
         $workflow | Should -Match '\$biArgs\.BuildCommit\s*='
         $workflow | Should -Match 'Verify-ReleaseArtifact\.ps1'
-        $workflow | Should -Match 'release\.prerelease'
+        $workflow | Should -Match 'Test-DunePrereleaseTag'
         $workflow | Should -Match 'refs/tags/\$env:BUILD_TAG\^\{commit\}'
+        $workflow | Should -Match 'Release assets are immutable; publish a new version instead'
+        $workflow | Should -Match "'--draft'"
+        $workflow | Should -Match "'release', 'edit'"
+        $workflow | Should -Match "'release', 'create'"
+        $workflow | Should -Not -Match 'release upload'
+        $workflow | Should -Not -Match '--clobber'
         $workflow | Should -Not -Match '\$biArgs\s*=\s*@\('
         $workflow | Should -Not -Match '\$biArgs\s*\+='
     }

--- a/tests/BuildMetadata.Tests.ps1
+++ b/tests/BuildMetadata.Tests.ps1
@@ -84,6 +84,7 @@ Describe 'Build artifact metadata' {
         $workflow | Should -Match 'Verify-ReleaseArtifact\.ps1'
         $workflow | Should -Match 'Test-DunePrereleaseTag'
         $workflow | Should -Match 'refs/tags/\$env:BUILD_TAG\^\{commit\}'
+        $workflow | Should -Match 'merge-base --is-ancestor \$tagCommit "refs/remotes/origin/\$env:DEFAULT_BRANCH"'
         $workflow | Should -Match 'Release assets are immutable; publish a new version instead'
         $workflow | Should -Match "'--draft'"
         $workflow | Should -Match "'release', 'edit'"


### PR DESCRIPTION
## Summary
- publish releases only from an existing immutable tag at the merged commit
- verify embedded tag/commit identity before publication
- create the release as a draft with its sole installer asset, then publish it
- refuse to modify any existing release or replace its assets
- ship the visible correction as v15.0.0-phase2-test1.1, preserving Test 2 for planned work

## Why
The v15.0.0-phase2-test1 installer was built from PR head `595eed99` but published under merge-commit tag `1d7a8de7`, so the updater correctly rejected the installed identity. Replacing that asset in place would make the tag, checksum, and tester reports untrustworthy. This makes releases immutable and moves the correction to a distinct point prerelease.