### PR TITLE
Add Test 5 ammo and buildable swatch tools

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -88,7 +88,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-phase2-test4"
+      placeholder: "v15.0.0-phase2-test5"
     validations:
       required: true
 
@@ -125,7 +125,7 @@ body:
         - Web portal — Gameplay Admin — Players
         - Web portal — Shared Inventory Explorer (Players / Bases / Vehicles / Economy — cached search / freshness / refresh / rename storage box / single or multi-delete / delete quantity / load more / item details / owning entity link)
         - Web portal — Gameplay Admin — Players — Specs (Set level / Apply level rewards / Repair Pattern / Max / Reset)
-        - Web portal — Gameplay Admin — Players — Give Item / Give Package / Give Vehicle Kit / Grant Cosmetic / All House Swatches / Max Augment Attributes / Variant (incl. "Allow overflow")
+        - Web portal — Gameplay Admin — Players — Give Item / Give Package / Give Vehicle Kit / Grant Cosmetic / All House Swatches / Buildable House Swatches / Max Augment Attributes / loaded weapon ammo / Variant (incl. "Allow overflow")
         - Web portal — Gameplay Admin — Players — Cheat Scripts / Dev-Perf Scripts (Live)
         - Web portal — Gameplay Admin — Players — Journey (node browser / complete / post-NPE reset to Find the Fremen / chosen starter-tree refund)
         - Web portal — Gameplay Admin — Players — Unlock Trainers (skill-tree ownership status) / Unlock Main Quest / Complete Contract (clear stuck contract) / Apply Quick Preset (Progression)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,21 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.0-phase2-test5] - 2026-09-04
+
+### Added
+
+- Added offline loaded-ammo editing for exact Self-Hosted player-carried ranged
+  weapons, with current-value protection and readback so stale inventory views
+  cannot overwrite a newer save.
+- Added a separate Buildable House Swatches delivery action for placeables-only
+  swatch tokens, while keeping the existing All House Swatches action.
+
 ### Changed
 
+- Reviewed House Swatch classification so the separate buildable delivery path
+  follows the dedicated `*_Placeables_Swatch` token family and does not infer
+  buildable status from inconsistent garment/armor display names.
 - Began the staged retirement of the separate Expo iOS and Android companion
   apps. Existing native builds remain functional during the transition, while
   in-app guidance directs users to the responsive Browser Portal over Tailscale.

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -166,7 +166,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 Write-DuneStartupLog 'Console presentation initialized'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.0-phase2-test4'
+$script:DuneToolVersion = '15.0.0-phase2-test5'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.0-phase2-test4',
+    [string]$Version = '15.0.0-phase2-test5',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/data/platform-route-policies.json
+++ b/app/data/platform-route-policies.json
@@ -152,7 +152,7 @@
     { "source": "FlsToken.ps1", "capabilityId": "settings.connectivity", "routeCount": 3, "sha256": "5dbda64c9121b306d6d6f3487aef4e6f630a73beba73d0067baa14373237f2bb" },
     { "source": "GameConfig.ps1", "capabilityId": "settings.game-server", "routeCount": 26, "sha256": "5864b52d958ef8dceeabb527268f413806b5b29b086f450b423359b34d7396ce" },
     { "source": "Gameplay.ps1", "capabilityId": "economy.market", "routeCount": 22, "sha256": "757d3fd58fe70e88c5ccc91b9549e8f9a121b9137c1a2c16cd574c271c46e258" },
-    { "source": "GameplayPlayers.ps1", "capabilityId": "player.manage", "routeCount": 27, "sha256": "4f822fc3645a5196c477810daed318d097c5319fb920a34b8ce8be6ab191d24e" },
+    { "source": "GameplayPlayers.ps1", "capabilityId": "player.manage", "routeCount": 28, "sha256": "0e84ced9699cd5a47f9e86ac5a404c0a23e5878f62bd6d18d9787209e90b516c" },
     { "source": "GameplayWorld.ps1", "capabilityId": "base.manage", "routeCount": 13, "sha256": "4c6dcb579d2a5fab1ef37a5fb84d399e493ea079e14994cdc56bbafaa56f9fc6" },
     { "source": "Inventory.ps1", "capabilityId": "inventory.read", "routeCount": 4, "sha256": "3e8a38114c67450782febd31b7f42339be467aca11b741283c8ae3d09ebe44d9" },
     { "source": "ItemPackages.ps1", "capabilityId": "player.inventory", "routeCount": 3, "sha256": "ed3aac4a943d300002f7aecacb8ecf04619917ee7aa549cde0068e1853e01cf9" },

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.0-phase2-test4</Version>
+    <Version>15.0.0-phase2-test5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.0-phase2-test4"
+#define MyAppVersion "15.0.0-phase2-test5"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"
@@ -121,7 +121,7 @@ Source: "..\..\tools\preflight\*"; DestDir: "{app}\tools\preflight"; Flags: igno
 Source: "..\..\helper\bridge\*"; DestDir: "{app}\helper\bridge"; Flags: ignoreversion recursesubdirs
 
 [InstallDelete]
-; v15.0.0-phase2-test4: Modern upgrades update in place so scheduled tasks
+; v15.0.0-phase2-test5: Modern upgrades update in place so scheduled tasks
 ; survive. Clear only installer-managed directory trees before copying to
 ; prevent removed scripts and hashed web assets from lingering.
 Type: filesandordirs; Name: "{app}\server"

