### PR TITLE
Restore Blueprints workspace in Finalphase 1.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -90,7 +90,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-finalphase-1.3"
+      placeholder: "v15.0.0-finalphase-1.4"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.0-finalphase-1.4] - 2026-09-06
+
+### Fixed
+
+- Restored the **Blueprints** tab in the Command Deck Bases workspace while keeping the legacy Gameplay Admin route available.
+
 ## [15.0.0-finalphase-1.3] - 2026-09-06
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -166,7 +166,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 Write-DuneStartupLog 'Console presentation initialized'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.0-finalphase-1.3'
+$script:DuneToolVersion = '15.0.0-finalphase-1.4'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.0-finalphase-1.3',
+    [string]$Version = '15.0.0-finalphase-1.4',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.0-finalphase-1.3</Version>
+    <Version>15.0.0-finalphase-1.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.0-finalphase-1.3"
+#define MyAppVersion "15.0.0-finalphase-1.4"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.0-finalphase-1.3"
+$script:ToolVersion = "15.0.0-finalphase-1.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/webui/src/pages/workspaces/BasesWorkspace.tsx
+++ b/webui/src/pages/workspaces/BasesWorkspace.tsx
@@ -1,26 +1,36 @@
 import { BasesTab } from '../gameplay/BasesTab'
+import { BlueprintsTab } from '../gameplay/BlueprintsTab'
 import { SharedInventoryExplorer } from '../../components/inventory/SharedInventoryExplorer'
 import { WorkspaceLayout, type WorkspaceTab } from '../../components/platform/WorkspaceLayout'
 import { getWorkspace } from '../../platform/workspaces'
 import { useSearch } from '../../router'
 
+type BasesView = 'bases' | 'blueprints' | 'inventory'
+
 const TABS: readonly WorkspaceTab[] = [
   { id: 'bases', label: 'Bases', to: '/bases?view=bases', icon: 'Castle' },
+  { id: 'blueprints', label: 'Blueprints', to: '/bases?view=blueprints', icon: 'ScrollText' },
   { id: 'inventory', label: 'Storage inventory', to: '/bases?view=inventory', icon: 'PackageSearch' },
 ]
 
+function currentView(search: string): BasesView {
+  const view = new URLSearchParams(search).get('view')
+  if (view === 'blueprints' || view === 'inventory') return view
+  return 'bases'
+}
+
 export default function BasesWorkspace() {
-  const view = new URLSearchParams(useSearch()).get('view') === 'inventory' ? 'inventory' : 'bases'
+  const view = currentView(useSearch())
   return (
     <WorkspaceLayout workspace={getWorkspace('bases')} tabs={TABS} activeTab={view}>
-      {view === 'inventory'
-        ? (
-            <SharedInventoryExplorer
-              entityTypes={['storage']}
-              description="Search proven storage-container contents. Base-wide membership is not inferred in this slice."
-            />
-          )
-        : <BasesTab />}
+      {view === 'bases' && <BasesTab />}
+      {view === 'blueprints' && <BlueprintsTab />}
+      {view === 'inventory' && (
+        <SharedInventoryExplorer
+          entityTypes={['storage']}
+          description="Search proven storage-container contents. Base-wide membership is not inferred in this slice."
+        />
+      )}
     </WorkspaceLayout>
   )
 }

--- a/webui/tests/inventoryWorkspaces.test.tsx
+++ b/webui/tests/inventoryWorkspaces.test.tsx
@@ -15,6 +15,10 @@ vi.mock('../src/pages/gameplay/BasesTab', () => ({
   BasesTab: () => <div>Bases fixture</div>,
 }))
 
+vi.mock('../src/pages/gameplay/BlueprintsTab', () => ({
+  BlueprintsTab: () => <div>Blueprints fixture</div>,
+}))
+
 vi.mock('../src/components/inventory/SharedInventoryExplorer', () => ({
   SharedInventoryExplorer: ({
     entityTypes,
@@ -54,6 +58,20 @@ describe('inventory workspace embedding', () => {
     render(<BrowserRouter><BasesWorkspace /></BrowserRouter>)
     expect(screen.getByText('Inventory fixture: storage')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Storage inventory' })).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('makes the existing Blueprints tools discoverable from Bases', () => {
+    window.history.replaceState(null, '', '/bases')
+    const view = render(<BrowserRouter><BasesWorkspace /></BrowserRouter>)
+    expect(screen.getByText('Bases fixture')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Blueprints' })).toHaveAttribute('href', '/bases?view=blueprints')
+    expect(screen.getByRole('link', { name: 'Storage inventory' })).toHaveAttribute('href', '/bases?view=inventory')
+
+    view.unmount()
+    window.history.replaceState(null, '', '/bases?view=blueprints')
+    render(<BrowserRouter><BasesWorkspace /></BrowserRouter>)
+    expect(screen.getByText('Blueprints fixture')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Blueprints' })).toHaveAttribute('aria-current', 'page')
   })
 
   it('keeps vehicle cargo visibly unavailable instead of mounting fleet writes', () => {

--- a/webui/tests/router.test.tsx
+++ b/webui/tests/router.test.tsx
@@ -24,6 +24,10 @@ import {
   rememberGameplayDestination,
 } from '../src/platform/gameplay'
 
+vi.mock('../src/pages/gameplay/BlueprintsTab', () => ({
+  BlueprintsTab: () => <div>Blueprints fixture</div>,
+}))
+
 function LocationProbe() {
   const { pathname } = useLocation()
   const search = useSearch()
@@ -213,6 +217,21 @@ describe('router compatibility layer', () => {
     expect(window.location.pathname).toBe('/map')
     expect(window.location.search).toBe('?view=atlas')
     expect(window.location.hash).toBe('#seed-detail')
+  })
+
+  it('keeps the legacy Gameplay Blueprints route working', async () => {
+    window.history.replaceState(null, '', '/gameplay?view=blueprints')
+    render(
+      <BrowserRouter>
+        <Routes>
+          <Route path="/gameplay" element={<GameplayEnvironment />} />
+        </Routes>
+      </BrowserRouter>,
+    )
+
+    expect(await screen.findByText('Blueprints fixture')).toBeInTheDocument()
+    expect(window.location.pathname).toBe('/gameplay')
+    expect(window.location.search).toBe('?view=blueprints')
   })
 
   it('updates the persisted gameplay destination when only the hash changes', async () => {


### PR DESCRIPTION
## Fixed
- Restores **Bases → Blueprints** in Command Deck using the existing Blueprint tools.
- Keeps `/gameplay?view=blueprints` available for existing links.

## Validation
- Focused workspace/router tests
- Production WebUI build
- Full local installer build

Closes #811