### PR TITLE
Release v15.0.0 Phase 2 Test 4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -88,7 +88,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-phase2-test3"
+      placeholder: "v15.0.0-phase2-test4"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -142,7 +142,7 @@ body:
         - Web portal — Maps — DD Atlas — wrong or missing POI / cave sector / layout data for a seed
         - Web portal — Solo Mode — connection / wrapper or schema validation / process lock
         - Web portal — Solo Mode — native and Engine settings (load / apply / retained INI backup)
-        - Web portal — Solo Mode — Current inventory browser / backpack slot capacity / ranged weapon ammo / Give Item / Vehicle Kit / Package / Cosmetics / backpack or built-storage delivery
+        - Web portal — Solo Mode — Current inventory browser / ranged weapon ammo / Give Item / Vehicle Kit / Package / Cosmetics / backpack or built-storage delivery
         - Web portal — Solo Mode — Import Base Blueprint / portable blueprint JSON (disabled in PTC)
         - Web portal — Solo Mode — Solari / Landsraad Scrip / Hajra Literjon fill
         - Web portal — Solo Mode — save backup / restore / single or multi-select delete / safety backup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.0-phase2-test4] - 2026-09-03
+
+### Changed
+
+- Updated v15 upgrades in place so the backend restarts while unchanged
+  scheduled tasks remain registered. The mobile bridge is reinstalled and
+  restarted only when its shipped payload changes.
+
 ## [15.0.0-phase2-test3] - 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ here cover everything those tags shipped.
   once, reusing that result for keep-alive state, and taking a health-only fast
   path when the mobile bridge is already responding.
 
+### Fixed
+
+- Removed the ineffective Solo backpack-slot editor. Field testing confirmed
+  that PTC recomputes the saved slot count from progression and rewrites direct
+  database changes back to 60.
+
 ## [15.0.0-phase2-test3] - 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ here cover everything those tags shipped.
 - Updated v15 upgrades in place so the backend restarts while unchanged
   scheduled tasks remain registered. The mobile bridge is reinstalled and
   restarted only when its shipped payload changes.
+- Reduced measured backend cold-start time by resolving scheduled-task modes
+  once, reusing that result for keep-alive state, and taking a health-only fast
+  path when the mobile bridge is already responding.
 
 ## [15.0.0-phase2-test3] - 2026-09-03
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -741,19 +741,18 @@ $script:DuneIconPath = $null
 # em-dashes or right-arrows here would risk the v11.4.0-class parse breakage
 # the v11.4.1 hotfix addressed.
 $script:DuneAutostartRegistered = $false
