### PR TITLE
release: v15.0.0 stable candidate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,6 +48,9 @@ body:
         > `maps-platform.txt` adds row-free cache integrity, structural
         > fingerprints, source timing/backoff, and map/dimension evidence
         > without cached rows, identifiers, payloads, paths, or coordinates.
+        > Review the ZIP before attaching it. If it contains private information,
+        > omit it and say what was withheld; never paste raw config, credentials,
+        > account/player/server identifiers, save paths, or browser storage.
 
         **✅ Do open an issue here** when the tool shows you a problem, e.g.:
         - The **Server Health** page shows the battlegroup as **Unknown** with
@@ -90,7 +93,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.0-finalphase-1.4"
+      placeholder: "v15.0.0"
     validations:
       required: true
 
@@ -101,7 +104,7 @@ body:
       description: Which part of the tool was affected? Pick the closest match. The primary navigation is server-first; gameplay destinations live inside the Gameplay Admin gateway.
       options:
         - Web portal - Command Deck / Spatial dashboard (globe / saved zoom and orientation / auto rotate / map status / map details / move maps / pulse lines / controls / Solo Mode dock shortcut)
-        - Web portal - Command Deck workspaces (Players dossier / compact inventory / Commands categories and controls / Bases / Vehicles / Economy details / section navigation)
+        - Web portal - Command Deck workspaces (Players dossier / compact inventory / Commands categories and controls / Bases → Blueprints / Vehicles / Economy details / section navigation)
         - Web portal - Appearance (Classic / Try Command Deck / Dashboard or Spatial home / shared themes and custom colors / square dock consistency)
         - Web portal — Server Health (Dashboard / Game Servers responsive pod rows / Game Ready State)
         - Web portal — Database — VM info card (disk / swap / active and failed database operations / failed-operation cleanup / retained build images / old-image cleanup / per-map memory limits)
@@ -149,7 +152,7 @@ body:
         - Web portal — Solo Mode — connection / wrapper or schema validation / process lock
         - Web portal — Solo Mode — native and Engine settings (load / apply / retained INI backup)
         - Web portal — Solo Mode — Current inventory browser / ranged weapon ammo / Give Item / pre-augmented item / Vehicle Kit / Package / Cosmetics / backpack or built-storage delivery
-        - Web portal — Solo Mode — Export Base Blueprint / portable DST JSON
+        - Web portal — Solo Mode — profile/save-folder selection / Export Base Blueprint / portable DST JSON
         - Web portal — Solo Mode — Import Base Blueprint / portable blueprint JSON (disabled in PTC)
         - Web portal — Solo Mode — Solari / Landsraad Scrip / Hajra Literjon fill
         - Web portal — Solo Mode — save backup / restore / single or multi-select delete / safety backup
@@ -187,7 +190,7 @@ body:
     attributes:
       label: Specific page / button / command
       description: Which button, tab, menu letter/number, or `-Cmd <name>` triggered the bug? For tray behavior, include left-click vs double-click vs right-click Open, whether the taskbar button returned, and whether the restored window was invisible, off-screen, or unexpectedly small. For Browser Portal authentication, include login vs forced change vs local Settings administration, whether account mode was enabled, transport (Funnel or Cloudflare), and HTTP status only—never include usernames, passwords, cookies, tokens, account IDs, hashes, or salts. For the DST updater, include Update Banner vs Settings, the visible TEST number before/after, and the exact verification message; attach fresh diagnostics so the sanitized relaunch, Inno, and installed-identity logs are included. For Game Config Storm Cycle, include the selected local Coriolis start time, displayed GMT/UTC hour, browser timezone, and whether Apply INIs & restart completed. For a pre-augmented grant, include Solo vs Self-Hosted, item name, item grade, each augment name and grade, offline state, and visible result after login—never include character, account, inventory, or item IDs. For Maps Live state, include whether the preview disclosure and tab were present, the freshness label, active-field count, source error code, and whether the host is Windows or Linux—never include raw database rows or private marker data. For Shared Inventory Explorer, include the workspace (Players, Bases, Vehicles, or Economy), Search vs Refresh vs Rename box vs single delete vs multi-delete vs delete quantity vs Load more vs item details vs owning-entity link, whether the view was global or scoped, the query text if it contains no private names, the Live database/Demo inventory source badge, freshness label, and exact visible error—never include owner, character, container, item, inventory, actor, or account identifiers. For Sidebar customization, include the page or section label, whether it was hidden or shown individually or by section, pointer vs keyboard input, and whether the layout was migrated, reset, or reopened in the same browser. For Sponsors & Credits, include the affected supporter name, Notes from Duke message, or support link. For the responsive Game Servers card, include viewport width, the affected pod name, and whether Phase / Ready / Players / Age were visible. For in-game commands, include the exact `!command`, chat channel, monitoring interval, cooldown, whether any broadcast appeared, and whether it used the character name. For shared teleport destinations, include direct Save location vs Arm live capture, whether the player paused about five seconds, and whether they teleported on foot or from a vehicle seat. For scheduled Funcom updates, include the scheduled time, whether Apply available Funcom server updates was enabled, installed/latest build IDs, and the last schedule result. For Reboot All, include the visible phase and whether an on-demand-map repair ran. For World Restart, include the failed progress step, whether rollback ran automatically, whether every player was offline, and whether the Roll back last restart button remains available. For Specs > Apply level, include the track, before/after level, and before/after unspent skill points. For Repair Pattern, include whether the player was fully offline, whether Pattern Upgrading became purchasable after login, and whether Grade 2-5 schematic recipes appeared after the in-game purchase. For Apply Quick Preset, include the exact preset and the first journey research/crafting objective still active afterward. For Full Delete, include whether the deleted character owned or co-owned the affected object and whether Claim Ownership appears—never include account, actor, or permission IDs. For Reset Journey, include whether the post-NPE story restarted at Find the Fremen, which starter-class tree was reset, and how many skill points were refunded. For DD Atlas, include the selected seed, POI type, displayed sector(s), and a current reference screenshot or link when possible. For an Experimental Lab control, include its exact CVar or INI key, source/risk badge, file and section, and whether local Engine.ini management was enabled. For Solo Mode, include the adapter, wrapper/schema status, whether the game was fully closed, and the exact action; for Current inventory include search/sort, item type, location label, and visible quantity/quality only—never include save paths or account identifiers. PTC Import Base Blueprint is intentionally disabled before save access; report only if the UI/backend allows the action or changes a save. After deleting/recreating a character, state whether PTC was fully restarted before creation. For Enable All Skills, state whether Bindu Sprint remained learnable. For a database migration, name the failing step.
-      placeholder: "e.g. Spatial > Auto rotate, dock > Solo Mode, theme > Atreides > Players, Commands > Battlegroup, or Players > Inventory > loaded ammo"
+      placeholder: "e.g. Spatial > Auto rotate, Bases > Blueprints, Solo Mode > selected profile > Export Base Blueprint, or Players > Inventory > loaded ammo"
     validations:
       required: true
 
@@ -226,6 +229,9 @@ body:
         details changed it. For theme differences, name the selected preset or
         custom color and the source/destination pages; include the globe and dock
         if affected. For Commands, name the category, control, and visible result.
+        For Bases → Blueprints, identify the Command Deck or legacy Gameplay
+        Admin route and the visible tab/result, but do not include base or
+        blueprint identifiers.
         For Solo Mode navigation, state whether the dock shortcut was visible and
         opened the expected page. For pulse or simulated
         travel visibility, name the affected toggle and include a screenshot of the
@@ -357,6 +363,9 @@ body:
         folder names. Also tell us:
 
         - PTC or retail/custom folder.
+        - For profile selection, whether the expected profile appeared and
+          whether DST showed its save folder; do not include the profile's
+          account-folder name or full path.
         - Exact step: Connect and validate, Apply Solo settings, Create backup,
           Restore/Delete one backup, Delete selected backups, Give Item, Give
           Vehicle Kit, Give Package, Grant Cosmetic / Building Set, Import Base
@@ -530,8 +539,9 @@ body:
         Browser Portal remote access defaults to a **Tailscale Funnel**: DST is
         reached at a stable `https://<name>.ts.net` address that proxies to a
         local loopback **bridge** (127.0.0.1:47900), which forwards into DST.
-        Existing **Cloudflare custom-domain** configurations remain supported
-        during deprecation, but new setups use Tailscale Funnel. If pairing or
+        v15 retains existing **Cloudflare custom-domain** configuration, but its
+        legacy portal is disabled by default until the host explicitly re-enables
+        it in local Settings. New setups use Tailscale Funnel. If pairing or
         remote access fails, note:
 
         - What **Settings → Remote Device Access** shows: the remote-address badge
