### PR TITLE
Begin native mobile app sunset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Changed
+
+- Began the staged retirement of the separate Expo iOS and Android companion
+  apps. Existing native builds remain functional during the transition, while
+  in-app guidance directs users to the responsive Browser Portal over Tailscale.
+- Clarified that deprecated Cloudflare named-tunnel and Access support remains
+  operational through the current test line and is scheduled for removal when
+  v15 promotes to stable.
+
 ## [15.0.0-phase2-test4] - 2026-09-03
 
 ### Changed

--- a/mobile/APP_STORE.md
+++ b/mobile/APP_STORE.md
@@ -1,4 +1,14 @@
-# App Store Description Guidelines
+# Native App Sunset
+
+The iOS and Android companion apps are in a short retirement transition. Keep
+the existing builds functional for several DST releases, publish one final
+notice-bearing build if needed, and direct every user to the responsive Browser
+Portal over Tailscale. Do not add native-only features during this period.
+
+Remove this directory only after the announced transition has elapsed and the
+Browser Portal replacement has been field-verified.
+
+## App Store Description Guidelines
 
 When publishing the **Dune Server Tool (DST)** mobile app to the Apple App Store
 or Google Play Store, make it clear that connecting requires the **server
@@ -14,6 +24,12 @@ Dune Server Tool (DST) Mobile Companion
 
 Manage and monitor your private Dune: Awakening server right from your phone.
 View server status, manage players, and perform admin actions on the go.
+
+SUNSET NOTICE
+The native companion app is being retired after a short transition. Existing
+users can continue using it temporarily, but should move now to DST's full
+Browser Portal in Safari or Chrome. Open DST Desktop, then use Settings >
+Remote Device Access to get the Tailscale link or QR code.
 
 ⚠️ REQUIREMENTS (server-side only)
 To connect, the DST server owner must have set up Tailscale Funnel on the host

--- a/mobile/EXPO.md
+++ b/mobile/EXPO.md
@@ -1,4 +1,9 @@
-# Running the DST Mobile App via Expo (interim — before the App Store / Play release)
+# Running the DST Mobile App via Expo
+
+> Sunset transition: the Expo iOS/Android companion is being retired after a
+> short compatibility period. Keep it functional for existing users, but make
+> no native-only feature additions. New remote use belongs in the responsive
+> Browser Portal over Tailscale.
 
 > **DRAFT / internal.** This is the interim distribution path for testers while the
 > app is not yet on the Apple App Store / Google Play. Do **not** publish these

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -33,6 +33,18 @@ const DstButton = ({ title, onPress, type = 'primary', disabled = false, loading
   );
 };
 
+const NativeAppSunsetNotice = () => (
+  <View style={styles.sunsetNotice} accessibilityRole="alert">
+    <Text style={styles.sunsetTitle}>Native app retirement planned</Text>
+    <Text style={styles.sunsetText}>
+      The iOS and Android companion apps will remain available during a short
+      transition, then retire. Move to DST&apos;s full Browser Portal in Safari or
+      Chrome using the Tailscale link or QR code in DST Desktop under Settings
+      and Remote Device Access.
+    </Text>
+  </View>
+);
+
 // --- Vehicle Data ---
 // Fetched at runtime from GET /api/catalog/vehicle-kits (the single source of
 // truth shared with the desktop app). Defaults below are only fallbacks used if
