### PR TITLE
Align site Node engine floor

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -9,7 +9,7 @@ This site lives inside the main `DST-DuneServerTool` repo so that:
 
 ## Local dev
 
-Requires **Node 20.19+, 22.13+, or 23.5+**.
+Requires **Node 22.19+**.
 
 ```powershell
 cd site

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -18,6 +18,9 @@
         "sharp": "^0.35.4",
         "tailwindcss": "^4.0.0",
         "typescript": "~5.7.2"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@astrojs/check": {

--- a/site/package.json
+++ b/site/package.json
@@ -29,5 +29,8 @@
   },
   "overrides": {
     "nanoid": "3.3.18"
+  },
+  "engines": {
+    "node": ">=22.19.0"
   }
 }


### PR DESCRIPTION
Follow-up to merged #823. Aligns the site package engine and local-development documentation with Undici's Node 22.19 minimum.

Validation: Node 22.19 locked install with engine strictness; `astro check` passed with 0 errors.