### PR TITLE
Add Wick to supporter credits

### DIFF
--- a/webui/src/data/sponsors.ts
+++ b/webui/src/data/sponsors.ts
@@ -21,5 +21,6 @@ export const SUPPORTER_CREDITS: readonly SupporterCredit[] = [
   { displayName: 'elwicki (@elwicki)', thanks: 'Thanks for helping the project thrive.' },
   { displayName: 'Maggie Malone (@magiemalone)', thanks: 'Your kindness keeps the work going.' },
   { displayName: 'William', thanks: 'Thank you for helping sustain DST.' },
+  { displayName: 'Wick', thanks: 'Thank you for standing with DST.' },
   { displayName: 'Ed O.', thanks: 'Your support strengthens the whole community. The strongest sietches are built together.' },
 ]

--- a/webui/tests/sponsorsCredits.test.tsx
+++ b/webui/tests/sponsorsCredits.test.tsx
@@ -42,6 +42,7 @@ const EXPECTED_CREDIT_NAMES = [
   'elwicki (@elwicki)',
   'Maggie Malone (@magiemalone)',
   'William',
+  'Wick',
   'Ed O.',
 ] as const
 
@@ -53,8 +54,8 @@ afterEach(() => {
 describe('Sponsors & Credits', () => {
   it('uses the typed source as the complete, unique public credit list', () => {
     expect(SUPPORTER_CREDITS.map(credit => credit.displayName)).toEqual(EXPECTED_CREDIT_NAMES)
-    expect(new Set(SUPPORTER_CREDITS.map(credit => credit.displayName)).size).toBe(18)
-    expect(new Set(SUPPORTER_CREDITS.map(credit => credit.thanks)).size).toBe(18)
+    expect(new Set(SUPPORTER_CREDITS.map(credit => credit.displayName)).size).toBe(19)
+    expect(new Set(SUPPORTER_CREDITS.map(credit => credit.thanks)).size).toBe(19)
     expect(SUPPORTER_CREDITS.every(credit => credit.thanks.startsWith('Thank') || credit.thanks.startsWith('You') || credit.thanks.startsWith('Your'))).toBe(true)
   })
 
@@ -69,7 +70,7 @@ describe('Sponsors & Credits', () => {
         "These personal thank-you notes are written by Duke, DST's AI admin—not by Coastal. 🙂",
       ),
     ).toBeInTheDocument()
-    expect(within(credits).getAllByRole('listitem')).toHaveLength(18)
+    expect(within(credits).getAllByRole('listitem')).toHaveLength(19)
     expect(within(credits).getAllByText('— Duke', { exact: true })).toHaveLength(SUPPORTER_CREDITS.length)
     for (const name of EXPECTED_CREDIT_NAMES) {
       expect(within(credits).getAllByText(name, { exact: true })).toHaveLength(1)


### PR DESCRIPTION
## Summary
- Add Wick to the in-app supporter credits.
- Update the existing supporter-list coverage.

## Validation
- Focused supporters test passed.
- WebUI production build passed.