### PR TITLE
fix: harden v15 stable upgrade path

### DIFF
--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -179,6 +179,10 @@ Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -Com
 ; autostart preference. Idempotent; never blocks install on failure.
 Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -Command ""try {{ Get-ScheduledTask -TaskPath '\Dune Server\' -ErrorAction SilentlyContinue | Where-Object {{ $_.TaskName -like 'DuneServer-Autostart-*' }} | Unregister-ScheduledTask -Confirm:$false -ErrorAction SilentlyContinue }} catch {{}}"""; Flags: runhidden waituntilterminated; Check: ShouldClearLegacyAutostart
 
+; A v12-v14 upgrade runs its old uninstaller, which removes these user-managed
+; tasks. Re-import the exact definitions captured immediately before that step.
+Filename: "powershell.exe"; Parameters: "{code:GetLegacyAutostartRestoreParameters|}"; Flags: runhidden waituntilterminated; Check: ShouldRestoreLegacyAutostart
+
 ; Install or replace the mobile/remote bridge only when its shipped payload
 ; changed. An unchanged bridge process and scheduled task survive modern
 ; in-place upgrades.
@@ -243,6 +247,8 @@ var
   SkipConfigPages: Boolean;
   PriorBridgeHash: string;
   PriorBridgeInstallerHash: string;
+  LegacyAutostartBackupDir: string;
+  LegacyAutostartBackupPresent: Boolean;
 
 // ---------- v12.0.0 one-time migration helpers ----------
 
@@ -254,11 +260,11 @@ var
 begin
   Result := '';
   if RegQueryStringValue(HKEY_LOCAL_MACHINE,
-       'Software\Microsoft\Windows\CurrentVersion\Uninstall\{#MyAppId}_is1',
+       'Software\Microsoft\Windows\CurrentVersion\Uninstall\{B3F8A2C1-7E5D-4F9A-8B2C-1D6E3A4F5C7D}_is1',
        'DisplayVersion', ver) then
     Result := ver
   else if RegQueryStringValue(HKEY_LOCAL_MACHINE,
-            'Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{#MyAppId}_is1',
+            'Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{B3F8A2C1-7E5D-4F9A-8B2C-1D6E3A4F5C7D}_is1',
             'DisplayVersion', ver) then
     Result := ver;
 end;
@@ -293,6 +299,85 @@ var
 begin
   major := VersionMajor(GetPriorInstalledVersion());
   Result := (major >= 0) and (major < 12);
+end;
+
+// v12-v14 upgrades still invoke the old uninstaller, which removes user-managed
+// autostart tasks. Export their exact task definitions before that handoff and
+// restore them after the v15 payload is copied. v15+ upgrades stay in place.
+function ShouldPreserveLegacyAutostart(): Boolean;
+var
+  major: Integer;
+begin
+  major := VersionMajor(GetPriorInstalledVersion());
+  Result := (major >= 12) and (major < 15);
+end;
+
+function EscapePowerShellSingleQuoted(Value: string): string;
+begin
+  Result := Value;
+  StringChangeEx(Result, '''', '''''', True);
+end;
+
+function CaptureLegacyAutostartTasks(): Boolean;
+var
+  command, escapedBackupDir: string;
+  resultCode: Integer;
+  findData: TFindRec;
+begin
+  Result := True;
+  LegacyAutostartBackupPresent := False;
+  if not ShouldPreserveLegacyAutostart() then Exit;
+
+  LegacyAutostartBackupDir := AddBackslash(ExpandConstant('{tmp}')) +
+    'DuneServer-autostart-migration';
+  escapedBackupDir := EscapePowerShellSingleQuoted(LegacyAutostartBackupDir);
+  command :=
+    '$ErrorActionPreference = ''Stop''; $backup = ''' + escapedBackupDir + '''; ' +
+    'New-Item -ItemType Directory -Path $backup -Force | Out-Null; ' +
+    'Get-ScheduledTask -ErrorAction Stop | ' +
+    'Where-Object { $_.TaskPath -eq ''\Dune Server\'' -and ' +
+    '$_.TaskName -like ''DuneServer-Autostart-*'' } | ' +
+    'ForEach-Object { Export-ScheduledTask -TaskPath $_.TaskPath -TaskName $_.TaskName | ' +
+    'Set-Content -LiteralPath (Join-Path $backup ($_.TaskName + ''.xml'')) ' +
+    '-NoNewline -Encoding UTF8 }';
+  if not Exec('powershell.exe',
+      '-NoProfile -ExecutionPolicy Bypass -Command "' + command + '"',
+      '', SW_HIDE, ewWaitUntilTerminated, resultCode) then
+  begin
+    Log('Could not start legacy autostart-task capture; blocking upgrade to preserve user tasks.');
+    Result := False;
+    Exit;
+  end;
+  if resultCode <> 0 then
+  begin
+    Log(Format('Legacy autostart-task capture exited with code %d; blocking upgrade to preserve user tasks.', [resultCode]));
+    Result := False;
+    Exit;
+  end;
+  if FindFirst(AddBackslash(LegacyAutostartBackupDir) + 'DuneServer-Autostart-*.xml',
+      findData) then
+  begin
+    LegacyAutostartBackupPresent := True;
+    FindClose(findData);
+    Log('Captured legacy autostart task definitions for v15 restoration.');
+  end;
+end;
+
+function ShouldRestoreLegacyAutostart(): Boolean;
+begin
+  Result := LegacyAutostartBackupPresent;
+end;
+
+function GetLegacyAutostartRestoreParameters(Param: string): string;
+var
+  escapedBackupDir: string;
+begin
+  escapedBackupDir := EscapePowerShellSingleQuoted(LegacyAutostartBackupDir);
+  Result := '-NoProfile -ExecutionPolicy Bypass -Command "$backup = ''' +
+    escapedBackupDir + '''; Get-ChildItem -LiteralPath $backup -Filter ' +
+    '''DuneServer-Autostart-*.xml'' -File | ForEach-Object { ' +
+    'Register-ScheduledTask -TaskPath ''\Dune Server\'' -TaskName $_.BaseName ' +
+    '-Xml (Get-Content -LiteralPath $_.FullName -Raw) -Force -ErrorAction Stop }"';
 end;
 
 // ---------- helpers ----------
@@ -678,6 +763,11 @@ begin
   begin
     PriorBridgeHash := '';
     PriorBridgeInstallerHash := '';
+    if not CaptureLegacyAutostartTasks() then
+    begin
+      Result := 'The upgrade could not safely preserve existing Windows startup tasks. No changes were made.';
+      Exit;
+    end;
     UninstallPreviousVersion();
   end;
 

--- a/app/server/routes/Diagnostics.ps1
+++ b/app/server/routes/Diagnostics.ps1
@@ -77,6 +77,21 @@ function Invoke-DstRedaction {
         '(?im)^(Username|RunAs User|Machine):\s*.*$',
         '${1}: <redacted>')
 
+    # 1i) Chat teleport traces correlate the command with its dispatch and
+    # readback stages, but their sender, bookmark, map, and position values are
+    # private gameplay data. Keep trace IDs, stages, and result status useful.
+    $out = [regex]::Replace(
+        $out,
+        '(?im)(chat command !tp from )[^:\r\n]+(:)',
+        '${1}<chat-sender>${2}')
+    $out = [regex]::Replace($out, '(?im)^.*\bchat tp trace=[^\r\n]*\r?$', {
+        param($trace)
+        return [regex]::Replace(
+            $trace.Value,
+            '(?i)\b(destination|(?:chat_origin|source|target)_(?:map|partition|dimension|x|y|z)|map|partition|dimension|x|y|z)="[^"]*"',
+            '${1}="<redacted>"')
+    })
+
     # 2) IPv4 addresses (but leave 127.0.0.1 / 0.0.0.0 / 255.255.255.255 alone —
     #    those carry no identifying info and matter for log readability).
     $out = [regex]::Replace($out, '\b(?!(?:127\.0\.0\.1|0\.0\.0\.0|255\.255\.255\.255)\b)(?:\d{1,3}\.){3}\d{1,3}\b', '<ip>')

--- a/app/server/routes/SoloMode.ps1
+++ b/app/server/routes/SoloMode.ps1
@@ -220,9 +220,18 @@ Register-DuneRoute -Method POST -Path '/api/solo/items/grant' -LocalOnly -Handle
 Register-DuneRoute -Method GET -Path '/api/solo/blueprints' -LocalOnly -Handler {
     param($req, $res, $routeParams, $body)
     try {
-        Write-DuneJson -Response $res -Body (Get-DuneSoloBlueprints)
+        $expectedProfileToken = [string]$req.QueryString['expectedProfileToken']
+        $result = Invoke-WithDuneLock -Name 'solo-profile-data' -Script {
+            Assert-DuneSoloExpectedProfile -ExpectedProfileToken $expectedProfileToken
+            $profile = Get-DuneSoloProfile
+            $blueprints = Get-DuneSoloBlueprints
+            Add-Member -InputObject $blueprints -NotePropertyName profileToken `
+                -NotePropertyValue (Get-DuneSoloProfileToken -DbPath $profile.dbPath) -Force
+            return $blueprints
+        }
+        Write-DuneJson -Response $res -Body $result
     } catch {
-        $status = if ($_.Exception.Message -like '*Connect a valid Solo save*') { 400 } else { 500 }
+        $status = if ($_.Exception.Message -like '*changed in another window*') { 409 } elseif ($_.Exception.Message -like '*Connect a valid Solo save*') { 400 } else { 500 }
         Write-DuneError -Response $res -Status $status -Message $_.Exception.Message
     }
 }
@@ -236,9 +245,14 @@ Register-DuneRoute -Method GET -Path '/api/solo/blueprints/export' -LocalOnly -H
             Write-DuneError -Response $res -Status 400 -Message 'Choose a saved Solo blueprint to export.'
             return
         }
-        Write-DuneJson -Response $res -Body (Export-DuneSoloBlueprint -Id $id)
+        $expectedProfileToken = [string]$req.QueryString['expectedProfileToken']
+        $result = Invoke-WithDuneLock -Name 'solo-profile-data' -Script {
+            Assert-DuneSoloExpectedProfile -ExpectedProfileToken $expectedProfileToken
+            Export-DuneSoloBlueprint -Id $id
+        }
+        Write-DuneJson -Response $res -Body $result
     } catch {
-        $status = if ($_.Exception.Message -like '*still running*' -or $_.Exception.Message -like '*Connect a valid Solo save*') { 400 } else { 500 }
+        $status = if ($_.Exception.Message -like '*changed in another window*') { 409 } elseif ($_.Exception.Message -like '*still running*' -or $_.Exception.Message -like '*Connect a valid Solo save*') { 400 } else { 500 }
         Write-DuneError -Response $res -Status $status -Message $_.Exception.Message
     }
 }

--- a/app/server/routes/Update.ps1
+++ b/app/server/routes/Update.ps1
@@ -171,24 +171,50 @@ function Get-DuneReleases {
     return $script:DuneReleasesCache.releases
 }
 
-function Test-DuneStableMirrorRelease {
+function Test-DuneStableMirrorLabel {
     param($Release)
     $text = "$($Release.name)`n$($Release.releaseNotes)"
     return ($text -match '(?i)\b(?:test|stable)(?:[-\s]+channel)?[-\s]+mirror\b')
 }
 
+function Test-DuneStableMirrorRelease {
+    param($Release, $StableRelease)
+    if (-not (Test-DuneStableMirrorLabel -Release $Release) -or -not $StableRelease) {
+        return $false
+    }
+    $releaseCore = Get-DuneVersionCore ([string]$Release.tag)
+    $stableCore = Get-DuneVersionCore ([string]$StableRelease.tag)
+    if (-not $releaseCore -or $releaseCore -ne $stableCore) { return $false }
+    $releaseCommit = Get-DuneReleaseExpectedCommit -Release $Release
+    $stableCommit = Get-DuneReleaseExpectedCommit -Release $StableRelease
+    return ($releaseCore -and $releaseCore -eq $stableCore -and
+        [string]::Equals($releaseCommit, $stableCommit,
+            [StringComparison]::OrdinalIgnoreCase))
+}
+
 # Test-channel candidates: the newest two published pre-releases that carry the
-# installer asset. A newest stable mirror stands alone so old test-cycle builds
-# do not remain selectable after the stable release ships.
+# installer asset. A stable mirror must identify the current stable release by
+# core version and immutable target commit. This keeps an old immutable mirror
+# from becoming a rollback target after the next stable release ships.
 function Get-DunePreReleaseList {
     param([switch]$Force)
     $candidates = @(Get-DuneReleases -Force:$Force |
         Where-Object { $_.isPrerelease -and -not $_.isDraft -and $_.assetUrl })
-    if ($candidates.Count -gt 0 -and (Test-DuneStableMirrorRelease -Release $candidates[0])) {
-        return @($candidates[0])
+    $stable = Get-DuneLatestRelease -Force:$Force
+    if ($candidates.Count -gt 0 -and (Test-DuneStableMirrorLabel -Release $candidates[0])) {
+        try {
+            if (Test-DuneStableMirrorRelease -Release $candidates[0] -StableRelease $stable) {
+                Add-Member -InputObject $candidates[0] -NotePropertyName isStableMirror -NotePropertyValue $true -Force
+                return @($candidates[0])
+            }
+        } catch {
+            # A branch-valued target_commitish must resolve through the immutable
+            # release tag. If that proof is unavailable, do not offer old tests.
+        }
+        return @()
     }
     return @($candidates |
-        Where-Object { -not (Test-DuneStableMirrorRelease -Release $_) } |
+        Where-Object { -not (Test-DuneStableMirrorLabel -Release $_) } |
         Select-Object -First 2)
 }
 
@@ -222,6 +248,18 @@ function Get-DuneSelectedRelease {
             Add-Member -InputObject $rel -NotePropertyName isPrerelease -NotePropertyValue $false -Force
         }
         return $rel
+    }
+    $stable = Get-DuneLatestRelease -Force:$Force
+    if ($list.Count -eq 1 -and $list[0].isStableMirror) {
+        $running = Get-DuneUpdateRunningBuildInfo
+        $runningCore = Get-DuneVersionCore ([string]$script:DuneToolVersion)
+        $stableCore = Get-DuneVersionCore ([string]$stable.tag)
+        if (-not $running.runningIsPrerelease -and $runningCore -and
+            $runningCore -eq $stableCore) {
+            Add-Member -InputObject $stable -NotePropertyName channel -NotePropertyValue 'test' -Force
+            Add-Member -InputObject $stable -NotePropertyName isPrerelease -NotePropertyValue $false -Force
+            return $stable
+        }
     }
     $pin = Get-DuneUpdatePreReleaseTag
     $chosen = $null

--- a/site/scripts/check-testing.mts
+++ b/site/scripts/check-testing.mts
@@ -7,6 +7,19 @@ import {
 
 const releases: GitHubTestRelease[] = [
   {
+    tag_name: "v15.0.0-test10",
+    name: "stable channel mirror",
+    prerelease: true,
+    published_at: "2026-09-07T03:00:00Z",
+    assets: [{ name: "DuneServerSetup.exe", browser_download_url: "https://x/fresh-mirror.exe" }],
+  },
+  {
+    tag_name: "v15.0.0",
+    prerelease: false,
+    published_at: "2026-09-07T02:00:00Z",
+    assets: [{ name: "DuneServerSetup.exe", browser_download_url: "https://x/stable-v15.exe" }],
+  },
+  {
     tag_name: "v15.0.0-test1",
     name: "stable channel mirror",
     prerelease: true,
@@ -39,7 +52,7 @@ const releases: GitHubTestRelease[] = [
   },
 ];
 
-assert.equal(getLatestStableRelease(releases)?.tag, "v14.0.5");
+assert.equal(getLatestStableRelease(releases)?.tag, "v15.0.0");
 assert.deepEqual(
   getActiveTestReleases(releases).map((release) => release.tag),
   ["v15.0.0-test3", "v15.0.0-test2"],

--- a/tests/Diagnostics.Tests.ps1
+++ b/tests/Diagnostics.Tests.ps1
@@ -103,6 +103,21 @@ Describe 'Invoke-DstRedaction' -Tag 'Pure' {
         $out | Should -Not -Match 'server-secret'
     }
 
+    It 'redacts private sender and location values from chat teleport traces' {
+        $raw = @'
+[2026-09-07T12:00:00.000Z] [INFO] chat command !tp from Funcom-Private-Handle: ok=True trace=msg_abc-123
+[2026-09-07T12:00:00.000Z] [INFO] chat tp trace=msg_abc-123 stage=dequeued channel="global" chat_origin_x="123.45" chat_origin_y="-67.89" chat_origin_z="42" command_timestamp="2026-09-07T12:00:00Z" destination="My Hidden Base"
+[2026-09-07T12:00:00.000Z] [INFO] chat tp trace=msg_abc-123 stage=dispatch destination="My Hidden Base" source_dimension="0" source_map="Hagga Basin" source_partition="21" source_x="123.45" source_y="-67.89" source_z="42" target_dimension="0" target_map="Hagga Basin" target_partition="21" target_x="900.1" target_y="800.2" target_z="700.3"
+[2026-09-07T12:00:00.000Z] [INFO] chat tp trace=msg_abc-123 stage=post-dispatch-db-readback dimension="0" map="Hagga Basin" ok="True" partition="21" sample="1" x="900.1" y="800.2" z="700.3"
+'@
+        $out = Invoke-DstRedaction -Text $raw
+
+        $out | Should -Match 'chat command !tp from <chat-sender>: ok=True trace=msg_abc-123'
+        $out | Should -Match 'chat tp trace=msg_abc-123 stage=dispatch'
+        $out | Should -Match 'stage=post-dispatch-db-readback.*ok="True".*sample="1"'
+        $out | Should -Not -Match 'Funcom-Private-Handle|My Hidden Base|Hagga Basin|123\.45|900\.1'
+    }
+
     It 'is a no-op on empty input' {
         Invoke-DstRedaction -Text '' | Should -Be ''
     }

--- a/tests/InstallerUpgrade.Tests.ps1
+++ b/tests/InstallerUpgrade.Tests.ps1
@@ -1,0 +1,77 @@
+BeforeAll {
+    . "$PSScriptRoot\_TestHelpers.ps1"
+}
+
+Describe 'Installer legacy autostart preservation' -Tag 'Pure' {
+    It 'exports v12-v14 autostart definitions before their uninstaller removes them' {
+        $installer = Get-Content -LiteralPath (Join-Path (Get-DstRepoRoot) 'app\installer\DuneServer.iss') -Raw
+        $prepare = $installer.Substring(
+            $installer.IndexOf('function PrepareToInstall'),
+            $installer.IndexOf('function ShouldInstallBridge') - $installer.IndexOf('function PrepareToInstall')
+        )
+
+        $installer | Should -Match 'function ShouldPreserveLegacyAutostart'
+        $installer | Should -Match 'Result := \(major >= 12\) and \(major < 15\);'
+        $installer | Should -Match 'Export-ScheduledTask'
+        $installer | Should -Match 'Register-ScheduledTask'
+        $installer | Should -Match 'Check: ShouldRestoreLegacyAutostart'
+        $installer | Should -Match '\\Uninstall\\\{B3F8A2C1-7E5D-4F9A-8B2C-1D6E3A4F5C7D\}_is1'
+        $installer | Should -Not -Match '\\Uninstall\\\{#MyAppId\}_is1'
+        $prepare | Should -Match 'CaptureLegacyAutostartTasks\(\)'
+        $prepare | Should -Match 'UninstallPreviousVersion\(\);'
+    }
+
+    It 'escapes apostrophes in capture and restore paths and emits valid PowerShell' {
+        $installer = Get-Content -LiteralPath (Join-Path (Get-DstRepoRoot) 'app\installer\DuneServer.iss') -Raw
+        $path = "C:\Users\O'Neil\AppData\Local\Temp\DuneServer-autostart-migration"
+        $escapedPath = $path.Replace("'", "''")
+        $command = '$backup = ''' + $escapedPath + '''; Get-ChildItem -LiteralPath $backup -Filter ''DuneServer-Autostart-*.xml'' -File | ForEach-Object { Register-ScheduledTask -TaskPath ''\Dune Server\'' -TaskName $_.BaseName -Xml (Get-Content -LiteralPath $_.FullName -Raw) -Force -ErrorAction Stop }'
+        $tokens = $null
+        $errors = $null
+        [void][System.Management.Automation.Language.Parser]::ParseInput(
+            $command,
+            [ref]$tokens,
+            [ref]$errors
+        )
+
+        $installer | Should -Match 'function EscapePowerShellSingleQuoted'
+        $installer | Should -Match ([regex]::Escape("StringChangeEx(Result, '''', '''''', True);"))
+        $installer | Should -Match 'escapedBackupDir := EscapePowerShellSingleQuoted\(LegacyAutostartBackupDir\);'
+        $errorPreference = '$ErrorActionPreference = ' + "''Stop''"
+        $installer | Should -Match ([regex]::Escape($errorPreference))
+        $installer | Should -Match 'Parameters: "\{code:GetLegacyAutostartRestoreParameters\|\}";'
+        $command | Should -Match "O''Neil"
+        $errors | Should -BeNullOrEmpty
+    }
+
+    It 'blocks a v12-v14 upgrade when autostart capture cannot complete' {
+        $installer = Get-Content -LiteralPath (Join-Path (Get-DstRepoRoot) 'app\installer\DuneServer.iss') -Raw
+        $prepare = $installer.Substring(
+            $installer.IndexOf('function PrepareToInstall'),
+            $installer.IndexOf('function ShouldInstallBridge') - $installer.IndexOf('function PrepareToInstall')
+        )
+
+        $installer | Should -Match 'function CaptureLegacyAutostartTasks\(\): Boolean;'
+        $installer | Should -Match 'Result := False;'
+        $prepare | Should -Match 'if not CaptureLegacyAutostartTasks\(\) then\s*begin'
+        $prepare | Should -Match 'No changes were made\.'
+        $prepare | Should -Match 'Exit;\s*end;\s*UninstallPreviousVersion\(\);'
+    }
+
+    It 'allows upgrades with no startup tasks while filtering the exact task folder locally' {
+        $installer = Get-Content -LiteralPath (Join-Path (Get-DstRepoRoot) 'app\installer\DuneServer.iss') -Raw
+        $capture = $installer.Substring(
+            $installer.IndexOf('function CaptureLegacyAutostartTasks'),
+            $installer.IndexOf('function ShouldRestoreLegacyAutostart') -
+                $installer.IndexOf('function CaptureLegacyAutostartTasks')
+        )
+
+        $capture | Should -Match 'Get-ScheduledTask -ErrorAction Stop'
+        $capture | Should -Not -Match 'Get-ScheduledTask -TaskPath'
+        $folderFilter = '$_.TaskPath -eq ' + "''\Dune Server\''"
+        $nameFilter = '$_.TaskName -like ' + "''DuneServer-Autostart-*''"
+        $capture | Should -Match ([regex]::Escape($folderFilter))
+        $capture | Should -Match ([regex]::Escape($nameFilter))
+        $capture | Should -Match 'Result := True;\s*LegacyAutostartBackupPresent := False;'
+    }
+}

--- a/tests/SoloMode.Tests.ps1
+++ b/tests/SoloMode.Tests.ps1
@@ -631,6 +631,80 @@ Describe 'Solo Mode route security metadata' {
             $script:CapturedSoloRoutes | Should -Contain $expected
         }
     }
+
+    It 'rejects a stale blueprint export before invoking the export helper' {
+        Register-DstStubs
+        $script:CapturedSoloRouteHandlers = @{}
+        function global:Write-DuneError {
+            param($Response, $Status, $Message)
+            $Response.Status = $Status
+            $Response.Message = $Message
+        }
+        function global:Invoke-WithDuneLock {
+            param($Name, $Script)
+            & $Script
+        }
+        Mock Register-DuneRoute {
+            param($Method, $Path, $Handler, [switch]$Inline, [switch]$LocalOnly)
+            $script:CapturedSoloRouteHandlers[$Path] = $Handler
+        }
+        Mock Invoke-WithDuneLock {
+            param($Name, $Script)
+            & $Script
+        }
+        Mock Assert-DuneSoloExpectedProfile {
+            throw 'The selected Solo profile changed in another window. Refresh and try again.'
+        }
+        Mock Export-DuneSoloBlueprint {}
+        . (Join-Path (Get-DstRepoRoot) 'app\server\routes\SoloMode.ps1')
+
+        $query = [Collections.Specialized.NameValueCollection]::new()
+        $query.Add('id', '7')
+        $query.Add('expectedProfileToken', 'stale-profile-token')
+        $request = [pscustomobject]@{ QueryString = $query }
+        $response = [pscustomobject]@{ Status = 0; Message = '' }
+        & $script:CapturedSoloRouteHandlers['/api/solo/blueprints/export'] $request $response $null $null
+
+        $response.Status | Should -Be 409
+        $response.Message | Should -Match 'changed in another window'
+        Assert-MockCalled Export-DuneSoloBlueprint -Times 0 -Exactly
+    }
+
+    It 'returns blueprint rows with the connected profile token' {
+        Register-DstStubs
+        $script:CapturedSoloRouteHandlers = @{}
+        function global:Write-DuneJson {
+            param($Response, $Body)
+            $Response.Body = $Body
+        }
+        function global:Invoke-WithDuneLock {
+            param($Name, $Script)
+            & $Script
+        }
+        Mock Register-DuneRoute {
+            param($Method, $Path, $Handler, [switch]$Inline, [switch]$LocalOnly)
+            $script:CapturedSoloRouteHandlers[$Path] = $Handler
+        }
+        Mock Assert-DuneSoloExpectedProfile {}
+        Mock Get-DuneSoloProfile { @{ dbPath = 'C:\Solo\profile\game.db' } }
+        Mock Get-DuneSoloBlueprints {
+            [pscustomobject]@{ ok = $true; blueprints = @([pscustomobject]@{ id = 7 }) }
+        }
+        Mock Get-DuneSoloProfileToken { 'active-profile-token' }
+        . (Join-Path (Get-DstRepoRoot) 'app\server\routes\SoloMode.ps1')
+
+        $query = [Collections.Specialized.NameValueCollection]::new()
+        $query.Add('expectedProfileToken', 'active-profile-token')
+        $request = [pscustomobject]@{ QueryString = $query }
+        $response = [pscustomobject]@{ Body = $null }
+        & $script:CapturedSoloRouteHandlers['/api/solo/blueprints'] $request $response $null $null
+
+        $response.Body.profileToken | Should -Be 'active-profile-token'
+        $response.Body.blueprints[0].id | Should -Be 7
+        Assert-MockCalled Get-DuneSoloProfileToken -Times 1 -Exactly -ParameterFilter {
+            $DbPath -eq 'C:\Solo\profile\game.db'
+        }
+    }
 }
 
 Describe 'Solo Mode PTC progression catalogs' {
@@ -686,6 +760,29 @@ Describe 'Solo Mode backup profile isolation' {
         { Assert-DuneSoloExpectedProfile -ExpectedProfileToken $token } | Should -Not -Throw
         { Assert-DuneSoloExpectedProfile -ExpectedProfileToken ('0' * 64) } |
             Should -Throw '*changed in another window*'
+    }
+
+    It 'keeps blueprint list and export behind the same stale-profile guard' {
+        $route = Get-Content -LiteralPath (Join-Path (Get-DstRepoRoot) 'app\server\routes\SoloMode.ps1') -Raw
+        $listRoute = $route.Substring(
+            $route.IndexOf("Register-DuneRoute -Method GET -Path '/api/solo/blueprints'"),
+            $route.IndexOf("Register-DuneRoute -Method GET -Path '/api/solo/blueprints/export'") -
+                $route.IndexOf("Register-DuneRoute -Method GET -Path '/api/solo/blueprints'")
+        )
+        $exportRoute = $route.Substring(
+            $route.IndexOf("Register-DuneRoute -Method GET -Path '/api/solo/blueprints/export'"),
+            $route.IndexOf("Register-DuneRoute -Method POST -Path '/api/solo/blueprints/import'") -
+                $route.IndexOf("Register-DuneRoute -Method GET -Path '/api/solo/blueprints/export'")
+        )
+
+        $listRoute | Should -Match "QueryString\['expectedProfileToken'\]"
+        $listRoute | Should -Match 'Invoke-WithDuneLock'
+        $listRoute | Should -Match 'Assert-DuneSoloExpectedProfile'
+        $listRoute | Should -Match 'profileToken'
+        $exportRoute | Should -Match "QueryString\['expectedProfileToken'\]"
+        $exportRoute | Should -Match 'Invoke-WithDuneLock'
+        $exportRoute | Should -Match 'Assert-DuneSoloExpectedProfile'
+        $exportRoute | Should -Match 'Export-DuneSoloBlueprint -Id \$id'
     }
 
     It 'lists only backups belonging to the connected profile' {

--- a/tests/UpdateChannel.Tests.ps1
+++ b/tests/UpdateChannel.Tests.ps1
@@ -24,6 +24,7 @@ BeforeAll {
             fetchedAt=[DateTime]::UtcNow; tag='v12.9.5'; name='v12.9.5'; htmlUrl='u'
             publishedAt='2026-06-21'; releaseNotes=''; assetName='DuneServerSetup.exe'
             assetUrl='https://x/final.exe'; assetSize=100
+            targetCommit='1234567890abcdef1234567890abcdef12345678'
         }
         function global:New-InstallRequest {
             param([hashtable]$Query = @{})
@@ -66,6 +67,7 @@ Describe 'Compare-DuneSemver (prerelease-aware)' {
 Describe 'Get-DunePreReleaseList filtering' {
     BeforeEach {
         function global:Get-DuneReleases { param([switch]$Force) New-DstReleaseFixture }
+        function global:Get-DuneLatestRelease { param([switch]$Force) New-DstStableLatest }
     }
     It 'keeps only the newest two published pre-releases carrying the installer asset' {
         $list = Get-DunePreReleaseList
@@ -80,24 +82,24 @@ Describe 'Get-DunePreReleaseList filtering' {
         $tags | Should -Not -Contain 'v12.9.6-test0'
         $tags | Should -Not -Contain 'v12.9.7-draft'
     }
-    It 'shows only the test1 stable mirror when it is the newest prerelease' {
+    It 'shows only a fresh stable mirror when it identifies the current stable commit' {
         function global:Get-DuneReleases {
             param([switch]$Force)
             @(
-                [pscustomobject]@{ tag='v12.9.6-test1'; name='Stable channel mirror'; releaseNotes='same bits'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/mirror.exe' }
+                [pscustomobject]@{ tag='v12.9.5-test10'; name='Stable channel mirror'; releaseNotes='same bits'; targetCommit='1234567890abcdef1234567890abcdef12345678'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/mirror.exe' }
                 [pscustomobject]@{ tag='v12.9.5-test9'; name='Old test'; releaseNotes=''; isPrerelease=$true; isDraft=$false; assetUrl='https://x/old.exe' }
             )
         }
         $list = Get-DunePreReleaseList
         @($list).Count | Should -Be 1
-        $list[0].tag | Should -Be 'v12.9.6-test1'
+        $list[0].tag | Should -Be 'v12.9.5-test10'
     }
     It 'does not let an older stable mirror displace the previous active test' {
         function global:Get-DuneReleases {
             param([switch]$Force)
             @(
                 [pscustomobject]@{ tag='v13.0.0-test3'; name='Current test'; releaseNotes=''; isPrerelease=$true; isDraft=$false; assetUrl='https://x/current.exe' }
-                [pscustomobject]@{ tag='v12.9.6-test1'; name='Stable channel mirror'; releaseNotes='same bits'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/mirror.exe' }
+                [pscustomobject]@{ tag='v12.9.5-test1'; name='Stable channel mirror'; releaseNotes='same bits'; targetCommit='1234567890abcdef1234567890abcdef12345678'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/mirror.exe' }
                 [pscustomobject]@{ tag='v13.0.0-test2'; name='Previous test'; releaseNotes=''; isPrerelease=$true; isDraft=$false; assetUrl='https://x/previous.exe' }
             )
         }
@@ -105,6 +107,40 @@ Describe 'Get-DunePreReleaseList filtering' {
         @($list).Count | Should -Be 2
         $list[0].tag | Should -Be 'v13.0.0-test3'
         $list[1].tag | Should -Be 'v13.0.0-test2'
+    }
+    It 'falls back to stable rather than obsolete tests when the newest mirror is unproven' {
+        function global:Get-DuneReleases {
+            param([switch]$Force)
+            @(
+                [pscustomobject]@{ tag='v15.0.0-test1'; name='Stable channel mirror'; releaseNotes='same bits'; targetCommit='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/old-mirror.exe' }
+                [pscustomobject]@{ tag='v15.0.0-test9'; name='Previous test'; releaseNotes=''; isPrerelease=$true; isDraft=$false; assetUrl='https://x/test.exe' }
+            )
+        }
+        function global:Get-DuneLatestRelease {
+            param([switch]$Force)
+            [pscustomobject]@{ tag='v15.0.0'; targetCommit='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'; assetUrl='https://x/stable.exe' }
+        }
+
+        $list = Get-DunePreReleaseList
+        @($list).Count | Should -Be 0
+    }
+    It 'resolves branch-valued release targets to prove a current stable mirror' {
+        function global:Get-DuneReleases {
+            param([switch]$Force)
+            @(
+                [pscustomobject]@{ tag='v15.0.0-test10'; name='Stable channel mirror'; releaseNotes='same stable commit'; targetCommit='main'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/mirror.exe' }
+            )
+        }
+        function global:Get-DuneLatestRelease {
+            param([switch]$Force)
+            [pscustomobject]@{ tag='v15.0.0'; targetCommit='main'; assetUrl='https://x/stable.exe' }
+        }
+        Mock Get-DuneReleaseCommitSha { 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
+
+        $list = Get-DunePreReleaseList
+        @($list).Count | Should -Be 1
+        $list[0].tag | Should -Be 'v15.0.0-test10'
+        Assert-MockCalled Get-DuneReleaseCommitSha -Times 2 -Exactly
     }
 }
 
@@ -166,6 +202,58 @@ Describe 'Get-DuneSelectedRelease channel resolution' {
         $r.tag | Should -Be 'v12.9.5'
         $r.channel | Should -Be 'test'
         $r.isPrerelease | Should -BeFalse
+    }
+
+    It 'uses a fresh stable mirror to update a Finalphase client without repointing test1' {
+        $script:DuneToolVersion = '15.0.0-finalphase-1.4'
+        function global:Get-DuneUpdateChannel { 'test' }
+        function global:Read-DuneConfigRaw { @{} }
+        function global:Get-DuneBuildMetadata {
+            @{ present=$true; prerelease=$true; tag='v15.0.0-finalphase-1.4'; commit='oldfinalphase' }
+        }
+        function global:Get-DuneLatestRelease {
+            param([switch]$Force)
+            [pscustomobject]@{
+                tag='v15.0.0'; targetCommit='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                assetUrl='https://x/stable.exe'; assetName='DuneServerSetup.exe'
+            }
+        }
+        function global:Get-DuneReleases {
+            param([switch]$Force)
+            @(
+                [pscustomobject]@{ tag='v15.0.0-test10'; name='Stable channel mirror'; releaseNotes='same stable commit'; targetCommit='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/fresh-mirror.exe' }
+                [pscustomobject]@{ tag='v15.0.0-test1'; name='Stable channel mirror'; releaseNotes='old immutable mirror'; targetCommit='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/old-mirror.exe' }
+            )
+        }
+
+        (Get-DuneSelectedRelease).tag | Should -Be 'v15.0.0-test10'
+    }
+
+    It 'keeps a fresh v15 stable client on the stable identity during mirror rollover' {
+        $script:DuneToolVersion = '15.0.0'
+        function global:Get-DuneUpdateChannel { 'test' }
+        function global:Read-DuneConfigRaw { @{} }
+        function global:Get-DuneBuildMetadata {
+            @{ present=$true; prerelease=$false; tag='v15.0.0'; commit='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
+        }
+        function global:Get-DuneLatestRelease {
+            param([switch]$Force)
+            [pscustomobject]@{
+                tag='v15.0.0'; targetCommit='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                assetUrl='https://x/stable.exe'; assetName='DuneServerSetup.exe'
+            }
+        }
+        function global:Get-DuneReleases {
+            param([switch]$Force)
+            @(
+                [pscustomobject]@{ tag='v15.0.0-test10'; name='Stable channel mirror'; releaseNotes='same stable commit'; targetCommit='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/fresh-mirror.exe' }
+                [pscustomobject]@{ tag='v15.0.0-test1'; name='Stable channel mirror'; releaseNotes='old immutable mirror'; targetCommit='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/old-mirror.exe' }
+            )
+        }
+
+        $release = Get-DuneSelectedRelease
+        $release.tag | Should -Be 'v15.0.0'
+        $release.isPrerelease | Should -BeFalse
     }
 }
 

--- a/webui/src/api/solo.ts
+++ b/webui/src/api/solo.ts
@@ -333,16 +333,20 @@ export interface SoloSavedBlueprint {
   pentashields: number
 }
 
-export function getSoloBlueprints(): Promise<{ ok: boolean; blueprints: SoloSavedBlueprint[] }> {
-  return api('/api/solo/blueprints')
+export function getSoloBlueprints(
+  expectedProfileToken: string,
+): Promise<{ ok: boolean; profileToken: string; blueprints: SoloSavedBlueprint[] }> {
+  return api(`/api/solo/blueprints?expectedProfileToken=${encodeURIComponent(expectedProfileToken)}`)
 }
 
-export function exportSoloBlueprint(id: number): Promise<{
+export function exportSoloBlueprint(id: number, expectedProfileToken: string): Promise<{
   ok: boolean
   filename: string
   blueprint: BlueprintFile
 }> {
-  return api(`/api/solo/blueprints/export?id=${encodeURIComponent(String(id))}`)
+  return api(
+    `/api/solo/blueprints/export?id=${encodeURIComponent(String(id))}&expectedProfileToken=${encodeURIComponent(expectedProfileToken)}`,
+  )
 }
 
 export function importSoloBlueprint(

--- a/webui/src/pages/SoloMode.tsx
+++ b/webui/src/pages/SoloMode.tsx
@@ -470,13 +470,17 @@ export function SoloMode() {
   const statusState = useApi<SoloStatus>('/api/solo/status')
   const runtimeState = useApi<SoloRuntime>('/api/solo/runtime', { intervalMs: 3000 })
   const connected = statusState.data?.connected === true
+  const activeProfileToken = statusState.data?.profileToken ?? ''
   const settingsState = useApi<SoloSettingsResponse>('/api/solo/settings', { enabled: connected })
   const consoleSettingsState = useApi<SoloConsoleSettingsResponse>(
     '/api/solo/console-settings',
     { enabled: connected },
   )
   const backupsState = useApi<SoloBackupsResponse>('/api/solo/backups', { enabled: connected })
-  const blueprintsState = useApi<{ ok: boolean; blueprints: SoloSavedBlueprint[] }>('/api/solo/blueprints', { enabled: connected })
+  const blueprintsState = useApi<{ ok: boolean; profileToken: string; blueprints: SoloSavedBlueprint[] }>(
+    `/api/solo/blueprints?expectedProfileToken=${encodeURIComponent(activeProfileToken)}`,
+    { enabled: connected && Boolean(activeProfileToken) },
+  )
   const [dataRoot, setDataRoot] = useState('')
   const [selectedDb, setSelectedDb] = useState('')
   const [discoveredProfiles, setDiscoveredProfiles] = useState<SoloProfile[]>([])
@@ -655,6 +659,8 @@ export function SoloMode() {
     && normalizeWindowsPath(dataRoot) === normalizeWindowsPath(statusState.data?.dataRoot ?? '')
     && normalizeWindowsPath(selectedDb) === normalizeWindowsPath(statusState.data?.dbPath ?? '')
   const canMutateActiveProfile = selectionMatchesActive && busy === null
+  const blueprintsMatchActiveProfile = blueprintsState.data?.profileToken === activeProfileToken
+  const savedBlueprints = blueprintsMatchActiveProfile ? blueprintsState.data?.blueprints ?? [] : []
 
   const saveSettings = async () => {
     if (!selectionMatchesActive) {
@@ -955,14 +961,14 @@ export function SoloMode() {
   }
 
   const exportSavedBlueprint = async (saved: SoloSavedBlueprint) => {
-    if (!connected) {
-      setNotice({ kind: 'err', text: 'Connect a Solo profile before exporting a blueprint.' })
+    if (!selectionMatchesActive || !blueprintsMatchActiveProfile) {
+      setNotice({ kind: 'err', text: 'Connect and validate the selected Solo profile before exporting a blueprint.' })
       return
     }
     setBusy(`export-blueprint-${saved.id}`)
     setNotice(null)
     try {
-      const result = await exportSoloBlueprint(saved.id)
+      const result = await exportSoloBlueprint(saved.id, activeProfileToken)
       downloadBlueprintFile(result.blueprint, result.filename || `${saved.name || 'blueprint'}.json`)
       setNotice({ kind: 'ok', text: `Exported ${result.filename || saved.name || 'blueprint'}.` })
     } catch (error) {
@@ -1966,7 +1972,7 @@ export function SoloMode() {
               <p className="text-xs text-text-muted mb-4">
                 Download a saved Solo solido as portable DST JSON. Import stays disabled in PTC.
               </p>
-              {(blueprintsState.data?.blueprints ?? []).length === 0 ? (
+              {savedBlueprints.length === 0 ? (
                 <div className="rounded border border-border bg-surface-2/50 p-3 text-xs text-text-muted">
                   {blueprintsState.loading
                     ? 'Reading saved blueprints…'
@@ -1974,7 +1980,7 @@ export function SoloMode() {
                 </div>
               ) : (
                 <div className="space-y-2">
-                  {(blueprintsState.data?.blueprints ?? []).map(saved => (
+                  {savedBlueprints.map(saved => (
                     <div key={saved.id} className="flex items-center gap-3 rounded border border-border bg-surface-2/40 px-3 py-2">
                       <div className="min-w-0 flex-1">
                         <div className="font-medium text-text truncate">{saved.name || `Blueprint ${saved.id}`}</div>
@@ -1984,7 +1990,7 @@ export function SoloMode() {
                       </div>
                       <button
                         className="btn-secondary shrink-0"
-                        disabled={!connected || busy === `export-blueprint-${saved.id}`}
+                        disabled={!selectionMatchesActive || !blueprintsMatchActiveProfile || busy === `export-blueprint-${saved.id}`}
                         onClick={() => void exportSavedBlueprint(saved)}
                       >
                         <Icon name={busy === `export-blueprint-${saved.id}` ? 'LoaderCircle' : 'Download'} size={14} className={busy === `export-blueprint-${saved.id}` ? 'animate-spin' : ''} />

--- a/webui/tests/api/solo.test.ts
+++ b/webui/tests/api/solo.test.ts
@@ -120,15 +120,15 @@ describe('Solo Mode API contracts', () => {
   })
 
   it('lists and exports saved Solo blueprints', async () => {
-    await solo.getSoloBlueprints()
+    await solo.getSoloBlueprints('profile-token')
     expect(last()).toEqual({
-      url: '/api/solo/blueprints',
+      url: '/api/solo/blueprints?expectedProfileToken=profile-token',
       method: undefined,
       body: undefined,
     })
-    await solo.exportSoloBlueprint(7)
+    await solo.exportSoloBlueprint(7, 'profile-token')
     expect(last()).toEqual({
-      url: '/api/solo/blueprints/export?id=7',
+      url: '/api/solo/blueprints/export?id=7&expectedProfileToken=profile-token',
       method: undefined,
       body: undefined,
     })


### PR DESCRIPTION
## Summary
- Protect diagnostic trace exports and prevent stale Solo blueprint exports.
- Preserve existing v14 autostart tasks through the v15 installer upgrade path.
- Make test-to-stable channel rollover resolve releases by immutable tag identity.

## Validation
- Focused Pester: 138 passed.
- Solo API Vitest: 10 passed.
- WebUI production build and site testing checks passed.
- PowerShell parse, BOM, installer-command expansion, and diff checks passed.

## Scope
Bug-fix-only stable preparation. No Cloudflare retirement, new feature work, live operations, or release changes.