### PR TITLE
Restore local tested release workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -134,12 +134,13 @@ A session worktree may not have warm `webui/node_modules` — run `npm ci` in
   Code-only releases break the in-app updater (it gates on an asset being
   present and silently reports "up to date"). After publishing, verify with
   `gh release view vX.Y.Z --json assets`.
-- **Release assets are immutable.** Publish through the
-  `Build & sign installer` workflow with an existing tag at the merged release
-  commit. The workflow builds from that tag, verifies the embedded identity,
-  creates a draft with `DuneServerSetup.exe`, and only then publishes it. Never
-  upload or replace an asset on an existing release; any correction gets a new
-  version and tag so checksums and tester reports remain trustworthy.
+- **Release assets are immutable.** After the tested PR is accepted and merged,
+  build the final installer locally from the exact release tag/40-character
+  commit with the intended prerelease metadata, copy it to the canonical primary
+  output path, verify its embedded identity, then create the new release directly
+  with `DuneServerSetup.exe` as its sole asset after the final publish gate.
+  Never upload or replace an asset on an existing release; any correction gets a
+  new version and tag so checksums and tester reports remain trustworthy.
 - **Every release, refresh the bug-report issue template.** When a release adds
   or changes user-facing features, update
   `.github/ISSUE_TEMPLATE/bug_report.yml` so bug reports and the log-gathering

--- a/app/README.md
+++ b/app/README.md
@@ -86,21 +86,26 @@ Outputs:
    `app\desktop\DuneShell\DuneShell.csproj`, and
    `app\installer\DuneServer.iss`.
 2. Add the dated CHANGELOG entry and refresh the bug-report template.
-3. Merge the release change, then create and push an annotated tag at that
-   merged commit:
+3. Build the clean PR candidate locally, copy
+   `DuneServerSetup.exe` to the primary checkout's canonical output path, and
+   wait for live acceptance before merging.
+4. After acceptance, merge the release change, then create and push an annotated
+   tag at that exact merge commit:
    ```powershell
    git tag -a vX.Y.Z -m "vX.Y.Z: ..."
    git push origin vX.Y.Z
    ```
-4. In GitHub Actions, run **Build & sign installer** with that immutable tag
-   and provide the release title and notes. Set **prerelease_build** for a test
-   tag. The workflow builds from the tag, verifies the embedded tag and commit,
-   attaches `DuneServerSetup.exe` to a new draft, and publishes it.
-5. Verify the published release has `DuneServerSetup.exe` as its sole asset.
+5. From a clean checkout of that tag, build the final installer locally with the
+   exact 40-character commit, tag, and prerelease metadata. Copy it to the
+   canonical output path and verify the embedded identity.
+6. After the separate final publish gate, create the new release directly with
+   the verified canonical installer as its sole asset.
+7. Verify the published release has exactly one `DuneServerSetup.exe` asset.
 
-The workflow is the only publication path. A local installer build is for
-validation only; do not create a release or upload/replace release assets with
-`gh release`.
+The **Build & sign installer** Actions workflow is optional and must be used only
+when explicitly requested. It never replaces the local pre-merge acceptance
+build or becomes the default publication path. Existing release assets are never
+uploaded again or replaced; publish a new version/tag for every correction.
 
 ## Regenerating the icon
 


### PR DESCRIPTION
Restores the established DST release sequence in the repository instructions: local pre-merge candidate build and acceptance, followed after merge by a local exact-tag publication build, canonical-path copy, embedded-identity verification, and direct creation of a new immutable release.

The GitHub Actions rebuild/publish workflow is no longer the default release path.