### PR TITLE
Clear handled release lookup exit code

### DIFF
--- a/.github/workflows/release-signed.yml
+++ b/.github/workflows/release-signed.yml
@@ -106,6 +106,7 @@ jobs:
           if (($lookupOutput -join "`n") -notmatch '(?m)^HTTP/\S+\s+404(?:\s|$)') {
             throw "Could not determine whether release $env:RELEASE_TAG exists:`n$($lookupOutput -join "`n")"
           }
+          $global:LASTEXITCODE = 0
 
       - name: Setup .NET 10 SDK
         uses: actions/setup-dotnet@v4
@@ -364,6 +365,7 @@ jobs:
           if (($lookupOutput -join "`n") -notmatch '(?m)^HTTP/\S+\s+404(?:\s|$)') {
             throw "Could not determine whether release $env:RELEASE_TAG exists:`n$($lookupOutput -join "`n")"
           }
+          $global:LASTEXITCODE = 0
 
           . '${{ github.workspace }}\app\build\BuildHelpers.ps1'
           $isPrerelease = Test-DunePrereleaseTag -BuildTag $env:RELEASE_TAG

--- a/tests/BuildMetadata.Tests.ps1
+++ b/tests/BuildMetadata.Tests.ps1
@@ -25,7 +25,7 @@ BeforeAll {
     function Get-ReleaseLookupGuardScripts {
         param([Parameter(Mandatory)][string]$Workflow)
 
-        $pattern = '(?ms)^ {10}\$nativeErrorPreference = .*?^ {10}if \(\(\$lookupOutput -join "`n"\) -notmatch .*?^ {10}\}\r?$'
+        $pattern = '(?ms)^ {10}\$nativeErrorPreference = .*?^ {10}if \(\(\$lookupOutput -join "`n"\) -notmatch .*?^ {10}\}\r?\n^ {10}\$global:LASTEXITCODE = 0\r?$'
         return @([regex]::Matches($Workflow, $pattern) | ForEach-Object {
             $source = $_.Value -replace '(?m)^ {10}', ''
             $source = $source.Replace('${{ github.repository }}', 'coastal-ms/DST-DuneServerTool')
@@ -153,6 +153,7 @@ Describe 'Build artifact metadata' {
                     -ExitCode 1 `
                     -Output "HTTP/2.0 404 Not Found`nContent-Type: application/json"
             } | Should -Not -Throw
+            (Get-Variable -Name LASTEXITCODE -Scope Global).Value | Should -Be 0
 
             {
                 Invoke-ReleaseLookupGuardScript `


### PR DESCRIPTION
Fixes the release workflow guard after an explicit HTTP 404 is correctly classified as an absent release. The step now clears the handled native exit code so GitHub Actions does not fail after successful classification.

Adds regression coverage that executes both production guard blocks and verifies the handled 404 leaves a successful process state.

Validation: `tests\BuildMetadata.Tests.ps1` — 20 passed.