-try {
-    if (Get-Command Test-DuneAutostartEnabled -ErrorAction SilentlyContinue) {
-        $script:DuneAutostartRegistered = [bool](Test-DuneAutostartEnabled)
-    }
-} catch { $script:DuneAutostartRegistered = $false }
-Write-DuneStartupLog 'Autostart task state resolved'
 $script:DuneServiceModeRegistered = $false
 try {
-    if (Get-Command Test-DuneServiceEnabled -ErrorAction SilentlyContinue) {
-        $script:DuneServiceModeRegistered = [bool](Test-DuneServiceEnabled)
+    if (Get-Command Get-DuneTaskModeState -ErrorAction SilentlyContinue) {
+        $taskModeState = Get-DuneTaskModeState
+        $script:DuneAutostartRegistered = [bool]$taskModeState.autostart
+        $script:DuneServiceModeRegistered = [bool]$taskModeState.service
     }
-} catch { $script:DuneServiceModeRegistered = $false }
-Write-DuneStartupLog 'Service task state resolved'
+} catch {
+    $script:DuneAutostartRegistered = $false
+    $script:DuneServiceModeRegistered = $false
+}
+Write-DuneStartupLog 'Scheduled task modes resolved'
 $script:DuneKeepAliveAfterShellClose = [bool]$script:DuneHeadlessMode -or $script:DuneAutostartRegistered -or $script:DuneServiceModeRegistered
 if (($script:DuneAutostartRegistered -or $script:DuneServiceModeRegistered) -and -not $script:DuneHeadlessMode) {
     Write-DuneLog "Autostart/service task registered for this user - closing the DuneShell window will leave the backend console running; click the shortcut again to re-open the viewer, or stop the backend explicitly via the tray / console window"
@@ -762,7 +761,12 @@ if (($script:DuneAutostartRegistered -or $script:DuneServiceModeRegistered) -and
 # The former includes service/headless mode; the latter is autostart-only.
 # Both are refreshed when either scheduled-task mode changes.
 if (Get-Command Update-DuneKeepAliveFlag -ErrorAction SilentlyContinue) {
-    try { [void](Update-DuneKeepAliveFlag) } catch {}
+    try {
+        [void](Update-DuneKeepAliveFlag `
+            -UseKnownState `
+            -AutostartEnabled $script:DuneAutostartRegistered `
+            -ServiceEnabled $script:DuneServiceModeRegistered)
+    } catch {}
 }
 Write-DuneStartupLog 'Keep-alive state persisted'
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -25,6 +25,7 @@ try {
 # BEFORE we know whether the normal logger will load. Any exception in the
 # bootstrap is appended here so users always have something to send us.
 $script:DuneStartupLog = $null
+$script:DuneStartupClock = [System.Diagnostics.Stopwatch]::StartNew()
 try {
     $stateDir = Join-Path $env:LOCALAPPDATA 'DuneServer'
     if (-not (Test-Path -LiteralPath $stateDir)) {
@@ -39,7 +40,8 @@ function Write-DuneStartupLog {
     param([string]$Message)
     if (-not $script:DuneStartupLog) { return }
     try {
-        Add-Content -LiteralPath $script:DuneStartupLog -Value "[$(Get-Date -Format 'HH:mm:ss')] $Message" -Encoding UTF8
+        $elapsedMs = $script:DuneStartupClock.ElapsedMilliseconds
+        Add-Content -LiteralPath $script:DuneStartupLog -Value "[$(Get-Date -Format 'HH:mm:ss') +${elapsedMs}ms] $Message" -Encoding UTF8
     } catch { }
 }
 
@@ -161,6 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
         # Non-fatal: console just stays at normal size if Win32 isn't available.
     }
 }
+Write-DuneStartupLog 'Console presentation initialized'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
 $script:DuneToolVersion = '15.0.0-phase2-test4'
@@ -301,6 +304,7 @@ if (-not $script:SingleInstanceOwned) {
         } catch {}
         exit 0
     }
+    Write-DuneStartupLog 'Single-instance gate complete'
 
     # Another instance is already running. Two scenarios:
     #
@@ -485,6 +489,7 @@ if (-not (Test-DuneIsAdmin)) {
     }
     exit 0
 }
+Write-DuneStartupLog 'Elevation confirmed'
 
 # ---------- Path resolution (works for ps2exe and plain pwsh) ------------------
 
@@ -557,6 +562,7 @@ $script:MainScript = Find-DuneSubpath 'dune-server.ps1'
 if (-not $script:MainScript) {
     Write-Host "WARNING: dune-server.ps1 not found near '$script:AppDir'. Command execution will fail." -ForegroundColor Yellow
 }
+Write-DuneStartupLog 'Runtime paths resolved'
 
 # ---------- Load server + routes -----------------------------------------------
 
@@ -577,6 +583,7 @@ $script:DuneLogFilePath = Join-Path $env:LOCALAPPDATA 'DuneServer\dune-server.lo
 Initialize-DuneLog -Path $script:DuneLogFilePath
 
 . (Join-Path $serverDir 'HttpServer.ps1')
+Write-DuneStartupLog 'HTTP module loaded'
 
 # Re-assert the server dir AFTER dot-sourcing HttpServer.ps1. Its top-level
 # declaration is guarded, but re-setting here is a second guarantee that the
@@ -589,6 +596,7 @@ $libDir = Join-Path $serverDir 'lib'
 if (Test-Path $libDir) {
     Get-ChildItem -Path $libDir -Filter '*.ps1' | ForEach-Object { . $_.FullName }
 }
+Write-DuneStartupLog 'Library modules loaded'
 
 # Hydrate the last persisted Maps read model before any HTTP route can observe it.
 # Source refresh is scheduled separately and never runs on the response path.
@@ -604,6 +612,7 @@ if (Get-Command Initialize-DunePlatformCache -ErrorAction SilentlyContinue) {
             Write-DuneLog "Maps platform startup refresh could not be scheduled: $($_.Exception.Message)" 'WARN'
         }
     }
+    Write-DuneStartupLog 'Platform cache initialized and refreshes scheduled'
     if (Get-Command Start-DuneInventoryCacheStartupRefresh -ErrorAction SilentlyContinue) {
         try {
             [void](Start-DuneInventoryCacheStartupRefresh -ServerDir $serverDir -AppDir $script:AppDir)
@@ -618,6 +627,7 @@ $routesDir = Join-Path $serverDir 'routes'
 if (Test-Path $routesDir) {
     Get-ChildItem -Path $routesDir -Filter '*.ps1' | ForEach-Object { . $_.FullName }
 }
+Write-DuneStartupLog 'Route modules loaded'
 
 # Start the native Market Bot ("Duke") scheduler in its own background runspace.
 # It only acts when the bot is enabled in gameplay-bot.json, so this is safe to
@@ -635,6 +645,7 @@ if (Get-Command Start-DuneGameplayBotScheduler -ErrorAction SilentlyContinue) {
 if (Get-Command Initialize-DuneMobileBridge -ErrorAction SilentlyContinue) {
     try { Initialize-DuneMobileBridge -ServerDir $serverDir } catch {}
 }
+Write-DuneStartupLog 'Background services initialized'
 
 # ---------- Token --------------------------------------------------------------
 
@@ -676,7 +687,7 @@ function Get-DuneShellExePath {
 
 # ---------- Start --------------------------------------------------------------
 
-Write-DuneStartupLog "Bootstrap complete, handing off to Start-DuneHttpServer"
+Write-DuneStartupLog 'Module bootstrap complete'
 Write-DuneLog "Dune Server v$script:DuneToolVersion starting"
 Write-DuneLog "Serving from: $script:DistRoot"
 
@@ -750,6 +761,7 @@ if (($script:DuneAutostartRegistered -or $script:DuneServiceModeRegistered) -and
 if (Get-Command Update-DuneKeepAliveFlag -ErrorAction SilentlyContinue) {
     try { [void](Update-DuneKeepAliveFlag) } catch {}
 }
+Write-DuneStartupLog 'Host lifecycle state resolved'
 
 $openInAppWindow = $false
 try { $openInAppWindow = Get-DstOpenInAppWindow } catch { $openInAppWindow = $true }
@@ -846,6 +858,7 @@ if ((-not $script:DuneHeadlessMode) -and -not ($openInAppWindow -and $script:Dun
 }
 
 try {
+    Write-DuneStartupLog 'Starting HTTP listener'
     Start-DuneHttpServer -DistRoot $script:DistRoot -PreferredPort 47823 -Token $script:LaunchToken
 } catch {
     Write-DuneLog "HTTP server failed: $($_.Exception.Message)" 'ERROR'

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -163,7 +163,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 }
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.0-phase2-test3'
+$script:DuneToolVersion = '15.0.0-phase2-test4'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -635,6 +635,7 @@ Write-DuneStartupLog 'Route modules loaded'
 if (Get-Command Start-DuneGameplayBotScheduler -ErrorAction SilentlyContinue) {
     try { [void](Start-DuneGameplayBotScheduler -ServerDir $serverDir) } catch {}
 }
+Write-DuneStartupLog 'Gameplay bot scheduler initialized'
 
 # Self-heal the mobile-app bridge (the loopback reverse-proxy + its background
 # task). Covers the case where the bridge task or listener is missing. The bridge
@@ -645,7 +646,7 @@ if (Get-Command Start-DuneGameplayBotScheduler -ErrorAction SilentlyContinue) {
 if (Get-Command Initialize-DuneMobileBridge -ErrorAction SilentlyContinue) {
     try { Initialize-DuneMobileBridge -ServerDir $serverDir } catch {}
 }
-Write-DuneStartupLog 'Background services initialized'
+Write-DuneStartupLog 'Mobile bridge initialized'
 
 # ---------- Token --------------------------------------------------------------
 
@@ -745,12 +746,14 @@ try {
         $script:DuneAutostartRegistered = [bool](Test-DuneAutostartEnabled)
     }
 } catch { $script:DuneAutostartRegistered = $false }
+Write-DuneStartupLog 'Autostart task state resolved'
 $script:DuneServiceModeRegistered = $false
 try {
     if (Get-Command Test-DuneServiceEnabled -ErrorAction SilentlyContinue) {
         $script:DuneServiceModeRegistered = [bool](Test-DuneServiceEnabled)
     }
 } catch { $script:DuneServiceModeRegistered = $false }
+Write-DuneStartupLog 'Service task state resolved'
 $script:DuneKeepAliveAfterShellClose = [bool]$script:DuneHeadlessMode -or $script:DuneAutostartRegistered -or $script:DuneServiceModeRegistered
 if (($script:DuneAutostartRegistered -or $script:DuneServiceModeRegistered) -and -not $script:DuneHeadlessMode) {
     Write-DuneLog "Autostart/service task registered for this user - closing the DuneShell window will leave the backend console running; click the shortcut again to re-open the viewer, or stop the backend explicitly via the tray / console window"
@@ -761,7 +764,7 @@ if (($script:DuneAutostartRegistered -or $script:DuneServiceModeRegistered) -and
 if (Get-Command Update-DuneKeepAliveFlag -ErrorAction SilentlyContinue) {
     try { [void](Update-DuneKeepAliveFlag) } catch {}
 }
-Write-DuneStartupLog 'Host lifecycle state resolved'
+Write-DuneStartupLog 'Keep-alive state persisted'
 
 $openInAppWindow = $false
 try { $openInAppWindow = Get-DstOpenInAppWindow } catch { $openInAppWindow = $true }

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.0-phase2-test3',
+    [string]$Version = '15.0.0-phase2-test4',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/data/platform-route-policies.json
+++ b/app/data/platform-route-policies.json
@@ -178,7 +178,7 @@
     { "source": "Setup.ps1", "capabilityId": "settings.setup", "routeCount": 11, "sha256": "c0fed70bfe378372fe315534a9598e6203b3b4c22b65a16070186cd296cac73c" },
     { "source": "Shutdown.ps1", "capabilityId": "host.lifecycle", "routeCount": 1, "sha256": "35a9d26192452ee7131cb3541e69cfcd242208f7db855c47e3a4998194797f4f" },
     { "source": "Sietch.ps1", "capabilityId": "operation.topology", "routeCount": 2, "sha256": "c8d97b8e6b93456bbb9eb3eb8a3a77cde95186a15891d5c8e135790e65b73ad6" },
-    { "source": "SoloMode.ps1", "capabilityId": "host.solo", "routeCount": 24, "sha256": "6a453d74048fe2fc46b38d1107f140cbd36c8b36054631656160ae009718fbb8" },
+    { "source": "SoloMode.ps1", "capabilityId": "host.solo", "routeCount": 23, "sha256": "b52465879d384dcf5a269898bbcd3244cb2aa63975afe02753b09fd50eaa0852" },
     { "source": "Status.ps1", "capabilityId": "platform.status", "routeCount": 3, "sha256": "d6cccf669f2d527afb82558161f0a8219345bd12240ddff6964ef0632d5cd56b" },
     { "source": "System.ps1", "capabilityId": "operation.health", "routeCount": 5, "sha256": "2840b487061a7fedff813099e99340c35828a620a1f7bdd703101a0a3fde5396" },
     { "source": "Terminal.ps1", "capabilityId": "host.powershell", "routeCount": 1, "sha256": "5d7ac95f866d37d8b7d5b1a1cfd35275ccac7a2f990f2ad2b80409717ad56873" },

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.0-phase2-test3</Version>
+    <Version>15.0.0-phase2-test4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -242,6 +242,7 @@ var
   PortModePage:    TInputOptionWizardPage;
   SkipConfigPages: Boolean;
   PriorBridgeHash: string;
+  PriorBridgeInstallerHash: string;
 
 // ---------- v12.0.0 one-time migration helpers ----------
 
@@ -659,9 +660,13 @@ begin
   NeedsRestart := False;
 
   PriorBridgeHash := '';
+  PriorBridgeInstallerHash := '';
   if FileExists(ExpandConstant('{app}\helper\bridge\DstHelperBridge.ps1')) then
     PriorBridgeHash :=
       GetSHA256OfFile(ExpandConstant('{app}\helper\bridge\DstHelperBridge.ps1'));
+  if FileExists(ExpandConstant('{app}\helper\bridge\Install-Bridge.ps1')) then
+    PriorBridgeInstallerHash :=
+      GetSHA256OfFile(ExpandConstant('{app}\helper\bridge\Install-Bridge.ps1'));
 
   if ShouldUseInPlaceUpgrade() then
   begin
@@ -672,6 +677,7 @@ begin
   else
   begin
     PriorBridgeHash := '';
+    PriorBridgeInstallerHash := '';
     UninstallPreviousVersion();
   end;
 
@@ -680,17 +686,23 @@ end;
 
 function ShouldInstallBridge(): Boolean;
 var
-  newBridgePath, newBridgeHash: string;
+  newBridgePath, newInstallerPath, newBridgeHash, newInstallerHash: string;
 begin
   newBridgePath := ExpandConstant('{app}\helper\bridge\DstHelperBridge.ps1');
-  if (PriorBridgeHash = '') or (not FileExists(newBridgePath)) then
+  newInstallerPath := ExpandConstant('{app}\helper\bridge\Install-Bridge.ps1');
+  if (PriorBridgeHash = '') or
+     (PriorBridgeInstallerHash = '') or
+     (not FileExists(newBridgePath)) or
+     (not FileExists(newInstallerPath)) then
   begin
     Result := True;
     Exit;
   end;
 
   newBridgeHash := GetSHA256OfFile(newBridgePath);
-  Result := PriorBridgeHash <> newBridgeHash;
+  newInstallerHash := GetSHA256OfFile(newInstallerPath);
+  Result := (PriorBridgeHash <> newBridgeHash) or
+            (PriorBridgeInstallerHash <> newInstallerHash);
   if Result then
     Log('Bridge payload changed; reinstalling and restarting bridge task.')
   else

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.0-phase2-test3"
+#define MyAppVersion "15.0.0-phase2-test4"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
@@ -120,6 +120,21 @@ Source: "..\..\tools\preflight\*"; DestDir: "{app}\tools\preflight"; Flags: igno
 ; Mobile/remote app bridge daemon (loopback reverse-proxy)
 Source: "..\..\helper\bridge\*"; DestDir: "{app}\helper\bridge"; Flags: ignoreversion recursesubdirs
 
+[InstallDelete]
+; v15.0.0-phase2-test4: Modern upgrades update in place so scheduled tasks
+; survive. Clear only installer-managed directory trees before copying to
+; prevent removed scripts and hashed web assets from lingering.
+Type: filesandordirs; Name: "{app}\server"
+Type: filesandordirs; Name: "{app}\lib"
+Type: filesandordirs; Name: "{app}\data"
+Type: filesandordirs; Name: "{app}\webui\dist"
+Type: filesandordirs; Name: "{app}\resources\remote-scripts"
+Type: filesandordirs; Name: "{app}\tools\preflight"
+Type: filesandordirs; Name: "{app}\tools\solo"
+Type: filesandordirs; Name: "{app}\tools\platform"
+Type: filesandordirs; Name: "{app}\helper\bridge"
+Type: filesandordirs; Name: "{app}\assets"
+
 [Icons]
 ; Start Menu shortcut (always created)
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyAppExeName}"; Comment: "Dune Awakening server management"; Flags: runminimized
@@ -164,8 +179,15 @@ Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -Com
 ; autostart preference. Idempotent; never blocks install on failure.
 Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -Command ""try {{ Get-ScheduledTask -TaskPath '\Dune Server\' -ErrorAction SilentlyContinue | Where-Object {{ $_.TaskName -like 'DuneServer-Autostart-*' }} | Unregister-ScheduledTask -Confirm:$false -ErrorAction SilentlyContinue }} catch {{}}"""; Flags: runhidden waituntilterminated; Check: ShouldClearLegacyAutostart
 
-; Install mobile/remote app bridge (loopback proxy + self-healing task)
-Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\helper\bridge\Install-Bridge.ps1"""; Flags: runhidden waituntilterminated
+; Install or replace the mobile/remote bridge only when its shipped payload
+; changed. An unchanged bridge process and scheduled task survive modern
+; in-place upgrades.
+Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\helper\bridge\Install-Bridge.ps1"""; Flags: runhidden waituntilterminated; Check: ShouldInstallBridge
+
+; The backend executable is replaced on every upgrade, so an existing service
+; task must start its fresh process every time even though its registration and
+; stored credentials remain untouched.
+Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -Command ""Get-ScheduledTask -TaskPath '\Dune Server\' -ErrorAction SilentlyContinue | Where-Object {{ $_.TaskName -like 'DuneServer-Service-*' }} | Start-ScheduledTask -ErrorAction SilentlyContinue"""; Flags: runhidden waituntilterminated
 
 ; Launch the shell immediately after install. It starts DuneServer.exe with
 ; --reattach when needed, so the user sees startup progress while the backend
@@ -219,6 +241,7 @@ var
   UserPage:        TInputQueryWizardPage;
   PortModePage:    TInputOptionWizardPage;
   SkipConfigPages: Boolean;
+  PriorBridgeHash: string;
 
 // ---------- v12.0.0 one-time migration helpers ----------
 
@@ -250,6 +273,14 @@ begin
   dotPos := Pos('.', ver);
   if dotPos > 0 then head := Copy(ver, 1, dotPos - 1) else head := ver;
   Result := StrToIntDef(head, -1);
+end;
+
+// v15+ uses a stable install layout and stable scheduled-task actions. Update
+// installer-managed files in place so upgrades restart the backend without
+// unregistering and recreating those tasks.
+function ShouldUseInPlaceUpgrade(): Boolean;
+begin
+  Result := VersionMajor(GetPriorInstalledVersion()) >= 15;
 end;
 
 // True when upgrading from a build older than 12.0.0 (and so we should run
@@ -626,6 +657,42 @@ end;
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 begin
   NeedsRestart := False;
-  UninstallPreviousVersion();
+
+  PriorBridgeHash := '';
+  if FileExists(ExpandConstant('{app}\helper\bridge\DstHelperBridge.ps1')) then
+    PriorBridgeHash :=
+      GetSHA256OfFile(ExpandConstant('{app}\helper\bridge\DstHelperBridge.ps1'));
+
+  if ShouldUseInPlaceUpgrade() then
+  begin
+    StopRunningDuneServer();
+    Sleep(500);
+    Log('Using v15+ in-place upgrade; scheduled tasks remain registered.');
+  end
+  else
+  begin
+    PriorBridgeHash := '';
+    UninstallPreviousVersion();
+  end;
+
   Result := '';
+end;
+
+function ShouldInstallBridge(): Boolean;
+var
+  newBridgePath, newBridgeHash: string;
+begin
+  newBridgePath := ExpandConstant('{app}\helper\bridge\DstHelperBridge.ps1');
+  if (PriorBridgeHash = '') or (not FileExists(newBridgePath)) then
+  begin
+    Result := True;
+    Exit;
+  end;
+
+  newBridgeHash := GetSHA256OfFile(newBridgePath);
+  Result := PriorBridgeHash <> newBridgeHash;
+  if Result then
+    Log('Bridge payload changed; reinstalling and restarting bridge task.')
+  else
+    Log('Bridge payload unchanged; preserving running bridge and scheduled task.');
 end;

--- a/app/server/lib/Autostart.ps1
+++ b/app/server/lib/Autostart.ps1
@@ -230,6 +230,26 @@ function Get-DuneServiceTaskName {
     return "DuneServer-Service-$suffix"
 }
 
+function Get-DuneTaskModeState {
+    $folder = Get-DuneAutostartTaskFolder
+    $autostartName = Get-DuneAutostartTaskName
+    $serviceName = Get-DuneServiceTaskName
+    try {
+        if (Get-Command Get-ScheduledTask -ErrorAction SilentlyContinue) {
+            $taskNames = @(Get-ScheduledTask -TaskPath $folder -ErrorAction SilentlyContinue |
+                ForEach-Object { $_.TaskName })
+            return [pscustomobject]@{
+                autostart = $taskNames -contains $autostartName
+                service   = $taskNames -contains $serviceName
+            }
+        }
+    } catch {}
+    return [pscustomobject]@{
+        autostart = [bool](Test-DuneAutostartEnabled)
+        service   = [bool](Test-DuneServiceEnabled)
+    }
+}
+
 # Whether the always-on service task currently exists for THIS user.
 function Test-DuneServiceEnabled {
     $folder = Get-DuneAutostartTaskFolder

--- a/app/server/lib/ConsoleHost.ps1
+++ b/app/server/lib/ConsoleHost.ps1
@@ -168,18 +168,28 @@ function Clear-DuneShellCloseToTrayFlag {
 # whether the autostart task is currently registered for this user) and write
 # or remove the sentinel file accordingly. Safe to call repeatedly.
 function Update-DuneKeepAliveFlag {
-    $autostart = $false
-    try {
-        if (Get-Command Test-DuneAutostartEnabled -ErrorAction SilentlyContinue) {
-            $autostart = [bool](Test-DuneAutostartEnabled)
-        }
-    } catch { $autostart = $false }
-    $service = $false
-    try {
-        if (Get-Command Test-DuneServiceEnabled -ErrorAction SilentlyContinue) {
-            $service = [bool](Test-DuneServiceEnabled)
-        }
-    } catch { $service = $false }
+    param(
+        [switch]$UseKnownState,
+        [bool]$AutostartEnabled = $false,
+        [bool]$ServiceEnabled = $false
+    )
+    if ($UseKnownState) {
+        $autostart = $AutostartEnabled
+        $service = $ServiceEnabled
+    } else {
+        $autostart = $false
+        try {
+            if (Get-Command Test-DuneAutostartEnabled -ErrorAction SilentlyContinue) {
+                $autostart = [bool](Test-DuneAutostartEnabled)
+            }
+        } catch { $autostart = $false }
+        $service = $false
+        try {
+            if (Get-Command Test-DuneServiceEnabled -ErrorAction SilentlyContinue) {
+                $service = [bool](Test-DuneServiceEnabled)
+            }
+        } catch { $service = $false }
+    }
     $keep = [bool]$script:DuneHeadlessMode -or $autostart -or $service
     if ($keep) { Set-DuneKeepAliveFlag } else { Clear-DuneKeepAliveFlag }
     # X retains the shell and tray only for the explicit "Run at Windows

--- a/app/server/lib/MobileBridge.ps1
+++ b/app/server/lib/MobileBridge.ps1
@@ -51,8 +51,9 @@ function Test-DuneBridgeElevated {
 }
 
 function Test-DuneBridgeHealth {
+    param([int]$TimeoutSec = 4)
     try {
-        $h = Invoke-RestMethod -Uri "http://127.0.0.1:$script:DuneMobileBridgePort/_dst/health" -TimeoutSec 1 -ErrorAction Stop
+        $h = Invoke-RestMethod -Uri "http://127.0.0.1:$script:DuneMobileBridgePort/_dst/health" -TimeoutSec $TimeoutSec -ErrorAction Stop
         return [bool]$h.ok
     } catch {
         return $false
@@ -147,7 +148,7 @@ function Invoke-DuneBridgeRepair {
 function Initialize-DuneMobileBridge {
     param([string]$ServerDir)
     try {
-        if (Test-DuneBridgeHealth) { return }
+        if (Test-DuneBridgeHealth -TimeoutSec 1) { return }
         $st = Get-DuneBridgeStatus
         if ($st.task -and $st.listening) { return }  # already healthy
         [void](Invoke-DuneBridgeRepair -NoWait)

--- a/app/server/lib/MobileBridge.ps1
+++ b/app/server/lib/MobileBridge.ps1
@@ -50,6 +50,15 @@ function Test-DuneBridgeElevated {
     } catch { return $false }
 }
 
+function Test-DuneBridgeHealth {
+    try {
+        $h = Invoke-RestMethod -Uri "http://127.0.0.1:$script:DuneMobileBridgePort/_dst/health" -TimeoutSec 1 -ErrorAction Stop
+        return [bool]$h.ok
+    } catch {
+        return $false
+    }
+}
+
 function Get-DuneBridgeStatus {
     $port = $script:DuneMobileBridgePort
 
@@ -64,11 +73,7 @@ function Get-DuneBridgeStatus {
     $listening = $false
     try { $listening = [bool](Get-NetTCPConnection -State Listen -LocalPort $port -ErrorAction SilentlyContinue) } catch {}
 
-    $healthOk = $false
-    try {
-        $h = Invoke-RestMethod -Uri "http://127.0.0.1:$port/_dst/health" -TimeoutSec 4 -ErrorAction Stop
-        $healthOk = [bool]$h.ok
-    } catch {}
+    $healthOk = Test-DuneBridgeHealth
 
     $issues = New-Object System.Collections.Generic.List[string]
     if (-not $hasTask)      { [void]$issues.Add('The mobile bridge background task is not installed.') }
@@ -142,6 +147,7 @@ function Invoke-DuneBridgeRepair {
 function Initialize-DuneMobileBridge {
     param([string]$ServerDir)
     try {
+        if (Test-DuneBridgeHealth) { return }
         $st = Get-DuneBridgeStatus
         if ($st.task -and $st.listening) { return }  # already healthy
         [void](Invoke-DuneBridgeRepair -NoWait)

--- a/app/server/lib/SoloMode.ps1
+++ b/app/server/lib/SoloMode.ps1
@@ -317,7 +317,7 @@ function Assert-DuneSoloGameClosed {
 
 function Invoke-DuneSoloHelper {
     param(
-        [Parameter(Mandatory)][ValidateSet('inspect','backup','restore','grant-items','import-blueprint','set-currencies','fill-water','set-weapon-ammo','set-backpack-slots','max-augment-attributes','max-specializations','complete-fremen','complete-npe','enable-skills','set-progression-points')][string]$Command,
+        [Parameter(Mandatory)][ValidateSet('inspect','backup','restore','grant-items','import-blueprint','set-currencies','fill-water','set-weapon-ammo','max-augment-attributes','max-specializations','complete-fremen','complete-npe','enable-skills','set-progression-points')][string]$Command,
         [Parameter(Mandatory)][hashtable]$Arguments
     )
 
@@ -594,36 +594,6 @@ function Set-DuneSoloWeaponAmmo {
         'safety-backup' = $safety
         'item-id' = $ItemId
         ammo = $Ammo
-        catalog = Get-DuneSoloGameplayCatalogPath
-    }
-}
-
-function Set-DuneSoloBackpackSlots {
-    param(
-        [Parameter(Mandatory)][long]$Slots,
-        [Parameter(Mandatory)][string]$Confirm
-    )
-
-    Assert-DuneSoloSupportedPlatform
-    if ($Confirm -ne 'SET SOLO BACKPACK SLOTS') {
-        throw 'Confirm the offline backpack slot update before continuing.'
-    }
-    Assert-DuneSoloGameClosed
-    if ($Slots -lt 1 -or $Slots -gt 100000) {
-        throw 'Backpack slots must be between 1 and 100000.'
-    }
-    $profile = Get-DuneSoloProfile
-    if (-not $profile.dbPath -or -not (Test-Path -LiteralPath $profile.dbPath -PathType Leaf)) {
-        throw 'Connect a valid Solo save before changing backpack slots.'
-    }
-    $safetyDir = Join-Path (Get-DuneSoloProfileBackupRoot -DbPath $profile.dbPath) 'pre-slots'
-    New-Item -ItemType Directory -Path $safetyDir -Force | Out-Null
-    $stamp = (Get-Date).ToUniversalTime().ToString('yyyyMMdd-HHmmssfff')
-    $safety = Join-Path $safetyDir "game-before-backpack-slots-$stamp.db"
-    return Invoke-DuneSoloHelper -Command 'set-backpack-slots' -Arguments @{
-        input = $profile.dbPath
-        'safety-backup' = $safety
-        slots = $Slots
         catalog = Get-DuneSoloGameplayCatalogPath
     }
 }

--- a/app/server/routes/SoloMode.ps1
+++ b/app/server/routes/SoloMode.ps1
@@ -308,23 +308,6 @@ Register-DuneRoute -Method PUT -Path '/api/solo/items/weapon-ammo' -LocalOnly -H
     }
 }
 
-Register-DuneRoute -Method PUT -Path '/api/solo/inventory/backpack-slots' -LocalOnly -Handler {
-    param($req, $res, $routeParams, $body)
-    try {
-        $slots = [long](Get-DuneSoloBodyField -Body $body -Name 'slots' -Default 0)
-        $confirm = [string](Get-DuneSoloBodyField -Body $body -Name 'confirm' -Default '')
-        $expectedProfileToken = [string](Get-DuneSoloBodyField -Body $body -Name 'expectedProfileToken' -Default '')
-        $result = Invoke-WithDuneLock -Name 'solo-profile-data' -Script {
-            Assert-DuneSoloExpectedProfile -ExpectedProfileToken $expectedProfileToken
-            Set-DuneSoloBackpackSlots -Slots $slots -Confirm $confirm
-        }
-        Write-DuneJson -Response $res -Body $result
-    } catch {
-        $status = if ($_.Exception.Message -like '*still running*' -or $_.Exception.Message -like '*changed in another window*') { 409 } else { 400 }
-        Write-DuneError -Response $res -Status $status -Message $_.Exception.Message
-    }
-}
-
 Register-DuneRoute -Method POST -Path '/api/solo/progression/specializations/max' -LocalOnly -Handler {
     param($req, $res, $routeParams, $body)
     try {

--- a/app/tools/DuneSoloDb/Program.cs
+++ b/app/tools/DuneSoloDb/Program.cs
@@ -99,11 +99,6 @@ internal static partial class Program
                     ParseItemId(RequireValue(options, "item-id")),
                     ParseBalance(RequireValue(options, "ammo"), "Ammo"),
                     Require(options, "catalog")),
-                "set-backpack-slots" => SetBackpackSlots(
-                    Require(options, "input"),
-                    Require(options, "safety-backup"),
-                    ParseBalance(RequireValue(options, "slots"), "Backpack slots"),
-                    Require(options, "catalog")),
                 "max-augment-attributes" => MaxAugmentAttributes(
                     Require(options, "input"),
                     Require(options, "safety-backup")),
@@ -644,140 +639,6 @@ internal static partial class Program
                 }
             }
         }
-
-    private static object SetBackpackSlots(
-        string input,
-        string safetyBackup,
-        long slots,
-        string catalogPath,
-        bool requireGameClosed = true)
-    {
-        if (slots is < 1 or > 100_000)
-        {
-            throw new InvalidDataException("Backpack slots must be between 1 and 100000.");
-        }
-        var catalog = ReadCatalog(catalogPath);
-        var originalBytes = ReadStable(input);
-        EnsureWritableInspection(InspectBytes(originalBytes, input, catalog));
-        var wrapped = Unwrap(originalBytes);
-        var root = Path.Combine(Path.GetTempPath(), $"dune-solo-slots-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(root);
-        long inventoryId = 0;
-        try
-        {
-            var sqlitePath = Path.Combine(root, "slots.sqlite");
-            File.WriteAllBytes(sqlitePath, wrapped.SqliteBytes);
-            var connectionString = new SqliteConnectionStringBuilder
-            {
-                DataSource = sqlitePath,
-                Mode = SqliteOpenMode.ReadWrite,
-                Pooling = false
-            }.ToString();
-            using (var connection = new SqliteConnection(connectionString))
-            {
-                connection.Open();
-                ExecuteNonQuery(connection, "PRAGMA foreign_keys = ON;");
-                ExecuteNonQuery(connection, "BEGIN IMMEDIATE;");
-                try
-                {
-                    var pawnId = ScalarLong(
-                        connection,
-                        "SELECT player_pawn_id FROM player_state LIMIT 1;");
-                    using var lookup = connection.CreateCommand();
-                    lookup.CommandText = """
-                        SELECT id
-                        FROM inventories
-                        WHERE actor_id = $pawn
-                          AND inventory_type = 0
-                          AND COALESCE(max_item_count, 0) > 0
-                        ORDER BY id
-                        LIMIT 1;
-                        """;
-                    lookup.Parameters.AddWithValue("$pawn", pawnId);
-                    var found = lookup.ExecuteScalar();
-                    if (found is null || found is DBNull)
-                    {
-                        throw new InvalidDataException(
-                            "The Solo character backpack inventory was not found.");
-                    }
-                    inventoryId = Convert.ToInt64(found);
-                    var affected = ExecuteNonQuery(
-                        connection,
-                        """
-                        UPDATE inventories
-                        SET max_item_count = $slots
-                        WHERE id = $inventory
-                          AND actor_id = $pawn
-                          AND inventory_type = 0;
-                        """,
-                        ("$slots", slots),
-                        ("$inventory", inventoryId),
-                        ("$pawn", pawnId));
-                    if (affected != 1)
-                    {
-                        throw new InvalidDataException(
-                            "The Solo character backpack inventory was not updated.");
-                    }
-                    var verified = ScalarLong(
-                        connection,
-                        "SELECT max_item_count FROM inventories WHERE id = $inventory;",
-                        ("$inventory", inventoryId));
-                    if (verified != slots)
-                    {
-                        throw new InvalidDataException("Backpack slot verification failed.");
-                    }
-                    var integrity = ScalarString(connection, "PRAGMA integrity_check;");
-                    var foreignKeys = ScalarLong(
-                        connection,
-                        "SELECT COUNT(*) FROM pragma_foreign_key_check;");
-                    if (!string.Equals(integrity, "ok", StringComparison.OrdinalIgnoreCase)
-                        || foreignKeys != 0)
-                    {
-                        throw new InvalidDataException(
-                            $"Backpack slot validation failed (integrity={integrity}, foreignKeys={foreignKeys}).");
-                    }
-                    ExecuteNonQuery(connection, "COMMIT;");
-                }
-                catch
-                {
-                    try { ExecuteNonQuery(connection, "ROLLBACK;"); } catch { }
-                    throw;
-                }
-            }
-
-            var mutated = Path.Combine(root, "game.db");
-            WrapSqlite(sqlitePath, mutated);
-            EnsureWritableInspection(InspectPath(mutated, catalogPath));
-            Restore(
-                mutated,
-                input,
-                safetyBackup,
-                expectedTargetBytes: originalBytes,
-                requireGameClosed);
-            return new
-            {
-                ok = true,
-                inventoryId,
-                slots,
-                safetyBackup,
-                inspection = InspectPath(input, catalogPath)
-            };
-        }
-        finally
-        {
-            try
-            {
-                if (Directory.Exists(root))
-                {
-                    Directory.Delete(root, recursive: true);
-                }
-            }
-            catch
-            {
-                // A stale temp directory is safer than hiding the slot result.
-            }
-        }
-    }
 
     private static object FillWaterContainer(
         string input,
@@ -1654,16 +1515,6 @@ internal static partial class Program
                 throw new InvalidOperationException(
                     "Infinite weapon ammo mode did not retain the verified non-decrementing value.");
             }
-            var slotSafety = Path.Combine(root, "safety", "before-backpack-slots.db");
-            SetBackpackSlots(target, slotSafety, 120, catalogPath, requireGameClosed: false);
-            var slotInspection = InspectPath(target, catalogPath);
-            if (!File.Exists(slotSafety)
-                || slotInspection.Inventories.Single(value =>
-                    value.Kind == "backpack").MaxItemCount != 120)
-            {
-                throw new InvalidOperationException(
-                    "Offline backpack slot update did not retain, write, and verify the exact inventory.");
-            }
             File.WriteAllText(
                 planPath,
                 """
@@ -2244,7 +2095,6 @@ internal static partial class Program
                     "custom-storage-labels-with-generic-fallback",
                     "solo-inventory-grouped-read-model",
                     "offline-weapon-ammo-update-with-safety-backup",
-                    "offline-backpack-slot-update-with-safety-backup",
                     "retained-backup",
                     "atomic-restore-with-safety-backup",
                     "unsupported-wrapper-rejected",

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.0-phase2-test3"
+$script:ToolVersion = "15.0.0-phase2-test4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/AutostartStartup.Tests.ps1
+++ b/tests/AutostartStartup.Tests.ps1
@@ -1,0 +1,20 @@
+Describe 'Autostart startup state' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..\app\server\lib\Autostart.ps1')
+    }
+
+    It 'resolves autostart and service modes with one scheduled-task query' {
+        Mock Get-ScheduledTask {
+            @(
+                [pscustomobject]@{ TaskName = Get-DuneAutostartTaskName }
+                [pscustomobject]@{ TaskName = Get-DuneServiceTaskName }
+            )
+        }
+
+        $state = Get-DuneTaskModeState
+
+        $state.autostart | Should -BeTrue
+        $state.service | Should -BeTrue
+        Should -Invoke Get-ScheduledTask -Times 1
+    }
+}

--- a/tests/ConsoleHostTrayPolicy.Tests.ps1
+++ b/tests/ConsoleHostTrayPolicy.Tests.ps1
@@ -46,4 +46,15 @@ Describe 'DuneShell close-to-tray policy' {
         Test-Path (Get-DuneKeepAliveStateFile) | Should -BeFalse
         Test-Path (Get-DuneShellCloseToTrayStateFile) | Should -BeFalse
     }
+
+    It 'uses known startup task state without querying Task Scheduler again' {
+        function global:Test-DuneAutostartEnabled { throw 'unexpected autostart query' }
+        function global:Test-DuneServiceEnabled { throw 'unexpected service query' }
+
+        Update-DuneKeepAliveFlag -UseKnownState -AutostartEnabled $false -ServiceEnabled $true |
+            Should -BeTrue
+
+        Test-Path (Get-DuneKeepAliveStateFile) | Should -BeTrue
+        Test-Path (Get-DuneShellCloseToTrayStateFile) | Should -BeFalse
+    }
 }

--- a/tests/MobileBridgeStartup.Tests.ps1
+++ b/tests/MobileBridgeStartup.Tests.ps1
@@ -1,0 +1,17 @@
+Describe 'Mobile bridge startup' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..\app\server\lib\MobileBridge.ps1')
+    }
+
+    It 'takes the health-only fast path when the bridge is already responding' {
+        Mock Invoke-RestMethod { [pscustomobject]@{ ok = $true } }
+        Mock Get-DuneBridgeStatus { throw 'full status should not run' }
+        Mock Invoke-DuneBridgeRepair { throw 'repair should not run' }
+
+        { Initialize-DuneMobileBridge } | Should -Not -Throw
+
+        Should -Invoke Invoke-RestMethod -Times 1
+        Should -Invoke Get-DuneBridgeStatus -Times 0
+        Should -Invoke Invoke-DuneBridgeRepair -Times 0
+    }
+}

--- a/tests/MobileBridgeStartup.Tests.ps1
+++ b/tests/MobileBridgeStartup.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'Mobile bridge startup' {
 
         { Initialize-DuneMobileBridge } | Should -Not -Throw
 
-        Should -Invoke Invoke-RestMethod -Times 1
+        Should -Invoke Invoke-RestMethod -Times 1 -ParameterFilter { $TimeoutSec -eq 1 }
         Should -Invoke Get-DuneBridgeStatus -Times 0
         Should -Invoke Invoke-DuneBridgeRepair -Times 0
     }

--- a/tests/PlatformContracts.Tests.ps1
+++ b/tests/PlatformContracts.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'Complete route classification' {
     It 'classifies the exact registered HTTP and WebSocket inventory' {
         $records = @(Get-PlatformRouteRecords)
         $manifest = Get-DuneRoutePolicyManifest
-        $records.Count | Should -Be 362
+        $records.Count | Should -Be 361
         $sources = @($records.SourceFile | Sort-Object -Unique)
         @($manifest.groups.source | Sort-Object) | Should -Be $sources
 
@@ -321,7 +321,7 @@ $result = @{
         $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
         $resultLine = @($output | Where-Object { [string]$_ -like 'ROUTE_RESULT:*' })[-1]
         $result = ([string]$resultLine).Substring('ROUTE_RESULT:'.Length) | ConvertFrom-Json
-        $result.total | Should -Be 362
+        $result.total | Should -Be 361
         $result.unclassified | Should -Be 0
         $result.incompatible | Should -Be 0
         $result.podsCleanup | Should -Be 1

--- a/tests/SoloMode.Tests.ps1
+++ b/tests/SoloMode.Tests.ps1
@@ -471,30 +471,6 @@ Describe 'Solo Mode write gates and settings backups' {
         }
     }
 
-    It 'builds a backup-safe backpack slot update while the game is closed' {
-        $layout = New-TestSoloLayout
-        Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
-        Mock Get-DuneSoloGameProcesses { @() }
-        Mock Get-DuneSoloGameplayCatalogPath { Join-Path $script:SoloTestRoot 'catalog.json' }
-        Mock Invoke-DuneSoloHelper {
-            @{
-                ok = $true
-                slots = 120
-                safetyBackup = 'test'
-            }
-        }
-        $result = Set-DuneSoloBackpackSlots -Slots 120 `
-            -Confirm 'SET SOLO BACKPACK SLOTS'
-
-        $result.ok | Should -BeTrue
-        Assert-MockCalled Invoke-DuneSoloHelper -Times 1 -ParameterFilter {
-            $Command -eq 'set-backpack-slots' -and
-            $Arguments.input -eq $layout.db -and
-            $Arguments.slots -eq 120 -and
-            $Arguments['safety-backup'] -like '*pre-slots*'
-        }
-    }
-
     It 'builds a backup-safe augment update while the game is closed' {
         $layout = New-TestSoloLayout
         Save-DuneSoloState -DataRoot $layout.root -DbPath $layout.db | Out-Null
@@ -578,7 +554,6 @@ Describe 'Solo Mode route security metadata' {
             '/api/solo/currencies',
             '/api/solo/fillables/water',
             '/api/solo/items/weapon-ammo',
-            '/api/solo/inventory/backpack-slots',
             '/api/solo/progression/specializations/max',
             '/api/solo/progression/find-the-fremen',
             '/api/solo/progression/npe/complete',

--- a/webui/src/api/solo.ts
+++ b/webui/src/api/solo.ts
@@ -413,26 +413,6 @@ export function setSoloWeaponAmmo(
   })
 }
 
-export function setSoloBackpackSlots(
-  slots: number,
-  expectedProfileToken: string,
-): Promise<{
-  ok: boolean
-  inventoryId: number
-  slots: number
-  safetyBackup: string
-  inspection: SoloInspection
-}> {
-  return api('/api/solo/inventory/backpack-slots', {
-    method: 'PUT',
-    body: JSON.stringify({
-      slots,
-      expectedProfileToken,
-      confirm: 'SET SOLO BACKPACK SLOTS',
-    }),
-  })
-}
-
 export function maxSoloAugmentAttributes(expectedProfileToken: string): Promise<{
   ok: boolean
   updated: number

--- a/webui/src/components/solo/SoloInventoryExplorer.tsx
+++ b/webui/src/components/solo/SoloInventoryExplorer.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { SharedInventoryGroup } from '../../api/gameplay'
 import type { SoloInventoryItemGroup, SoloRangedWeapon } from '../../api/solo'
-import type { SoloInventoryDestination } from '../../api/solo'
 import { Icon } from '../Icon'
 import { InventorySlot } from '../inventory/InventorySlot'
 import { DataState } from '../platform/DataState'
@@ -310,66 +309,6 @@ export function SoloWeaponAmmoEditor({
           >
             <Icon name={busy ? 'LoaderCircle' : 'Save'} size={14} className={busy ? 'animate-spin' : undefined} />
             {busy ? 'Saving...' : 'Set ammo'}
-          </button>
-        </div>
-      )}
-    </section>
-  )
-}
-
-export function SoloBackpackSlotsEditor({
-  backpack,
-  disabled,
-  busy,
-  onSave,
-}: {
-  backpack?: SoloInventoryDestination
-  disabled: boolean
-  busy: boolean
-  onSave: (slots: number) => void
-}) {
-  const [slots, setSlots] = useState(backpack?.maxItemCount ?? 60)
-
-  useEffect(() => {
-    setSlots(backpack?.maxItemCount ?? 60)
-  }, [backpack?.id, backpack?.maxItemCount])
-
-  return (
-    <section className="card p-5" aria-labelledby="solo-backpack-slots-title">
-      <h2 id="solo-backpack-slots-title" className="flex items-center gap-2 font-semibold">
-        <Icon name="Backpack" size={16} />
-        Backpack slot capacity
-      </h2>
-      <p className="mt-1 text-sm text-text-muted">
-        Change the backpack item-slot limit independently from inventory volume. The game must be fully closed; DST retains and verifies the save.
-      </p>
-      {!backpack ? (
-        <div className="mt-4">
-          <DataState state="empty" title="No Solo backpack inventory found" />
-        </div>
-      ) : (
-        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
-          <label className="w-full text-sm font-medium text-text sm:max-w-xs">
-            Maximum backpack slots
-            <input
-              type="number"
-              min={1}
-              max={100_000}
-              step={1}
-              className="input mt-1 min-h-11 w-full"
-              value={slots}
-              disabled={disabled || busy}
-              onChange={event => setSlots(Number(event.target.value))}
-            />
-          </label>
-          <button
-            type="button"
-            className="btn-primary min-h-11"
-            disabled={disabled || busy || !Number.isSafeInteger(slots) || slots < 1 || slots > 100_000}
-            onClick={() => onSave(slots)}
-          >
-            <Icon name={busy ? 'LoaderCircle' : 'Save'} size={14} className={busy ? 'animate-spin' : undefined} />
-            {busy ? 'Saving...' : 'Set backpack slots'}
           </button>
         </div>
       )}

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -4,7 +4,6 @@ import { PageHeader } from '../components/PageHeader'
 import { CollapsibleCard } from '../components/CollapsibleCard'
 import { ItemPicker } from '../components/ItemPicker'
 import {
-  SoloBackpackSlotsEditor,
   SoloInventoryExplorer,
   SoloWeaponAmmoEditor,
 } from '../components/solo/SoloInventoryExplorer'
@@ -27,7 +26,6 @@ import {
   restoreSoloBackup,
   saveSoloConsoleSettings,
   saveSoloSettings,
-  setSoloBackpackSlots,
   setSoloWeaponAmmo,
   setSoloCurrencies,
   setSoloProgressionPoints,
@@ -1082,35 +1080,6 @@ export function SoloMode() {
     }
   }
 
-  const setBackpackSlots = async (slots: number) => {
-    if (!selectionMatchesActive) {
-      setNotice({ kind: 'err', text: 'Connect and validate the selected Solo profile before changing backpack slots.' })
-      return
-    }
-    if (gameRunning) {
-      setNotice({ kind: 'err', text: 'Close Dune: Awakening completely before changing Solo backpack slots.' })
-      return
-    }
-    if (!window.confirm(
-      `Set the Solo backpack to ${slots.toLocaleString()} item slots?\n\n`
-      + 'DST will retain the current game.db, update only the exact character backpack, and verify the saved limit.',
-    )) return
-    setBusy('backpack-slots')
-    setNotice(null)
-    try {
-      const result = await setSoloBackpackSlots(slots, statusState.data?.profileToken ?? '')
-      setNotice({
-        kind: 'ok',
-        text: `Backpack slot capacity set to ${result.slots.toLocaleString()}. Backup: ${result.safetyBackup}`,
-      })
-      await Promise.all([statusState.refresh(), runtimeState.refresh(), backupsState.refresh()])
-    } catch (error) {
-      setNotice({ kind: 'err', text: error instanceof Error ? error.message : String(error) })
-    } finally {
-      setBusy(null)
-    }
-  }
-
   const maxAugmentAttributes = async () => {
     if (!selectionMatchesActive) {
       setNotice({ kind: 'err', text: 'Connect and validate the selected Solo profile before changing augments.' })
@@ -1799,12 +1768,6 @@ export function SoloMode() {
       {tab === 'inventory' && (
         <div className="space-y-4">
           <SoloInventoryExplorer items={inspection?.inventoryItems ?? []} connected={connected} />
-          <SoloBackpackSlotsEditor
-            backpack={inspection?.inventories.find(inventory => inventory.kind === 'backpack')}
-            disabled={!canMutateActiveProfile || gameRunning || busy !== null}
-            busy={busy === 'backpack-slots'}
-            onSave={slots => { void setBackpackSlots(slots) }}
-          />
           <SoloWeaponAmmoEditor
             weapons={inspection?.rangedWeapons ?? []}
             disabled={!canMutateActiveProfile || gameRunning || busy !== null}


### PR DESCRIPTION
## Summary
- reduce measured backend cold-start time by avoiding repeated scheduled-task queries and using a healthy-bridge fast path
- preserve unchanged scheduled tasks during v15 upgrades while restarting the backend every time
- remove the ineffective Solo backpack-slot editor after field testing confirmed PTC rewrites direct database changes

## Validation
- full PowerShell suite: 1,348 tests, 0 failures
- DuneSoloDb self-test passed
- web UI production build passed
- full installer build passed
- secret scan passed