### PR TITLE
Add correlated tracing for intermittent chat teleports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -90,7 +90,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-finalphase-1.1"
+      placeholder: "v15.0.0-finalphase-1.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ here cover everything those tags shipped.
 - Added one correlated diagnostic trail for each `!tp` request, covering its
   live chat origin, queue dequeue, destination validation, broker publication,
   and bounded post-dispatch database location readbacks.
+- The Command Deck footer now keeps the running DST version visible beneath
+  its "Built with Duke with love" attribution.
 
 ## [15.0.0-finalphase-1.1] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Patch releases within a major series are rolled up under the major's entry
 on GitHub still exist for each individual release; the consolidated entries
 here cover everything those tags shipped.
 
+## [15.0.0-finalphase-1.2] - 2026-09-05
+
+### Fixed
+
+- Added one correlated diagnostic trail for each `!tp` request, covering its
+  live chat origin, queue dequeue, destination validation, broker publication,
+  and bounded post-dispatch database location readbacks.
+
 ## [15.0.0-finalphase-1.1] - 2026-09-05
 
 ### Fixed

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -166,7 +166,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 Write-DuneStartupLog 'Console presentation initialized'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.0-finalphase-1.1'
+$script:DuneToolVersion = '15.0.0-finalphase-1.2'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.0-finalphase-1.1',
+    [string]$Version = '15.0.0-finalphase-1.2',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.0-finalphase-1.1</Version>
+    <Version>15.0.0-finalphase-1.2</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.0-finalphase-1.1"
+#define MyAppVersion "15.0.0-finalphase-1.2"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"

--- a/app/server/lib/ChatCommands.ps1
+++ b/app/server/lib/ChatCommands.ps1
@@ -54,6 +54,7 @@ $script:DuneChatTeleportCaptureFile = $null
 $script:DuneChatTeleportMax = 20
 $script:DuneChatTeleportNameMax = 40
 $script:DuneChatTeleportCaptureTtlSeconds = 120
