### PR TITLE
Repair DST instruction control plane

### DIFF
--- a/.github/DST-OPERATING-CONTRACT.md
+++ b/.github/DST-OPERATING-CONTRACT.md
@@ -1,0 +1,29 @@
+# DST operating contract
+
+This file is the canonical source for DST session routing. Other instructions,
+skills, routines, and handoffs must reference or mechanically mirror it rather
+than redefine it.
+
+- **Sync trigger:** Run `sync` only when Coastal's entire message is exactly
+  `sync` or `/sync`. Run `syncsave` only when the entire message is exactly
+  `syncsave` or `/syncsave`. Loading tools, entering this repository, opening a
+  session, `go`, and ordinary DST work are not triggers.
+- **Parent authority:** GPT-5.6 Sol is the proven active DST parent. The parent
+  owns user communication, context, integration, validation reconciliation,
+  approval gates, Discord, release authority, and completion.
+- **Implementation routing:** Meaningful, broad, or safety-critical DST coding
+  goes only to app-native coordinated child sessions with an explicitly selected
+  appropriate GPT-5.6 Sol or GPT-6 Astra model. Do not use Task/background agents
+  for substantive DST work. A tiny, clearly bounded edit may remain in the parent
+  when that is safer than delegation.
+- **Child communication:** Children report work, evidence, blockers, and
+  questions to the parent and never ask Coastal directly.
+- **Discord ownership:** Discord monitoring and member communication stay with
+  the active parent while implementation children work.
+- **Release authority:** Children may prepare bounded evidence or code, but the
+  parent owns integration, release validation, approval gates, publishing, and
+  final completion.
+
+When this contract changes, update this file first, update only the necessary
+references, then run the local control-plane validator documented by the private
+DST routines.

--- a/.github/DST-OPERATING-CONTRACT.md
+++ b/.github/DST-OPERATING-CONTRACT.md
@@ -17,10 +17,10 @@ than redefine it.
   for substantive DST work. A tiny, clearly bounded edit may remain in the parent
   when that is safer than delegation.
 - **Child communication:** Children report work, evidence, blockers, and
-  questions to the parent and never ask Coastal directly. After durable results
-  are preserved, the parent archives children it created.
-- **Discord ownership:** Discord monitoring and member communication stay with
-  the active parent while implementation children work.
+  questions upward to the parent and never ask Coastal directly. The parent
+  archives a child only after its durable branch/work is preserved.
+- **Discord ownership:** Discord monitoring and member communication stay only
+  with the active parent while implementation children work.
 - **Release authority:** Children may prepare bounded evidence or code, but the
   parent owns integration, release validation, approval gates, publishing, and
   final completion. Before release publication or release-facing communication,

--- a/.github/DST-OPERATING-CONTRACT.md
+++ b/.github/DST-OPERATING-CONTRACT.md
@@ -17,12 +17,15 @@ than redefine it.
   for substantive DST work. A tiny, clearly bounded edit may remain in the parent
   when that is safer than delegation.
 - **Child communication:** Children report work, evidence, blockers, and
-  questions to the parent and never ask Coastal directly.
+  questions to the parent and never ask Coastal directly. After durable results
+  are preserved, the parent archives children it created.
 - **Discord ownership:** Discord monitoring and member communication stay with
   the active parent while implementation children work.
 - **Release authority:** Children may prepare bounded evidence or code, but the
   parent owns integration, release validation, approval gates, publishing, and
-  final completion.
+  final completion. Before release publication or release-facing communication,
+  the parent recalls the relevant project and community context through the
+  canonical continuity routine.
 
 When this contract changes, update this file first, update only the necessary
 references, then run the local control-plane validator documented by the private

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,21 +18,15 @@ Landsraad, market bot). The repo `coastal-ms/DST-DuneServerTool` is public and
 forkable. Day-to-day work is: reproduce a reported bug, fix it across the
 PS backend + webui, build the installer, ship a release.
 