@@ -499,6 +511,7 @@ export default function App() {
         <StatusBar barStyle="light-content" />
         <Text style={styles.title}>Pair with Server</Text>
         <Text style={styles.subtitle}>Scan the pairing code from the DST Desktop app Settings tab.</Text>
+        <NativeAppSunsetNotice />
         <View style={styles.alertBox}>
           <Text style={styles.alertText}><Text style={{ fontWeight: 'bold' }}>No VPN needed.</Text> Start the secure tunnel in the DST Desktop app (Settings &gt; Mobile App), then scan the code it shows.</Text>
         </View>
@@ -685,6 +698,7 @@ export default function App() {
       <StatusBar barStyle="light-content" />
       <Text style={styles.title}>DST Dashboard</Text>
       <Text style={styles.subtitle}>Connected to {liveHost || (serverInfo.rendezvousBase ? 'your server' : apiHost(serverInfo))}</Text>
+      <NativeAppSunsetNotice />
       
       <View style={styles.card}>
         <Text style={styles.cardTitle}>Server State</Text>
@@ -832,5 +846,8 @@ const styles = StyleSheet.create({
   button: { paddingVertical: 14, borderRadius: 10, alignItems: 'center', justifyContent: 'center', borderWidth: 1, shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.2, shadowRadius: 4, elevation: 3 },
   buttonText: { color: '#fff', fontSize: 16, fontWeight: '700', letterSpacing: 0.5 },
   alertBox: { backgroundColor: '#1e293b', padding: 16, borderRadius: 8, borderWidth: 1, borderColor: '#3b82f6', marginBottom: 20 },
-  alertText: { color: '#cbd5e1', fontSize: 14, lineHeight: 20 }
+  alertText: { color: '#cbd5e1', fontSize: 14, lineHeight: 20 },
+  sunsetNotice: { backgroundColor: '#422006', padding: 16, borderRadius: 10, borderWidth: 1, borderColor: '#f59e0b', marginBottom: 20 },
+  sunsetTitle: { color: '#fde68a', fontSize: 16, fontWeight: '800', marginBottom: 6 },
+  sunsetText: { color: '#fef3c7', fontSize: 14, lineHeight: 20 }
 });

--- a/webui/src/pages/settings/MobileAppCard.tsx
+++ b/webui/src/pages/settings/MobileAppCard.tsx
@@ -103,6 +103,17 @@ export function MobileAppCard() {
       headerClassName="card-header"
       bodyClassName="card-body"
     >
+        <div className="card p-3 border-warning/40 bg-warning/10 text-sm" style={{ marginBottom: '1rem' }} role="status">
+          <div className="flex items-center gap-2 text-warning" style={{ fontWeight: 600 }}>
+            <Icon name="TriangleAlert" size={16} /> Native mobile apps are being retired
+          </div>
+          <p className="mt-2 text-text-muted">
+            The separate iOS and Android companion apps will keep working during
+            a short transition, then be removed. Use the Browser Portal link or
+            QR code below in Safari or Chrome. Tailscale remote access and this
+            responsive portal remain supported.
+          </p>
+        </div>
 
         {/* Secure remote access via Tailscale Funnel — the supported path for new
             Browser Portal setups. Existing Cloudflare custom-domain URLs remain

--- a/webui/src/pages/settings/RemoteAccessCard.tsx
+++ b/webui/src/pages/settings/RemoteAccessCard.tsx
@@ -210,7 +210,8 @@ export function RemoteAccessCard() {
                 <Icon name="Info" size={14} className="mt-0.5 flex-none" />
                 <span>
                   <strong>Deprecated — existing configurations only.</strong> Cloudflare
-                  named-tunnel/Access support is planned for removal. Existing
+                  named-tunnel/Access support is scheduled for removal when the
+                  current v15 test line promotes to stable. Existing
                   configurations remain editable and operational during migration,
                   but new setups should use <strong>Tailscale Funnel</strong> plus
                   Browser Portal accounts under <strong>Remote Device Access</strong>.
@@ -232,7 +233,7 @@ export function RemoteAccessCard() {
               </p>
 
               <div className="rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm text-text-muted">
-                <div className="font-semibold text-warning mb-2">Migrate before Cloudflare removal</div>
+                <div className="font-semibold text-warning mb-2">Migrate before the v15 stable release</div>
                 <ol className="list-decimal pl-5 space-y-1">
                   <li>
                     Run <code className="break-all font-mono text-xs">tailscale funnel --bg http://127.0.0.1:47900</code> in

--- a/webui/tests/remoteAccessRetirement.test.ts
+++ b/webui/tests/remoteAccessRetirement.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('remote access retirement guidance', () => {
+  it('keeps Expo functional while directing users to the Tailscale Browser Portal', () => {
+    const nativeSource = readFileSync(
+      resolve(process.cwd(), '..', 'mobile', 'app', 'index.tsx'),
+      'utf8',
+    )
+    const settingsSource = readFileSync(
+      resolve(process.cwd(), 'src', 'pages', 'settings', 'MobileAppCard.tsx'),
+      'utf8',
+    )
+
+    expect(nativeSource).toContain('Native app retirement planned')
+    expect(nativeSource).toContain('Browser Portal')
+    expect(nativeSource).toContain('Tailscale link or QR code')
+    expect(settingsSource).toContain('Native mobile apps are being retired')
+    expect(settingsSource).toContain('Tailscale remote access and this')
+    expect(settingsSource).toContain('responsive portal remain supported')
+  })
+
+  it('states the stable-release cutoff for legacy Cloudflare support', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'src', 'pages', 'settings', 'RemoteAccessCard.tsx'),
+      'utf8',
+    )
+
+    expect(source).toContain('scheduled for removal when the')
+    expect(source).toContain('current v15 test line promotes to stable')
+    expect(source).toContain('Migrate before the v15 stable release')
+  })
+})


### PR DESCRIPTION
## Summary
- add visible retirement guidance to the Expo iOS/Android companion and Remote Device Access settings
- direct users to the responsive Browser Portal over Tailscale
- state that legacy Cloudflare support remains operational through the v15 test line and is removed at v15 stable
- keep Expo, Cloudflare, bridge, pairing routes, and Browser Portal fully operational

## Validation
- Expo TypeScript check passed
- web UI production build passed
- retirement guidance contract tests passed
- Impeccable detector returned no findings

No installer build or release is included.