### PR TITLE
Limit site changelog to four releases

### DIFF
--- a/site/scripts/check-changelog.mts
+++ b/site/scripts/check-changelog.mts
@@ -9,44 +9,62 @@ Introductory copy.
 
 - Pending change.
 
-## [14.2.0] - 2026-08-20
+## [15.0.0] - 2026-09-01
 
-- Recent release.
+- Newest release.
 
-## [13.0.0] - 2026-07-30
+## [14.0.0] - 2026-08-01
 
-- Oldest detailed release.
+- Second release.
 
-## [12.21.3] - 2026-07-27
+## [13.0.0] - 2026-07-01
 
-- Legacy detail that should be removed.
+- Third release.
 
-## [14.0.0] - unexpected ordering
+## [12.0.0] - 2026-06-01
 
-- Content after the cutoff should not return.
+- Fourth release.
+
+## [11.0.0] - 2026-05-01
+
+- First hidden release.
 `;
 
 const trimmed = trimChangelogForSite(source);
 assert.match(trimmed, /^# Changelog/m);
 assert.match(trimmed, /^## \[Unreleased\]/m);
-assert.match(trimmed, /^## \[14\.2\.0\]/m);
+assert.match(trimmed, /^## \[15\.0\.0\]/m);
+assert.match(trimmed, /^## \[14\.0\.0\]/m);
 assert.match(trimmed, /^## \[13\.0\.0\]/m);
-assert.doesNotMatch(trimmed, /^## \[12\.21\.3\]/m);
-assert.doesNotMatch(trimmed, /Legacy detail that should be removed/);
-assert.doesNotMatch(trimmed, /unexpected ordering/);
-assert.match(trimmed, /^## Legacy releases \(v1-v12\)$/m);
+assert.match(trimmed, /^## \[12\.0\.0\]/m);
+assert.doesNotMatch(trimmed, /^## \[11\.0\.0\]/m);
+assert.doesNotMatch(trimmed, /First hidden release/);
+assert.match(trimmed, /^## Earlier releases$/m);
 assert.match(
   trimmed,
   /https:\/\/github\.com\/coastal-ms\/DST-DuneServerTool\/blob\/main\/CHANGELOG\.md/,
 );
 
-const currentOnly = `# Changelog
+const nextRelease = source.replace(
+  "## [15.0.0]",
+  "## [16.0.0] - 2026-10-01\n\n- New rolling release.\n\n## [15.0.0]",
+);
+const rolled = trimChangelogForSite(nextRelease);
+assert.match(rolled, /^## \[16\.0\.0\]/m);
+assert.match(rolled, /^## \[13\.0\.0\]/m);
+assert.doesNotMatch(rolled, /^## \[12\.0\.0\]/m);
+
+const fewerThanFour = `# Changelog
 
 ## [Unreleased]
 
-## [13.0.0] - 2026-07-30
+## [3.0.0] - 2026-03-01
+
+## [2.0.0] - 2026-02-01
+
+## [1.0.0] - 2026-01-01
 `;
-assert.equal(trimChangelogForSite(currentOnly), currentOnly);
+assert.equal(trimChangelogForSite(fewerThanFour), fewerThanFour);
 
 const malformed = `# Changelog
 

--- a/site/src/lib/changelog.ts
+++ b/site/src/lib/changelog.ts
@@ -2,28 +2,22 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 const CHANGELOG_PATH = join(process.cwd(), "..", "CHANGELOG.md");
-const DETAILED_RELEASE_MAJOR = 13;
+const RELEASE_LIMIT = 4;
 const NUMERIC_RELEASE_HEADING = /^## \[(\d+)\.[^\]]+\][^\r\n]*$/gm;
-const LEGACY_SUMMARY = `## Legacy releases (v1-v12)
+const EARLIER_RELEASES = `## Earlier releases
 
-Earlier releases established DST's core server-management experience and expanded it through successive administration and reliability improvements.
-
-- **v12** — Major expansion of gameplay administration and supporting server workflows.
-- **v9-v11** — Iterative additions and refinements across configuration, diagnostics, and operator workflows.
-- **v1-v8** — Foundation releases for setup, updates, the desktop app, and core server management.
-
-[View the complete changelog on GitHub](https://github.com/coastal-ms/DST-DuneServerTool/blob/main/CHANGELOG.md) for every legacy release and patch.`;
+[View the complete changelog on GitHub](https://github.com/coastal-ms/DST-DuneServerTool/blob/main/CHANGELOG.md) for all earlier releases.`;
 
 export function trimChangelogForSite(source: string): string {
-  const firstLegacyRelease = [...source.matchAll(NUMERIC_RELEASE_HEADING)].find(
-    (match) => Number(match[1]) < DETAILED_RELEASE_MAJOR,
-  );
+  const firstHiddenRelease = [
+    ...source.matchAll(NUMERIC_RELEASE_HEADING),
+  ][RELEASE_LIMIT];
 
-  if (firstLegacyRelease?.index === undefined) {
+  if (firstHiddenRelease?.index === undefined) {
     return source;
   }
 
-  return `${source.slice(0, firstLegacyRelease.index).trimEnd()}\n\n${LEGACY_SUMMARY}\n`;
+  return `${source.slice(0, firstHiddenRelease.index).trimEnd()}\n\n${EARLIER_RELEASES}\n`;
 }
 
 export async function getChangelog(): Promise<string> {

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -15,7 +15,7 @@ const html = marked.parse(raw, { gfm: true, breaks: false });
   <PageHeader
     eyebrow="History"
     title="Changelog"
-    intro="Detailed notes for v13 and newer, followed by a concise legacy summary with a link to the complete history."
+    intro="Detailed notes for the latest four releases, with a link to the complete history."
   />
 
   <section class="mx-auto max-w-3xl px-6 pb-20">


### PR DESCRIPTION
## Summary

Limit the marketing changelog to the newest four released versions while preserving `Unreleased` and linking to the complete repository history.

## Related issue

N/A

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (menu option removed/renamed, config key changed, etc.)
- [ ] Docs only
- [ ] Chore / CI / refactor

## Testing

- [x] `npm run test:changelog`
- [x] `npm run build`
- [x] Confirmed the built page contains `Unreleased`, four release headings, and the earlier-history link

## Changelog

- [ ] I added an entry to `CHANGELOG.md` under `[Unreleased]`

Not needed for this site-only presentation change; the repository changelog remains complete and unchanged.

## Screenshots / output

N/A