-## Work orchestration — do the work in-session
+## DST operating contract
 
-Apply this in **every session**, unless the maintainer explicitly asks otherwise:
+Read and follow [`.github/DST-OPERATING-CONTRACT.md`](DST-OPERATING-CONTRACT.md)
+before acting. It is the canonical source for sync triggers, parent and child
+routing, model selection, Discord ownership, and release authority. Do not
+redefine those rules here.
 
-- **Do the work in the session you are in.** Decompose the goal into the session
-  `todos` table (and `todo_deps` for ordering) when that helps you keep track,
-  but write the implementation yourself. There is no planner/builder split and
-  no separate "executor" role — do not narrate one.
-- **Child sessions and sub-agents are allowed for bounded independent work or
-  separate context.** The parent session remains the sole
-  user-facing coordinator and owns approval gates. Every child reports results,
-  progress, blockers, and questions to the parent instead of asking the
-  maintainer directly. Automatically started children follow the same rule.
-  Children inherit the parent session's active model; never select a different
-  model. Do not recreate a planner/builder split.
+- Use the session `todos` table (and `todo_deps` when ordering matters) when it
+  helps keep multi-step work explicit.
 - **Discord monitoring belongs to the active parent, never a child responder.**
   Attach the parent to the persistent local gateway ears-only, batch/deduplicate
   startup catch-up, and get one maintainer decision before live autonomy.

--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,7 +1,7 @@
 instructions: |-
   Duke, the Discord ai admin bot, that you use to work in discord, identifies as a he. and members will refer to you as a he. you are named after Duke Atreides, the head of the atreides faction in Dune, the book, movie and this game.
-  Load the repository instructions before acting.
-  For DST work, use the canonical sync routine to load current status, Discord integrations, and recent releases.
+  Load the repository instructions and .github/DST-OPERATING-CONTRACT.md before acting.
+  Run sync only when the user's entire message is exactly sync or /sync. Run syncsave only when the entire message is exactly syncsave or /syncsave. Never infer either trigger from ordinary DST work, loading tools, opening a session, or go.
   When you present a question and a live source is being monitored, include a numbered
   option to keep reading new messages before deciding. Omit it when nothing is live.
 automation:

--- a/.github/skills/sync/SKILL.md
+++ b/.github/skills/sync/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: sync
+description: Use only when Coastal's entire message is exactly sync or /sync.
+---
+
+# sync
+
+Activate only when Coastal's entire message is exactly `sync` or `/sync`.
+Ordinary DST work, loading tools, opening a session, and `go` do not activate
+this skill.
+
+Read `.github/DST-OPERATING-CONTRACT.md`, then execute the canonical sync
+routine available in the current host environment verbatim.

--- a/.github/skills/syncsave/SKILL.md
+++ b/.github/skills/syncsave/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: syncsave
+description: Use only when Coastal's entire message is exactly syncsave or /syncsave.
+---
+
+# syncsave
+
+Activate only when Coastal's entire message is exactly `syncsave` or
+`/syncsave`. Session silence, ordinary DST work, loading tools, opening a
+session, and `go` do not activate this skill.
+
+Read `.github/DST-OPERATING-CONTRACT.md`, then execute the canonical syncsave
+routine available in the current host environment verbatim.


### PR DESCRIPTION
## Summary
- Establish one canonical DST operating contract for exact sync triggers, parent/child model routing, Discord ownership, and release authority.
- Remove conflicting automatic-sync and inherited-model instructions from active repository surfaces.
- Add deterministic sync/syncsave control-plane drift validation and clean-session probe coverage.

## Validation
- Control-plane validator passed against the corrected surfaces and its eight matcher scenarios.
- YAML, PowerShell parsing, mirror hashes, gitleaks, and public-boundary checks passed.

## Scope
Instruction and routine control-plane repair only. Product and release work remain frozen pending clean-session validation.