@@ -543,9 +553,11 @@ body:
         - Whether Browser Portal account login is enabled, and whether the QR/link
           is the stable token-free URL or legacy `?key=` magic link. Never paste
           the key, password, cookie, account ID, hash, or salt.
-        - For a legacy Cloudflare setup, whether the team domain and application
-          AUD are configured. DST requires a valid signed Access JWT and does
-          not trust the raw email header.
+        - For a legacy Cloudflare setup, whether **Legacy Cloudflare custom
+          domain** is shown as enabled or disabled, and whether the team domain
+          and application AUD are configured. Do not paste their values, service
+          tokens, tunnel details, or Cloudflare credentials. DST requires a
+          valid signed Access JWT and does not trust the raw email header.
         - On the host, the bridge health probe:
 
         ```

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -232,6 +232,8 @@ body:
         For Bases → Blueprints, identify the Command Deck or legacy Gameplay
         Admin route and the visible tab/result, but do not include base or
         blueprint identifiers.
+        For the DD Atlas dock shortcut, state whether it opened the static atlas
+        and remained selected after navigation.
         For Solo Mode navigation, state whether the dock shortcut was visible and
         opened the expected page. For pulse or simulated
         travel visibility, name the affected toggle and include a screenshot of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.0] - 2026-09-07
+
+### Added
+
+- Added the opt-in **Command Deck** with server-health and spatial dashboards,
+  task-led workspaces, accessible navigation, saved presentation preferences,
+  and focused player, command, base, vehicle, and economy workflows.
+- Added the Shared Inventory Explorer, storage-box naming, guarded occurrence
+  deletion, and an offline Solo inventory browser with supported storage details.
+- Added Solo saved-base blueprint export, selected-profile save-folder browsing,
+  compatible item augments, and loaded-ammo editing.
+- Added Coriolis cycle start controls, expanded player-management cards, and
+  shared Command Deck **Bases → Blueprints** access while retaining the legacy
+  Gameplay Admin route.
+
+### Changed
+
+- Made Stable the primary release path. During an active test cycle, Test shows
+  only the newest two eligible builds; after stable publication, a verified
+  same-commit Test mirror keeps Test users on the current stable build.
+- Retained legacy Cloudflare custom-domain configuration in v15.0.0, but leave
+  its portal disabled by default until the host explicitly re-enables it in
+  local Settings. New remote setups continue on the Tailscale Funnel Browser
+  Portal path.
+
+### Fixed
+
+- Hardened item grants, progression actions, Solo save selection, desktop-shell
+  state, and startup responsiveness while preserving existing safeguards.
+- Expanded sanitized diagnostics for update, backend, map, inventory, and
+  teleport dispatch tracing. Teleport tracing improves investigation only; it
+  does not claim a game-side teleport fix.
+- Strengthened diagnostic redaction so support bundles avoid credentials, private
+  identifiers, paths, and raw inventory or map data.
+
 ## [15.0.0-finalphase-1.4] - 2026-09-06
 
 ### Fixed
@@ -141,8 +176,7 @@ here cover everything those tags shipped.
   apps. Existing native builds remain functional during the transition, while
   in-app guidance directs users to the responsive Browser Portal over Tailscale.
 - Clarified that deprecated Cloudflare named-tunnel and Access support remains
-  operational through the current test line and is scheduled for removal when
-  v15 promotes to stable.
+  operational through v15 stable while migration to Tailscale Funnel continues.
 
 ## [15.0.0-phase2-test4] - 2026-09-03
 
@@ -8751,7 +8785,8 @@ at the time. Also folds in the v3.0.1 / v3.1.2 patches.
   (`ssh`, `Gameplay Admin`, `setup-guide`, `report-issue`). _(originally
   3.1.2)_
 
-[Unreleased]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.8.0...HEAD
+[Unreleased]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v15.0.0...HEAD
+[15.0.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v14.0.3...v15.0.0
 [13.8.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.7.0...v13.8.0
 [13.7.0]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.6.5...v13.7.0
 [13.0.2]: https://github.com/coastal-ms/DST-DuneServerTool/compare/v13.0.1...v13.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ here cover everything those tags shipped.
 - Added Coriolis cycle start controls, expanded player-management cards, and
   shared Command Deck **Bases → Blueprints** access while retaining the legacy
   Gameplay Admin route.
+- Added a Command Deck bottom-dock shortcut directly to the static **DD Atlas**.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Solo saves.
 [Changelog](CHANGELOG.md) ·
 [Discord](https://discord.gg/tj2x7cywSC)**
 
-Current stable release: **v14.0.1**
+Current stable release: **v15.0.0**
 
 Confirmed compatible with Dune: Awakening **1.4.10.4**.
 
@@ -34,8 +34,9 @@ guarded controls in one native Windows app.
 - Manage one local VM or a separate Hyper-V host over LAN.
 - Use the responsive full Browser Portal from a phone, tablet, or PC with
   optional host-managed Owner and Admin accounts.
-- Use Tailscale Funnel for new remote setups. Existing Cloudflare custom-domain
-  configurations remain supported during deprecation but are planned for removal.
+- Use Tailscale Funnel and the Browser Portal for new remote setups. v15 keeps
+  existing Cloudflare custom-domain configuration but disables its legacy portal
+  by default; the host can explicitly re-enable it in local Settings.
 
 ### Solo Mode
 
@@ -230,8 +231,8 @@ controls and read-only previews follow the selected light/dark palette.
 The Spatial dashboard reserves its dock below the globe and controls, without
 overlap. In other themed workspaces, the same single dock floats when its natural
 footer position is offscreen and returns without a horizontal jump.
-The UX is intended for a **finalphase-1** community-review prerelease before
-promotion to stable.
+The v15 Command Deck is an opt-in alternative to the Classic layout and retains
+the same guarded administration behavior.
 
 **Signal**, available through **Settings > Appearance**, is a complete alternative
 visual treatment for both layouts: carbon canvas, graphite panels, violet primary

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -166,7 +166,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 Write-DuneStartupLog 'Console presentation initialized'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.0-finalphase-1.4'
+$script:DuneToolVersion = '15.0.0'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.0-finalphase-1.4',
+    [string]$Version = '15.0.0',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.0-finalphase-1.4</Version>
+    <Version>15.0.0</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.0-finalphase-1.4"
+#define MyAppVersion "15.0.0"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"

--- a/app/server/HttpServer.ps1
+++ b/app/server/HttpServer.ps1
@@ -833,6 +833,18 @@ function Resolve-DuneStaticPath {
 
 # ---------- Token --------------------------------------------------------------
 
+function Test-DuneLegacyCloudflareLaunchTokenRequest {
+    param($Request)
+
+    # Only the full portal receives the per-launch token after a verified
+    # Cloudflare Access browser request. Do not treat native service-token,
+    # Tailscale bridge, or genuine desktop traffic as this legacy browser path.
+    $email = ''
+    try { $email = [string]$Request.Headers['Cf-Access-Authenticated-User-Email'] } catch {}
+    if (-not $email) { return $false }
+    return -not (Test-DuneLocalOnlyRequest -Request $Request)
+}
+
 function Test-DuneToken {
     param($Request)
     $hdr = $Request.Headers['X-Dune-Token']
@@ -840,7 +852,16 @@ function Test-DuneToken {
 
     # Per-launch token (desktop portal + local API). Empty == dev-mode escape hatch.
     if ([string]::IsNullOrEmpty($script:DuneToken)) { return $true }
-    if ($hdr -eq $script:DuneToken) { return $true }
+    if ($hdr -eq $script:DuneToken) {
+        if (Test-DuneLegacyCloudflareLaunchTokenRequest -Request $Request) {
+            try {
+                if (-not (Test-DuneLegacyCloudflarePortalEnabled)) { return $false }
+            } catch {
+                return $false
+            }
+        }
+        return $true
+    }
 
     # Permanent remote token (the paired mobile app / friend magic link). The
     # per-launch token rotates every start, so the phone holds this stable one
@@ -1182,9 +1203,11 @@ function Invoke-DuneContext {
     $isRemoteApi = $rawPath.StartsWith('/api/remote/')
     $isRemoteSpa = $rawPath.StartsWith('/remote/') -or $rawPath -eq '/remote'
     if ($isRemoteApi -or $isRemoteSpa) {
-        $legacyRemoteDisabled = $false
-        try { $legacyRemoteDisabled = [bool](Test-DunePortalAccountModeEnabled) } catch {}
-        if ($legacyRemoteDisabled) {
+        $legacyRemoteEnabled = $false
+        try { $legacyRemoteEnabled = [bool](Test-DuneLegacyCloudflarePortalEnabled) } catch {}
+        $accountMode = $false
+        try { $accountMode = [bool](Test-DunePortalAccountModeEnabled) } catch {}
+        if (-not $legacyRemoteEnabled -or $accountMode) {
             Write-DuneError -Response $res -Status 404 -Message 'Not found.'
             return
         }

--- a/app/server/lib/RemoteAccess.ps1
+++ b/app/server/lib/RemoteAccess.ps1
@@ -5,8 +5,10 @@
 # Cloudflare Tunnel + Cloudflare Access policy. This file owns:
 #
 #   * The ACL file (%APPDATA%\DuneServer\remote-acl.json) — schema:
-#       { "owner": "you@example.com", "admins": ["friend@example", ...] }
-#     Empty "owner" == remote portal disabled (fail-closed).
+#       { "owner": "you@example.com", "admins": ["friend@example", ...],
+#         "legacyCloudflareEnabled": false }
+#     legacyCloudflareEnabled defaults to false so v15 upgrades fail closed
+#     without discarding existing Cloudflare configuration.
 #
 #   * The middleware (Test-DuneRemoteRequest) called by the listener for any
 #     /api/remote/* or /remote/* path BEFORE route matching. Validates the
@@ -19,8 +21,9 @@
 #
 # Public functions:
 #   Get-DuneRemoteAclPath
-#   Get-DuneRemoteAcl                    -> hashtable {owner; admins[]}
+#   Get-DuneRemoteAcl                    -> hashtable {owner; admins[]; legacyCloudflareEnabled}
 #   Save-DuneRemoteAcl -Acl <ht>         atomic write (temp + Move-Item -Force)
+#   Test-DuneLegacyCloudflarePortalEnabled -> bool
 #   Get-DuneRemoteRole -Email <e>        -> 'owner' | 'admin' | $null
 #   Test-DuneRemoteRequest -Request <r>  -> @{ok=$true; email; role}
 #                                          | @{ok=$false; status; message}
@@ -131,12 +134,12 @@ function Clear-DuneMobileServiceToken {
 
 # ---------- ACL --------------------------------------------------------------
 
-# Returns a hashtable {owner=''; admins=@()} even when the file is missing or
-# unreadable so callers don't have to nil-check. NEVER writes to disk — a
+# Returns a hashtable with a disabled legacy Cloudflare portal even when the
+# file is missing or unreadable so callers don't have to nil-check. NEVER writes to disk — a
 # malformed file deliberately stays untouched so a transient parse error can't
 # silently nuke the allowlist.
 function Get-DuneRemoteAcl {
-    $default = @{ owner = ''; admins = @(); hostname = ''; cloudflareTeamDomain = ''; cloudflareAudience = '' }
+    $default = @{ owner = ''; admins = @(); hostname = ''; cloudflareTeamDomain = ''; cloudflareAudience = ''; legacyCloudflareEnabled = $false }
     $path = Get-DuneRemoteAclPath
     if (-not (Test-Path -LiteralPath $path)) { return $default }
     try {
@@ -180,7 +183,18 @@ function Get-DuneRemoteAcl {
     if ($obj.PSObject.Properties.Name -contains 'cloudflareAudience' -and $obj.cloudflareAudience) {
         $audience = ([string]$obj.cloudflareAudience).Trim()
     }
-    return @{ owner = $owner; admins = @($admins); hostname = $hostname; cloudflareTeamDomain = $team; cloudflareAudience = $audience }
+    # Only a JSON boolean true can enable the retired Cloudflare portal. Older,
+    # missing, or malformed fields deliberately remain disabled.
+    $legacyCloudflareEnabled = ($obj.PSObject.Properties.Name -contains 'legacyCloudflareEnabled') -and
+        ($obj.legacyCloudflareEnabled -is [bool]) -and $obj.legacyCloudflareEnabled
+    return @{
+        owner = $owner
+        admins = @($admins)
+        hostname = $hostname
+        cloudflareTeamDomain = $team
+        cloudflareAudience = $audience
+        legacyCloudflareEnabled = [bool]$legacyCloudflareEnabled
+    }
 }
 
 # Atomic write: temp + Move-Item -Force. A SIGKILL between Set-Content and
@@ -215,6 +229,13 @@ function Save-DuneRemoteAcl {
     if ($Acl.ContainsKey('cloudflareAudience') -and $Acl.cloudflareAudience) {
         $audience = ([string]$Acl.cloudflareAudience).Trim()
     }
+    $legacyCloudflareEnabled = $false
+    if ($Acl.ContainsKey('legacyCloudflareEnabled')) {
+        if ($Acl.legacyCloudflareEnabled -isnot [bool]) {
+            throw 'legacyCloudflareEnabled must be a boolean.'
+        }
+        $legacyCloudflareEnabled = $Acl.legacyCloudflareEnabled
+    }
 
     $out = [ordered]@{
         owner = $owner
@@ -222,6 +243,7 @@ function Save-DuneRemoteAcl {
         hostname = $hostname
         cloudflareTeamDomain = $team
         cloudflareAudience = $audience
+        legacyCloudflareEnabled = [bool]$legacyCloudflareEnabled
     }
 
     $path = Get-DuneRemoteAclPath
@@ -236,13 +258,21 @@ function Save-DuneRemoteAcl {
     return $out
 }
 
+function Test-DuneLegacyCloudflarePortalEnabled {
+    [CmdletBinding()]
+    param()
+
+    $acl = Get-DuneRemoteAcl
+    return [bool]$acl.legacyCloudflareEnabled
+}
+
 function Get-DuneRemoteRole {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$Email)
     $e = $Email.Trim().ToLowerInvariant()
     if (-not $e) { return $null }
     $acl = Get-DuneRemoteAcl
-    if (-not $acl.owner) { return $null }       # remote disabled
+    if (-not $acl.legacyCloudflareEnabled -or -not $acl.owner) { return $null }
     if ($e -eq $acl.owner) { return 'owner' }
     if ($acl.admins -contains $e) { return 'admin' }
     return $null
@@ -325,7 +355,8 @@ function Test-DuneCloudflareAccessJwt {
 #
 # Fail-closed cases (401, generic message — don't leak path validity):
 #   * No valid Cf-Access-Jwt-Assertion header
-#   * ACL missing or owner unset (remote disabled)
+#   * ACL missing, malformed, or not explicitly enabled for v15
+#   * ACL owner unset
 #   * ACL malformed (Get-DuneRemoteAcl returns the default)
 # Forbidden case (403):
 #   * Valid header but email not in owner+admins list
@@ -334,10 +365,9 @@ function Test-DuneRemoteRequest {
     param([Parameter(Mandatory)]$Request)
 
     $acl = Get-DuneRemoteAcl
-    if (-not $acl.owner) {
-        # Remote portal explicitly off (default for fresh installs). We deny
-        # with 401 (not 403) so a misconfigured tunnel does not advertise
-        # which paths are gated by which ACL.
+    if (-not $acl.legacyCloudflareEnabled -or -not $acl.owner) {
+        # The v15 default is off even for retained legacy metadata. Deny before
+        # JWT processing so malformed or upgraded ACLs fail closed.
         return @{ ok = $false; status = 401; message = 'Remote portal not enabled.' }
     }
     $identity = Test-DuneCloudflareAccessJwt -Request $Request -Acl $acl

--- a/app/server/routes/RemoteAccess.ps1
+++ b/app/server/routes/RemoteAccess.ps1
@@ -7,8 +7,8 @@
 # Cloudflare tunnel by design (the desktop portal sets the token; the
 # remote SPA does not).
 #
-#   GET  /api/remote-access/acl                    -> {owner; admins[]; hostname}
-#   PUT  /api/remote-access/acl                    body: {owner; admins[]; hostname}
+#   GET  /api/remote-access/acl                    -> {owner; admins[]; hostname; legacyCloudflareEnabled}
+#   PUT  /api/remote-access/acl                    body: {owner; admins[]; hostname; legacyCloudflareEnabled}
 #   GET  /api/remote-access/audit-log?lines=N      -> {lines: [parsed entries...]}
 #   GET  /api/remote-access/cloudflared-status     -> {installed; path; version}
 
@@ -22,6 +22,7 @@ Register-DuneRoute -Method GET -Path '/api/remote-access/acl' -LocalOnly -Handle
             hostname = $acl.hostname
             cloudflareTeamDomain = $acl.cloudflareTeamDomain
             cloudflareAudience = $acl.cloudflareAudience
+            legacyCloudflareEnabled = [bool]$acl.legacyCloudflareEnabled
         }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
@@ -36,18 +37,33 @@ Register-DuneRoute -Method PUT -Path '/api/remote-access/acl' -LocalOnly -Handle
         $hostname = ''
         $cloudflareTeamDomain = ''
         $cloudflareAudience = ''
+        $legacyCloudflareEnabled = $false
         if ($body -is [hashtable]) {
             if ($body.ContainsKey('owner'))    { $owner    = [string]$body['owner'] }
             if ($body.ContainsKey('admins'))   { $admins   = @($body['admins']) }
             if ($body.ContainsKey('hostname')) { $hostname = [string]$body['hostname'] }
             if ($body.ContainsKey('cloudflareTeamDomain')) { $cloudflareTeamDomain = [string]$body['cloudflareTeamDomain'] }
             if ($body.ContainsKey('cloudflareAudience')) { $cloudflareAudience = [string]$body['cloudflareAudience'] }
+            if ($body.ContainsKey('legacyCloudflareEnabled')) {
+                if ($body['legacyCloudflareEnabled'] -isnot [bool]) {
+                    Write-DuneError -Response $res -Status 400 -Message 'legacyCloudflareEnabled must be a boolean.'
+                    return
+                }
+                $legacyCloudflareEnabled = $body['legacyCloudflareEnabled']
+            }
         } elseif ($null -ne $body) {
             if ($body.PSObject.Properties.Name -contains 'owner')    { $owner    = [string]$body.owner }
             if ($body.PSObject.Properties.Name -contains 'admins')   { $admins   = @($body.admins) }
             if ($body.PSObject.Properties.Name -contains 'hostname') { $hostname = [string]$body.hostname }
             if ($body.PSObject.Properties.Name -contains 'cloudflareTeamDomain') { $cloudflareTeamDomain = [string]$body.cloudflareTeamDomain }
             if ($body.PSObject.Properties.Name -contains 'cloudflareAudience') { $cloudflareAudience = [string]$body.cloudflareAudience }
+            if ($body.PSObject.Properties.Name -contains 'legacyCloudflareEnabled') {
+                if ($body.legacyCloudflareEnabled -isnot [bool]) {
+                    Write-DuneError -Response $res -Status 400 -Message 'legacyCloudflareEnabled must be a boolean.'
+                    return
+                }
+                $legacyCloudflareEnabled = $body.legacyCloudflareEnabled
+            }
         }
         $saved = Save-DuneRemoteAcl -Acl @{
             owner = $owner
@@ -55,6 +71,7 @@ Register-DuneRoute -Method PUT -Path '/api/remote-access/acl' -LocalOnly -Handle
             hostname = $hostname
             cloudflareTeamDomain = $cloudflareTeamDomain
             cloudflareAudience = $cloudflareAudience
+            legacyCloudflareEnabled = [bool]$legacyCloudflareEnabled
         }
         Write-DuneJson -Response $res -Body @{
             owner    = $saved.owner
@@ -62,6 +79,7 @@ Register-DuneRoute -Method PUT -Path '/api/remote-access/acl' -LocalOnly -Handle
             hostname = $saved.hostname
             cloudflareTeamDomain = $saved.cloudflareTeamDomain
             cloudflareAudience = $saved.cloudflareAudience
+            legacyCloudflareEnabled = [bool]$saved.legacyCloudflareEnabled
         }
     } catch {
         Write-DuneError -Response $res -Status 500 -Message "Save failed: $($_.Exception.Message)"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.0-finalphase-1.4"
+$script:ToolVersion = "15.0.0"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/helper/bridge/DstHelperBridge.ps1
+++ b/helper/bridge/DstHelperBridge.ps1
@@ -374,11 +374,27 @@ function Test-DuneRequestIsLocal {
     # cloudflared adds X-Forwarded-For; a real local request (e.g. the desktop
     # app or curl 127.0.0.1) carries none of these. Treat the presence of ANY
     # proxy/edge header as "arrived through a tunnel" and therefore NOT local.
-    param([System.Net.HttpListenerRequest]$Request)
-    foreach ($h in @('Cf-Ray','Cf-Connecting-Ip','Cf-Worker','X-Forwarded-For','X-Forwarded-Proto','Cf-Warp-Tag-Id')) {
+    param($Request)
+    $isLoopback = $false
+    try { $isLoopback = [Net.IPAddress]::IsLoopback($Request.RemoteEndPoint.Address) } catch {}
+    if (-not $isLoopback) { return $false }
+    foreach ($h in @(
+        'Cf-Ray','Cf-Connecting-Ip','Cf-Worker',
+        'Cf-Access-Authenticated-User-Email','Cf-Access-Jwt-Assertion',
+        'X-Forwarded-For','X-Forwarded-Proto','Cf-Warp-Tag-Id'
+    )) {
         if ($Request.Headers[$h]) { return $false }
     }
     return $true
+}
+
+function Test-DuneBridgeWebSocketUpgradeAllowed {
+    param($Request)
+
+    # The backend must see direct desktop WebSocket upgrades only. A proxied
+    # request loses its edge headers while the bridge opens a new loopback
+    # socket, which would otherwise make a remote terminal look host-local.
+    return (Test-DuneRequestIsLocal -Request $Request)
 }
 
 function Invoke-Request {
@@ -434,6 +450,12 @@ function Invoke-Request {
         $dst = Get-CurrentDst
 
         if ($req.IsWebSocketRequest) {
+            if (-not (Test-DuneBridgeWebSocketUpgradeAllowed -Request $req)) {
+                $res.StatusCode = 403
+                $res.OutputStream.Close()
+                Write-BridgeLog "403 WS $($req.HttpMethod) $path from $client (remote WebSocket refused)"
+                return
+            }
             # WebSocket upgrades (currently just /ws/terminal). Handled inline
             # — see Invoke-WsProxy for the trade-off note about main-loop blocking.
             Invoke-WsProxy -Context $Context -Dst $dst

--- a/site/src/pages/install.astro
+++ b/site/src/pages/install.astro
@@ -108,8 +108,9 @@ const base = import.meta.env.BASE_URL;
         >
         — the responsive full Browser Portal on a phone, tablet, or PC, with
         optional Owner/Admin accounts. New setups use a free Tailscale Funnel
-        with no domain. Existing Cloudflare custom-domain configurations remain
-        supported during deprecation but are planned for removal.
+        with no domain. v15 retains existing Cloudflare custom-domain
+        configuration, but its legacy portal is disabled by default and can be
+        explicitly re-enabled in local Settings.
       </li>
     </ul>
 
@@ -205,11 +206,12 @@ const base = import.meta.env.BASE_URL;
     <div class="mt-12 rounded-xl border border-dune-border bg-dune-surface p-6">
       <h2 class="text-2xl font-semibold mb-3">Remote access</h2>
       <p class="text-dune-muted leading-relaxed">
-        Remote access is optional. v14 uses the same responsive Browser Portal
+        Remote access is optional. v15 uses the same responsive Browser Portal
         as the desktop app, with host-created Owner/Admin accounts and
         role-enforced navigation and APIs. New setups use Tailscale Funnel.
-        Existing Cloudflare custom domains should migrate before that legacy
-        path is removed. Use the dedicated guide for account setup, migration,
+        Existing Cloudflare custom-domain configuration is retained, but its
+        legacy portal defaults to disabled until explicitly re-enabled in local
+        Settings. Use the dedicated guide for account setup, migration,
         role boundaries, transport security, and revocation instead of exposing
         DST's local port directly.
       </p>

--- a/site/src/pages/remote.astro
+++ b/site/src/pages/remote.astro
@@ -161,10 +161,10 @@ import PageHeader from "../components/PageHeader.astro";
     <div id="cloudflare">
       <h2 class="text-2xl font-semibold mb-4">6 · Migrate an existing Cloudflare domain <span class="text-dune-muted text-base font-normal">— deprecated</span></h2>
       <p class="text-dune-muted leading-relaxed mb-3">
-        Cloudflare named-tunnel/Access support remains operational for existing
-        users during deprecation, but it is planned for removal and should not be
-        used for new setups. Keep it running until the replacement Funnel path is
-        proven from an outside device.
+        v15 retains existing Cloudflare named-tunnel/Access configuration, but
+        its legacy portal is disabled by default. It can be explicitly
+        re-enabled in local Settings if needed, but new setups use Tailscale
+        Funnel. DST does not manage the Cloudflare tunnel itself.
       </p>
       <ol class="list-decimal list-inside space-y-2 text-dune-muted leading-relaxed text-sm">
         <li>Run <span class="font-mono">tailscale funnel --bg http://127.0.0.1:47900</span> in PowerShell.</li>
@@ -173,7 +173,7 @@ import PageHeader from "../components/PageHeader.astro";
         <li>Acknowledge native-app retirement, then enable account login.</li>
         <li>Create any Browser Portal Admin account needed for role-boundary testing.</li>
         <li>Test Owner sign-in and Admin restricted navigation from outside the LAN.</li>
-        <li>Disable the legacy Cloudflare portal in Settings, then stop the Cloudflare tunnel.</li>
+        <li>Leave the legacy Cloudflare portal disabled in local Settings unless you explicitly need to restore it.</li>
       </ol>
     </div>
 
@@ -218,7 +218,7 @@ import PageHeader from "../components/PageHeader.astro";
         <li><strong class="text-dune-text">One device:</strong> sign out, or revoke that account's sessions from local Settings.</li>
         <li><strong class="text-dune-text">One account:</strong> disable, reset, demote, or delete it from Browser Portal account management.</li>
         <li><strong class="text-dune-text">All account sessions:</strong> use the local emergency Disable action. This restores legacy magic-link behavior.</li>
-        <li><strong class="text-dune-text">Public endpoint:</strong> turn off Funnel. Existing Cloudflare users should stop that tunnel only after migration succeeds.</li>
+        <li><strong class="text-dune-text">Public endpoint:</strong> turn off Funnel. Legacy Cloudflare portal enablement is separate from its tunnel lifecycle, which DST does not manage.</li>
         <li><strong class="text-dune-text">Background access:</strong> disable <strong>Help → Keep serving while DST is closed</strong>.</li>
       </ul>
     </div>

--- a/tests/BridgeOrigin.Tests.ps1
+++ b/tests/BridgeOrigin.Tests.ps1
@@ -83,6 +83,36 @@ Describe 'Trusted bridge origin forwarding' {
             Should -BeFalse
     }
 
+    It 'refuses proxied WebSocket upgrades before the bridge can recreate them as loopback' {
+        $local = [pscustomobject]@{
+            Headers = @{}
+            RemoteEndPoint = [pscustomobject]@{ Address = [Net.IPAddress]::Loopback }
+        }
+        $cloudflare = [pscustomobject]@{
+            Headers = @{ 'Cf-Access-Authenticated-User-Email' = 'owner@example.test' }
+            RemoteEndPoint = [pscustomobject]@{ Address = [Net.IPAddress]::Loopback }
+        }
+        $tailscale = [pscustomobject]@{
+            Headers = @{ 'X-Forwarded-For' = '100.64.0.10' }
+            RemoteEndPoint = [pscustomobject]@{ Address = [Net.IPAddress]::Loopback }
+        }
+        $directRemote = [pscustomobject]@{
+            Headers = @{}
+            RemoteEndPoint = [pscustomobject]@{ Address = [Net.IPAddress]::Parse('192.0.2.10') }
+        }
+
+        Test-DuneBridgeWebSocketUpgradeAllowed -Request $local | Should -BeTrue
+        Test-DuneBridgeWebSocketUpgradeAllowed -Request $cloudflare | Should -BeFalse
+        Test-DuneBridgeWebSocketUpgradeAllowed -Request $tailscale | Should -BeFalse
+        Test-DuneBridgeWebSocketUpgradeAllowed -Request $directRemote | Should -BeFalse
+
+        $source = Get-Content (Join-Path $root 'helper\bridge\DstHelperBridge.ps1') -Raw
+        $guard = $source.IndexOf('if (-not (Test-DuneBridgeWebSocketUpgradeAllowed -Request $req))')
+        $proxy = $source.IndexOf('Invoke-WsProxy -Context $Context -Dst $dst')
+        $guard | Should -BeGreaterThan -1
+        $proxy | Should -BeGreaterThan $guard
+    }
+
     It 'normalizes effective HTTPS ports and IPv6 authorities exactly' {
         Test-DunePortalRequestOrigin (New-OriginRequest `
             -Origin 'https://[2001:db8::1]:8443' -RequestHost '[2001:db8::1]:8443' -Address '192.0.2.5') |

