### PR TITLE
Fix false storage mutation results

### DIFF
--- a/app/server/lib/GameplayWorld.ps1
+++ b/app/server/lib/GameplayWorld.ps1
@@ -216,7 +216,7 @@ SELECT COUNT(*)::text AS updated_count FROM updated;
 "@
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
-    $rows = @(ConvertTo-DuneRowMaps -Result $res)
+    $rows = ConvertTo-DuneRowMaps -Result $res
     $updated = if ($rows.Count -gt 0) { ConvertTo-DuneInt $rows[0]['updated_count'] } else { 0 }
     if ($updated -eq 0) {
         return @{ ok = $false; error = "Storage container $ContainerId was not found or has no permission name row." }
@@ -740,7 +740,8 @@ SELECT dune.delete_item(id) FROM matched;
 "@
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
-    if (@(ConvertTo-DuneRowMaps -Result $res).Count -eq 0) {
+    $rows = ConvertTo-DuneRowMaps -Result $res
+    if ($rows.Count -eq 0) {
         return @{ ok = $false; error = 'Item quantity changed or the item no longer exists. Refresh and try again.' }
     }
     return @{ ok = $true; message = "Removed item $ItemId from container." }
@@ -765,7 +766,7 @@ RETURNING id::text AS item_id;
 "@
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
-    $affected = @(ConvertTo-DuneRowMaps -Result $res).Count
+    $affected = (ConvertTo-DuneRowMaps -Result $res).Count
     if ($affected -eq 0) {
         return @{ ok = $false; error = 'Item quantity changed or the item no longer exists. Refresh and try again.' }
     }

--- a/tests/StorageOverview.Tests.ps1
+++ b/tests/StorageOverview.Tests.ps1
@@ -59,7 +59,7 @@ Describe 'Storage overview container coverage' -Tag 'Pure' {
         }
         Mock ConvertTo-DuneRowMaps {
             param($Result)
-            return @($Result.rows)
+            return ,@($Result.rows)
         }
 
         $result = Invoke-DuneStorageRename -Ip '1.2.3.4' -ContainerId 123 -Name "  Duke's Ore  "
@@ -93,6 +93,36 @@ Describe 'Storage overview container coverage' -Tag 'Pure' {
         $result.ok | Should -BeTrue
         $script:stackSql | Should -Match 'SET stack_size = 6::bigint'
         $script:stackSql | Should -Match 'AND stack_size = 10::bigint'
+    }
+
+    It 'reports a stale storage stack update when no row changed' {
+        Mock Invoke-DuneSqlQuery {
+            return @{ ok = $true; rows = @() }
+        }
+        Mock ConvertTo-DuneRowMaps {
+            param($Result)
+            return ,@($Result.rows)
+        }
+
+        $result = Invoke-DuneStorageSetItemStack -Ip '1.2.3.4' -ItemId 42 -StackSize 6 -ExpectedStackSize 10
+
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'quantity changed'
+    }
+
+    It 'reports a stale storage deletion when no row matched' {
+        Mock Invoke-DuneSqlQuery {
+            return @{ ok = $true; rows = @() }
+        }
+        Mock ConvertTo-DuneRowMaps {
+            param($Result)
+            return ,@($Result.rows)
+        }
+
+        $result = Invoke-DuneStorageDeleteItem -Ip '1.2.3.4' -ItemId 42 -ExpectedStackSize 10
+
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'quantity changed'
     }
 
     It 'guards full player item deletion with the quantity originally loaded' {


### PR DESCRIPTION
Fixes storage rename reporting an error after the database update succeeds by preserving the row-map helper's array shape.

Also restores fail-closed behavior when guarded storage stack updates or deletions affect no rows.

Tests: `Invoke-Pester -Path tests\StorageOverview.Tests.ps1` (9 passed)