--- a/app/server/lib/Gameplay.ps1
+++ b/app/server/lib/Gameplay.ps1
@@ -188,11 +188,20 @@ function Get-DuneCosmeticsCatalog {
 }
 
 function Get-DuneHouseSwatchCatalog {
+    param([ValidateSet('all','placeables')][string]$Kind = 'all')
     $catalog = Get-DuneCosmeticsCatalog
     return @($catalog.templates |
         Where-Object {
             [string]$_.group -eq 'Swatches (Dyes)' -and
-            [string]$_.name -match '^House .+ Swatch$'
+            (
+                (
+                    $Kind -eq 'all' -and
+                    [string]$_.name -match '^House .+ Swatch$'
+                ) -or (
+                    $Kind -eq 'placeables' -and
+                    [string]$_.template -match '_Placeables_Swatch$'
+                )
+            )
         } |
         Sort-Object { $_.name }, { $_.template })
 }

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -54,7 +54,8 @@ SELECT i.id, i.template_id, i.stack_size, COALESCE(i.quality_level, 0) AS qualit
        COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'), 'N/A') AS durability,
        COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability'), 'N/A')     AS max_durability,
        COALESCE((i.stats->'FFillableItemStats'->1->>'CurrentAmount'), 'N/A')               AS water_amount,
-       COALESCE((i.stats->'FFillableItemStats'->1->>'FillableType'), '')                   AS water_type
+       COALESCE((i.stats->'FFillableItemStats'->1->>'FillableType'), '')                   AS water_type,
+       COALESCE((i.stats->'FWeaponItemStats'->1->>'CurrentAmmo'), 'N/A')                   AS current_ammo
 FROM dune.items i
 JOIN dune.inventories inv ON i.inventory_id = inv.id
 WHERE inv.actor_id = {0}::bigint
@@ -127,6 +128,7 @@ function Get-DunePlayerDetailLive {
             max_durability = [string]$r['max_durability']
             water_amount   = [string]$r['water_amount']
             water_type     = [string]$r['water_type']
+            current_ammo   = [string]$r['current_ammo']
         }
     }
     $specs = @()
@@ -617,6 +619,57 @@ RETURNING id::text AS item_id;
         return @{ ok = $false; error = 'Item quantity changed or the item no longer exists. Refresh and try again.' }
     }
     return @{ ok = $true; message = "Set item $ItemId stack to $StackSize." }
+}
+
+function Invoke-DunePlayerSetWeaponAmmo {
+    param([string]$Ip, [long]$PawnId, [long]$ItemId, [long]$Ammo, [long]$ExpectedAmmo)
+    if ($PawnId -le 0) { return @{ ok = $false; error = 'pawn_id is required.' } }
+    if ($ItemId -le 0) { return @{ ok = $false; error = 'item_id is required.' } }
+    if ($Ammo -lt 0 -or $Ammo -gt 2000000000) { return @{ ok = $false; error = 'ammo must be between 0 and 2000000000.' } }
+    if ($ExpectedAmmo -lt 0 -or $ExpectedAmmo -gt 2000000000) { return @{ ok = $false; error = 'expected_ammo must be between 0 and 2000000000.' } }
+
+    $off = Test-DunePlayerOffline -Ip $Ip -PawnId $PawnId -RequireVerifiedStatus
+    if (-not $off.ok) { return @{ ok = $false; error = "Player must be offline before changing loaded weapon ammo. $($off.reason)" } }
+
+    $sql = @"
+WITH target AS (
+    SELECT i.id,
+           i.stats->'FWeaponItemStats'->1->>'CurrentAmmo' AS before_ammo
+    FROM dune.items i
+    JOIN dune.inventories inv ON inv.id = i.inventory_id
+    WHERE inv.actor_id = $PawnId::bigint
+      AND i.id = $ItemId::bigint
+      AND i.stats ? 'FWeaponItemStats'
+      AND jsonb_typeof(i.stats->'FWeaponItemStats') = 'array'
+      AND jsonb_array_length(i.stats->'FWeaponItemStats') > 1
+      AND i.stats->'FWeaponItemStats'->1 ? 'CurrentAmmo'
+      AND i.stats->'FWeaponItemStats'->1->>'CurrentAmmo' ~ '^[0-9]+$'
+    FOR UPDATE
+),
+updated AS (
+    UPDATE dune.items i
+    SET stats = jsonb_set(i.stats, '{FWeaponItemStats,1,CurrentAmmo}', to_jsonb($Ammo::bigint), false)
+    FROM target t
+    WHERE i.id = t.id
+      AND t.before_ammo::bigint = $ExpectedAmmo::bigint
+    RETURNING i.id::text AS item_id, t.before_ammo, i.stats->'FWeaponItemStats'->1->>'CurrentAmmo' AS after_ammo
+)
+SELECT item_id, before_ammo, after_ammo FROM updated;
+"@
+    $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
+    if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
+    $rows = ConvertTo-DuneRowMaps -Result $res
+    if (@($rows).Count -eq 0) {
+        return @{ ok = $false; error = 'Weapon ammo changed, the item is not a ranged weapon, or it no longer belongs to this offline player. Refresh and try again.' }
+    }
+    $row = $rows[0]
+    return @{
+        ok = $true
+        message = "Set weapon ammo on item $ItemId from $($row['before_ammo']) to $($row['after_ammo'])."
+        item_id = (ConvertTo-DuneInt $row['item_id'])
+        before_ammo = (ConvertTo-DuneInt $row['before_ammo'])
+        after_ammo = (ConvertTo-DuneInt $row['after_ammo'])
+    }
 }
 
 # Give item (give-item): stack onto a matching backpack stack or insert a new one.