--- a/tests/HttpServerLocalOnly.Tests.ps1
+++ b/tests/HttpServerLocalOnly.Tests.ps1
@@ -117,10 +117,10 @@ Describe 'HTTP local-only request enforcement' {
         $server | Should -Match "\`$routeParams\['portalAccountRole'\]"
     }
 
-    It 'disables the legacy remote surface while account mode is enabled' {
+    It 'fails closed on the legacy remote surface unless its explicit ACL flag is enabled' {
         $source = Get-Content (Join-Path (Get-DstRepoRoot) 'app\server\HttpServer.ps1') -Raw
-        $source | Should -Match '\$legacyRemoteDisabled = \[bool\]\(Test-DunePortalAccountModeEnabled\)'
-        $source | Should -Match 'if \(\$legacyRemoteDisabled\)[\s\S]+?Status 404'
+        $source | Should -Match '\$legacyRemoteEnabled = \[bool\]\(Test-DuneLegacyCloudflarePortalEnabled\)'
+        $source | Should -Match 'if \(-not \$legacyRemoteEnabled -or \$accountMode\)[\s\S]+?Status 404'
     }
 
     It 'keeps the launch-token browser handoff host-only' {

--- a/tests/PortalAuth.Tests.ps1
+++ b/tests/PortalAuth.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
     . (Join-Path (Get-DstRepoRoot) 'app\server\lib\RemoteIdentity.ps1')
     . (Join-Path (Get-DstRepoRoot) 'app\server\lib\PortalAuth.ps1')
     . (Join-Path (Get-DstRepoRoot) 'app\server\lib\RemoteAccess.ps1')
+    . (Join-Path (Get-DstRepoRoot) 'app\server\lib\RequestPrincipal.ps1')
     . (Join-Path (Get-DstRepoRoot) 'app\server\HttpServer.ps1')
     function New-PortalTestRequest {
         param([string]$Cookie = '', [string]$Address = '127.0.0.1', [string]$Origin = 'https://portal.example.test')
@@ -81,6 +82,205 @@ Describe 'Portal account migration safety' {
         Save-DunePortalAccountStore $store
         Set-Content -LiteralPath (Get-DunePortalAccountsPath) -Value '{broken' -Encoding UTF8
         (Get-DunePortalAccountStore).accountLoginEnabled | Should -BeFalse
+    }
+}
+
+Describe 'Legacy Cloudflare ACL enablement' {
+    BeforeEach { Remove-Item -LiteralPath $script:PortalTestRoot -Recurse -Force -ErrorAction SilentlyContinue }
+
+    It 'defaults legacy ACLs to disabled while preserving their re-enable metadata' {
+        $aclDir = Split-Path -Parent (Get-DuneRemoteAclPath)
+        New-Item -ItemType Directory -Path $aclDir -Force | Out-Null
+        @{
+            owner = 'OWNER@example.test'
+            admins = @('Admin@example.test')
+            hostname = 'portal.example.test'
+            cloudflareTeamDomain = 'team.cloudflareaccess.com'
+            cloudflareAudience = 'audience-value'
+        } | ConvertTo-Json | Set-Content -LiteralPath (Get-DuneRemoteAclPath) -Encoding UTF8
+
+        $acl = Get-DuneRemoteAcl
+
+        $acl.legacyCloudflareEnabled | Should -BeFalse
+        (Test-DuneLegacyCloudflarePortalEnabled) | Should -BeFalse
+        $acl.owner | Should -Be 'owner@example.test'
+        $acl.admins | Should -Contain 'admin@example.test'
+        $acl.hostname | Should -Be 'portal.example.test'
+        $acl.cloudflareTeamDomain | Should -Be 'team.cloudflareaccess.com'
+        $acl.cloudflareAudience | Should -Be 'audience-value'
+    }
+
+    It 'fails closed when the persisted enablement field is malformed' {
+        $aclDir = Split-Path -Parent (Get-DuneRemoteAclPath)
+        New-Item -ItemType Directory -Path $aclDir -Force | Out-Null
+        @{
+            owner = 'owner@example.test'
+            legacyCloudflareEnabled = 'true'
+        } | ConvertTo-Json | Set-Content -LiteralPath (Get-DuneRemoteAclPath) -Encoding UTF8
+
+        $acl = Get-DuneRemoteAcl
+
+        $acl.legacyCloudflareEnabled | Should -BeFalse
+        $acl.owner | Should -Be 'owner@example.test'
+    }
+
+    It 'persists only an explicit boolean enablement setting' {
+        $saved = Save-DuneRemoteAcl -Acl @{
+            owner = 'owner@example.test'
+            admins = @('admin@example.test')
+            hostname = 'portal.example.test'
+            cloudflareTeamDomain = 'team.cloudflareaccess.com'
+            cloudflareAudience = 'audience-value'
+            legacyCloudflareEnabled = $true
+        }
+
+        $saved.legacyCloudflareEnabled | Should -BeTrue
+        (Get-DuneRemoteAcl).legacyCloudflareEnabled | Should -BeTrue
+        { Save-DuneRemoteAcl -Acl @{ legacyCloudflareEnabled = 'true' } } |
+            Should -Throw '*must be a boolean*'
+    }
+
+    It 'denies disabled legacy Cloudflare traffic before JWT validation' {
+        Save-DuneRemoteAcl -Acl @{
+            owner = 'owner@example.test'
+            legacyCloudflareEnabled = $false
+        } | Out-Null
+        Mock Test-DuneCloudflareAccessJwt { throw 'JWT validation must not run while disabled' }
+
+        $result = Test-DuneRemoteRequest -Request ([pscustomobject]@{ Headers = @{} })
+
+        $result.ok | Should -BeFalse
+        $result.status | Should -Be 401
+        Assert-MockCalled Test-DuneCloudflareAccessJwt -Times 0 -Exactly
+    }
+
+    It 'keeps JWT and owner authorization unchanged after an explicit re-enable' {
+        Save-DuneRemoteAcl -Acl @{
+            owner = 'owner@example.test'
+            legacyCloudflareEnabled = $true
+        } | Out-Null
+        Mock Test-DuneCloudflareAccessJwt { @{ ok = $true; email = 'owner@example.test' } }
+
+        $result = Test-DuneRemoteRequest -Request ([pscustomobject]@{ Headers = @{} })
+
+        $result.ok | Should -BeTrue
+        $result.role | Should -Be 'owner'
+        Assert-MockCalled Test-DuneCloudflareAccessJwt -Times 1 -Exactly
+    }
+
+    It 'revokes ordinary API and WebSocket launch-token access after disablement' {
+        $originalRoutes = $script:DuneRoutes
+        $originalWsRoutes = $script:DuneWsRoutes
+        $originalToken = $script:DuneToken
+        $originalRemoteToken = $script:DuneRemoteToken
+        $originalPoolState = $script:DuneApiPoolEnabled
+        try {
+            $script:DuneRoutes = [Collections.Generic.List[object]]::new()
+            $script:DuneWsRoutes = [Collections.Generic.List[object]]::new()
+            $script:DuneToken = 'legacy-launch-token'
+            $script:DuneApiPoolEnabled = $false
+            Register-DuneRoute -Method GET -Path '/api/legacy-token-regression' -Handler {
+                param($req, $res, $routeParams, $body)
+                Write-DuneJson -Response $res -Body @{
+                    principal = $routeParams.requestPrincipal.type
+                    transport = $routeParams.requestPrincipal.transport.kind
+                }
+            }
+
+            $newRequest = {
+                param([bool]$IsWebSocket = $false)
+                $url = if ($IsWebSocket) {
+                    'http://127.0.0.1/ws/legacy-token-regression'
+                } else {
+                    'http://127.0.0.1/api/legacy-token-regression'
+                }
+                [pscustomobject]@{
+                    Url = [uri]$url
+                    HttpMethod = 'GET'
+                    IsWebSocketRequest = $IsWebSocket
+                    HasEntityBody = $false
+                    Headers = @{
+                        'X-Dune-Token' = 'legacy-launch-token'
+                        'Cf-Access-Authenticated-User-Email' = 'owner@example.test'
+                    }
+                    QueryString = [Collections.Specialized.NameValueCollection]::new()
+                    RemoteEndPoint = [pscustomobject]@{ Address = [Net.IPAddress]::Loopback }
+                }
+            }
+            $newResponse = {
+                [pscustomobject]@{
+                    StatusCode = 0
+                    ContentType = ''
+                    ContentLength64 = 0L
+                    Headers = @{}
+                    OutputStream = [IO.MemoryStream]::new()
+                }
+            }
+
+            Save-DuneRemoteAcl -Acl @{
+                owner = 'owner@example.test'
+                legacyCloudflareEnabled = $true
+            } | Out-Null
+            $enabledResponse = & $newResponse
+            Invoke-DuneContext -Ctx ([pscustomobject]@{
+                Request = (& $newRequest)
+                Response = $enabledResponse
+            })
+            $enabledBody = [Text.Encoding]::UTF8.GetString($enabledResponse.OutputStream.ToArray()) | ConvertFrom-Json
+
+            $enabledResponse.StatusCode | Should -Be 200
+            $enabledBody.principal | Should -Be 'legacy-token'
+            $enabledBody.transport | Should -Be 'cloudflare-access'
+
+            Save-DuneRemoteAcl -Acl @{
+                owner = 'owner@example.test'
+                legacyCloudflareEnabled = $false
+            } | Out-Null
+            $disabledResponse = & $newResponse
+            Invoke-DuneContext -Ctx ([pscustomobject]@{
+                Request = (& $newRequest)
+                Response = $disabledResponse
+            })
+
+            $disabledResponse.StatusCode | Should -Be 401
+
+            $disabledWsResponse = & $newResponse
+            Invoke-DuneContext -Ctx ([pscustomobject]@{
+                Request = (& $newRequest $true)
+                Response = $disabledWsResponse
+            })
+
+            $disabledWsResponse.StatusCode | Should -Be 401
+
+            $desktopRequest = & $newRequest
+            $desktopRequest.Headers.Remove('Cf-Access-Authenticated-User-Email')
+            $desktopResponse = & $newResponse
+            Invoke-DuneContext -Ctx ([pscustomobject]@{
+                Request = $desktopRequest
+                Response = $desktopResponse
+            })
+
+            $desktopResponse.StatusCode | Should -Be 200
+
+            $script:DuneRemoteToken = 'paired-service-token'
+            $serviceRequest = & $newRequest
+            $serviceRequest.Headers['X-Dune-Token'] = 'paired-service-token'
+            $serviceRequest.Headers.Remove('Cf-Access-Authenticated-User-Email')
+            $serviceRequest.Headers['Cf-Ray'] = 'service-token-path'
+            $serviceResponse = & $newResponse
+            Invoke-DuneContext -Ctx ([pscustomobject]@{
+                Request = $serviceRequest
+                Response = $serviceResponse
+            })
+
+            $serviceResponse.StatusCode | Should -Be 200
+        } finally {
+            $script:DuneRoutes = $originalRoutes
+            $script:DuneWsRoutes = $originalWsRoutes
+            $script:DuneToken = $originalToken
+            $script:DuneRemoteToken = $originalRemoteToken
+            $script:DuneApiPoolEnabled = $originalPoolState
+        }
     }
 }
 
@@ -257,7 +457,12 @@ Describe 'Portal auth route enforcement' {
     }
 
     It 'never trusts a raw Cloudflare email header without a signed JWT' {
-        Save-DuneRemoteAcl -Acl @{ owner = 'owner@example.test'; admins = @(); hostname = 'portal.example.test' } | Out-Null
+        Save-DuneRemoteAcl -Acl @{
+            owner = 'owner@example.test'
+            admins = @()
+            hostname = 'portal.example.test'
+            legacyCloudflareEnabled = $true
+        } | Out-Null
         $request = [pscustomobject]@{ Headers = @{ 'Cf-Access-Authenticated-User-Email' = 'owner@example.test' } }
         $result = Test-DuneRemoteRequest -Request $request
         $result.ok | Should -BeFalse

--- a/tests/PortalAuthRoutes.Tests.ps1
+++ b/tests/PortalAuthRoutes.Tests.ps1
@@ -5,8 +5,10 @@ BeforeAll {
     $env:APPDATA = $script:PortalRouteTestRoot
     . (Join-Path (Get-DstRepoRoot) 'app\server\lib\RemoteIdentity.ps1')
     . (Join-Path (Get-DstRepoRoot) 'app\server\lib\PortalAuth.ps1')
+    . (Join-Path (Get-DstRepoRoot) 'app\server\lib\RemoteAccess.ps1')
     . (Join-Path (Get-DstRepoRoot) 'app\server\HttpServer.ps1')
     . (Join-Path (Get-DstRepoRoot) 'app\server\routes\PortalAuth.ps1')
+    . (Join-Path (Get-DstRepoRoot) 'app\server\routes\RemoteAccess.ps1')
     $script:PortalLoginRoute = @($script:DuneRoutes | Where-Object { $_.Method -eq 'POST' -and $_.Path -eq '/api/portal-auth/login' })[0]
     $script:PortalLogoutRoute = @($script:DuneRoutes | Where-Object { $_.Method -eq 'POST' -and $_.Path -eq '/api/portal-auth/logout' })[0]
     $script:PortalModeRoute = @($script:DuneRoutes | Where-Object { $_.Method -eq 'PUT' -and $_.Path -eq '/api/remote-access/portal-account-mode' })[0]
@@ -42,6 +44,66 @@ BeforeAll {
 AfterAll {
     $env:APPDATA = $script:OriginalAppData
     Remove-Item -LiteralPath $script:PortalRouteTestRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Legacy Cloudflare ACL routes' {
+    BeforeEach {
+        Remove-Item -LiteralPath $script:PortalRouteTestRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'keeps the enablement flag and retained ACL metadata behind local-only routes' {
+        $getRoute = @($script:DuneRoutes | Where-Object {
+            $_.Method -eq 'GET' -and $_.Path -eq '/api/remote-access/acl'
+        })[0]
+        $putRoute = @($script:DuneRoutes | Where-Object {
+            $_.Method -eq 'PUT' -and $_.Path -eq '/api/remote-access/acl'
+        })[0]
+        $getRoute.LocalOnly | Should -BeTrue
+        $putRoute.LocalOnly | Should -BeTrue
+
+        $response = New-RouteResponse
+        & $putRoute.Handler (New-RouteRequest) $response @{} @{
+            owner = 'owner@example.test'
+            admins = @('admin@example.test')
+            hostname = 'portal.example.test'
+            cloudflareTeamDomain = 'team.cloudflareaccess.com'
+            cloudflareAudience = 'audience-value'
+            legacyCloudflareEnabled = $true
+        }
+        $body = [Text.Encoding]::UTF8.GetString($response.OutputStream.ToArray()) | ConvertFrom-Json
+
+        $response.StatusCode | Should -Be 200
+        $body.legacyCloudflareEnabled | Should -BeTrue
+        $body.owner | Should -Be 'owner@example.test'
+        $body.admins | Should -Contain 'admin@example.test'
+        $body.hostname | Should -Be 'portal.example.test'
+
+        $disabledResponse = New-RouteResponse
+        & $putRoute.Handler (New-RouteRequest) $disabledResponse @{} @{
+            owner = 'owner@example.test'
+            admins = @('admin@example.test')
+            hostname = 'portal.example.test'
+            cloudflareTeamDomain = 'team.cloudflareaccess.com'
+            cloudflareAudience = 'audience-value'
+            legacyCloudflareEnabled = $false
+        }
+        $disabled = [Text.Encoding]::UTF8.GetString($disabledResponse.OutputStream.ToArray()) | ConvertFrom-Json
+
+        $disabled.legacyCloudflareEnabled | Should -BeFalse
+        $disabled.owner | Should -Be 'owner@example.test'
+        (Get-DuneRemoteAcl).cloudflareAudience | Should -Be 'audience-value'
+    }
+
+    It 'rejects a non-boolean legacy portal enablement value' {
+        $response = New-RouteResponse
+        & (Get-RegisteredHandler PUT '/api/remote-access/acl') (New-RouteRequest) $response @{} @{
+            legacyCloudflareEnabled = 'true'
+        }
+        $body = [Text.Encoding]::UTF8.GetString($response.OutputStream.ToArray()) | ConvertFrom-Json
+
+        $response.StatusCode | Should -Be 400
+        $body.error | Should -Be 'legacyCloudflareEnabled must be a boolean.'
+    }
 }
 
 Describe 'Registered portal login/logout production handlers' {

--- a/webui/src/api/remoteAccess.ts
+++ b/webui/src/api/remoteAccess.ts
@@ -13,6 +13,7 @@ export interface RemoteAcl {
   hostname: string
   cloudflareTeamDomain: string
   cloudflareAudience: string
+  legacyCloudflareEnabled: boolean
 }
 
 export interface PortalManagedAccount {

--- a/webui/src/layout/SpatialFrame.tsx
+++ b/webui/src/layout/SpatialFrame.tsx
@@ -17,8 +17,15 @@ import './floatingDock.css'
 import './dashboardFrame.css'
 import './portalWorkspace.css'
 
-const DOCK = ['/', '/solo', '/players', '/bases', '/vehicles', '/economy', '/commands', '/database']
+const DOCK = ['/', '/map?view=atlas', '/solo', '/players', '/bases', '/vehicles', '/economy', '/commands', '/database']
 const NEUTRAL_PALETTES = new Set(['world-control', 'daylight', 'signal'])
+
+function isActiveDockDestination(destination: string, pathname: string, search: string) {
+  const target = new URL(destination, window.location.origin)
+  if (pathname !== target.pathname) return false
+  const current = new URLSearchParams(search)
+  return [...target.searchParams].every(([key, value]) => current.get(key) === value)
+}
 
 export default function SpatialFrame({ children, onDetails, tools = false, dashboard = false }: {
   children: ReactNode
@@ -110,7 +117,7 @@ export default function SpatialFrame({ children, onDetails, tools = false, dashb
           <div ref={dockAnchorRef} className="spatial-dock-slot">
             <nav ref={dockRef} className="spatial-dock" aria-label="Workspace dock">
               {DOCK.filter(route => tools || route !== '/').flatMap(route => destinations.filter(item => item.to === route)).map(item => (
-                <Link to={item.to} key={item.to} aria-current={pathname === item.to ? 'page' : undefined}><Icon name={item.icon} size={20} /><span>{item.to === '/' ? 'World' : item.label}</span></Link>
+                <Link to={item.to} key={item.to} aria-current={isActiveDockDestination(item.to, pathname, search) ? 'page' : undefined}><Icon name={item.icon} size={20} /><span>{item.to === '/' ? 'World' : item.label}</span></Link>
               ))}
               <button onClick={openFinder} aria-haspopup="dialog"><Icon name="Grid2X2" size={20} /><span>All tools</span></button>
             </nav>

--- a/webui/src/layout/commandDeckModel.ts
+++ b/webui/src/layout/commandDeckModel.ts
@@ -12,12 +12,17 @@ const TASK_COPY: Record<string, { description: string; keywords: string }> = {
   '/vehicles': { description: 'Inspect the fleet and vehicle inventory.', keywords: 'ornithopter buggy cargo' },
   '/economy': { description: 'Review market and governance tools.', keywords: 'market trade landsraad' },
   '/map': { description: 'Explore the atlas and map workspace.', keywords: 'deep desert atlas' },
+  '/map?view=atlas': { description: 'Open the static Deep Desert atlas.', keywords: 'deep desert atlas map' },
   '/gameplay': { description: 'Open all gameplay administration views.', keywords: 'storage blueprints market landsraad' },
   '/gameconfig': { description: 'Review and edit server configuration.', keywords: 'ini settings' },
   '/broadcasts': { description: 'Send a message through the existing broadcast tools.', keywords: 'message announcement' },
   '/solo': { description: 'Work with local Solo saves and inventory.', keywords: 'ptc single player' },
   '/settings': { description: 'Configure DST, connections, and remote access.', keywords: 'appearance theme remote accounts updates' },
 }
+
+const STATIC_DECK_DESTINATIONS: NavItem[] = [
+  { to: '/map?view=atlas', label: 'DD Atlas', icon: 'Map' },
+]
 
 export type DeckDestination = NavItem & { description: string; keywords: string }
 
@@ -39,7 +44,7 @@ export function getDeckDestinations(access: Parameters<typeof getVisibleNavItems
       to: item.path, label: item.label, icon: item.icon,
       ownerOnly: item.visibility === 'owner',
     }))
-  return [...visible, ...workspaces].map(item => ({
+  return [...visible, ...workspaces, ...STATIC_DECK_DESTINATIONS].map(item => ({
     ...item,
     description: TASK_COPY[item.to]?.description ?? `Open ${item.label}.`,
     keywords: TASK_COPY[item.to]?.keywords ?? '',

--- a/webui/src/pages/settings/RemoteAccessCard.tsx
+++ b/webui/src/pages/settings/RemoteAccessCard.tsx
@@ -20,9 +20,8 @@ import {
 // Modeled on AppearanceCard.tsx for visual consistency. All requests go
 // to /api/remote-access/* (DuneToken-gated, desktop-portal-only).
 //
-// "Remote enabled" is implemented as a single bit on the owner field —
-// empty string = disabled, non-empty = enabled. The toggle just hides /
-// restores the owner from a buffer.
+// The legacy portal has an explicit persisted enablement flag. Retained ACL
+// metadata stays editable while disabled so the owner can deliberately restore it.
 
 export function RemoteAccessCard() {
   const { open: expanded, setOpen: setExpanded } = useCardCollapse('settings.remoteAccess', false)
@@ -36,8 +35,7 @@ export function RemoteAccessCard() {
   const [audit, setAudit] = useState<RemoteAuditEntry[] | null>(null)
   const [auditLoading, setAuditLoading] = useState(false)
   const [newAdmin, setNewAdmin] = useState('')
-  const [ownerBuffer, setOwnerBuffer] = useState('')   // remembered owner while toggled off
-  const [enabled, setEnabled] = useState(false)        // UI on/off, decoupled from owner so you can enable THEN type the owner
+  const [enabled, setEnabled] = useState(false)
 
   // Legacy native-app Cloudflare Access service token. Browser Portal account
   // mode uses normal interactive sign-in instead. The secret is write-only:
@@ -54,8 +52,7 @@ export function RemoteAccessCard() {
       const [a, c, s] = await Promise.allSettled([getAcl(), getCloudflaredStatus(), getMobileServiceToken()])
       if (a.status === 'fulfilled') {
         setAcl(a.value)
-        setEnabled(!!a.value.owner)
-        if (a.value.owner) setOwnerBuffer(a.value.owner)
+        setEnabled(a.value.legacyCloudflareEnabled)
       } else throw a.reason
       if (c.status === 'fulfilled') setCf(c.value)
       if (s.status === 'fulfilled') {
@@ -81,16 +78,7 @@ export function RemoteAccessCard() {
   const onToggleEnabled = (v: boolean) => {
     if (!acl) return
     setEnabled(v)
-    if (v) {
-      // Enable now; the owner field becomes editable. Restore a remembered
-      // owner if we have one — otherwise leave it blank for the user to fill in.
-      if (ownerBuffer && !acl.owner) updateAcl({ owner: ownerBuffer })
-    } else {
-      // Disabling — stash the current owner so we can restore it next toggle,
-      // then clear it (empty owner = disabled server-side).
-      if (acl.owner) setOwnerBuffer(acl.owner)
-      updateAcl({ owner: '' })
-    }
+    updateAcl({ legacyCloudflareEnabled: v })
   }
 
   const onAddAdmin = () => {
@@ -124,9 +112,8 @@ export function RemoteAccessCard() {
     try {
       const saved = await saveAcl(acl)
       setAcl(saved)
-      setEnabled(!!saved.owner)
-      if (saved.owner) setOwnerBuffer(saved.owner)
-      setSavedMsg('Saved.')
+      setEnabled(saved.legacyCloudflareEnabled)
+      setSavedMsg(saved.legacyCloudflareEnabled ? 'Saved. Legacy Cloudflare portal enabled.' : 'Saved. Legacy Cloudflare portal disabled.')
       window.setTimeout(() => setSavedMsg(null), 3000)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
@@ -181,6 +168,7 @@ export function RemoteAccessCard() {
         <div className="flex items-center gap-2">
           <span className="pill-warning text-xs">deprecated</span>
           {enabled && <span className="pill-success text-xs">enabled</span>}
+          {!enabled && <span className="pill-muted text-xs">disabled</span>}
           {cf?.installed
             ? <span className="pill-info text-xs">cloudflared {cf.version || 'detected'}</span>
             : enabled
@@ -210,11 +198,11 @@ export function RemoteAccessCard() {
                 <Icon name="Info" size={14} className="mt-0.5 flex-none" />
                 <span>
                   <strong>Deprecated — existing configurations only.</strong> Cloudflare
-                  named-tunnel/Access support is scheduled for removal when the
-                  current v15 test line promotes to stable. Existing
-                  configurations remain editable and operational during migration,
-                  but new setups should use <strong>Tailscale Funnel</strong> plus
-                  Browser Portal accounts under <strong>Remote Device Access</strong>.
+                  named-tunnel/Access configuration is retained in v15.0.0, but
+                  its legacy portal is disabled by default. Existing settings remain
+                  editable and can be explicitly re-enabled; new setups should use
+                  <strong> Tailscale Funnel</strong> plus Browser Portal accounts
+                  under <strong>Remote Device Access</strong>.
                 </span>
               </div>
               <p className="text-sm text-text-muted">
@@ -233,7 +221,7 @@ export function RemoteAccessCard() {
               </p>
 
               <div className="rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm text-text-muted">
-                <div className="font-semibold text-warning mb-2">Migrate before the v15 stable release</div>
+                <div className="font-semibold text-warning mb-2">Plan your migration to the Browser Portal</div>
                 <ol className="list-decimal pl-5 space-y-1">
                   <li>
                     Run <code className="break-all font-mono text-xs">tailscale funnel --bg http://127.0.0.1:47900</code> in
@@ -243,10 +231,10 @@ export function RemoteAccessCard() {
                   <li>Acknowledge native-app retirement, then enable account login.</li>
                   <li>Create any Browser Portal Admin accounts needed for role-boundary testing.</li>
                   <li>Test Owner sign-in and Admin restricted navigation from an outside device.</li>
-                  <li>Only then disable this legacy portal and stop the Cloudflare tunnel.</li>
+                  <li>Only then leave this legacy portal disabled. DST does not manage the Cloudflare tunnel.</li>
                 </ol>
                 <p className="mt-2 text-xs text-text-dim">
-                  Keep Cloudflare enabled until the replacement Funnel path is proven.
+                  Keep the legacy portal disabled unless you explicitly need to restore it.
                 </p>
               </div>
 
@@ -260,8 +248,8 @@ export function RemoteAccessCard() {
                 <span className="text-sm">
                   <strong>Enable legacy Cloudflare portal</strong>
                   <span className="block text-xs text-text-dim">
-                    Clears the owner field on disable — every /remote/* request is
-                    refused until re-enabled.
+                    Disabled by default in v15. Saving this deliberate setting controls
+                    every legacy /remote/* request without clearing the owner or ACL.
                   </span>
                 </span>
               </label>
@@ -273,8 +261,7 @@ export function RemoteAccessCard() {
                   type="email"
                   value={acl.owner}
                   onChange={e => updateAcl({ owner: e.target.value })}
-                  disabled={!enabled}
-                  className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text disabled:opacity-50"
+                  className="w-full px-3 py-2 rounded-lg bg-surface-2 border border-border text-text"
                   placeholder="you@example.com"
                 />
                 <p className="text-xs text-text-dim mt-1">

--- a/webui/tests/commandDeck.test.tsx
+++ b/webui/tests/commandDeck.test.tsx
@@ -34,6 +34,7 @@ describe('Command Deck destinations', () => {
   it('uses the existing viewer restrictions including owner and Windows-only tools', () => {
     const admin = getDeckDestinations({ local: false, windows: true, canAccessOwnerSurfaces: false })
     expect(admin.some(item => item.to === '/players')).toBe(true)
+    expect(admin.some(item => item.to === '/map?view=atlas')).toBe(true)
     for (const route of ['/database', '/settings', '/experimental', '/gameconfig', '/terminal', '/solo', '/setup']) {
       expect(admin.some(item => item.to === route)).toBe(false)
     }

--- a/webui/tests/floatingDock.test.tsx
+++ b/webui/tests/floatingDock.test.tsx
@@ -142,6 +142,23 @@ beforeEach(() => {
 afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
 
 describe('Single floating workspace dock', () => {
+  it('links directly to the static DD Atlas and marks only its query route active', () => {
+    window.history.replaceState({}, '', '/map?view=lifecycle')
+    const first = mount()
+    const lifecycleAtlas = within(elements().dock).getByRole('link', { name: 'DD Atlas' })
+    expect(lifecycleAtlas).toHaveAttribute('href', '/map?view=atlas')
+    expect(lifecycleAtlas).not.toHaveAttribute('aria-current')
+
+    first.unmount()
+    window.history.replaceState({}, '', '/map?view=atlas')
+    mount()
+    const atlas = within(elements().dock).getByRole('link', { name: 'DD Atlas' })
+    expect(atlas).toHaveAttribute('aria-current', 'page')
+    fireEvent.click(atlas)
+    expect(window.location.pathname).toBe('/map')
+    expect(window.location.search).toBe('?view=atlas')
+  })
+
   it.each([false, true])('links directly to Solo Mode from the dock (tools=%s)', tools => {
     mount(tools)
     const solo = within(elements().dock).getByRole('link', { name: 'Solo Mode' })

--- a/webui/tests/remoteAccessRetirement.test.ts
+++ b/webui/tests/remoteAccessRetirement.test.ts
@@ -21,14 +21,17 @@ describe('remote access retirement guidance', () => {
     expect(settingsSource).toContain('responsive portal remain supported')
   })
 
-  it('states the stable-release cutoff for legacy Cloudflare support', () => {
+  it('keeps legacy Cloudflare configuration reversible but disabled by default in v15', () => {
     const source = readFileSync(
       resolve(process.cwd(), 'src', 'pages', 'settings', 'RemoteAccessCard.tsx'),
       'utf8',
     )
 
-    expect(source).toContain('scheduled for removal when the')
-    expect(source).toContain('current v15 test line promotes to stable')
-    expect(source).toContain('Migrate before the v15 stable release')
+    expect(source).toContain('configuration is retained in v15.0.0')
+    expect(source).toContain('legacy portal is disabled by default')
+    expect(source).toContain('can be explicitly re-enabled')
+    expect(source).toContain('without clearing the owner or ACL')
+    expect(source).toContain('Plan your migration to the Browser Portal')
+    expect(source).toContain('Tailscale Funnel')
   })
 })


### PR DESCRIPTION
## Summary
- Promote the reviewed v15 release source to a stable candidate.
- Default legacy Cloudflare portal access off while preserving an explicit re-enable path.
- Include the completed privacy, Solo export, updater rollover, and v14 upgrade reliability fixes.

## Validation
- Targeted PowerShell, WebUI, site, parse, BOM, and release-metadata checks passed.
- Independent source and security reviews passed.

## Scope
Stable candidate only. No public release, tag, installer publication, Cloudflare removal, or new feature work.