+$script:DuneChatTeleportTraceReadbackDelaysMs = @(1000, 2000, 3000)
 
 function Get-DuneChatCommandsStatePath {
     if ($script:DuneChatStateFile) { return $script:DuneChatStateFile }
@@ -691,6 +692,7 @@ function ConvertFrom-DuneChatMessage {
 
     return @{
         type      = [string]$outer.Type
+        messageId = [string]$inner.m_Id
         channel   = $channel
         fromId    = [string]$inner.m_FuncomIdFrom
         toId      = [string]$inner.m_UserNameTo
@@ -977,7 +979,10 @@ function Get-DuneChatPlayerLocation {
 SELECT COALESCE(ps.online_status::text, 'Offline') AS status,
        COALESCE(actor.map, '') AS map,
        COALESCE(actor.partition_id, 0)::text AS partition,
-       COALESCE(actor.dimension_index, 0)::text AS dimension
+       COALESCE(actor.dimension_index, 0)::text AS dimension,
+       (actor.transform).location.x AS x,
+       (actor.transform).location.y AS y,
+       (actor.transform).location.z AS z
 FROM dune.accounts account
 JOIN dune.player_state ps ON ps.account_id = account.id
 JOIN dune.actors actor ON actor.id = ps.player_pawn_id
@@ -995,6 +1000,9 @@ LIMIT 1;
         map = [string]$rows[0]['map']
         partition = [int64](ConvertTo-DuneInt $rows[0]['partition'])
         dimension = [int](ConvertTo-DuneInt $rows[0]['dimension'])
+        x = $rows[0]['x']
+        y = $rows[0]['y']
+        z = $rows[0]['z']
     }
 }
 
@@ -1360,8 +1368,67 @@ function Invoke-DuneChatCommandItem {
     return @{ ok = $true; reply = $reply; template = [string]$hit.templateId; qty = $qty }
 }
 
+function Write-DuneChatTeleportTrace {
+    param(
+        [string]$TraceId,
+        [string]$Stage,
+        [hashtable]$Fields = @{},
+        [string]$Level = 'INFO'
+    )
+    if (-not (Get-Command Write-DuneLog -ErrorAction SilentlyContinue)) { return }
+    $safeTrace = if ($TraceId) { $TraceId -replace '[^A-Za-z0-9_-]', '' } else { 'unknown' }
+    $parts = [System.Collections.Generic.List[string]]::new()
+    foreach ($key in @($Fields.Keys | Sort-Object)) {
+        $value = [string]$Fields[$key]
+        $value = ($value -replace '\s+', ' ').Trim()
+        if ($value.Length -gt 120) { $value = $value.Substring(0, 120) }
+        $parts.Add(('{0}="{1}"' -f $key, ($value -replace '"', "'")))
+    }
+    $detail = if ($parts.Count -gt 0) { ' ' + ($parts -join ' ') } else { '' }
+    try { Write-DuneLog "chat tp trace=$safeTrace stage=$Stage$detail" $Level } catch {}
+}
+
+function Write-DuneChatTeleportReadbackTrace {
+    param(
+        [string]$Ip,
+        [string]$FuncomId,
+        [string]$TraceId
+    )
+    $sample = 0
+    foreach ($delayMs in @($script:DuneChatTeleportTraceReadbackDelaysMs)) {
+        $sample++
+        if ([int]$delayMs -gt 0) { Start-Sleep -Milliseconds ([int]$delayMs) }
+        try {
+            $location = Get-DuneChatPlayerLocation -Ip $Ip -FuncomId $FuncomId
+            $fields = @{
+                sample = $sample
+                ok = [bool]$location.ok
+                status = [string]$location.status
+                map = [string]$location.map
+                partition = [string]$location.partition
+                dimension = [string]$location.dimension
+                x = [string]$location.x
+                y = [string]$location.y
+                z = [string]$location.z
+            }
+            if (-not $location.ok) { $fields['error'] = [string]$location.message }
+            Write-DuneChatTeleportTrace -TraceId $TraceId -Stage 'post-dispatch-db-readback' `
+                -Fields $fields -Level $(if ($location.ok) { 'INFO' } else { 'WARN' })
+        } catch {
+            Write-DuneChatTeleportTrace -TraceId $TraceId -Stage 'post-dispatch-db-readback' `
+                -Fields @{ sample = $sample; ok = $false; error = $_.Exception.Message } -Level 'WARN'
+        }
+    }
+}
+
 function Invoke-DuneChatCommandTeleport {
-    param([string]$Ip, [string]$FuncomId, [string[]]$CommandArgs, [hashtable]$Message)
+    param(
+        [string]$Ip,
+        [string]$FuncomId,
+        [string[]]$CommandArgs,
+        [hashtable]$Message,
+        [string]$TraceId
+    )
     $wanted = (@($CommandArgs) -join ' ').Trim()
     $argv = @($CommandArgs)
     if ($argv.Count -gt 0 -and [string]$argv[0] -ieq 'save') {
@@ -1425,24 +1492,54 @@ function Invoke-DuneChatCommandTeleport {
 
     $fls = Resolve-DuneChatFlsId -Ip $Ip -FuncomId $FuncomId
     if (-not $fls.ok) { return @{ ok = $false; reply = 'Could not resolve your player id for teleport.' } }
+    Write-DuneChatTeleportTrace -TraceId $TraceId -Stage 'dispatch' -Fields @{
+        destination = [string]$bookmark.name
+        source_map = [string]$current.map
+        source_partition = [string]$current.partition
+        source_dimension = [string]$current.dimension
+        source_x = [string]$current.x
+        source_y = [string]$current.y
+        source_z = [string]$current.z
+        target_map = [string]$bookmark.map
+        target_partition = [string]$bookmark.partition
+        target_dimension = [string]$bookmark.dimension
+        target_x = [string]$bookmark.x
+        target_y = [string]$bookmark.y
+        target_z = [string]$bookmark.z
+    }
     # Let the game resolve a safe landing surface. TeleportToExact can force a
     # distant stored Z before destination terrain finishes streaming. Shared
     # destination replay is repeat-safe, so publish it twice inside one paced
     # broker call to absorb an intermittent game-side command miss.
     $res = Invoke-DuneRmqTeleportTo -FlsId $fls.flsId `
         -X ([double]$bookmark.x) -Y ([double]$bookmark.y) -Z ([double]$bookmark.z) `
-        -RepeatForReliability
+        -RepeatForReliability -TraceId $TraceId
+    Write-DuneChatTeleportTrace -TraceId $TraceId -Stage 'published' -Fields @{
+        ok = [bool]$res.ok
+        action = [string]$res.action
+        status = [string]$res.status
+        message = [string]$res.message
+    } -Level $(if ($res.ok) { 'INFO' } else { 'WARN' })
     if (-not $res.ok) { return @{ ok = $false; reply = "Teleport to '$($bookmark.name)' failed." } }
+    Write-DuneChatTeleportReadbackTrace -Ip $Ip -FuncomId $FuncomId -TraceId $TraceId
     return @{ ok = $true; reply = "Teleported to $($bookmark.name)." }
 }
 
 function Invoke-DuneChatCommandExecutor {
-    param([string]$Ip, [hashtable]$State, [string]$Verb, [string]$FuncomId, [string[]]$CommandArgs, [hashtable]$Message)
+    param(
+        [string]$Ip,
+        [hashtable]$State,
+        [string]$Verb,
+        [string]$FuncomId,
+        [string[]]$CommandArgs,
+        [hashtable]$Message,
+        [string]$TraceId
+    )
     switch ("$Verb".ToLowerInvariant()) {
         'kit'     { return Invoke-DuneChatCommandKit -Ip $Ip -State $State -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
         'item'    { return Invoke-DuneChatCommandItem -Ip $Ip -State $State -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
         'water'   { return Invoke-DuneChatCommandWater -Ip $Ip -FuncomId $FuncomId }
-        'tp'      { return Invoke-DuneChatCommandTeleport -Ip $Ip -FuncomId $FuncomId -CommandArgs @($CommandArgs) -Message $Message }
+        'tp'      { return Invoke-DuneChatCommandTeleport -Ip $Ip -FuncomId $FuncomId -CommandArgs @($CommandArgs) -Message $Message -TraceId $TraceId }
         'vehicle' { return Invoke-DuneChatCommandVehicle -Ip $Ip -FuncomId $FuncomId -CommandArgs @($CommandArgs) }
         'small'   { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Small' }
         'medium'  { return Invoke-DuneChatCommandSpiceField -Ip $Ip -Size 'Medium' }
@@ -1494,8 +1591,21 @@ function Invoke-DuneChatCommandTick {
                     $handled++
                 }
                 'run' {
+                    $traceId = ''
+                    if ($act.verb -eq 'tp') {
+                        $traceId = (([string]$msg.messageId).Trim() -replace '[^A-Za-z0-9_-]', '')
+                        if (-not $traceId) { $traceId = [guid]::NewGuid().ToString('N') }
+                        Write-DuneChatTeleportTrace -TraceId $traceId -Stage 'dequeued' -Fields @{
+                            command_timestamp = [string]$msg.timestamp
+                            channel = [string]$msg.channel
+                            destination = (@($act.args) -join ' ')
+                            chat_origin_x = [string]$msg.location.x
+                            chat_origin_y = [string]$msg.location.y
+                            chat_origin_z = [string]$msg.location.z
+                        }
+                    }
                     $res = Invoke-DuneChatCommandExecutor -Ip $ip -State $state -Verb $act.verb `
-                              -FuncomId $msg.fromId -CommandArgs @($act.args) -Message $msg
+                              -FuncomId $msg.fromId -CommandArgs @($act.args) -Message $msg -TraceId $traceId
                     if ($res.reply) {
                         [void](Send-DuneChatReply -Ip $ip -State $state -ToFuncomId $msg.fromId -Message $res.reply)
                     }
@@ -1507,7 +1617,10 @@ function Invoke-DuneChatCommandTick {
                     }
                     $handled++
                     if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
-                        try { Write-DuneLog "chat command !$($act.verb) from $($msg.fromId): ok=$($res.ok)" 'INFO' } catch {}
+                        try {
+                            $traceSuffix = if ($traceId) { " trace=$traceId" } else { '' }
+                            Write-DuneLog "chat command !$($act.verb) from $($msg.fromId): ok=$($res.ok)$traceSuffix" 'INFO'
+                        } catch {}
                     }
                 }
                 default { }

--- a/app/server/lib/Rmq.ps1
+++ b/app/server/lib/Rmq.ps1
@@ -285,7 +285,8 @@ function Invoke-DuneRmqTeleportTo {
         [Parameter(Mandatory)] [double] $X,
         [Parameter(Mandatory)] [double] $Y,
         [Parameter(Mandatory)] [double] $Z,
-        [switch] $RepeatForReliability
+        [switch] $RepeatForReliability,
+        [string] $TraceId
     )
     $fields = @{
         ServerCommand = 'TeleportTo'
@@ -294,11 +295,12 @@ function Invoke-DuneRmqTeleportTo {
         Y             = $Y
         Z             = $Z
     }
+    $extra = if ($TraceId) { @{ trace_id = $TraceId } } else { $null }
     if ($RepeatForReliability) {
         return Send-DuneRmqServerCommandBatch -Fields @($fields, $fields) `
-            -SpacingMilliseconds 750 -Action 'teleport-live-repeat'
+            -SpacingMilliseconds 750 -Action 'teleport-live-repeat' -Extra $extra
     }
-    Send-DuneRmqServerCommand -Fields $fields -Action 'teleport-live'
+    Send-DuneRmqServerCommand -Fields $fields -Action 'teleport-live' -Extra $extra
 }
 
 function Invoke-DuneRmqTeleportToExact {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.0-finalphase-1.1"
+$script:ToolVersion = "15.0.0-finalphase-1.2"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/ChatCommands.Tests.ps1
+++ b/tests/ChatCommands.Tests.ps1
@@ -37,6 +37,7 @@ Describe 'ConvertFrom-DuneChatMessage' {
         $m.type | Should -Be 'TextChat'
         $m.channel | Should -Be 'Proximity'
         $m.fromId | Should -Be 'Coastal#45066'
+        $m.messageId | Should -Be 'C6BA73B94B132A51F6B937AC6960C0C1'
         $m.text | Should -Be '!large'
         $m.timestamp | Should -Be '2026.08.05-00.13.11'
     }
@@ -396,7 +397,7 @@ Describe 'teleport bookmarks' {
             function global:Invoke-DuneSqlQuery { param($Ip, $Sql, $ReadOnly, $MaxRows, $TimeoutSec) }
         }
         if (-not (Get-Command Invoke-DuneRmqTeleportTo -ErrorAction SilentlyContinue)) {
-            function global:Invoke-DuneRmqTeleportTo { param($FlsId, $X, $Y, $Z, [switch]$RepeatForReliability) }
+            function global:Invoke-DuneRmqTeleportTo { param($FlsId, $X, $Y, $Z, [switch]$RepeatForReliability, $TraceId) }
         }
         if (-not (Get-Command Invoke-DuneRmqTeleportToExact -ErrorAction SilentlyContinue)) {
             function global:Invoke-DuneRmqTeleportToExact { param($FlsId, $X, $Y, $Z) }
@@ -660,19 +661,52 @@ Describe 'teleport bookmarks' {
         Save-DuneChatTeleports -Bookmarks @(
             [ordered]@{ name = 'Base'; key = 'base'; map = 'HaggaBasin'; partition = 1; dimension = 0; x = 1; y = 2; z = 3; capturedFrom = 'Coastal'; capturedAt = '2026-08-16T00:00:00Z' }
         ) | Should -BeTrue
-        Mock Get-DuneChatPlayerLocation { @{ ok = $true; status = 'Online'; map = 'HaggaBasin'; partition = 1; dimension = 0 } }
+        Mock Get-DuneChatPlayerLocation { @{ ok = $true; status = 'Online'; map = 'HaggaBasin'; partition = 1; dimension = 0; x = 100; y = 200; z = 300 } }
         Mock Resolve-DuneChatFlsId { @{ ok = $true; flsId = 'FLS1' } }
         Mock Invoke-DuneRmqTeleportTo { @{ ok = $true } }
         Mock Invoke-DuneRmqTeleportToExact { @{ ok = $true } }
+        Mock Write-DuneChatTeleportTrace {}
+        Mock Write-DuneChatTeleportReadbackTrace {}
 
-        $r = Invoke-DuneChatCommandExecutor -Ip 'vm' -State (New-DstChatState) -Verb 'tp' -FuncomId 'A#1' -CommandArgs @('Base')
+        $r = Invoke-DuneChatCommandExecutor -Ip 'vm' -State (New-DstChatState) -Verb 'tp' `
+            -FuncomId 'A#1' -CommandArgs @('Base') -TraceId 'TRACE123'
         $r.ok | Should -BeTrue
         $r.reply | Should -Be 'Teleported to Base.'
         Should -Invoke Invoke-DuneRmqTeleportTo -Times 1 -Exactly -ParameterFilter {
             $FlsId -eq 'FLS1' -and $X -eq 1 -and $Y -eq 2 -and $Z -eq 3 -and
-            $RepeatForReliability
+            $RepeatForReliability -and $TraceId -eq 'TRACE123'
         }
         Should -Invoke Invoke-DuneRmqTeleportToExact -Times 0 -Exactly
+        Should -Invoke Write-DuneChatTeleportTrace -Times 1 -Exactly -ParameterFilter {
+            $TraceId -eq 'TRACE123' -and $Stage -eq 'dispatch'
+        }
+        Should -Invoke Write-DuneChatTeleportTrace -Times 1 -Exactly -ParameterFilter {
+            $TraceId -eq 'TRACE123' -and $Stage -eq 'published'
+        }
+        Should -Invoke Write-DuneChatTeleportReadbackTrace -Times 1 -Exactly -ParameterFilter {
+            $TraceId -eq 'TRACE123' -and $Ip -eq 'vm' -and $FuncomId -eq 'A#1'
+        }
+    }
+
+    It 'records factual post-dispatch location samples without declaring success' {
+        try {
+            $script:DuneChatTeleportTraceReadbackDelaysMs = @(0, 0, 0)
+            Mock Get-DuneChatPlayerLocation {
+                @{ ok = $true; status = 'Online'; map = 'HaggaBasin'; partition = 4; dimension = 0; x = 11; y = 22; z = 33 }
+            }
+            Mock Write-DuneChatTeleportTrace {}
+
+            Write-DuneChatTeleportReadbackTrace -Ip 'vm' -FuncomId 'A#1' -TraceId 'TRACE456'
+
+            Should -Invoke Get-DuneChatPlayerLocation -Times 3 -Exactly
+            Should -Invoke Write-DuneChatTeleportTrace -Times 3 -Exactly -ParameterFilter {
+                $TraceId -eq 'TRACE456' -and $Stage -eq 'post-dispatch-db-readback' -and
+                $Fields.ok -and $Fields.map -eq 'HaggaBasin' -and
+                $Fields.x -eq '11' -and $Fields.y -eq '22' -and $Fields.z -eq '33'
+            }
+        } finally {
+            $script:DuneChatTeleportTraceReadbackDelaysMs = @(1000, 2000, 3000)
+        }
     }
 
     It 'blocks a destination on another map before sending RMQ' {

--- a/tests/Rmq.Tests.ps1
+++ b/tests/Rmq.Tests.ps1
@@ -170,6 +170,15 @@ Describe 'Send-DuneRmqServerCommandBatch envelope' -Tag 'Rmq' {
         @($payloads | ForEach-Object Y) | Should -Be @(2, 2)
         @($payloads | ForEach-Object Z) | Should -Be @(3, 3)
     }
+
+    It 'carries a teleport trace id in result metadata without changing the game payload' {
+        Invoke-DuneRmqTeleportTo -FlsId 'abc123' -X 1 -Y 2 -Z 3 `
+            -RepeatForReliability -TraceId 'TRACE123' | Out-Null
+
+        $script:lastAction | Should -Be 'teleport-live-repeat'
+        $script:lastExtra.trace_id | Should -Be 'TRACE123'
+        $script:lastErl | Should -Not -Match 'TRACE123'
+    }
 }
 
 Describe 'Send-DuneRmqCourierMessage envelope' -Tag 'Rmq' {

--- a/webui/src/layout/SpatialFrame.tsx
+++ b/webui/src/layout/SpatialFrame.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Link, useLocation, useSearch } from '../router'
 import { Icon } from '../components/Icon'
 import { useStatus } from '../hooks/useStatus'
+import { useUpdateCheck } from '../hooks/useUpdateCheck'
 import { setCommandDeck } from '../hooks/useCommandDeck'
 import { usePortalAccess } from '../auth/portalAccess'
 import { isLocalViewer, isWindowsViewer } from '../util/viewer'
@@ -10,6 +11,7 @@ import { getDeckDestinations, searchDeck } from './commandDeckModel'
 import { useFloatingDock } from './useFloatingDock'
 import { useDashboardViewport } from './useDashboardViewport'
 import { colorSchemeForBase } from '../theme/colorScheme'
+import { fmtToolVersion } from '../format'
 import '../pages/workspaces/spatial.css'
 import './floatingDock.css'
 import './dashboardFrame.css'
@@ -25,6 +27,7 @@ export default function SpatialFrame({ children, onDetails, tools = false, dashb
   dashboard?: boolean
 }) {
   const { status, error, loading } = useStatus()
+  const { data: update } = useUpdateCheck()
   const { canAccessOwnerSurfaces } = usePortalAccess()
   const theme = useTheme()
   const { pathname } = useLocation()
@@ -112,7 +115,13 @@ export default function SpatialFrame({ children, onDetails, tools = false, dashb
               <button onClick={openFinder} aria-haspopup="dialog"><Icon name="Grid2X2" size={20} /><span>All tools</span></button>
             </nav>
           </div>
-          {!dashboard && <span className="spatial-system-label">LOCAL CONTROL<br /><b>NO AI SERVICE REQUIRED</b></span>}
+          {!dashboard && (
+            <span className="spatial-system-label">
+              LOCAL CONTROL
+              <b>BUILT WITH DUKE WITH LOVE</b>
+              <small>{update?.currentVersion ? fmtToolVersion(update.currentVersion) : '—'}</small>
+            </span>
+          )}
         </footer>
       </div>
       <dialog ref={dialog} className="spatial-finder" aria-labelledby="spatial-finder-title"

--- a/webui/src/pages/workspaces/spatial.css
+++ b/webui/src/pages/workspaces/spatial.css
@@ -173,8 +173,9 @@
 .spatial-dock a, .spatial-dock button { display:flex; flex-direction:column; align-items:center; gap:7px; text-decoration:none; color:var(--space-muted); font-size:9px; padding:10px 12px; border-radius:8px; min-width:66px; }
 .spatial-dock a:hover,.spatial-dock button:hover { background:var(--color-surface-3); color:var(--space-ink); }
 .spatial-dock a[aria-current="page"] { background:var(--color-surface); color:var(--space-ink); box-shadow:inset 0 -2px var(--space-sand); }
-.spatial-system-label { color:var(--space-muted); font-size:8px; letter-spacing:.12em; line-height:1.8; text-align:right; }
-.spatial-system-label b { font-size:7px; font-weight:400; }
+.spatial-system-label { display:flex; flex-direction:column; align-items:flex-end; color:var(--space-muted); font-size:8px; letter-spacing:.12em; line-height:1.55; text-align:right; }
+.spatial-system-label b { font-size:7px; font-weight:400; color:var(--space-ink); }
+.spatial-system-label small { font-size:7px; color:var(--space-muted); }
 .spatial-finder { margin:12vh auto auto; width:min(560px,calc(100% - 24px)); max-height:75vh; padding:24px; background:var(--color-surface); color:var(--space-ink); border:1px solid var(--color-border-bright); border-radius:12px; box-shadow:0 20px 60px #0006; }
 .spatial-finder::backdrop { background:#0006; }
 .spatial-finder > div { display:flex; flex-direction:column; max-height:calc(75vh - 48px); }

--- a/webui/tests/dashboardFrame.test.tsx
+++ b/webui/tests/dashboardFrame.test.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from '../src/theme/ThemeContext'
 
 const controls = vi.hoisted(() => ({ owner: true, dashboard: vi.fn(), classic: vi.fn() }))
 vi.mock('../src/hooks/useStatus', () => ({ useStatus: () => ({ status: null, loading: false, error: null }) }))
+vi.mock('../src/hooks/useUpdateCheck', () => ({ useUpdateCheck: () => ({ data: { currentVersion: '15.0.0-finalphase-1.2' } }) }))
 vi.mock('../src/auth/portalAccess', () => ({ usePortalAccess: () => ({ canAccessOwnerSurfaces: controls.owner }) }))
 vi.mock('../src/util/viewer', () => ({ isLocalViewer: () => true, isWindowsViewer: () => true }))
 vi.mock('../src/hooks/useCommandDeck', () => ({ setCommandDeck: controls.classic }))

--- a/webui/tests/floatingDock.test.tsx
+++ b/webui/tests/floatingDock.test.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from '../src/theme/ThemeContext'
 
 const access = vi.hoisted(() => ({ owner: true, local: true, windows: true }))
 vi.mock('../src/hooks/useStatus', () => ({ useStatus: () => ({ status: null, loading: false, error: null }) }))
+vi.mock('../src/hooks/useUpdateCheck', () => ({ useUpdateCheck: () => ({ data: { currentVersion: '15.0.0-finalphase-1.2' } }) }))
 vi.mock('../src/auth/portalAccess', () => ({ usePortalAccess: () => ({ canAccessOwnerSurfaces: access.owner }) }))
 vi.mock('../src/util/viewer', () => ({ isLocalViewer: () => access.local, isWindowsViewer: () => access.windows }))
 

--- a/webui/tests/spatialWorkspace.test.tsx
+++ b/webui/tests/spatialWorkspace.test.tsx
@@ -31,6 +31,7 @@ const state = vi.hoisted(() => ({
   rosterReads: vi.fn(),
 }))
 vi.mock('../src/hooks/useStatus', () => ({ useStatus: () => state }))
+vi.mock('../src/hooks/useUpdateCheck', () => ({ useUpdateCheck: () => ({ data: { currentVersion: '15.0.0-finalphase-1.2' } }) }))
 vi.mock('../src/hooks/useApi', () => ({ useApi: () => { state.rosterReads(); return state.roster } }))
 vi.mock('../src/auth/portalAccess', () => ({ usePortalAccess: () => ({ canAccessOwnerSurfaces: state.owner }) }))
 vi.mock('../src/util/viewer', () => ({ isLocalViewer: () => false, isWindowsViewer: () => true }))
@@ -63,6 +64,12 @@ beforeEach(() => {
 afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
 
 describe('Spatial object workspace', () => {
+  it('shows Duke attribution and the running version beside the dock', () => {
+    render(<SpatialFrame tools><p>Tools</p></SpatialFrame>)
+    expect(screen.getByText('BUILT WITH DUKE WITH LOVE')).toBeInTheDocument()
+    expect(screen.getByText('v15.0.0-finalphase-1.2')).toBeInTheDocument()
+  })
+
   it.each(PRESETS)('keeps the complete $name theme selected across globe and tool frames', preset => {
     const home = render(<SpatialFrame><p>Globe</p></SpatialFrame>)
     fireEvent.change(screen.getByRole('combobox', { name: 'Workspace palette' }), { target: { value: preset.id } })


### PR DESCRIPTION
## What changed
- carries each `!tp` chat message ID through dequeue and RMQ dispatch
- logs the live chat origin, validated destination, broker publication result, and bounded post-dispatch database location samples under one trace ID
- keeps trace metadata out of the game command payload
- restores the running version beside the Command Deck dock beneath the requested Duke attribution
- bumps the prerelease candidate to `v15.0.0-finalphase-1.2`

## Validation
- 1,369 PowerShell tests passed (2 skipped)
- 85 focused Command Deck tests passed; WebUI production build passed
- full installer build completed from clean commit `6d1d36cbaa6e921392cfc21a185f572edf25e9ac`
- candidate: `DuneServerSetup.exe`, 112,863,757 bytes, SHA-256 `EB3F9E45196F268EC52562547E6D8560C48B5DD6783CCCBB519C96D22C4C482D`