### PR TITLE
Fix ammo state on augmented weapon grants

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -88,7 +88,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-phase2-test6"
+      placeholder: "v15.0.0-phase2-test6.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.0-phase2-test6.1] - 2026-09-05
+
+### Fixed
+
+- Pre-augmented ranged-weapon grants now include loaded-ammo state so they
+  appear in the offline ammo editor.
+
 ## [15.0.0-phase2-test6] - 2026-09-04
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -166,7 +166,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 Write-DuneStartupLog 'Console presentation initialized'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.0-phase2-test6'
+$script:DuneToolVersion = '15.0.0-phase2-test6.1'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.0-phase2-test6',
+    [string]$Version = '15.0.0-phase2-test6.1',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.0-phase2-test6</Version>
+    <Version>15.0.0-phase2-test6.1</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.0-phase2-test6"
+#define MyAppVersion "15.0.0-phase2-test6.1"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"

--- a/app/server/lib/AugmentCatalog.ps1
+++ b/app/server/lib/AugmentCatalog.ps1
@@ -153,9 +153,17 @@ function New-DuneAugmentedItemStatsJson {
     [void]$durabilityPair.Add([object[]]@())
     [void]$durabilityPair.Add([ordered]@{})
 
-    return ([ordered]@{
+    $stats = [ordered]@{
         FCustomizationStats = $customizationPair
         FAugmentedItemStats = $augmentPair
         FItemStackAndDurabilityStats = $durabilityPair
-    } | ConvertTo-Json -Depth 12 -Compress)
+    }
+    if (@($itemTags | Where-Object { $_ -like 'Items.Holsters.RangedWeapons*' }).Count -gt 0) {
+        $weaponPair = New-Object Collections.ArrayList
+        [void]$weaponPair.Add([object[]]@())
+        [void]$weaponPair.Add([ordered]@{ CurrentAmmo = 0 })
+        $stats.FWeaponItemStats = $weaponPair
+    }
+
+    return ($stats | ConvertTo-Json -Depth 12 -Compress)
 }

--- a/app/tools/DuneSoloDb/AugmentedGrants.cs
+++ b/app/tools/DuneSoloDb/AugmentedGrants.cs
@@ -153,7 +153,7 @@ internal static partial class Program
             });
         }
 
-        return new JsonObject
+        var stats = new JsonObject
         {
             ["FCustomizationStats"] = new JsonArray(new JsonArray(), new JsonObject()),
             ["FAugmentedItemStats"] = new JsonArray(
@@ -165,6 +165,14 @@ internal static partial class Program
                     ["AppliedAugmentRollData"] = appliedRollData
                 }),
             ["FItemStackAndDurabilityStats"] = new JsonArray(new JsonArray(), new JsonObject())
-        }.ToJsonString();
+        };
+        if (itemTags.Any(tag =>
+                tag.StartsWith("Items.Holsters.RangedWeapons", StringComparison.OrdinalIgnoreCase)))
+        {
+            stats["FWeaponItemStats"] = new JsonArray(
+                new JsonArray(),
+                new JsonObject { ["CurrentAmmo"] = 0 });
+        }
+        return stats.ToJsonString();
     }
 }

--- a/app/tools/DuneSoloDb/Program.cs
+++ b/app/tools/DuneSoloDb/Program.cs
@@ -1528,10 +1528,11 @@ internal static partial class Program
                 || augmentedValues?["AppliedAugmentQualities"]?[0]?.GetValue<int>() != 5
                 || augmentedValues?["AppliedAugmentQualities"]?[1]?.GetValue<int>() != 4
                 || augmentedValues?["AppliedAugmentRollData"]?[0]?["StatRolls"]?[0]
-                    ?.GetValue<decimal>() != DuneAugmentMaxRoll)
+                    ?.GetValue<decimal>() != DuneAugmentMaxRoll
+                || augmentedStats?["FWeaponItemStats"]?[1]?["CurrentAmmo"]?.GetValue<int>() != 0)
             {
                 throw new InvalidOperationException(
-                    "Pre-augmented grant stats did not preserve ids, grade, and maximum rolls.");
+                    "Pre-augmented ranged grant stats did not preserve augments and loaded ammo.");
             }
             var catalog = ReadCatalog(catalogPath);
             if (catalog["RepairTool5"].Volume != 10d

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.0-phase2-test6"
+$script:ToolVersion = "15.0.0-phase2-test6.1"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/GiveItemStats.Tests.ps1
+++ b/tests/GiveItemStats.Tests.ps1
@@ -57,6 +57,8 @@ Describe 'Get-DuneGiveItemStatsJson' -Tag 'Pure' {
         @($augmented.AppliedAugmentQualities) | Should -Be @(5, 4)
         @($augmented.AppliedAugmentRollData).Count | Should -Be 2
         [double]$augmented.AppliedAugmentRollData[0].StatRolls[0] | Should -Be 1.003398
+        $stats.PSObject.Properties.Name | Should -Contain 'FWeaponItemStats'
+        $stats.FWeaponItemStats[1].PSObject.Properties.Name | Should -Contain 'CurrentAmmo'
         [int]$stats.FWeaponItemStats[1].CurrentAmmo | Should -Be 0
     }
 

--- a/tests/GiveItemStats.Tests.ps1
+++ b/tests/GiveItemStats.Tests.ps1
@@ -57,6 +57,7 @@ Describe 'Get-DuneGiveItemStatsJson' -Tag 'Pure' {
         @($augmented.AppliedAugmentQualities) | Should -Be @(5, 4)
         @($augmented.AppliedAugmentRollData).Count | Should -Be 2
         [double]$augmented.AppliedAugmentRollData[0].StatRolls[0] | Should -Be 1.003398
+        [int]$stats.FWeaponItemStats[1].CurrentAmmo | Should -Be 0
     }
 
     It 'rejects incompatible augments instead of creating invalid gear' {


### PR DESCRIPTION
## Summary
- initialize loaded-ammo state on pre-augmented ranged-weapon grants
- apply the same stats shape in Self-Hosted and Solo Mode
- publish the correction as `v15.0.0-phase2-test6.1`

## Risk boundary
- only ranged weapons receive `FWeaponItemStats`; garments remain unchanged
- new grants start with zero loaded ammo and can then use the existing offline ammo editor
- no existing items or player data are mutated by installation

## Validation
- 83 targeted Pester tests passed
- DuneSoloDb self-test passed
- full installer build succeeded
- independent code review found no issues
- gitleaks and public-boundary checks passed