--- a/app/server/lib/PlayersAdmin.ps1
+++ b/app/server/lib/PlayersAdmin.ps1
@@ -22,10 +22,15 @@ function Get-DuneRawFuncomId {
 
 # checkPlayerOffline(pawn) — nil player_state row is treated as offline.
 function Test-DunePlayerOffline {
-    param([string]$Ip, [long]$PawnId)
+    param([string]$Ip, [long]$PawnId, [switch]$RequireVerifiedStatus)
     $sql = "SELECT online_status::text AS status FROM dune.player_state WHERE player_pawn_id = $PawnId::bigint;"
     $r = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 10
-    if (-not $r.ok) { return @{ ok = $true; reason = $null } }
+    if (-not $r.ok) {
+        if ($RequireVerifiedStatus) {
+            return @{ ok = $false; reason = "player status could not be verified - $($r.error)" }
+        }
+        return @{ ok = $true; reason = $null }
+    }
     $maps = ConvertTo-DuneRowMaps -Result $r
     if ($maps.Count -eq 0) { return @{ ok = $true; reason = $null } }
     $status = [string]$maps[0]['status']

--- a/app/server/lib/PlayersWrites.ps1
+++ b/app/server/lib/PlayersWrites.ps1
@@ -460,7 +460,7 @@ function Invoke-DunePlayerGiveItemsBulk {
 }
 
 function Invoke-DunePlayerGrantHouseSwatches {
-    param([string]$Ip, [long]$PawnId, [long]$AccountId)
+    param([string]$Ip, [long]$PawnId, [long]$AccountId, [ValidateSet('all','placeables')][string]$Kind = 'all')
     if ($PawnId -le 0) { return @{ ok = $false; error = 'pawn_id is required.' } }
     if ($AccountId -le 0) { return @{ ok = $false; error = 'account_id is required.' } }
 
@@ -471,9 +471,10 @@ function Invoke-DunePlayerGrantHouseSwatches {
     $fls = Resolve-DuneFlsIdOrError -Ip $Ip -ActorId $PawnId
     if (-not $fls.ok) { return @{ ok = $false; error = $fls.error } }
 
-    $houseSwatches = @(Get-DuneHouseSwatchCatalog)
+    $label = if ($Kind -eq 'placeables') { 'Buildable House Swatches' } else { 'House Swatches' }
+    $houseSwatches = @(Get-DuneHouseSwatchCatalog -Kind $Kind)
     if ($houseSwatches.Count -eq 0) {
-        return @{ ok = $false; error = 'House Swatch catalog is empty.' }
+        return @{ ok = $false; error = "$label catalog is empty." }
     }
 
     $before = Get-DunePlayerOwnedCosmeticsLive -Ip $Ip -AccountId $AccountId
@@ -489,7 +490,7 @@ function Invoke-DunePlayerGrantHouseSwatches {
     if ($missing.Count -eq 0) {
         return @{
             ok = $true
-            message = "All $($houseSwatches.Count) House Swatches are already owned."
+            message = "All $($houseSwatches.Count) $label are already owned."
             total = $houseSwatches.Count
             already_owned = $alreadyOwned
             requested = 0
@@ -504,7 +505,7 @@ function Invoke-DunePlayerGrantHouseSwatches {
     if (-not $result.ok) {
         return @{
             ok = $false
-            error = "House Swatch token batch failed: $($result.message)"
+            error = "$label token batch failed: $($result.message)"
             total = $houseSwatches.Count
             already_owned = $alreadyOwned
             requested = $missing.Count
@@ -518,7 +519,7 @@ function Invoke-DunePlayerGrantHouseSwatches {
     $granted = $missing.Count
     return @{
         ok = $true
-        message = "Delivered $granted missing House Swatch token$(if ($granted -eq 1) { '' } else { 's' }) through the live game. Delivery starts immediately; the player must remain online until the activation cascade starts and completely stops. This usually takes about a minute. Overflow drops beside the player."
+        message = "Delivered $granted missing $label token$(if ($granted -eq 1) { '' } else { 's' }) through the live game. Delivery starts immediately; the player must remain online until the activation cascade starts and completely stops. This usually takes about a minute. Overflow drops beside the player."
         total = $houseSwatches.Count
         already_owned = $alreadyOwned
         requested = $missing.Count

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -329,6 +329,28 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/set-item-stack' -Ha
     }
 }
 
+# POST /api/gameplay/players/set-weapon-ammo  { pawn_id, item_id, ammo, expected_ammo }
+# Offline-only loaded-ammo editor for player-carried ranged weapons. The expected
+# value prevents overwriting a stale row after the inventory view was loaded.
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/set-weapon-ammo' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        $iid = Get-DuneBodyInt -Body $body -Name 'item_id'
+        $ammo = Get-DuneBodyInt -Body $body -Name 'ammo'
+        $expected = Get-DuneBodyInt -Body $body -Name 'expected_ammo'
+        if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
+        if ($null -eq $iid -or $iid -le 0) { Write-DuneError -Response $res -Status 400 -Message 'item_id is required.'; return }
+        if ($null -eq $ammo -or $ammo -lt 0) { Write-DuneError -Response $res -Status 400 -Message 'ammo must be at least 0.'; return }
+        if ($null -eq $expected -or $expected -lt 0) { Write-DuneError -Response $res -Status 400 -Message 'expected_ammo must be at least 0.'; return }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip)
+            Invoke-DunePlayerSetWeaponAmmo -Ip $ip -PawnId $pawn -ItemId $iid -Ammo $ammo -ExpectedAmmo $expected
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Set weapon ammo failed: $($_.Exception.Message)"
+    }
+}
+
 # ===========================================================================
 # v11.5.6 — extended player surface routes.
 # ===========================================================================

--- a/app/server/routes/PlayersWrites.ps1
+++ b/app/server/routes/PlayersWrites.ps1
@@ -25,17 +25,20 @@ Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-items' -Handle
     }
 }
 
-# POST /api/gameplay/players/grant-house-swatches  { pawn_id, account_id }
+# POST /api/gameplay/players/grant-house-swatches  { pawn_id, account_id, kind? }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/grant-house-swatches' -Handler {
     param($req, $res, $routeParams, $body)
     try {
         $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
         $account = Get-DuneBodyInt -Body $body -Name 'account_id'
+        $kind = [string](Get-DuneBodyValue -Body $body -Name 'kind')
+        if ([string]::IsNullOrWhiteSpace($kind)) { $kind = 'all' }
+        if ($kind -notin @('all','placeables')) { Write-DuneError -Response $res -Status 400 -Message 'kind must be all or placeables.'; return }
         if ($null -eq $pawn -or $pawn -le 0) { Write-DuneError -Response $res -Status 400 -Message 'pawn_id is required.'; return }
         if ($null -eq $account -or $account -le 0) { Write-DuneError -Response $res -Status 400 -Message 'account_id is required.'; return }
         Invoke-DunePlayerWriteRoute -Response $res -Action {
             param($ip)
-            Invoke-DunePlayerGrantHouseSwatches -Ip $ip -PawnId $pawn -AccountId $account
+            Invoke-DunePlayerGrantHouseSwatches -Ip $ip -PawnId $pawn -AccountId $account -Kind $kind
         }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Grant House Swatches failed: $($_.Exception.Message)"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.0-phase2-test4"
+$script:ToolVersion = "15.0.0-phase2-test5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/PlatformContracts.Tests.ps1
+++ b/tests/PlatformContracts.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'Complete route classification' {
     It 'classifies the exact registered HTTP and WebSocket inventory' {
         $records = @(Get-PlatformRouteRecords)
         $manifest = Get-DuneRoutePolicyManifest
-        $records.Count | Should -Be 361
+        $records.Count | Should -Be 362
         $sources = @($records.SourceFile | Sort-Object -Unique)
         @($manifest.groups.source | Sort-Object) | Should -Be $sources
 
@@ -321,7 +321,7 @@ $result = @{
         $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
         $resultLine = @($output | Where-Object { [string]$_ -like 'ROUTE_RESULT:*' })[-1]
         $result = ([string]$resultLine).Substring('ROUTE_RESULT:'.Length) | ConvertFrom-Json
-        $result.total | Should -Be 361
+        $result.total | Should -Be 362
         $result.unclassified | Should -Be 0
         $result.incompatible | Should -Be 0
         $result.podsCleanup | Should -Be 1

--- a/tests/PlayersAdmin.Tests.ps1
+++ b/tests/PlayersAdmin.Tests.ps1
@@ -177,6 +177,22 @@ Describe 'Test-DunePlayerOfflineByController' -Tag 'PlayersAdmin' {
     }
 }
 
+Describe 'Test-DunePlayerOffline verified status' -Tag 'PlayersAdmin' {
+    BeforeEach {
+        $script:onlineStatus = 'Offline'
+        $script:statusQueryOk = $true
+    }
+
+    It 'fails closed when verification is required and the status query fails' {
+        $script:statusQueryOk = $false
+
+        $r = Test-DunePlayerOffline -Ip 'x' -PawnId 200 -RequireVerifiedStatus
+
+        $r.ok | Should -BeFalse
+        $r.reason | Should -Match 'could not be verified'
+    }
+}
+
 Describe 'Invoke-DunePlayerAwardCharXp offline actor targeting' -Tag 'PlayersAdmin' {
     BeforeEach {
         $script:onlineStatus     = 'Offline'

--- a/tests/PlayersWrites.Tests.ps1
+++ b/tests/PlayersWrites.Tests.ps1
@@ -235,6 +235,10 @@ Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
         function global:Test-DunePlayerOffline { return @{ ok = $false; reason = 'Player is online.' } }
         function global:Resolve-DuneFlsIdOrError { return @{ ok = $true; fls_id = 'fls-test' } }
         function global:Get-DuneHouseSwatchCatalog {
+            param([string]$Kind = 'all')
+            if ($Kind -eq 'placeables') {
+                return @(@{ template = 'Ecaz_Placeables_Swatch'; name = 'House Ecaz Placeables Swatch'; group = 'Swatches (Dyes)' })
+            }
             return @(
                 @{ template = 'Ecaz_HeavyArmor_Swatch'; name = 'House Ecaz Garment Swatch'; group = 'Swatches (Dyes)' },
                 @{ template = 'Ecaz_Placeables_Swatch'; name = 'House Ecaz Placeables Swatch'; group = 'Swatches (Dyes)' }
@@ -265,7 +269,10 @@ Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
     }
 
     It 'rejects an offline player before granting' {
-        function global:Test-DunePlayerOffline { return @{ ok = $true } }
+        function global:Test-DunePlayerOffline {
+            param($Ip, $PawnId, [switch]$RequireVerifiedStatus)
+            return @{ ok = $true }
+        }
         $r = Invoke-DunePlayerGrantHouseSwatches -Ip '1.2.3.4' -PawnId 10 -AccountId 20
         $r.ok | Should -BeFalse
         $r.error | Should -Match 'online'
@@ -287,6 +294,68 @@ Describe 'Invoke-DunePlayerGrantHouseSwatches' -Tag 'Pure' {
         $script:batchCalls | Should -Be 1
         $script:batchTemplates | Should -Be @('Ecaz_Placeables_Swatch')
         $script:batchSpacing | Should -Be 200
+    }
+
+    It 'can grant only buildable/placeables swatches' {
+        function global:Get-DunePlayerOwnedCosmeticsLive { return @{ ok = $true; owned = @() } }
+
+        $r = Invoke-DunePlayerGrantHouseSwatches -Ip '1.2.3.4' -PawnId 10 -AccountId 20 -Kind placeables
+
+        $r.ok | Should -BeTrue -Because $r.error
+        $r.total | Should -Be 1
+        $r.requested | Should -Be 1
+        $r.message | Should -Match 'Buildable House Swatches'
+        $script:batchTemplates | Should -Be @('Ecaz_Placeables_Swatch')
+    }
+}
+
+Describe 'Invoke-DunePlayerSetWeaponAmmo' -Tag 'Pure' {
+    BeforeEach {
+        $script:capturedSql = $null
+        Set-Item function:global:ConvertTo-DuneRowMaps $script:realRowMaps
+        Set-Item function:global:ConvertTo-DuneInt $script:realDuneInt
+        function global:Test-DunePlayerOffline { return @{ ok = $true } }
+        function global:Invoke-DuneSqlQuery {
+            param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec)
+            $script:capturedSql = $Sql
+            return @{
+                ok = $true
+                columns = @('item_id', 'before_ammo', 'after_ammo')
+                rows = @(, @('9001', '17', '250'))
+            }
+        }
+    }
+
+    AfterEach {
+        Remove-Item function:global:Test-DunePlayerOffline -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+    }
+
+    It 'requires the player to be offline' {
+        function global:Test-DunePlayerOffline {
+            param($Ip, $PawnId, [switch]$RequireVerifiedStatus)
+            return @{ ok = $false; reason = 'Player is online.' }
+        }
+
+        $r = Invoke-DunePlayerSetWeaponAmmo -Ip '1.2.3.4' -PawnId 42 -ItemId 9001 -Ammo 250 -ExpectedAmmo 17
+
+        $r.ok | Should -BeFalse
+        $r.error | Should -Match 'offline'
+        $script:capturedSql | Should -BeNullOrEmpty
+    }
+
+    It 'updates CurrentAmmo only for the selected player item with expected-value protection' {
+        $r = Invoke-DunePlayerSetWeaponAmmo -Ip '1.2.3.4' -PawnId 42 -ItemId 9001 -Ammo 250 -ExpectedAmmo 17
+
+        $r.ok | Should -BeTrue -Because $r.error
+        $r.before_ammo | Should -Be 17
+        $r.after_ammo | Should -Be 250
+        $script:capturedSql | Should -Match 'inv\.actor_id = 42::bigint'
+        $script:capturedSql | Should -Match 'i\.id = 9001::bigint'
+        $script:capturedSql | Should -Match "FWeaponItemStats"
+        $script:capturedSql | Should -Match "CurrentAmmo"
+        $script:capturedSql | Should -Match 't\.before_ammo::bigint = 17::bigint'
+        $script:capturedSql | Should -Match 'to_jsonb\(250::bigint\)'
     }
 }
 

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -743,6 +743,7 @@ export interface InventoryItem {
   max_durability: string
   water_amount: string
   water_type: string
+  current_ammo?: string
 }
 
 export interface SpecTrack {
@@ -846,6 +847,13 @@ export function setItemStack(itemId: number, stackSize: number, expectedStackSiz
   return api<WriteResult>('/api/gameplay/players/set-item-stack', {
     method: 'POST',
     body: JSON.stringify({ item_id: itemId, stack_size: stackSize, expected_stack_size: expectedStackSize }),
+  })
+}
+
+export function setWeaponAmmo(pawnId: number, itemId: number, ammo: number, expectedAmmo: number) {
+  return api<WriteResult>('/api/gameplay/players/set-weapon-ammo', {
+    method: 'POST',
+    body: JSON.stringify({ pawn_id: pawnId, item_id: itemId, ammo, expected_ammo: expectedAmmo }),
   })
 }
 
@@ -1419,9 +1427,14 @@ interface CosmeticsResponse { templates?: CosmeticEntry[]; total?: number }
 let _cosmeticsCache: CosmeticEntry[] | null = null
 let _cosmeticsPromise: Promise<CosmeticEntry[]> | null = null
 
-export function getHouseSwatchCosmetics(catalog: CosmeticEntry[]): CosmeticEntry[] {
+export type HouseSwatchKind = 'all' | 'placeables'
+
+export function getHouseSwatchCosmetics(catalog: CosmeticEntry[], kind: HouseSwatchKind = 'all'): CosmeticEntry[] {
   return catalog
-    .filter(entry => entry.group === 'Swatches (Dyes)' && /^House .+ Swatch$/i.test(entry.name))
+    .filter(entry => entry.group === 'Swatches (Dyes)')
+    .filter(entry => kind === 'placeables'
+      ? /_Placeables_Swatch$/i.test(entry.template)
+      : /^House .+ Swatch$/i.test(entry.name))
     .sort((a, b) => a.name.localeCompare(b.name) || a.template.localeCompare(b.template))
 }
 
@@ -2091,9 +2104,9 @@ export interface HouseSwatchGrantResponse extends WriteResult {
   result?: HouseSwatchGrantResult
 }
 
-export function grantHouseSwatches(pawnId: number, accountId: number) {
+export function grantHouseSwatches(pawnId: number, accountId: number, kind: HouseSwatchKind = 'all') {
   return api<HouseSwatchGrantResponse>('/api/gameplay/players/grant-house-swatches', {
-    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, account_id: accountId }),
+    method: 'POST', body: JSON.stringify({ pawn_id: pawnId, account_id: accountId, kind }),
   })
 }
 

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -21,13 +21,13 @@ import {
   giveScrip, giveSolari, grantAllKeystones, grantMaxSpec,
   kickPlayer, maxAugmentAttributes, refuelVehicle, renamePlayer, repairGear, repairInventoryItem,
   getPlayerVehicles,
-  setItemDurability, setItemStack, setItemWater,
+  setItemDurability, setItemStack, setItemWater, setWeaponAmmo,
   resetAllKeystones, resetAllSpecs, resetJourney, resetProgressionLive, resetSpec,
   restoreDestroyed,
   setFactionTier, setSkillPoints,
   setStarterClass, spawnVehicle, teleportToPlayer, teleportToLocation, setRespawn, getTeleportDestinations, getPlayers, updatePlayerTags, wipeCodex, resetFaction, snapshotBuilds, getFreshStartSnapshots, restoreBuilds, grantAllSkills,
   chatWhisper, isValidTemplateId, getItemCatalog, getCosmeticsCatalog, getPlayerOwnedCosmetics, filterCosmeticsCatalog, getHouseSwatchCosmetics, type CosmeticEntry,
-  parseTcnoPackageText, grantHouseSwatches,
+  parseTcnoPackageText, grantHouseSwatches, type HouseSwatchKind,
   giveItems, getItemPackages, saveItemPackage, deleteItemPackage,
   getLandsraadOverview, getLandsraadPlayerContributions, setLandsraadContribution,
   getPlayerJourneyNodes, completeJourneyNode, resetJourneyNode,
@@ -607,7 +607,7 @@ interface ActionDef {
   offlineOnly?: boolean   // requires player to be offline (DB write the game caches in memory)
   experimental?: boolean  // unverified — may not take effect in-game; shown with an EXPERIMENTAL badge
   fields?: ActionField[]
-  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'funcom-spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'complete-contract' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'teleport-player' | 'teleport-location' | 'set-respawn' | 'reset-faction' | 'grant-cosmetic' | 'grant-house-swatches' | 'fresh-start'
+  custom?: 'give-item' | 'grant-reward' | 'whisper' | 'spawn-vehicle' | 'funcom-spawn-vehicle' | 'quick-presets' | 'vehicle-kit' | 'give-package' | 'cheat-scripts' | 'dev-scripts' | 'unlock-trainers' | 'unlock-mainquest' | 'complete-contract' | 'progression-unlock' | 'refuel-vehicle' | 'starter-class' | 'teleport-player' | 'teleport-location' | 'set-respawn' | 'reset-faction' | 'grant-cosmetic' | 'grant-house-swatches' | 'grant-buildable-swatches' | 'fresh-start'
   balance?: 'solari' | 'scrip' | 'intel'  // show the player's current balance read-only above the form
   confirm?: (p: Player) => string  // confirm message; if returns '' no prompt
   doubleConfirm?: boolean // also requires a typed "i acknowledge" prompt inside run()
@@ -724,6 +724,9 @@ const ACTIONS: ActionDef[] = [
     run: () => Promise.resolve({ message: '' }) },
   { id: 'grant-house-swatches', group: 'Items', label: 'All House Swatches', icon: 'Palette', custom: 'grant-house-swatches', liveOnly: true,
     rowNote: 'Online required. Delivery starts immediately; remain online until the activation cascade starts and completely stops (about a minute).',
+    run: () => Promise.resolve({ message: '' }) },
+  { id: 'grant-buildable-swatches', group: 'Items', label: 'Buildable House Swatches', icon: 'PaintBucket', custom: 'grant-buildable-swatches', liveOnly: true,
+    rowNote: 'Online required. Delivers only the Buildables/Placeables House Swatch tokens through the live game.',
     run: () => Promise.resolve({ message: '' }) },
   { id: 'repair-gear', group: 'Items', label: 'Repair All Items', icon: 'Wrench',
     run: p => repairGear(p.id) },
@@ -1111,13 +1114,14 @@ function ActionRow({ def, player, busy, stats, open, danger, onToggle, runAction
                 })
                 return succeeded
               }} />
-          ) : def.custom === 'grant-house-swatches' ? (
+          ) : def.custom === 'grant-house-swatches' || def.custom === 'grant-buildable-swatches' ? (
             <GrantHouseSwatchesForm busy={busy} playerName={player.name} accountId={player.account_id}
+              kind={def.custom === 'grant-buildable-swatches' ? 'placeables' : 'all'}
               playerOnline={(player.online_status || '').toLowerCase() === 'online'}
               onGrant={async () => {
                 let succeeded = false
                 await runAction(def, async () => {
-                  const r = await grantHouseSwatches(player.id, player.account_id)
+                  const r = await grantHouseSwatches(player.id, player.account_id, def.custom === 'grant-buildable-swatches' ? 'placeables' : 'all')
                   succeeded = true
                   return { message: r.message || `House Swatches updated for ${player.name}.` }
                 })
@@ -1459,10 +1463,11 @@ function GrantCosmeticForm({ busy, playerName, accountId, onGrant }: {
   )
 }
 
-function GrantHouseSwatchesForm({ busy, playerName, accountId, playerOnline, onGrant }: {
+function GrantHouseSwatchesForm({ busy, playerName, accountId, kind, playerOnline, onGrant }: {
   busy: boolean
   playerName: string
   accountId: number
+  kind: HouseSwatchKind
   playerOnline: boolean
   onGrant: () => Promise<boolean>
 }) {
@@ -1488,11 +1493,13 @@ function GrantHouseSwatchesForm({ busy, playerName, accountId, playerOnline, onG
     return () => { alive = false }
   }, [accountId])
 
-  const houseSwatches = useMemo(() => getHouseSwatchCosmetics(catalog || []), [catalog])
+  const houseSwatches = useMemo(() => getHouseSwatchCosmetics(catalog || [], kind), [catalog, kind])
   const missingHouseSwatches = useMemo(
     () => houseSwatches.filter(entry => !owned?.has(entry.template.toLowerCase())),
     [houseSwatches, owned],
   )
+  const label = kind === 'placeables' ? 'Buildable House Swatches' : 'House Swatches'
+  const tokenLabel = kind === 'placeables' ? 'Buildable House Swatch' : 'House Swatch'
 
   useEffect(() => {
     if (!activationQueued || houseSwatches.length === 0) return
@@ -1532,7 +1539,7 @@ function GrantHouseSwatchesForm({ busy, playerName, accountId, playerOnline, onG
     <div className="space-y-3">
       <div className="flex items-start justify-between gap-3">
         <div className="text-xs text-text-dim leading-relaxed">
-          Delivers verified physical House Swatch tokens through Funcom's live RMQ item command. Tokens use backpack slots; forced overflow drops excess tokens beside the player.
+          Delivers verified physical {label} tokens through Funcom's live RMQ item command. Tokens use backpack slots; forced overflow drops excess tokens beside the player.
         </div>
         <span className="text-[11px] text-text-dim whitespace-nowrap">
           {houseSwatches.length - missingHouseSwatches.length}/{houseSwatches.length} detected
@@ -1542,7 +1549,7 @@ function GrantHouseSwatchesForm({ busy, playerName, accountId, playerOnline, onG
         Online required. Delivery starts immediately, then Dune activates each token in a cascade. Remain online until the notifications start and completely stop, usually about a minute. DST skips persisted unlocks and tokens still in the player's inventory. Forced overflow drops excess tokens beside the player; Funcom does not link those loot bags back to a player, so pick up any overflow tokens before running this action again.
       </div>
       {ownershipWarning && <div className="text-xs text-warning">{ownershipWarning}</div>}
-      {!playerOnline && <div className="text-xs text-warning">Player must be online to receive House Swatch tokens.</div>}
+      {!playerOnline && <div className="text-xs text-warning">Player must be online to receive {label} tokens.</div>}
       <button
         type="button"
         className="btn-primary w-full"
@@ -1550,7 +1557,7 @@ function GrantHouseSwatchesForm({ busy, playerName, accountId, playerOnline, onG
         title={!playerOnline ? 'Player must be online' : undefined}
         onClick={async () => {
           if (!window.confirm(
-            `Deliver ${missingHouseSwatches.length} missing House Swatch token${missingHouseSwatches.length === 1 ? '' : 's'} to ${playerName}?\n\n` +
+            `Deliver ${missingHouseSwatches.length} missing ${tokenLabel} token${missingHouseSwatches.length === 1 ? '' : 's'} to ${playerName}?\n\n` +
             'Online required. Delivery starts immediately. Remain online until the activation notifications start and completely stop, usually about a minute.\n\nDST forces overflow, so excess tokens drop beside the player. Pick up all dropped tokens before running this action again.'
           )) return
           if (await onGrant()) {
@@ -1559,12 +1566,12 @@ function GrantHouseSwatchesForm({ busy, playerName, accountId, playerOnline, onG
         }}
       >
         {busy
-          ? <><Icon name="Loader2" size={13} className="animate-spin" /> Delivering House Swatch tokens...</>
+          ? <><Icon name="Loader2" size={13} className="animate-spin" /> Delivering {label} tokens...</>
           : activationQueued
             ? <><Icon name="Loader2" size={13} className="animate-spin" /> Activation cascade running — remain online</>
           : missingHouseSwatches.length === 0
-            ? <><Icon name="Check" size={13} /> All House Swatches detected</>
-            : <><Icon name="Palette" size={13} /> Deliver {missingHouseSwatches.length} missing House Swatch tokens</>}
+            ? <><Icon name="Check" size={13} /> All {label} detected</>
+            : <><Icon name="Palette" size={13} /> Deliver {missingHouseSwatches.length} missing {tokenLabel} tokens</>}
       </button>
     </div>
   )
@@ -2689,18 +2696,20 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
         </button>
       </div>
       <ItemList title={`Inventory (${fmtNum(groups.gear.length)})`} icon="Backpack" items={groups.gear}
+        playerId={player.id}
         canWrite={canWrite} busy={busy} run={run} isOnline={isOnline}
         extra={<ItemsActionBlock player={player} canWrite={canWrite} flash={flash} onChanged={onChanged} onFlush={onFlush} />} />
       <ItemList title={`Emotes (${fmtNum(groups.emotes.length)})`} icon="Smile" items={groups.emotes} collapsed
-        canWrite={canWrite} busy={busy} run={run} isOnline={isOnline} />
+        playerId={player.id} canWrite={canWrite} busy={busy} run={run} isOnline={isOnline} />
       <ItemList title={`Contract items (${fmtNum(groups.contracts.length)})`} icon="FileText" items={groups.contracts} collapsed
-        canWrite={canWrite} busy={busy} run={run} isOnline={isOnline} />
+        playerId={player.id} canWrite={canWrite} busy={busy} run={run} isOnline={isOnline} />
     </div>
   )
 }
 
-function ItemList({ title, icon, items, canWrite, busy, run, collapsed, extra, isOnline }: {
+function ItemList({ title, icon, items, playerId, canWrite, busy, run, collapsed, extra, isOnline }: {
   title: string; icon: string; items: InventoryItem[]; canWrite: boolean; busy: boolean
+  playerId: number
   run: (fn: () => Promise<{ message: string }>, label: string) => Promise<boolean>
   collapsed?: boolean
   extra?: React.ReactNode
@@ -2729,6 +2738,8 @@ function ItemList({ title, icon, items, canWrite, busy, run, collapsed, extra, i
               const hasDur = it.durability !== 'N/A' && Number.isFinite(curN) && Number.isFinite(maxN) && maxN > 0
               const waterN = parseFloat(it.water_amount)
               const hasWater = it.water_amount !== 'N/A' && it.water_type === 'Water' && Number.isFinite(waterN)
+              const ammoN = parseInt(it.current_ammo ?? 'N/A', 10)
+              const hasAmmo = it.current_ammo !== 'N/A' && Number.isFinite(ammoN)
               const ratio = hasDur ? curN / maxN : 1
               const durCls =
                 !hasDur          ? 'text-text-dim' :
@@ -2769,6 +2780,11 @@ function ItemList({ title, icon, items, canWrite, busy, run, collapsed, extra, i
                         </span>
                       )}
                       <span className="ml-1.5 font-mono text-text-dim text-xs">×{fmtNum(it.stack_size)}</span>
+                      {hasAmmo && (
+                        <span className="ml-1.5 font-mono text-info text-xs" title={`Loaded ammo ${ammoN}`}>
+                          <Icon name="Crosshair" size={10} className="inline-block mr-0.5 -mt-0.5" />{fmtNum(ammoN)}
+                        </span>
+                      )}
                     </span>
                     {canWrite && (
                       <span className="flex items-center gap-2 shrink-0" onClick={e => e.stopPropagation()}>
@@ -2793,6 +2809,9 @@ function ItemList({ title, icon, items, canWrite, busy, run, collapsed, extra, i
                       )}
                       {hasWater && (
                         <WaterEditor item={it} busy={busy} run={run} onClose={() => setEditingId(null)} />
+                      )}
+                      {hasAmmo && (
+                        <AmmoEditor item={it} playerId={playerId} busy={busy} run={run} isOnline={isOnline} onClose={() => setEditingId(null)} />
                       )}
                     </div>
                   )}
@@ -3027,6 +3046,58 @@ function WaterEditor({ item, busy, run, onClose }: {
             <Icon name="Save" size={12} /> Save water
           </button>
         </div>
+      </div>
+    </div>
+  )
+}
+
+function AmmoEditor({ item, playerId, busy, run, isOnline, onClose }: {
+  item: InventoryItem
+  playerId: number
+  busy: boolean
+  run: (fn: () => Promise<{ message: string }>, label: string) => Promise<boolean>
+  isOnline: boolean
+  onClose: () => void
+}) {
+  const current = parseInt(item.current_ammo ?? '0', 10)
+  const [ammoStr, setAmmoStr] = useState(Number.isFinite(current) ? String(current) : '0')
+  const ammo = parseInt(ammoStr, 10)
+  const valid = Number.isFinite(ammo) && ammo >= 0 && ammo <= 2000000000
+
+  return (
+    <div className="border-t border-border/50 px-3 py-3 bg-surface-1/60 rounded-b-lg space-y-3">
+      <div className="text-[11px] text-warning flex items-start gap-1.5">
+        <Icon name="WifiOff" size={11} className="mt-0.5 shrink-0" />
+        <span>
+          Loaded ammo is written inside the weapon stats blob and only persists safely while the player is offline.
+          DST checks the current ammo value before writing so a stale inventory row cannot overwrite a newer save.
+        </span>
+      </div>
+      <div className="flex items-end gap-2">
+        <label className="text-xs flex-1">
+          <div className="text-text-dim mb-1">Loaded ammo</div>
+          <input
+            type="number" inputMode="numeric" step={1} min={0}
+            value={ammoStr}
+            onChange={e => setAmmoStr(e.target.value)}
+            disabled={busy || isOnline}
+            className="w-full font-mono text-sm bg-surface-2 border border-border rounded px-2 py-1"
+          />
+        </label>
+        <button
+          type="button"
+          className="btn-primary text-xs"
+          disabled={busy || isOnline || !valid}
+          title={isOnline ? 'Player must be offline' : undefined}
+          onClick={() => {
+            if (!valid || isOnline) return
+            void (async () => {
+              if (await run(() => setWeaponAmmo(playerId, item.id, ammo, current), 'Save ammo')) onClose()
+            })()
+          }}
+        >
+          <Icon name="Save" size={12} /> Save ammo
+        </button>
       </div>
     </div>
   )

--- a/webui/tests/api/filterCatalog.test.ts
+++ b/webui/tests/api/filterCatalog.test.ts
@@ -61,6 +61,7 @@ describe('filterCosmeticsCatalog', () => {
   const cosmetics: CosmeticEntry[] = [
     { template: 'Atreides_Buggy_Variant', name: 'Atreides Buggy Variant', group: 'Vehicle Skins' },
     { template: 'D_Choam_HeavyArmor_Swatch', name: 'CHOAM Heavy Armor Swatch', group: 'Swatches (Dyes)' },
+    { template: 'Atreides_Placeables_Swatch', name: 'Atreides Buildables Swatch', group: 'Swatches (Dyes)' },
     { template: 'Ecaz_HeavyArmor_Swatch', name: 'House Ecaz Garment Swatch', group: 'Swatches (Dyes)' },
     { template: 'Ecaz_Placeables_Swatch', name: 'House Ecaz Placeables Swatch', group: 'Swatches (Dyes)' },
     { template: 'NotASwatch', name: 'House Example Swatch', group: 'Other Customization' },
@@ -76,6 +77,10 @@ describe('filterCosmeticsCatalog', () => {
   })
 
   it('selects only vendor House Swatches in stable name order', () => {
-    expect(getHouseSwatchCosmetics(cosmetics)).toEqual([cosmetics[2], cosmetics[3]])
+    expect(getHouseSwatchCosmetics(cosmetics)).toEqual([cosmetics[3], cosmetics[4]])
+  })
+
+  it('can select only buildable/placeables House Swatches', () => {
+    expect(getHouseSwatchCosmetics(cosmetics, 'placeables')).toEqual([cosmetics[2], cosmetics[4]])
   })
 })

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -264,6 +264,18 @@ describe('Phase G+H — RMQ live commands (PlayerTarget shape)', () => {
     expect(last().url).toBe('/api/gameplay/players/reset-progression')
   })
 
+  it('setWeaponAmmo sends pawn, item, ammo, and expected ammo', async () => {
+    await gp.setWeaponAmmo(42, 9001, 250, 17)
+    expect(last().url).toBe('/api/gameplay/players/set-weapon-ammo')
+    expect(last().body).toEqual({ pawn_id: 42, item_id: 9001, ammo: 250, expected_ammo: 17 })
+  })
+
+  it('grantHouseSwatches can request only buildable/placeables tokens', async () => {
+    await gp.grantHouseSwatches(42, 99, 'placeables')
+    expect(last().url).toBe('/api/gameplay/players/grant-house-swatches')
+    expect(last().body).toEqual({ pawn_id: 42, account_id: 99, kind: 'placeables' })
+  })
+
   it('setSkillModuleLive sends module_id + level', async () => {
     await gp.setSkillModuleLive({ fls_id: 'F-x' }, 'mod.weapons', 3)
     expect(last().body).toEqual({ fls_id: 'F-x', module_id: 'mod.weapons', level: 3 })


### PR DESCRIPTION
## Summary
- add offline, stale-write-protected loaded-ammo editing for Self-Hosted player-carried ranged weapons
- add a separate Buildable House Swatches delivery action while preserving All House Swatches
- bump the prerelease line to v15.0.0-phase2-test5 and update route contracts and diagnostics

## Validation
- full backend suite: 1,342 passed before route manifest update; affected suites: 114 passed after final changes
- WebUI tests: 64 passed
- WebUI production build passed
- full installer build passed