### PR TITLE
Players & Inventory: Command Deck parity, guarded Reserve recovery & delete protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Added
+
+- Added **Players > Community tools** to Command Deck, exposing the existing
+  in-game chat command controls, shared `!tp` destinations, and Welcome Back
+  packages while retaining their opt-in defaults and existing safeguards.
+
 ## [15.0.2] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ here cover everything those tags shipped.
 - Added **Players > Community tools** to Command Deck, exposing the existing
   in-game chat command controls, shared `!tp` destinations, and Welcome Back
   packages while retaining their opt-in defaults and existing safeguards.
+- Added guarded hidden-Reserve recovery to Player Inventory. DST previews the
+  exact rows and Backpack positions, requires the player to be Offline, verifies
+  a fresh local backup and exact slot/volume capacity, moves rows intact in one
+  changed-state-guarded transaction, reads them back, and retains exact rollback.
+
+### Changed
+
+- Protected Reserve items from direct deletion, quantity reduction, and live
+  Clean Inventory so hidden remaining rows cannot keep base recycling blocked.
 
 ## [15.0.2] - 2026-09-09
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,10 @@ contextual dossier, with section navigation beside the selected character.
 Player and inventory actions use a searchable task list and one focused form,
 retaining existing confirmations and live/offline rules. Switching characters
 clears the previous character's action form; filtering the directory does not
-silently change the current target. Classic retains its action lists.
+silently change the current target. **Players > Community tools** exposes the
+existing in-game chat command controls, shared `!tp` destinations, and Welcome
+Back packages without changing their opt-in defaults or safety gates. Classic
+retains the same controls and action lists.
 Commands uses the same task workbench while keeping its local-only layout
 editor. Bases, market entries, and vehicles have keyboard-accessible detail
 panels; fleet search and source labels distinguish reported and sample records.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,12 @@ clears the previous character's action form; filtering the directory does not
 silently change the current target. **Players > Community tools** exposes the
 existing in-game chat command controls, shared `!tp` destinations, and Welcome
 Back packages without changing their opt-in defaults or safety gates. Classic
-retains the same controls and action lists.
+retains the same controls and action lists. Player Inventory also identifies
+hidden Reserve rows and blocks direct deletion, quantity reduction, and live
+Clean Inventory when those operations could strand remaining items. **Recover
+Reserve to Backpack** is available only for an Offline player after exact
+identity, free-slot, item-volume, changed-state, and fresh local-backup checks;
+it moves rows intact and preserves an exact guarded rollback.
 Commands uses the same task workbench while keeping its local-only layout
 editor. Bases, market entries, and vehicles have keyboard-accessible detail
 panels; fleet search and source labels distinguish reported and sample records.

--- a/app/data/platform-route-policies.json
+++ b/app/data/platform-route-policies.json
@@ -156,7 +156,7 @@
     { "source": "FlsToken.ps1", "capabilityId": "settings.connectivity", "routeCount": 3, "sha256": "5dbda64c9121b306d6d6f3487aef4e6f630a73beba73d0067baa14373237f2bb" },
     { "source": "GameConfig.ps1", "capabilityId": "settings.game-server", "routeCount": 26, "sha256": "5864b52d958ef8dceeabb527268f413806b5b29b086f450b423359b34d7396ce" },
     { "source": "Gameplay.ps1", "capabilityId": "economy.market", "routeCount": 22, "sha256": "757d3fd58fe70e88c5ccc91b9549e8f9a121b9137c1a2c16cd574c271c46e258" },
-    { "source": "GameplayPlayers.ps1", "capabilityId": "player.manage", "routeCount": 29, "sha256": "12c6846a931b7d3e34d58f171411615be54a76bf401f7ace4ab09442cea6c8f0" },
+    { "source": "GameplayPlayers.ps1", "capabilityId": "player.manage", "routeCount": 32, "sha256": "273a4061bd3f23dc40ee3094c186f7df7cf94dd2ce169a63876d9d966cef5378" },
     { "source": "GameplayWorld.ps1", "capabilityId": "base.manage", "routeCount": 13, "sha256": "4c6dcb579d2a5fab1ef37a5fb84d399e493ea079e14994cdc56bbafaa56f9fc6" },
     { "source": "Inventory.ps1", "capabilityId": "inventory.read", "routeCount": 4, "sha256": "3e8a38114c67450782febd31b7f42339be467aca11b741283c8ae3d09ebe44d9" },
     { "source": "ItemPackages.ps1", "capabilityId": "player.inventory", "routeCount": 3, "sha256": "ed3aac4a943d300002f7aecacb8ecf04619917ee7aa549cde0068e1853e01cf9" },

--- a/app/server/lib/GameplayPlayers.ps1
+++ b/app/server/lib/GameplayPlayers.ps1
@@ -51,6 +51,13 @@ ORDER BY ps.account_id
 # Inventory for one pawn actor id ($1).
 $script:DunePlayerInventorySql = @'
 SELECT i.id, i.template_id, i.stack_size, COALESCE(i.quality_level, 0) AS quality_level,
+       inv.id AS inventory_id, inv.inventory_type,
+       (inv.inventory_type = 33 AND EXISTS (
+           SELECT 1
+           FROM dune.actor_inventories ai
+           WHERE ai.inventory_id = inv.id
+             AND ai.component_name_hash = -689927216
+       )) AS is_reserve,
        COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'), 'N/A') AS durability,
        COALESCE((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability'), 'N/A')     AS max_durability,
        COALESCE((i.stats->'FFillableItemStats'->1->>'CurrentAmount'), 'N/A')               AS water_amount,
@@ -124,6 +131,9 @@ function Get-DunePlayerDetailLive {
             kind           = (Get-DuneItemKind -TemplateId $tmpl)
             stack_size     = (ConvertTo-DuneInt $r['stack_size'])
             quality        = (ConvertTo-DuneInt $r['quality_level'])
+            inventory_id   = (ConvertTo-DuneInt $r['inventory_id'])
+            inventory_type = (ConvertTo-DuneInt $r['inventory_type'])
+            is_reserve     = (Test-DuneTruthy $r['is_reserve'])
             durability     = [string]$r['durability']
             max_durability = [string]$r['max_durability']
             water_amount   = [string]$r['water_amount']
@@ -400,17 +410,34 @@ function Invoke-DunePlayerDeleteItem {
     $expectedClause = if ($null -ne $ExpectedStackSize) { " AND stack_size = $ExpectedStackSize::bigint" } else { '' }
     $sql = @"
 WITH matched AS (
-    SELECT id
-    FROM dune.items
-    WHERE id = $ItemId::bigint$expectedClause
+    SELECT i.id,
+           (inv.inventory_type = 33 AND EXISTS (
+               SELECT 1 FROM dune.actor_inventories ai
+               WHERE ai.inventory_id = inv.id
+                 AND ai.component_name_hash = -689927216
+           )) AS is_reserve
+    FROM dune.items i
+    JOIN dune.inventories inv ON inv.id = i.inventory_id
+    WHERE i.id = $ItemId::bigint$($expectedClause.Replace('stack_size', 'i.stack_size'))
     FOR UPDATE
+),
+deleted AS MATERIALIZED (
+    SELECT dune.delete_item(id) AS result
+    FROM matched
+    WHERE NOT is_reserve
 )
-SELECT dune.delete_item(id) FROM matched;
+SELECT CASE WHEN is_reserve THEN 'reserve_blocked' ELSE 'deleted' END AS status,
+       (SELECT count(*) FROM deleted)::text AS changed
+FROM matched;
 "@
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
-    if (@(ConvertTo-DuneRowMaps -Result $res).Count -eq 0) {
+    $rows = @(ConvertTo-DuneRowMaps -Result $res)
+    if ($rows.Count -eq 0) {
         return @{ ok = $false; error = 'Item quantity changed or the item no longer exists. Refresh and try again.' }
+    }
+    if ([string]$rows[0]['status'] -ceq 'reserve_blocked') {
+        return @{ ok = $false; error = 'Reserve items cannot be deleted directly. Deleting any Reserve row can hide and strand the remaining Reserve contents while base recycling stays blocked. Use guarded Recover Reserve instead.' }
     }
     return @{ ok = $true; message = "Deleted item $ItemId." }
 }
@@ -605,18 +632,43 @@ function Invoke-DunePlayerSetItemStack {
     param([string]$Ip, [long]$ItemId, [long]$StackSize, [Nullable[long]]$ExpectedStackSize)
     if ($ItemId -le 0) { return @{ ok = $false; error = 'item_id is required.' } }
     if ($StackSize -lt 1) { return @{ ok = $false; error = 'stack_size must be at least 1.' } }
-    $expectedClause = if ($null -ne $ExpectedStackSize) { " AND stack_size = $ExpectedStackSize::bigint" } else { '' }
+    $expectedClause = if ($null -ne $ExpectedStackSize) { " AND i.stack_size = $ExpectedStackSize::bigint" } else { '' }
     $sql = @"
-UPDATE dune.items
-SET stack_size = $StackSize::bigint
-WHERE id = $ItemId::bigint$expectedClause
-RETURNING id::text AS item_id;
+WITH matched AS (
+    SELECT i.id, i.stack_size,
+           (inv.inventory_type = 33 AND EXISTS (
+               SELECT 1 FROM dune.actor_inventories ai
+               WHERE ai.inventory_id = inv.id
+                 AND ai.component_name_hash = -689927216
+           )) AS is_reserve
+    FROM dune.items i
+    JOIN dune.inventories inv ON inv.id = i.inventory_id
+    WHERE i.id = $ItemId::bigint$expectedClause
+    FOR UPDATE
+),
+updated AS (
+    UPDATE dune.items i
+       SET stack_size = $StackSize::bigint
+      FROM matched m
+     WHERE i.id = m.id
+       AND (NOT m.is_reserve OR $StackSize::bigint >= m.stack_size)
+    RETURNING i.id
+)
+SELECT CASE
+           WHEN is_reserve AND $StackSize::bigint < stack_size THEN 'reserve_blocked'
+           WHEN EXISTS (SELECT 1 FROM updated) THEN 'updated'
+           ELSE 'stale'
+       END AS status
+FROM matched;
 "@
     $res = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $false -MaxRows 1 -TimeoutSec 30
     if (-not $res.ok) { return @{ ok = $false; error = $res.error } }
-    $affected = @(ConvertTo-DuneRowMaps -Result $res).Count
-    if ($affected -eq 0) {
+    $rows = @(ConvertTo-DuneRowMaps -Result $res)
+    if ($rows.Count -eq 0 -or [string]$rows[0]['status'] -eq 'stale') {
         return @{ ok = $false; error = 'Item quantity changed or the item no longer exists. Refresh and try again.' }
+    }
+    if ([string]$rows[0]['status'] -eq 'reserve_blocked') {
+        return @{ ok = $false; error = 'Reserve quantities cannot be reduced directly because remaining rows can become hidden and keep base recycling blocked. Use guarded Recover Reserve instead.' }
     }
     return @{ ok = $true; message = "Set item $ItemId stack to $StackSize." }
 }

--- a/app/server/lib/PlayersRmq.ps1
+++ b/app/server/lib/PlayersRmq.ps1
@@ -184,6 +184,32 @@ function Invoke-DunePlayerCleanInventoryLive {
     param([string] $Ip, [string] $FlsId, [long] $ActorId = 0)
     $r = Resolve-DuneFlsIdOrError -Ip $Ip -FlsId $FlsId -ActorId $ActorId
     if (-not $r.ok) { return @{ ok = $false; error = $r.error } }
+    $pawnId = $ActorId
+    if ($pawnId -le 0) {
+        $safeFls = ([string]$r.fls_id) -replace "'", "''"
+        $target = Invoke-DuneSqlQuery -Ip $Ip -Sql @"
+SELECT ps.player_pawn_id::text AS pawn_id
+FROM dune.player_state ps
+JOIN dune.accounts account ON account.id = ps.account_id
+WHERE account."user" = '$safeFls';
+"@ -ReadOnly $true -MaxRows 2 -TimeoutSec 15
+        if (-not $target.ok) { return @{ ok = $false; error = "Clean Inventory target could not be proven. $($target.error)" } }
+        $targetRows = @(ConvertTo-DuneRowMaps -Result $target)
+        if ($targetRows.Count -ne 1) {
+            return @{ ok = $false; error = 'Clean Inventory requires one exact player target before Reserve safety can be checked.' }
+        }
+        $pawnId = [long](ConvertTo-DuneInt $targetRows[0]['pawn_id'])
+    }
+    $reserve = Test-DunePlayerReserveItems -Ip $Ip -PawnId $pawnId
+    if (-not $reserve.ok) {
+        return @{ ok = $false; error = "Clean Inventory was blocked because Reserve safety could not be proven. $($reserve.error)" }
+    }
+    if ($reserve.item_rows -gt 0) {
+        return @{
+            ok = $false
+            error = "Clean Inventory is blocked while Reserve contains $($reserve.item_rows) item row(s). Cleaning can strand hidden Reserve contents and keep base recycling blocked; use guarded Recover Reserve first."
+        }
+    }
     $res = Invoke-DuneRmqCleanPlayerInventory -FlsId $r.fls_id
     if ($res.ok) { $res.message = "Clean inventory command sent for $($r.fls_id)." }
     return $res

--- a/app/server/lib/ReserveRecovery.ps1
+++ b/app/server/lib/ReserveRecovery.ps1
@@ -1,0 +1,707 @@
+# Guarded recovery for hidden player Reserve inventories. Field evidence proved
+# Reserve as a pawn-owned type-33 inventory with this exact actor component.
+
+$script:DuneReserveInventoryType = 33
+$script:DuneReserveComponentHash = -689927216
+$script:DuneReserveRecoveryStateFile = $null
+
+function Get-DuneReserveRecoveryStatePath {
+    if ($script:DuneReserveRecoveryStateFile) { return $script:DuneReserveRecoveryStateFile }
+    $dir = if ($env:APPDATA) { Join-Path $env:APPDATA 'DuneServer' } else { $env:TEMP }
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    return (Join-Path $dir 'reserve-recoveries.json')
+}
+
+function New-DuneReserveRecoveryState {
+    return @{ version = 1; entries = @(); history = @(); updated = [datetime]::UtcNow.ToString('o') }
+}
+
+function Read-DuneReserveRecoveryState {
+    $path = Get-DuneReserveRecoveryStatePath
+    if (-not (Test-Path -LiteralPath $path)) { return (New-DuneReserveRecoveryState) }
+    try {
+        $raw = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
+        if ([string]::IsNullOrWhiteSpace($raw)) { return (New-DuneReserveRecoveryState) }
+        $parsed = $raw | ConvertFrom-Json -ErrorAction Stop
+        return @{
+            version = 1
+            entries = @($parsed.entries)
+            history = @($parsed.history)
+            updated = [string]$parsed.updated
+        }
+    } catch {
+        throw "Reserve recovery state could not be read: $($_.Exception.Message)"
+    }
+}
+
+function Save-DuneReserveRecoveryState {
+    param([Parameter(Mandatory)]$State)
+    $path = Get-DuneReserveRecoveryStatePath
+    $State.updated = [datetime]::UtcNow.ToString('o')
+    $tmp = "$path.$([guid]::NewGuid().ToString('N')).tmp"
+    try {
+        [IO.File]::WriteAllText(
+            $tmp,
+            ($State | ConvertTo-Json -Depth 20),
+            (New-Object Text.UTF8Encoding($false))
+        )
+        Move-Item -LiteralPath $tmp -Destination $path -Force
+    } finally {
+        if (Test-Path -LiteralPath $tmp) {
+            Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Set-DuneReserveStateValue {
+    param([Parameter(Mandatory)]$Entry, [Parameter(Mandatory)][string]$Name, $Value)
+    if ($Entry -is [Collections.IDictionary]) {
+        $Entry[$Name] = $Value
+    } else {
+        $Entry | Add-Member -NotePropertyName $Name -NotePropertyValue $Value -Force
+    }
+}
+
+function Get-DuneReserveActiveRollback {
+    param([long]$PawnId, [string]$DatabaseScope)
+    $state = Read-DuneReserveRecoveryState
+    $matches = @($state.entries | Where-Object {
+        [long]$_.pawn_id -eq $PawnId -and [string]$_.database_scope -ceq $DatabaseScope -and
+        [string]$_.status -in @('moved', 'readback_failed')
+    })
+    if ($matches.Count -gt 1) { throw "Multiple active Reserve rollback records exist for pawn $PawnId." }
+    if ($matches.Count -eq 1) { return $matches[0] }
+    return $null
+}
+
+function Test-DunePlayerReserveItems {
+    param([string]$Ip, [long]$PawnId)
+    if ($PawnId -le 0) { return @{ ok = $false; error = 'A proven player pawn is required.' } }
+    $sql = @"
+SELECT count(i.id)::text AS item_rows,
+       COALESCE(sum(i.stack_size), 0)::text AS item_units
+FROM dune.inventories inv
+JOIN dune.actor_inventories ai
+  ON ai.inventory_id = inv.id
+ AND ai.component_name_hash = $script:DuneReserveComponentHash::bigint
+LEFT JOIN dune.items i ON i.inventory_id = inv.id
+WHERE inv.actor_id = $PawnId::bigint
+  AND inv.inventory_type = $script:DuneReserveInventoryType;
+"@
+    $result = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows 1 -TimeoutSec 15
+    if (-not $result.ok) {
+        return @{ ok = $false; error = "Reserve inventory could not be checked. $($result.error)" }
+    }
+    $rows = @(ConvertTo-DuneRowMaps -Result $result)
+    if ($rows.Count -ne 1) {
+        return @{ ok = $false; error = 'Reserve inventory could not be checked exactly.' }
+    }
+    return @{
+        ok = $true
+        item_rows = [long](ConvertTo-DuneInt $rows[0]['item_rows'])
+        item_units = [long](ConvertTo-DuneInt $rows[0]['item_units'])
+    }
+}
+
+function Get-DuneReserveSnapshotSql {
+    param([long]$PawnId, [long]$ControllerId)
+    return @"
+WITH exact_player AS (
+    SELECT ps.*
+    FROM dune.player_state ps
+    WHERE ps.player_pawn_id = $PawnId::bigint
+      AND ps.player_controller_id = $ControllerId::bigint
+),
+reserve_rows AS (
+    SELECT inv.*, to_jsonb(ai) AS actor_inventory
+    FROM dune.inventories inv
+    JOIN dune.actor_inventories ai
+      ON ai.inventory_id = inv.id
+     AND ai.component_name_hash = $script:DuneReserveComponentHash::bigint
+    WHERE inv.actor_id = $PawnId::bigint
+      AND inv.inventory_type = $script:DuneReserveInventoryType
+),
+backpack_rows AS (
+    SELECT inv.*
+    FROM dune.inventories inv
+    WHERE inv.actor_id = $PawnId::bigint
+      AND inv.inventory_type = 0
+),
+reserve_items AS (
+    SELECT jsonb_build_object(
+        'row', to_jsonb(i),
+        'invariant_revision', md5((to_jsonb(i) - 'inventory_id' - 'position_index')::text)
+    ) AS item
+    FROM dune.items i
+    JOIN reserve_rows r ON r.id = i.inventory_id
+    ORDER BY i.id
+),
+backpack_items AS (
+    SELECT jsonb_build_object(
+        'row', to_jsonb(i),
+        'invariant_revision', md5((to_jsonb(i) - 'inventory_id' - 'position_index')::text)
+    ) AS item
+    FROM dune.items i
+    JOIN backpack_rows b ON b.id = i.inventory_id
+    ORDER BY i.id
+),
+snapshot AS (
+    SELECT jsonb_build_object(
+        'player', COALESCE((SELECT to_jsonb(p) FROM exact_player p), '{}'::jsonb),
+        'reserve', COALESCE((SELECT jsonb_agg(to_jsonb(r) ORDER BY r.id) FROM reserve_rows r), '[]'::jsonb),
+        'reserve_items', COALESCE((SELECT jsonb_agg(item) FROM reserve_items), '[]'::jsonb),
+        'backpack', COALESCE((SELECT jsonb_agg(to_jsonb(b) ORDER BY b.id) FROM backpack_rows b), '[]'::jsonb),
+        'backpack_items', COALESCE((SELECT jsonb_agg(item) FROM backpack_items), '[]'::jsonb)
+    ) AS value
+)
+SELECT (SELECT count(*) FROM exact_player)::text AS player_count,
+       COALESCE((SELECT online_status::text FROM exact_player), '') AS online_status,
+       (SELECT count(*) FROM reserve_rows)::text AS reserve_count,
+       (SELECT count(*) FROM backpack_rows)::text AS backpack_count,
+       COALESCE((SELECT to_jsonb(r)::text FROM reserve_rows r ORDER BY r.id LIMIT 1), '{}') AS reserve_inventory,
+       COALESCE((SELECT to_jsonb(b)::text FROM backpack_rows b ORDER BY b.id LIMIT 1), '{}') AS backpack_inventory,
+       COALESCE((SELECT jsonb_agg(item)::text FROM reserve_items), '[]') AS reserve_items,
+       COALESCE((SELECT jsonb_agg(item)::text FROM backpack_items), '[]') AS backpack_items,
+       md5((SELECT value::text FROM snapshot)) AS snapshot_revision;
+"@
+}
+
+function ConvertFrom-DuneReserveJson {
+    param([string]$Value, $Fallback)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $Fallback }
+    try { return ($Value | ConvertFrom-Json -ErrorAction Stop) } catch { throw "Reserve snapshot JSON was invalid: $($_.Exception.Message)" }
+}
+
+function Get-DuneReserveSnapshot {
+    param([string]$Ip, [long]$PawnId, [long]$ControllerId)
+    if ($PawnId -le 0 -or $ControllerId -le 0) {
+        return @{ ok = $false; error = 'Both pawn and controller identities are required.' }
+    }
+    try {
+        $scope = Get-DuneVehicleHostScope -Ip $Ip
+    } catch {
+        return @{ ok = $false; error = "Database scope could not be proven. $($_.Exception.Message)" }
+    }
+    $result = Invoke-DuneSqlQuery -Ip $Ip -Sql (Get-DuneReserveSnapshotSql -PawnId $PawnId -ControllerId $ControllerId) `
+        -ReadOnly $true -MaxRows 1 -TimeoutSec 30
+    if (-not $result.ok) { return @{ ok = $false; error = $result.error } }
+    $rows = @(ConvertTo-DuneRowMaps -Result $result)
+    if ($rows.Count -ne 1) { return @{ ok = $false; error = 'Reserve snapshot did not return exactly one result.' } }
+    $row = $rows[0]
+    try {
+        return @{
+            ok = $true
+            database_scope = [string]$scope.key
+            player_count = [int](ConvertTo-DuneInt $row['player_count'])
+            online_status = [string]$row['online_status']
+            reserve_count = [int](ConvertTo-DuneInt $row['reserve_count'])
+            backpack_count = [int](ConvertTo-DuneInt $row['backpack_count'])
+            reserve_inventory = ConvertFrom-DuneReserveJson -Value ([string]$row['reserve_inventory']) -Fallback ([pscustomobject]@{})
+            backpack_inventory = ConvertFrom-DuneReserveJson -Value ([string]$row['backpack_inventory']) -Fallback ([pscustomobject]@{})
+            reserve_items = @(ConvertFrom-DuneReserveJson -Value ([string]$row['reserve_items']) -Fallback @())
+            backpack_items = @(ConvertFrom-DuneReserveJson -Value ([string]$row['backpack_items']) -Fallback @())
+            snapshot_revision = [string]$row['snapshot_revision']
+        }
+    } catch {
+        return @{ ok = $false; error = $_.Exception.Message }
+    }
+}
+
+function Get-DuneReserveBoundRevision {
+    param([string]$DatabaseScope, [string]$SnapshotRevision)
+    $bytes = [Text.Encoding]::UTF8.GetBytes("$DatabaseScope|$SnapshotRevision")
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try { return ([BitConverter]::ToString($sha.ComputeHash($bytes))).Replace('-', '').ToLowerInvariant() } finally { $sha.Dispose() }
+}
+
+function Resolve-DuneReserveUnitVolume {
+    param([Parameter(Mandatory)]$Item)
+    $row = $Item.row
+    $override = 0.0
+    if ($null -ne $row.volume_override -and [double]::TryParse(
+        [string]$row.volume_override,
+        [Globalization.NumberStyles]::Float,
+        [Globalization.CultureInfo]::InvariantCulture,
+        [ref]$override
+    ) -and $override -gt 0) {
+        return @{ ok = $true; volume = $override; source = 'override' }
+    }
+    $rule = Get-DuneGameplayItemRule -TemplateId ([string]$row.template_id)
+    if ($rule -and $rule.ContainsKey('volume') -and $null -ne $rule.volume) {
+        $volume = [double]$rule.volume
+        if ([double]::IsNaN($volume) -or [double]::IsInfinity($volume) -or $volume -lt 0) {
+            return @{ ok = $false; error = "Item $($row.id) has an invalid catalog volume." }
+        }
+        return @{ ok = $true; volume = $volume; source = 'catalog' }
+    }
+    return @{ ok = $false; error = "Item $($row.id) ($($row.template_id)) has no proven volume." }
+}
+
+function ConvertTo-DuneReservePreview {
+    param([Parameter(Mandatory)]$Snapshot, [long]$PawnId, [long]$ControllerId)
+    $preview = [ordered]@{
+        ok = $true
+        source = 'live'
+        available = $false
+        blocked_reason = $null
+        pawn_id = $PawnId
+        controller_id = $ControllerId
+        online_status = [string]$Snapshot.online_status
+        reserve_inventory_id = 0L
+        backpack_inventory_id = 0L
+        item_rows = 0
+        item_units = 0L
+        required_volume = 0.0
+        used_volume = 0.0
+        max_slots = 0
+        used_slots = 0
+        max_volume = 0.0
+        revision = ''
+        items = @()
+        rollback = $null
+        database_scope = [string]$Snapshot.database_scope
+        snapshot_revision = [string]$Snapshot.snapshot_revision
+    }
+    if ($Snapshot.player_count -ne 1) { $preview.blocked_reason = 'The exact pawn/controller pair no longer identifies one player.'; return $preview }
+    if ([string]$Snapshot.online_status -cne 'Offline') { $preview.blocked_reason = 'The player must be Offline before Reserve recovery.'; return $preview }
+    if ($Snapshot.reserve_count -ne 1) { $preview.blocked_reason = 'DST requires exactly one Reserve inventory with the proven type and component identity.'; return $preview }
+    if ($Snapshot.backpack_count -ne 1) { $preview.blocked_reason = 'DST requires exactly one pawn-owned Backpack inventory.'; return $preview }
+    if ([string]$Snapshot.snapshot_revision -notmatch '^[a-f0-9]{32}$') { $preview.blocked_reason = 'The database snapshot revision could not be proven.'; return $preview }
+
+    $reserveId = [long]$Snapshot.reserve_inventory.id
+    $backpackId = [long]$Snapshot.backpack_inventory.id
+    $maxSlots = [int]$Snapshot.backpack_inventory.max_item_count
+    $maxVolume = [double]$Snapshot.backpack_inventory.max_item_volume
+    $preview.reserve_inventory_id = $reserveId
+    $preview.backpack_inventory_id = $backpackId
+    $preview.max_slots = $maxSlots
+    $preview.max_volume = $maxVolume
+    if ($reserveId -le 0 -or $backpackId -le 0 -or $reserveId -eq $backpackId) {
+        $preview.blocked_reason = 'Reserve and Backpack identities could not be proven.'; return $preview
+    }
+    $reserveItems = @($Snapshot.reserve_items)
+    $backpackItems = @($Snapshot.backpack_items)
+    $preview.item_rows = $reserveItems.Count
+    foreach ($item in $reserveItems) { $preview.item_units += [long]$item.row.stack_size }
+    $preview.used_slots = $backpackItems.Count
+    $preview.revision = Get-DuneReserveBoundRevision -DatabaseScope $Snapshot.database_scope -SnapshotRevision $Snapshot.snapshot_revision
+    try {
+        $active = Get-DuneReserveActiveRollback -PawnId $PawnId -DatabaseScope $Snapshot.database_scope
+        if ($active) {
+            $preview.rollback = @{
+                recovery_id = [string]$active.recovery_id
+                item_rows = @($active.items).Count
+                created_at = [string]$active.created_at
+            }
+        }
+    } catch {
+        $preview.blocked_reason = $_.Exception.Message; return $preview
+    }
+    if ($reserveItems.Count -eq 0) {
+        $preview.blocked_reason = if ($preview.rollback) { 'Reserve is empty. The last guarded recovery can still be rolled back.' } else { 'Reserve is empty.' }
+        return $preview
+    }
+    if ($preview.rollback) {
+        $preview.blocked_reason = 'A prior Reserve recovery still has an active rollback record.'; return $preview
+    }
+    if ($maxSlots -le 0 -or $maxVolume -le 0) {
+        $preview.blocked_reason = 'Backpack slot and volume capacities must both be present and positive.'; return $preview
+    }
+
+    $occupied = [Collections.Generic.HashSet[int]]::new()
+    $usedVolume = 0.0
+    foreach ($item in $backpackItems) {
+        $position = [int]$item.row.position_index
+        if ($position -lt 0 -or $position -ge $maxSlots -or -not $occupied.Add($position)) {
+            $preview.blocked_reason = 'Backpack positions are invalid or duplicated.'; return $preview
+        }
+        $volume = Resolve-DuneReserveUnitVolume -Item $item
+        if (-not $volume.ok) { $preview.blocked_reason = $volume.error; return $preview }
+        $usedVolume += [double]$volume.volume * [long]$item.row.stack_size
+    }
+    $free = [Collections.Generic.List[int]]::new()
+    for ($position = 0; $position -lt $maxSlots -and $free.Count -lt $reserveItems.Count; $position++) {
+        if (-not $occupied.Contains($position)) { [void]$free.Add($position) }
+    }
+    if ($free.Count -ne $reserveItems.Count) {
+        $preview.blocked_reason = "Backpack needs $($reserveItems.Count) free slots but only $($maxSlots - $occupied.Count) are available."; return $preview
+    }
+    $movingVolume = 0.0
+    $planned = @()
+    $sourcePositions = [Collections.Generic.HashSet[int]]::new()
+    for ($index = 0; $index -lt $reserveItems.Count; $index++) {
+        $item = $reserveItems[$index]
+        $sourcePosition = [int]$item.row.position_index
+        if ($sourcePosition -lt 0 -or -not $sourcePositions.Add($sourcePosition)) {
+            $preview.blocked_reason = "Reserve item $($item.row.id) has an invalid or duplicated source position."; return $preview
+        }
+        $volume = Resolve-DuneReserveUnitVolume -Item $item
+        if (-not $volume.ok) { $preview.blocked_reason = $volume.error; return $preview }
+        $totalVolume = [double]$volume.volume * [long]$item.row.stack_size
+        $movingVolume += $totalVolume
+        $planned += [ordered]@{
+            item_id = [long]$item.row.id
+            template_id = [string]$item.row.template_id
+            name = Get-DuneGameplayItemName -TemplateId ([string]$item.row.template_id)
+            stack_size = [long]$item.row.stack_size
+            quality = [long]$item.row.quality_level
+            source_position = $sourcePosition
+            destination_position = [int]$free[$index]
+            unit_volume = [double]$volume.volume
+            total_volume = $totalVolume
+            invariant_revision = [string]$item.invariant_revision
+            before_image = $item.row
+        }
+    }
+    $preview.used_volume = $usedVolume
+    $preview.required_volume = $movingVolume
+    $preview.items = $planned
+    if (($usedVolume + $movingVolume) -gt ($maxVolume + 0.000001)) {
+        $preview.blocked_reason = "Backpack volume is insufficient: $([Math]::Round($usedVolume + $movingVolume, 3)) required of $maxVolume."; return $preview
+    }
+    $preview.available = $true
+    return $preview
+}
+
+function Get-DuneReserveRecoveryPreview {
+    param([string]$Ip, [long]$PawnId, [long]$ControllerId)
+    $snapshot = Get-DuneReserveSnapshot -Ip $Ip -PawnId $PawnId -ControllerId $ControllerId
+    if (-not $snapshot.ok) { return $snapshot }
+    return ConvertTo-DuneReservePreview -Snapshot $snapshot -PawnId $PawnId -ControllerId $ControllerId
+}
+
+function ConvertTo-DuneReservePublicPreview {
+    param([Parameter(Mandatory)]$Preview)
+    return [ordered]@{
+        source = 'live'
+        available = [bool]$Preview.available
+        blocked_reason = [string]$Preview.blocked_reason
+        pawn_id = [long]$Preview.pawn_id
+        controller_id = [long]$Preview.controller_id
+        online_status = [string]$Preview.online_status
+        reserve_inventory_id = [long]$Preview.reserve_inventory_id
+        backpack_inventory_id = [long]$Preview.backpack_inventory_id
+        item_rows = [int]$Preview.item_rows
+        item_units = [long]$Preview.item_units
+        required_volume = [double]$Preview.required_volume
+        used_volume = [double]$Preview.used_volume
+        max_slots = [int]$Preview.max_slots
+        used_slots = [int]$Preview.used_slots
+        max_volume = [double]$Preview.max_volume
+        revision = [string]$Preview.revision
+        rollback = $Preview.rollback
+        items = @($Preview.items | ForEach-Object {
+            [ordered]@{
+                item_id = [long]$_.item_id
+                template_id = [string]$_.template_id
+                name = [string]$_.name
+                stack_size = [long]$_.stack_size
+                quality = [long]$_.quality
+                source_position = [int]$_.source_position
+                destination_position = [int]$_.destination_position
+                unit_volume = [double]$_.unit_volume
+                total_volume = [double]$_.total_volume
+            }
+        })
+    }
+}
+
+function Get-DuneReserveMoveSql {
+    param([Parameter(Mandatory)]$Preview)
+    $snapshotSql = (Get-DuneReserveSnapshotSql -PawnId ([long]$Preview.pawn_id) -ControllerId ([long]$Preview.controller_id)).Trim().TrimEnd(';')
+    $values = @($Preview.items | ForEach-Object {
+        "($([long]$_.item_id)::bigint,$([int]$_.source_position)::integer,$([int]$_.destination_position)::integer,'$([string]$_.invariant_revision)'::text)"
+    }) -join ",`n        "
+    return @"
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+DO `$dst`$
+DECLARE
+    actual_revision text;
+    moved_count integer;
+BEGIN
+    PERFORM 1 FROM dune.encrypted_player_state
+     WHERE player_pawn_id = $([long]$Preview.pawn_id)::bigint FOR UPDATE;
+    IF NOT EXISTS (
+        SELECT 1 FROM dune.player_state
+        WHERE player_pawn_id = $([long]$Preview.pawn_id)::bigint
+          AND player_controller_id = $([long]$Preview.controller_id)::bigint
+          AND online_status::text = 'Offline'
+    ) THEN RAISE EXCEPTION 'player identity or Offline state changed'; END IF;
+
+    PERFORM 1 FROM dune.inventories
+     WHERE id IN ($([long]$Preview.reserve_inventory_id)::bigint, $([long]$Preview.backpack_inventory_id)::bigint)
+     ORDER BY id FOR UPDATE;
+    PERFORM 1 FROM dune.actor_inventories
+     WHERE inventory_id = $([long]$Preview.reserve_inventory_id)::bigint
+       AND component_name_hash = $script:DuneReserveComponentHash::bigint
+     FOR UPDATE;
+    PERFORM 1 FROM dune.items
+     WHERE inventory_id IN ($([long]$Preview.reserve_inventory_id)::bigint, $([long]$Preview.backpack_inventory_id)::bigint)
+     ORDER BY id FOR UPDATE;
+
+    SELECT snapshot_revision INTO actual_revision
+    FROM ($snapshotSql) current_snapshot;
+    IF actual_revision IS DISTINCT FROM '$([string]$Preview.snapshot_revision)' THEN
+        RAISE EXCEPTION 'Reserve or Backpack changed after preview';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM dune.inventories inv
+        JOIN dune.actor_inventories ai
+          ON ai.inventory_id = inv.id
+         AND ai.component_name_hash = $script:DuneReserveComponentHash::bigint
+        WHERE inv.id = $([long]$Preview.reserve_inventory_id)::bigint
+          AND inv.actor_id = $([long]$Preview.pawn_id)::bigint
+          AND inv.inventory_type = $script:DuneReserveInventoryType
+    ) OR NOT EXISTS (
+        SELECT 1 FROM dune.inventories inv
+        WHERE inv.id = $([long]$Preview.backpack_inventory_id)::bigint
+          AND inv.actor_id = $([long]$Preview.pawn_id)::bigint
+          AND inv.inventory_type = 0
+    ) THEN RAISE EXCEPTION 'Reserve or Backpack identity changed'; END IF;
+
+    WITH plan(item_id, source_position, destination_position, invariant_revision) AS (
+        VALUES $values
+    )
+    UPDATE dune.items i
+       SET inventory_id = $([long]$Preview.backpack_inventory_id)::bigint,
+           position_index = plan.destination_position
+      FROM plan
+     WHERE i.id = plan.item_id
+       AND i.inventory_id = $([long]$Preview.reserve_inventory_id)::bigint
+       AND i.position_index = plan.source_position
+       AND md5((to_jsonb(i) - 'inventory_id' - 'position_index')::text) = plan.invariant_revision;
+    GET DIAGNOSTICS moved_count = ROW_COUNT;
+    IF moved_count <> $(@($Preview.items).Count) THEN RAISE EXCEPTION 'exact Reserve rows changed before move'; END IF;
+    IF EXISTS (SELECT 1 FROM dune.items WHERE inventory_id = $([long]$Preview.reserve_inventory_id)::bigint) THEN
+        RAISE EXCEPTION 'Reserve did not become empty';
+    END IF;
+    IF EXISTS (
+        WITH plan(item_id, source_position, destination_position, invariant_revision) AS (VALUES $values)
+        SELECT 1 FROM plan
+        LEFT JOIN dune.items i
+          ON i.id = plan.item_id
+         AND i.inventory_id = $([long]$Preview.backpack_inventory_id)::bigint
+         AND i.position_index = plan.destination_position
+         AND md5((to_jsonb(i) - 'inventory_id' - 'position_index')::text) = plan.invariant_revision
+        WHERE i.id IS NULL
+    ) THEN RAISE EXCEPTION 'Reserve move readback failed'; END IF;
+END
+`$dst`$;
+COMMIT;
+"@
+}
+
+function Test-DuneReserveMovedReadback {
+    param([string]$Ip, [Parameter(Mandatory)]$Entry)
+    $ids = @($Entry.items | ForEach-Object { [long]$_.item_id }) -join ','
+    $sql = @"
+SELECT i.id::text AS item_id, i.inventory_id::text AS inventory_id,
+       i.position_index::text AS position_index,
+       md5((to_jsonb(i) - 'inventory_id' - 'position_index')::text) AS invariant_revision
+FROM dune.items i
+WHERE i.id IN ($ids)
+ORDER BY i.id;
+"@
+    $result = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows @($Entry.items).Count -TimeoutSec 20
+    if (-not $result.ok) { return @{ ok = $false; error = $result.error } }
+    $actual = @(ConvertTo-DuneRowMaps -Result $result)
+    if ($actual.Count -ne @($Entry.items).Count) { return @{ ok = $false; error = 'Moved item count did not read back exactly.' } }
+    foreach ($expected in @($Entry.items)) {
+        $row = @($actual | Where-Object { [long]$_['item_id'] -eq [long]$expected.item_id })
+        if ($row.Count -ne 1 -or [long]$row[0]['inventory_id'] -ne [long]$Entry.backpack_inventory_id -or
+            [int]$row[0]['position_index'] -ne [int]$expected.destination_position -or
+            [string]$row[0]['invariant_revision'] -cne [string]$expected.invariant_revision) {
+            return @{ ok = $false; error = "Moved item $($expected.item_id) did not read back exactly." }
+        }
+    }
+    $reserve = Test-DunePlayerReserveItems -Ip $Ip -PawnId ([long]$Entry.pawn_id)
+    if (-not $reserve.ok -or $reserve.item_rows -ne 0) {
+        return @{ ok = $false; error = 'Reserve did not read back empty.' }
+    }
+    return @{ ok = $true }
+}
+
+function Invoke-DuneReserveRecovery {
+    param([string]$Ip, [long]$PawnId, [long]$ControllerId, [string]$Revision)
+    if ($Revision -notmatch '^[a-f0-9]{64}$') { return @{ ok = $false; error = 'A current Reserve preview revision is required.' } }
+    $preview = Get-DuneReserveRecoveryPreview -Ip $Ip -PawnId $PawnId -ControllerId $ControllerId
+    if (-not $preview.ok) { return $preview }
+    if (-not $preview.available) { return @{ ok = $false; error = [string]$preview.blocked_reason } }
+    if ($preview.revision -cne $Revision) { return @{ ok = $false; error = 'Reserve or Backpack changed. Refresh the preview before recovering.' } }
+
+    $backup = Invoke-DuneVerifiedSafetyBackup -Ip $Ip -StemPrefix 'dst-reserve-recovery' -ProofLabel 'DST_RESERVE_BACKUP'
+    if (-not $backup.ok) { return @{ ok = $false; error = "Reserve recovery stopped because $($backup.error)" } }
+    if ($backup.database_scope -cne $preview.database_scope) {
+        return @{ ok = $false; error = 'The database scope changed before backup. Nothing was moved.' }
+    }
+    $state = Read-DuneReserveRecoveryState
+    $entry = [ordered]@{
+        recovery_id = [guid]::NewGuid().ToString('N')
+        pawn_id = $PawnId
+        controller_id = $ControllerId
+        database_scope = $preview.database_scope
+        preview_revision = $preview.revision
+        snapshot_revision = $preview.snapshot_revision
+        reserve_inventory_id = $preview.reserve_inventory_id
+        backpack_inventory_id = $preview.backpack_inventory_id
+        backup_path = $backup.path
+        backup_bytes = $backup.bytes
+        items = @($preview.items)
+        status = 'prepared'
+        created_at = [datetime]::UtcNow.ToString('o')
+        updated_at = [datetime]::UtcNow.ToString('o')
+        message = 'Before-image persisted; no move has been confirmed.'
+    }
+    $state.entries = @(@($state.entries) + $entry)
+    Save-DuneReserveRecoveryState -State $state
+
+    $write = Invoke-DuneSqlQuery -Ip $Ip -Sql (Get-DuneReserveMoveSql -Preview $preview) -ReadOnly $false -MaxRows 1 -TimeoutSec 45 -Bulk
+    if (-not $write.ok) {
+        Set-DuneReserveStateValue -Entry $entry -Name status -Value 'failed'
+        Set-DuneReserveStateValue -Entry $entry -Name updated_at -Value ([datetime]::UtcNow.ToString('o'))
+        Set-DuneReserveStateValue -Entry $entry -Name message -Value $write.error
+        Save-DuneReserveRecoveryState -State $state
+        return @{ ok = $false; error = "Reserve recovery transaction rolled back. $($write.error)" }
+    }
+    Set-DuneReserveStateValue -Entry $entry -Name status -Value 'moved'
+    Set-DuneReserveStateValue -Entry $entry -Name updated_at -Value ([datetime]::UtcNow.ToString('o'))
+    Set-DuneReserveStateValue -Entry $entry -Name message -Value 'Reserve rows moved intact to Backpack; rollback remains available.'
+    Save-DuneReserveRecoveryState -State $state
+
+    $readback = Test-DuneReserveMovedReadback -Ip $Ip -Entry $entry
+    if (-not $readback.ok) {
+        Set-DuneReserveStateValue -Entry $entry -Name status -Value 'readback_failed'
+        Set-DuneReserveStateValue -Entry $entry -Name message -Value $readback.error
+        Save-DuneReserveRecoveryState -State $state
+        return @{
+            ok = $false
+            error = "The transaction committed but the independent readback failed. Exact rollback $($entry.recovery_id) is available. $($readback.error)"
+        }
+    }
+    return @{
+        ok = $true
+        message = "Recovered $(@($entry.items).Count) Reserve item row(s) into Backpack. Exact rollback remains available."
+        recovery_id = $entry.recovery_id
+        item_rows = @($entry.items).Count
+    }
+}
+
+function Get-DuneReserveRollbackSql {
+    param([Parameter(Mandatory)]$Entry)
+    $values = @($Entry.items | ForEach-Object {
+        "($([long]$_.item_id)::bigint,$([int]$_.source_position)::integer,$([int]$_.destination_position)::integer,'$([string]$_.invariant_revision)'::text)"
+    }) -join ",`n        "
+    return @"
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+DO `$dst`$
+DECLARE restored_count integer;
+BEGIN
+    PERFORM 1 FROM dune.encrypted_player_state
+     WHERE player_pawn_id = $([long]$Entry.pawn_id)::bigint FOR UPDATE;
+    IF NOT EXISTS (
+        SELECT 1 FROM dune.player_state
+        WHERE player_pawn_id = $([long]$Entry.pawn_id)::bigint
+          AND player_controller_id = $([long]$Entry.controller_id)::bigint
+          AND online_status::text = 'Offline'
+    ) THEN RAISE EXCEPTION 'player identity or Offline state changed'; END IF;
+    PERFORM 1 FROM dune.inventories
+     WHERE id IN ($([long]$Entry.reserve_inventory_id)::bigint, $([long]$Entry.backpack_inventory_id)::bigint)
+     ORDER BY id FOR UPDATE;
+    PERFORM 1 FROM dune.actor_inventories
+     WHERE inventory_id = $([long]$Entry.reserve_inventory_id)::bigint
+       AND component_name_hash = $script:DuneReserveComponentHash::bigint
+     FOR UPDATE;
+    PERFORM 1 FROM dune.items
+     WHERE inventory_id IN ($([long]$Entry.reserve_inventory_id)::bigint, $([long]$Entry.backpack_inventory_id)::bigint)
+     ORDER BY id FOR UPDATE;
+    IF NOT EXISTS (
+        SELECT 1 FROM dune.inventories inv
+        JOIN dune.actor_inventories ai
+          ON ai.inventory_id = inv.id
+         AND ai.component_name_hash = $script:DuneReserveComponentHash::bigint
+        WHERE inv.id = $([long]$Entry.reserve_inventory_id)::bigint
+          AND inv.actor_id = $([long]$Entry.pawn_id)::bigint
+          AND inv.inventory_type = $script:DuneReserveInventoryType
+    ) OR NOT EXISTS (
+        SELECT 1 FROM dune.inventories inv
+        WHERE inv.id = $([long]$Entry.backpack_inventory_id)::bigint
+          AND inv.actor_id = $([long]$Entry.pawn_id)::bigint
+          AND inv.inventory_type = 0
+    ) THEN RAISE EXCEPTION 'Reserve or Backpack identity changed'; END IF;
+    IF EXISTS (SELECT 1 FROM dune.items WHERE inventory_id = $([long]$Entry.reserve_inventory_id)::bigint) THEN
+        RAISE EXCEPTION 'Reserve changed after recovery';
+    END IF;
+    IF EXISTS (
+        WITH plan(item_id, source_position, destination_position, invariant_revision) AS (VALUES $values)
+        SELECT 1 FROM plan
+        LEFT JOIN dune.items i
+          ON i.id = plan.item_id
+         AND i.inventory_id = $([long]$Entry.backpack_inventory_id)::bigint
+         AND i.position_index = plan.destination_position
+         AND md5((to_jsonb(i) - 'inventory_id' - 'position_index')::text) = plan.invariant_revision
+        WHERE i.id IS NULL
+    ) THEN RAISE EXCEPTION 'recovered rows changed after recovery'; END IF;
+
+    WITH plan(item_id, source_position, destination_position, invariant_revision) AS (VALUES $values)
+    UPDATE dune.items i
+       SET inventory_id = $([long]$Entry.reserve_inventory_id)::bigint,
+           position_index = plan.source_position
+      FROM plan
+     WHERE i.id = plan.item_id
+       AND i.inventory_id = $([long]$Entry.backpack_inventory_id)::bigint
+       AND i.position_index = plan.destination_position
+       AND md5((to_jsonb(i) - 'inventory_id' - 'position_index')::text) = plan.invariant_revision;
+    GET DIAGNOSTICS restored_count = ROW_COUNT;
+    IF restored_count <> $(@($Entry.items).Count) THEN RAISE EXCEPTION 'exact recovered rows changed before rollback'; END IF;
+    IF EXISTS (
+        WITH plan(item_id, source_position, destination_position, invariant_revision) AS (VALUES $values)
+        SELECT 1 FROM plan
+        LEFT JOIN dune.items i
+          ON i.id = plan.item_id
+         AND i.inventory_id = $([long]$Entry.reserve_inventory_id)::bigint
+         AND i.position_index = plan.source_position
+         AND md5((to_jsonb(i) - 'inventory_id' - 'position_index')::text) = plan.invariant_revision
+        WHERE i.id IS NULL
+    ) THEN RAISE EXCEPTION 'Reserve rollback readback failed'; END IF;
+END
+`$dst`$;
+COMMIT;
+"@
+}
+
+function Invoke-DuneReserveRecoveryRollback {
+    param([string]$Ip, [long]$PawnId, [long]$ControllerId, [string]$RecoveryId)
+    if ($PawnId -le 0 -or $ControllerId -le 0 -or $RecoveryId -notmatch '^[a-f0-9]{32}$') {
+        return @{ ok = $false; error = 'A player identity and recovery_id are required.' }
+    }
+    try { $scope = Get-DuneVehicleHostScope -Ip $Ip } catch { return @{ ok = $false; error = $_.Exception.Message } }
+    $state = Read-DuneReserveRecoveryState
+    $matches = @($state.entries | Where-Object {
+        [string]$_.recovery_id -ceq $RecoveryId -and [long]$_.pawn_id -eq $PawnId -and
+        [long]$_.controller_id -eq $ControllerId -and [string]$_.database_scope -ceq [string]$scope.key -and
+        [string]$_.status -in @('moved', 'readback_failed')
+    })
+    if ($matches.Count -ne 1) { return @{ ok = $false; error = 'No exact active rollback record matches this player and database.' } }
+    $entry = $matches[0]
+    $backup = Invoke-DuneVerifiedSafetyBackup -Ip $Ip -StemPrefix 'dst-reserve-rollback' -ProofLabel 'DST_RESERVE_BACKUP'
+    if (-not $backup.ok) { return @{ ok = $false; error = "Rollback stopped because $($backup.error)" } }
+    if ($backup.database_scope -cne [string]$entry.database_scope) {
+        return @{ ok = $false; error = 'The database scope changed before rollback. Nothing was moved.' }
+    }
+    $write = Invoke-DuneSqlQuery -Ip $Ip -Sql (Get-DuneReserveRollbackSql -Entry $entry) -ReadOnly $false -MaxRows 1 -TimeoutSec 45 -Bulk
+    if (-not $write.ok) { return @{ ok = $false; error = "Reserve rollback transaction made no changes. $($write.error)" } }
+    Set-DuneReserveStateValue -Entry $entry -Name status -Value 'rolled_back'
+    Set-DuneReserveStateValue -Entry $entry -Name updated_at -Value ([datetime]::UtcNow.ToString('o'))
+    Set-DuneReserveStateValue -Entry $entry -Name rollback_backup_path -Value $backup.path
+    Set-DuneReserveStateValue -Entry $entry -Name message -Value 'Exact original Reserve positions were restored and verified inside the transaction.'
+    $state.entries = @($state.entries | Where-Object { [string]$_.recovery_id -cne $RecoveryId })
+    $state.history = @($entry) + @($state.history) | Select-Object -First 50
+    Save-DuneReserveRecoveryState -State $state
+    return @{ ok = $true; message = "Rolled back Reserve recovery $RecoveryId and restored $(@($entry.items).Count) item row(s)." }
+}

--- a/app/server/lib/VehicleDeletion.ps1
+++ b/app/server/lib/VehicleDeletion.ps1
@@ -215,10 +215,14 @@ function Test-DuneVehicleWindowStopped {
     return @{ ok = $true }
 }
 
-function Invoke-DuneVehicleSafetyBackup {
-    param([string]$Ip)
+function Invoke-DuneVerifiedSafetyBackup {
+    param(
+        [string]$Ip,
+        [ValidatePattern('^[a-z0-9-]+$')][string]$StemPrefix,
+        [ValidatePattern('^[A-Z0-9_]+$')][string]$ProofLabel
+    )
     $scope = Get-DuneVehicleHostScope -Ip $Ip
-    $stem = 'dst-vehicle-delete-' + [guid]::NewGuid().ToString('N')
+    $stem = $StemPrefix + '-' + [guid]::NewGuid().ToString('N')
     $script = @'
 set -euo pipefail
 /home/dune/.dune/bin/battlegroup backup '__STEM__'
@@ -226,14 +230,25 @@ mapfile -t files < <(find '/funcom/artifacts/database-dumps/__WORLD__' -maxdepth
 [ "${#files[@]}" -eq 1 ]
 bytes=$(stat -c %s -- "${files[0]}")
 [ "$bytes" -gt 1024 ]
-printf '\nDST_VEHICLE_BACKUP=%s|%s\n' "${files[0]}" "$bytes"
-'@.Replace('__STEM__', $stem).Replace('__WORLD__', $scope.world)
+printf '\n__PROOF__=%s|%s\n' "${files[0]}" "$bytes"
+'@.Replace('__STEM__', $stem).Replace('__WORLD__', $scope.world).Replace('__PROOF__', $ProofLabel)
     $backup = Invoke-DuneBackupShell -Ip $Ip -Script $script -TimeoutSec 900
-    $proof = if ($backup) { [regex]::Matches([string]$backup.out, '(?m)^DST_VEHICLE_BACKUP=([^\r\n|]+)\|([0-9]+)\r?$') } else { @() }
+    $proof = if ($backup) {
+        [regex]::Matches([string]$backup.out, "(?m)^$([regex]::Escape($ProofLabel))=([^\r\n|]+)\|([0-9]+)\r?$")
+    } else { @() }
     if ($null -eq $backup -or $backup.rc -ne 0 -or $proof.Count -ne 1 -or [long]$proof[0].Groups[2].Value -le 1024) {
-        return @{ ok = $false; error = 'The fresh safety backup was not verified on disk. No vehicles were deleted.' }
+        return @{ ok = $false; error = 'the fresh safety backup was not verified on disk. No database write was attempted.' }
     }
     return @{ ok = $true; path = $proof[0].Groups[1].Value; bytes = [long]$proof[0].Groups[2].Value; database_scope = $scope.key }
+}
+
+function Invoke-DuneVehicleSafetyBackup {
+    param([string]$Ip)
+    $result = Invoke-DuneVerifiedSafetyBackup -Ip $Ip -StemPrefix 'dst-vehicle-delete' -ProofLabel 'DST_VEHICLE_BACKUP'
+    if (-not $result.ok) {
+        $result.error = 'The fresh safety backup was not verified on disk. No vehicles were deleted.'
+    }
+    return $result
 }
 
 function Invoke-DuneVehicleDeleteTransaction {

--- a/app/server/routes/GameplayPlayers.ps1
+++ b/app/server/routes/GameplayPlayers.ps1
@@ -98,6 +98,74 @@ function Invoke-DunePlayerWriteRoute {
     Write-DuneJson -Response $Response -Body @{ ok = $true; message = $result.message; result = $result }
 }
 
+# GET /api/gameplay/players/reserve-recovery?pawn=<id>&controller=<id>
+Register-DuneRoute -Method GET -Path '/api/gameplay/players/reserve-recovery' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn = 0L; $controller = 0L
+        [void][Int64]::TryParse((Get-DuneQ $req 'pawn'), [ref]$pawn)
+        [void][Int64]::TryParse((Get-DuneQ $req 'controller'), [ref]$controller)
+        if ($pawn -le 0 -or $controller -le 0) {
+            Write-DuneError -Response $res -Status 400 -Message 'pawn and controller ids are required.'
+            return
+        }
+        $ctx = Get-DuneDbContext
+        if (-not $ctx.ok) { Write-DuneError -Response $res -Status 503 -Message $ctx.message; return }
+        $preview = Get-DuneReserveRecoveryPreview -Ip $ctx.ip -PawnId $pawn -ControllerId $controller
+        if (-not $preview.ok) { Write-DuneError -Response $res -Status 503 -Message $preview.error; return }
+        Write-DuneJson -Response $res -Body (ConvertTo-DuneReservePublicPreview -Preview $preview)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Reserve recovery preview failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/reserve-recovery  { pawn_id, controller_id, revision }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/reserve-recovery' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        $controller = Get-DuneBodyInt -Body $body -Name 'controller_id'
+        $revision = [string](Get-DuneBodyValue -Body $body -Name 'revision')
+        if ($null -eq $pawn -or $pawn -le 0 -or $null -eq $controller -or $controller -le 0) {
+            Write-DuneError -Response $res -Status 400 -Message 'pawn_id and controller_id are required.'
+            return
+        }
+        if ($revision -notmatch '^[a-f0-9]{64}$') {
+            Write-DuneError -Response $res -Status 400 -Message 'A current Reserve preview revision is required.'
+            return
+        }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip)
+            Invoke-DuneReserveRecovery -Ip $ip -PawnId $pawn -ControllerId $controller -Revision $revision
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Reserve recovery failed: $($_.Exception.Message)"
+    }
+}
+
+# POST /api/gameplay/players/reserve-recovery/rollback
+# { pawn_id, controller_id, recovery_id }
+Register-DuneRoute -Method POST -Path '/api/gameplay/players/reserve-recovery/rollback' -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        $pawn = Get-DuneBodyInt -Body $body -Name 'pawn_id'
+        $controller = Get-DuneBodyInt -Body $body -Name 'controller_id'
+        $recoveryId = [string](Get-DuneBodyValue -Body $body -Name 'recovery_id')
+        if ($null -eq $pawn -or $pawn -le 0 -or $null -eq $controller -or $controller -le 0) {
+            Write-DuneError -Response $res -Status 400 -Message 'pawn_id and controller_id are required.'
+            return
+        }
+        if ($recoveryId -notmatch '^[a-f0-9]{32}$') {
+            Write-DuneError -Response $res -Status 400 -Message 'recovery_id is required.'
+            return
+        }
+        Invoke-DunePlayerWriteRoute -Response $res -Action { param($ip)
+            Invoke-DuneReserveRecoveryRollback -Ip $ip -PawnId $pawn -ControllerId $controller -RecoveryId $recoveryId
+        }
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message "Reserve recovery rollback failed: $($_.Exception.Message)"
+    }
+}
+
 # POST /api/gameplay/players/give-solari  { controller_id, amount }
 Register-DuneRoute -Method POST -Path '/api/gameplay/players/give-solari' -Handler {
     param($req, $res, $routeParams, $body)

--- a/tests/PlatformContracts.Tests.ps1
+++ b/tests/PlatformContracts.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'Complete route classification' {
     It 'classifies the exact registered HTTP and WebSocket inventory' {
         $records = @(Get-PlatformRouteRecords)
         $manifest = Get-DuneRoutePolicyManifest
-        $records.Count | Should -Be 368
+        $records.Count | Should -Be 371
         $sources = @($records.SourceFile | Sort-Object -Unique)
         @($manifest.groups.source | Sort-Object) | Should -Be $sources
 
@@ -321,7 +321,7 @@ $result = @{
         $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
         $resultLine = @($output | Where-Object { [string]$_ -like 'ROUTE_RESULT:*' })[-1]
         $result = ([string]$resultLine).Substring('ROUTE_RESULT:'.Length) | ConvertFrom-Json
-        $result.total | Should -Be 368
+        $result.total | Should -Be 371
         $result.unclassified | Should -Be 0
         $result.incompatible | Should -Be 0
         $result.podsCleanup | Should -Be 1

--- a/tests/PlayersRmq.Tests.ps1
+++ b/tests/PlayersRmq.Tests.ps1
@@ -11,6 +11,7 @@ Describe 'Resolve-DuneStackMax' -Tag 'Pure' {
         function global:Invoke-DuneSqlQuery {
             return @{ ok = $true; rows = @(@{ s = '0' }) }
         }
+
     }
 
     AfterEach {
@@ -56,6 +57,56 @@ Describe 'Resolve-DuneStackMax' -Tag 'Pure' {
         $r.ok         | Should -BeTrue
         $r.new_stacks | Should -Be 1
         $r.free_slots | Should -Be 111
+    }
+}
+
+Describe 'Clean Inventory Reserve safety' -Tag 'Pure' {
+    BeforeEach {
+        function global:Resolve-DuneFlsIdOrError { @{ ok = $true; fls_id = 'fixture-user' } }
+        $script:reserveChecks = 0
+        $script:rmqCleanCalls = 0
+        function global:Test-DunePlayerReserveItems {
+            $script:reserveChecks++
+            @{ ok = $true; item_rows = 0; item_units = 0 }
+        }
+        function global:Invoke-DuneRmqCleanPlayerInventory {
+            $script:rmqCleanCalls++
+            @{ ok = $true }
+        }
+    }
+    AfterEach {
+        Remove-Item function:global:Resolve-DuneFlsIdOrError -ErrorAction SilentlyContinue
+        Remove-Item function:global:Test-DunePlayerReserveItems -ErrorAction SilentlyContinue
+        Remove-Item function:global:Invoke-DuneRmqCleanPlayerInventory -ErrorAction SilentlyContinue
+    }
+
+    It 'sends the command only after proving Reserve empty for the exact pawn' {
+        $result = Invoke-DunePlayerCleanInventoryLive -Ip fixture -ActorId 42
+        $result.ok | Should -BeTrue
+        $script:reserveChecks | Should -Be 1
+        $script:rmqCleanCalls | Should -Be 1
+    }
+
+    It 'blocks Clean Inventory whenever Reserve contains rows' {
+        function global:Test-DunePlayerReserveItems {
+            $script:reserveChecks++
+            @{ ok = $true; item_rows = 2; item_units = 9 }
+        }
+        $result = Invoke-DunePlayerCleanInventoryLive -Ip fixture -ActorId 42
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'blocked while Reserve contains 2'
+        $script:rmqCleanCalls | Should -Be 0
+    }
+
+    It 'fails closed when Reserve inspection fails' {
+        function global:Test-DunePlayerReserveItems {
+            $script:reserveChecks++
+            @{ ok = $false; error = 'database unavailable' }
+        }
+        $result = Invoke-DunePlayerCleanInventoryLive -Ip fixture -ActorId 42
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'safety could not be proven'
+        $script:rmqCleanCalls | Should -Be 0
     }
 }
 

--- a/tests/ReserveRecovery.Tests.ps1
+++ b/tests/ReserveRecovery.Tests.ps1
@@ -1,0 +1,186 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'Gameplay.ps1'
+    Import-DstLib 'ReserveRecovery.ps1'
+    function global:Invoke-DuneSqlQuery { throw 'Test must mock Invoke-DuneSqlQuery.' }
+    function global:ConvertTo-DuneRowMaps { param($Result) return @($Result.rows) }
+    function global:Invoke-DuneVerifiedSafetyBackup { throw 'Test must mock Invoke-DuneVerifiedSafetyBackup.' }
+}
+
+AfterAll {
+    Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+    Remove-Item function:global:Invoke-DuneVerifiedSafetyBackup -ErrorAction SilentlyContinue
+    Remove-Item function:global:New-TestReserveItem -ErrorAction SilentlyContinue
+    Remove-Item function:global:New-TestReserveSnapshot -ErrorAction SilentlyContinue
+}
+
+function global:New-TestReserveItem {
+    param([long]$Id, [long]$InventoryId, [int]$Position, [string]$Template = 'CopperBar', [long]$Stack = 1, [double]$Volume = 1)
+    return [pscustomobject]@{
+        row = [pscustomobject]@{
+            id = $Id
+            inventory_id = $InventoryId
+            position_index = $Position
+            template_id = $Template
+            stack_size = $Stack
+            quality_level = 0
+            volume_override = $Volume
+            stats = [pscustomobject]@{}
+        }
+        invariant_revision = ('a' * 32)
+    }
+}
+
+function global:New-TestReserveSnapshot {
+    param([string]$Status = 'Offline', [object[]]$ReserveItems, [object[]]$BackpackItems)
+    if ($null -eq $ReserveItems) { $ReserveItems = @((New-TestReserveItem -Id 301 -InventoryId 216 -Position 4 -Stack 6 -Volume 2)) }
+    if ($null -eq $BackpackItems) { $BackpackItems = @((New-TestReserveItem -Id 201 -InventoryId 205 -Position 1 -Stack 2 -Volume 1)) }
+    return @{
+        ok = $true
+        database_scope = ('b' * 64)
+        player_count = 1
+        online_status = $Status
+        reserve_count = 1
+        backpack_count = 1
+        reserve_inventory = [pscustomobject]@{ id = 216; max_item_count = 50; max_item_volume = 1000 }
+        backpack_inventory = [pscustomobject]@{ id = 205; max_item_count = 10; max_item_volume = 100 }
+        reserve_items = @($ReserveItems)
+        backpack_items = @($BackpackItems)
+        snapshot_revision = ('c' * 32)
+    }
+}
+
+Describe 'Reserve identity and destructive guards' -Tag 'Pure' {
+    It 'checks the exact Reserve inventory type and actor component hash read-only' {
+        $script:reserveSql = ''
+        Mock Invoke-DuneSqlQuery {
+            param($Sql, $ReadOnly)
+            $script:reserveSql = $Sql
+            $ReadOnly | Should -BeTrue
+            return @{ ok = $true; rows = @(@{ item_rows = '2'; item_units = '9' }) }
+        }
+        $result = Test-DunePlayerReserveItems -Ip 'fixture' -PawnId 42
+        $result.ok | Should -BeTrue
+        $result.item_rows | Should -Be 2
+        $script:reserveSql | Should -Match 'inventory_type = 33'
+        $script:reserveSql | Should -Match 'component_name_hash = -689927216'
+        $script:reserveSql | Should -Match 'inv\.actor_id = 42::bigint'
+    }
+
+    It 'fails closed when Reserve cannot be inspected' {
+        Mock Invoke-DuneSqlQuery { @{ ok = $false; error = 'unavailable' } }
+        (Test-DunePlayerReserveItems -Ip 'fixture' -PawnId 42).ok | Should -BeFalse
+    }
+}
+
+Describe 'Reserve recovery preview' -Tag 'Pure' {
+    BeforeEach {
+        $script:DuneReserveRecoveryStateFile = Join-Path $TestDrive 'reserve-state.json'
+        Remove-Item -LiteralPath $script:DuneReserveRecoveryStateFile -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'assigns deterministic free Backpack positions and proves slot and volume capacity' {
+        $snapshot = New-TestReserveSnapshot
+        $preview = ConvertTo-DuneReservePreview -Snapshot $snapshot -PawnId 42 -ControllerId 43
+        $preview.available | Should -BeTrue
+        $preview.items[0].destination_position | Should -Be 0
+        $preview.used_slots | Should -Be 1
+        $preview.used_volume | Should -Be 2
+        $preview.required_volume | Should -Be 12
+        $preview.revision | Should -Match '^[a-f0-9]{64}$'
+    }
+
+    It 'blocks online players before considering a move' {
+        $preview = ConvertTo-DuneReservePreview -Snapshot (New-TestReserveSnapshot -Status Online) -PawnId 42 -ControllerId 43
+        $preview.available | Should -BeFalse
+        $preview.blocked_reason | Should -Match 'Offline'
+    }
+
+    It 'fails closed when an item volume is neither overridden nor catalogued' {
+        $unknown = New-TestReserveItem -Id 301 -InventoryId 216 -Position 0 -Template 'UnknownFutureItem' -Volume 0
+        $preview = ConvertTo-DuneReservePreview -Snapshot (New-TestReserveSnapshot -ReserveItems @($unknown)) -PawnId 42 -ControllerId 43
+        $preview.available | Should -BeFalse
+        $preview.blocked_reason | Should -Match 'no proven volume'
+    }
+
+    It 'blocks insufficient slots and volume instead of falling back to game validation' {
+        $snapshot = New-TestReserveSnapshot
+        $snapshot.backpack_inventory.max_item_count = 1
+        $snapshot.backpack_items[0].row.position_index = 0
+        (ConvertTo-DuneReservePreview -Snapshot $snapshot -PawnId 42 -ControllerId 43).blocked_reason | Should -Match 'free slots'
+        $snapshot = New-TestReserveSnapshot
+        $snapshot.backpack_inventory.max_item_volume = 10
+        (ConvertTo-DuneReservePreview -Snapshot $snapshot -PawnId 42 -ControllerId 43).blocked_reason | Should -Match 'volume is insufficient'
+    }
+
+    It 'reports empty Reserve as a safe no-op' {
+        $preview = ConvertTo-DuneReservePreview -Snapshot (New-TestReserveSnapshot -ReserveItems @()) -PawnId 42 -ControllerId 43
+        $preview.available | Should -BeFalse
+        $preview.blocked_reason | Should -Be 'Reserve is empty.'
+    }
+}
+
+Describe 'Guarded Reserve move and rollback' -Tag 'Pure' {
+    BeforeEach {
+        $script:DuneReserveRecoveryStateFile = Join-Path $TestDrive 'reserve-state.json'
+        Remove-Item -LiteralPath $script:DuneReserveRecoveryStateFile -Force -ErrorAction SilentlyContinue
+        $script:preview = ConvertTo-DuneReservePreview -Snapshot (New-TestReserveSnapshot) -PawnId 42 -ControllerId 43
+        Mock Get-DuneReserveRecoveryPreview { $script:preview }
+        Mock Invoke-DuneVerifiedSafetyBackup {
+            @{ ok = $true; path = '/local/backup'; bytes = 2048; database_scope = ('b' * 64) }
+        }
+        Mock Invoke-DuneSqlQuery { @{ ok = $true; rows = @() } }
+        Mock Test-DuneReserveMovedReadback { @{ ok = $true } }
+    }
+
+    It 'rejects a changed preview before creating a backup or writing' {
+        $result = Invoke-DuneReserveRecovery -Ip fixture -PawnId 42 -ControllerId 43 -Revision ('d' * 64)
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'changed'
+        Should -Invoke Invoke-DuneVerifiedSafetyBackup -Times 0
+        Should -Invoke Invoke-DuneSqlQuery -Times 0
+    }
+
+    It 'persists an exact before-image before one guarded transaction and readback' {
+        $script:writeSql = ''
+        Mock Invoke-DuneSqlQuery {
+            param($Sql, $ReadOnly, [switch]$Bulk)
+            $script:writeSql = $Sql
+            $ReadOnly | Should -BeFalse
+            $Bulk | Should -BeTrue
+            @{ ok = $true; rows = @() }
+        }
+        $result = Invoke-DuneReserveRecovery -Ip fixture -PawnId 42 -ControllerId 43 -Revision $script:preview.revision
+        $result.ok | Should -BeTrue
+        $state = Read-DuneReserveRecoveryState
+        $state.entries.Count | Should -Be 1
+        $state.entries[0].items[0].before_image.inventory_id | Should -Be 216
+        $state.entries[0].backup_bytes | Should -Be 2048
+        $script:writeSql | Should -Match 'player identity or Offline state changed'
+        $script:writeSql | Should -Match 'Reserve or Backpack changed after preview'
+        $script:writeSql | Should -Match 'Reserve did not become empty'
+        $script:writeSql | Should -Match 'Reserve move readback failed'
+        $script:writeSql | Should -Not -Match 'delete_item|base_backup_recycle'
+    }
+
+    It 'leaves an exact rollback record when independent readback fails' {
+        Mock Test-DuneReserveMovedReadback { @{ ok = $false; error = 'readback unavailable' } }
+        $result = Invoke-DuneReserveRecovery -Ip fixture -PawnId 42 -ControllerId 43 -Revision $script:preview.revision
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'rollback'
+        (Read-DuneReserveRecoveryState).entries[0].status | Should -Be 'readback_failed'
+    }
+
+    It 'generates a changed-state rollback that restores only inventory and position' {
+        $entry = [pscustomobject]@{
+            pawn_id = 42; controller_id = 43; reserve_inventory_id = 216; backpack_inventory_id = 205
+            items = @($script:preview.items)
+        }
+        $sql = Get-DuneReserveRollbackSql -Entry $entry
+        $sql | Should -Match 'Reserve changed after recovery'
+        $sql | Should -Match 'recovered rows changed after recovery'
+        $sql | Should -Match 'SET inventory_id = 216::bigint,\s+position_index = plan\.source_position'
+        $sql | Should -Not -Match 'delete_item|base_backup_recycle'
+    }
+}

--- a/tests/StorageOverview.Tests.ps1
+++ b/tests/StorageOverview.Tests.ps1
@@ -130,15 +130,38 @@ Describe 'Storage overview container coverage' -Tag 'Pure' {
         Mock Invoke-DuneSqlQuery {
             param($Sql)
             $script:deleteSql = $Sql
-            return @{ ok = $true; rows = @(@{ deleted = '' }) }
+            return @{ ok = $true; rows = @(@{ status = 'deleted'; changed = '1' }) }
         }
 
         $result = Invoke-DunePlayerDeleteItem -Ip '1.2.3.4' -ItemId 43 -ExpectedStackSize 4
 
         $result.ok | Should -BeTrue
         $script:deleteSql | Should -Match 'FROM dune\.items'
-        $script:deleteSql | Should -Match 'AND stack_size = 4::bigint'
+        $script:deleteSql | Should -Match 'AND i\.stack_size = 4::bigint'
         $script:deleteSql | Should -Match 'FOR UPDATE'
+        $script:deleteSql | Should -Match 'inventory_type = 33'
+        $script:deleteSql | Should -Match 'component_name_hash = -689927216'
+    }
+
+    It 'blocks every exact Reserve item instead of deleting it' {
+        Mock Invoke-DuneSqlQuery {
+            return @{ ok = $true; rows = @(@{ status = 'reserve_blocked'; changed = '0' }) }
+        }
+        $result = Invoke-DunePlayerDeleteItem -Ip '1.2.3.4' -ItemId 43 -ExpectedStackSize 4
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'Reserve items cannot be deleted'
+    }
+
+    It 'blocks Reserve quantity reductions while allowing non-destructive increases' {
+        Mock Invoke-DuneSqlQuery {
+            param($Sql)
+            if ($Sql -match 'SET stack_size = 3') {
+                return @{ ok = $true; rows = @(@{ status = 'reserve_blocked' }) }
+            }
+            return @{ ok = $true; rows = @(@{ status = 'updated' }) }
+        }
+        (Invoke-DunePlayerSetItemStack -Ip fixture -ItemId 43 -StackSize 3 -ExpectedStackSize 4).ok | Should -BeFalse
+        (Invoke-DunePlayerSetItemStack -Ip fixture -ItemId 43 -StackSize 5 -ExpectedStackSize 4).ok | Should -BeTrue
     }
 
     Describe 'Placed-base portable blueprint ids' -Tag 'Pure' {

--- a/webui/src/api/gameplay.ts
+++ b/webui/src/api/gameplay.ts
@@ -744,6 +744,9 @@ export interface InventoryItem {
   water_amount: string
   water_type: string
   current_ammo?: string
+  inventory_id?: number
+  inventory_type?: number
+  is_reserve?: boolean
 }
 
 export interface SpecTrack {
@@ -857,6 +860,64 @@ export function preparePatternUpgrading(controllerId: number) {
 export function deleteInventoryItem(itemId: number, expectedStackSize?: number) {
   return api<WriteResult>('/api/gameplay/players/delete-item', {
     method: 'POST', body: JSON.stringify({ item_id: itemId, expected_stack_size: expectedStackSize }),
+  })
+}
+
+export interface ReserveRecoveryItem {
+  item_id: number
+  template_id: string
+  name: string
+  stack_size: number
+  quality: number
+  source_position: number
+  destination_position: number
+  unit_volume: number
+  total_volume: number
+}
+
+export interface ReserveRecoveryPreview {
+  source: 'live'
+  available: boolean
+  blocked_reason: string
+  pawn_id: number
+  controller_id: number
+  online_status: string
+  reserve_inventory_id: number
+  backpack_inventory_id: number
+  item_rows: number
+  item_units: number
+  required_volume: number
+  used_volume: number
+  max_slots: number
+  used_slots: number
+  max_volume: number
+  revision: string
+  items: ReserveRecoveryItem[]
+  rollback: null | {
+    recovery_id: string
+    item_rows: number
+    created_at: string
+  }
+}
+
+export function getReserveRecovery(pawnId: number, controllerId: number) {
+  return api<ReserveRecoveryPreview>(`/api/gameplay/players/reserve-recovery${qs({
+    pawn: pawnId,
+    controller: controllerId,
+  })}`)
+}
+
+export function recoverReserve(pawnId: number, controllerId: number, revision: string) {
+  return api<WriteResult>('/api/gameplay/players/reserve-recovery', {
+    method: 'POST',
+    body: JSON.stringify({ pawn_id: pawnId, controller_id: controllerId, revision }),
+  })
+}
+
+export function rollbackReserve(pawnId: number, controllerId: number, recoveryId: string) {
+  return api<WriteResult>('/api/gameplay/players/reserve-recovery/rollback', {
+    method: 'POST',
+    body: JSON.stringify({ pawn_id: pawnId, controller_id: controllerId, recovery_id: recoveryId }),
   })
 }
 

--- a/webui/src/components/inventory/SharedInventoryExplorer.tsx
+++ b/webui/src/components/inventory/SharedInventoryExplorer.tsx
@@ -597,9 +597,12 @@ function OccurrencePanel({
       return
     }
     const quantity = requests.reduce((sum, request) => sum + request.quantity, 0)
-    const message = targets.length === 1
+    const baseMessage = targets.length === 1
       ? `Delete ${quantity} of ${targets[0].displayName} (stack x${targets[0].quantity}) from ${targets[0].entity.label || entityTypeLabel(targets[0].entity.type)}? This cannot be undone.`
       : `Delete ${quantity} total items across ${targets.length} selected occurrences? Any full stacks will be removed. This cannot be undone.`
+    const message = targets.some(item => item.entity.type === 'player')
+      ? `${baseMessage}\n\nReserve rows cannot be deleted or reduced here. DST will reject them because remaining Reserve contents can become hidden and keep base recycling blocked.`
+      : baseMessage
     if (!window.confirm(message)) return
 
     setDeleteBusy(true)

--- a/webui/src/layout/commandDeckModel.ts
+++ b/webui/src/layout/commandDeckModel.ts
@@ -7,7 +7,10 @@ const TASK_COPY: Record<string, { description: string; keywords: string }> = {
   '/operations': { description: 'Review runtime activity and maintenance tools.', keywords: 'runtime maintenance' },
   '/commands': { description: 'Choose a server action and review its safeguards.', keywords: 'start stop restart update' },
   '/database': { description: 'Manage backups, restores, and database queries.', keywords: 'backup restore sql protection' },
-  '/players': { description: 'Inspect a character, inventory, and progression.', keywords: 'give item grant ammo augments skills' },
+  '/players': {
+    description: 'Inspect players, inventory, progression, and community tools.',
+    keywords: 'give item grant ammo augments skills chat commands welcome back shared destinations teleport tp',
+  },
   '/bases': { description: 'Inspect claims, ownership, and base inventory.', keywords: 'buildings claims' },
   '/vehicles': { description: 'Inspect the fleet and vehicle inventory.', keywords: 'ornithopter buggy cargo' },
   '/economy': { description: 'Review market and governance tools.', keywords: 'market trade landsraad' },

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -36,6 +36,7 @@ import {
   getMainQuestCatalog, unlockMainQuest,
   getContracts, completeContract,
   getVehicleKitCatalog,
+  getReserveRecovery, recoverReserve, rollbackReserve,
   type Player, type PlayerEvent, type PlayerStats, type ProgressionPreset, type SpecTrackFull,
   type AugmentSelection, type CatalogItem, type ItemPackage, type GiveItemEntry, type FreshStartSnapshot,
   type LandsraadHouse, type LandsraadIniSetting,
@@ -43,6 +44,7 @@ import {
   type PlayerVehicleRow, type TeleportDestination,
   type VehicleTemplate, type VehicleKitCatalog,
   type ContractRow,
+  type ReserveRecoveryPreview,
 } from '../../../api/gameplay'
 import { fmtNum, fmtSolari } from '../shared'
 import { useCommandDeck } from '../../../hooks/useCommandDeck'
@@ -772,7 +774,8 @@ const ACTIONS: ActionDef[] = [
   { id: 'fill-water', group: 'Items', label: 'Fill Water', icon: 'Droplets',
     run: p => fillWater(p.id) },
   { id: 'clean-inventory', group: 'Items', label: 'Clean Inventory (live)', icon: 'Trash', liveOnly: true,
-    confirm: p => `WIPE ${p.name}'s inventory? Cannot be undone.`,
+    rowNote: 'Blocked while the exact Reserve contains any item rows; recover Reserve first.',
+    confirm: p => `WIPE ${p.name}'s inventory? Cannot be undone.\n\nDST will refuse this command if Reserve contains items, because cleaning can strand hidden Reserve contents and keep base recycling blocked.`,
     run: p => cleanPlayerInventory({ actor_id: p.id }) },
 
   // ----- Vehicle -----
@@ -2767,6 +2770,8 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
   const [err, setErr] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [tick, setTick] = useState(0)
+  const [reserve, setReserve] = useState<ReserveRecoveryPreview | null>(null)
+  const [reserveErr, setReserveErr] = useState<string | null>(null)
   const isOnline = (player.online_status || '').toLowerCase() === 'online'
 
   useEffect(() => {
@@ -2776,6 +2781,16 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
       .then(r => { if (alive) setDetail(r) })
       .catch(e => { if (alive) setErr(e instanceof Error ? e.message : String(e)) })
       .finally(() => { if (alive) setLoading(false) })
+    return () => { alive = false }
+  }, [player.id, player.controller_id, demo, refreshKey, tick])
+
+  useEffect(() => {
+    let alive = true
+    if (demo) { setReserve(null); setReserveErr(null); return () => { alive = false } }
+    setReserveErr(null)
+    getReserveRecovery(player.id, player.controller_id)
+      .then(r => { if (alive) setReserve(r) })
+      .catch(e => { if (alive) setReserveErr(e instanceof Error ? e.message : String(e)) })
     return () => { alive = false }
   }, [player.id, player.controller_id, demo, refreshKey, tick])
 
@@ -2816,6 +2831,14 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
   return (
     <div className="space-y-4">
       {!contextual && <div className="flex items-center justify-end">{refreshButton}</div>}
+      {!demo && <ReserveRecoveryCard
+        preview={reserve}
+        error={reserveErr}
+        canWrite={canWrite}
+        busy={busy}
+        player={player}
+        run={run}
+      />}
       <ItemList title={`Inventory (${fmtNum(groups.gear.length)})`} icon="Backpack" items={groups.gear}
         playerId={player.id}
         toolbar={contextual ? refreshButton : undefined}
@@ -2825,6 +2848,91 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
       <ItemList title={`Contract items (${fmtNum(groups.contracts.length)})`} icon="FileText" items={groups.contracts} collapsed
         playerId={player.id} canWrite={canWrite} busy={busy} run={run} isOnline={isOnline} />
     </div>
+  )
+}
+
+function ReserveRecoveryCard({ preview, error, canWrite, busy, player, run }: {
+  preview: ReserveRecoveryPreview | null
+  error: string | null
+  canWrite: boolean
+  busy: boolean
+  player: Player
+  run: (fn: () => Promise<{ message: string }>, label: string) => Promise<boolean>
+}) {
+  const [ack, setAck] = useState('')
+  useEffect(() => { setAck('') }, [preview?.revision, preview?.rollback?.recovery_id])
+  if (error) {
+    return <div className="rounded-lg border border-danger/40 bg-danger/5 px-3 py-2 text-xs text-danger" role="alert">
+      Reserve safety preview unavailable: {error}
+    </div>
+  }
+  if (!preview) {
+    return <div className="rounded-lg border border-border bg-surface-2 px-3 py-2 text-xs text-text-dim">Checking Reserve safety…</div>
+  }
+  const recoveryAck = ack === 'RECOVER'
+  const rollbackAck = ack === 'ROLLBACK'
+  const afterVolume = preview.used_volume + preview.required_volume
+  return (
+    <section className="rounded-lg border border-warning/40 bg-warning/5 p-3 space-y-3" aria-label="Reserve recovery">
+      <div className="flex items-start gap-2">
+        <Icon name="ShieldAlert" size={15} className="text-warning mt-0.5 shrink-0" />
+        <div>
+          <div className="text-sm font-semibold text-text">Hidden Reserve safety</div>
+          <p className="text-xs text-text-dim mt-1">
+            Direct deletion is blocked for every Reserve item because it can leave other rows hidden while base recycling remains blocked.
+            Guarded recovery moves intact rows only to this player&apos;s Backpack after a verified fresh backup.
+          </p>
+        </div>
+      </div>
+      {preview.item_rows > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
+          <div><span className="text-text-dim">Reserve rows</span><div className="font-mono">{fmtNum(preview.item_rows)}</div></div>
+          <div><span className="text-text-dim">Units</span><div className="font-mono">{fmtNum(preview.item_units)}</div></div>
+          <div><span className="text-text-dim">Backpack slots</span><div className="font-mono">{preview.used_slots + preview.item_rows}/{preview.max_slots}</div></div>
+          <div><span className="text-text-dim">Backpack volume</span><div className="font-mono">{afterVolume.toFixed(1)}/{preview.max_volume.toFixed(1)}</div></div>
+        </div>
+      )}
+      {preview.items.length > 0 && (
+        <div className="max-h-36 overflow-auto rounded border border-border/60 bg-surface-1/60 divide-y divide-border/50">
+          {preview.items.map(item => (
+            <div key={item.item_id} className="flex items-center justify-between gap-3 px-2 py-1.5 text-xs">
+              <span className="truncate">{item.name || item.template_id} <span className="text-text-dim">×{fmtNum(item.stack_size)}</span></span>
+              <span className="font-mono text-text-dim shrink-0">Reserve {item.source_position} → Backpack {item.destination_position}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {!preview.available && preview.blocked_reason && (
+        <div className="text-xs text-warning">{preview.blocked_reason}</div>
+      )}
+      {preview.available && (
+        <div className="space-y-2">
+          <label className="block text-xs">
+            <span className="text-text-dim">Type <strong className="text-text">RECOVER</strong> to create a fresh verified backup and move these exact rows.</span>
+            <input className="mt-1 w-full max-w-48 font-mono bg-surface-2 border border-border rounded px-2 py-1"
+              value={ack} onChange={e => setAck(e.target.value)} disabled={busy} aria-label="Reserve recovery confirmation" />
+          </label>
+          <button className="btn-danger text-xs" disabled={!canWrite || busy || !recoveryAck}
+            onClick={() => void run(() => recoverReserve(player.id, player.controller_id, preview.revision), 'Recover Reserve')}>
+            <Icon name="ArchiveRestore" size={12} /> Recover Reserve to Backpack
+          </button>
+        </div>
+      )}
+      {preview.rollback && (
+        <div className="space-y-2 border-t border-warning/30 pt-2">
+          <p className="text-xs text-text-dim">Exact rollback remains available for the last {preview.rollback.item_rows}-row recovery.</p>
+          <label className="block text-xs">
+            <span className="text-text-dim">Type <strong className="text-text">ROLLBACK</strong> to create another fresh backup and restore the original Reserve positions.</span>
+            <input className="mt-1 w-full max-w-48 font-mono bg-surface-2 border border-border rounded px-2 py-1"
+              value={ack} onChange={e => setAck(e.target.value)} disabled={busy} aria-label="Reserve rollback confirmation" />
+          </label>
+          <button className="btn-danger text-xs" disabled={!canWrite || busy || !rollbackAck}
+            onClick={() => void run(() => rollbackReserve(player.id, player.controller_id, preview.rollback!.recovery_id), 'Rollback Reserve recovery')}>
+            <Icon name="Undo2" size={12} /> Roll back recovery
+          </button>
+        </div>
+      )}
+    </section>
   )
 }
 
@@ -2893,6 +3001,7 @@ function ItemList({ title, icon, items, playerId, canWrite, busy, run, collapsed
                         <Icon name={isEditing ? 'ChevronDown' : 'ChevronRight'} size={11} className="inline-block mr-1 text-text-dim" />
                       )}
                       <span className="text-text">{it.name || it.template_id}</span>
+                      {it.is_reserve && <span className="ml-1.5 text-[10px] uppercase tracking-wide text-warning">Reserve · protected</span>}
                       {it.quality > 0 && <span className={`ml-1.5 text-[11px] ${qualityClass(it.quality)}`}>Q{it.quality}</span>}
                       {hasDur && (
                         <span className={`ml-1.5 font-mono text-[11px] ${durCls}`} title={`Durability ${curN.toFixed(0)} / ${maxN.toFixed(0)} (${Math.round(ratio * 100)}%)`}>
@@ -2919,8 +3028,8 @@ function ItemList({ title, icon, items, playerId, canWrite, busy, run, collapsed
                             <Icon name="Wrench" size={13} />
                           </button>
                         )}
-                        <button className="text-danger/80 hover:text-danger" title="Delete item" disabled={busy}
-                          onClick={() => void run(() => deleteInventoryItem(it.id), 'Delete')}>
+                        <button className="text-danger/80 hover:text-danger" title={it.is_reserve ? 'Reserve items cannot be deleted directly; use guarded Recover Reserve' : 'Delete item'} disabled={busy || it.is_reserve}
+                          onClick={() => void run(() => deleteInventoryItem(it.id, it.stack_size), 'Delete')}>
                           <Icon name="Trash2" size={13} />
                         </button>
                       </span>
@@ -2967,6 +3076,7 @@ function StackEditor({ item, busy, run, isOnline, onClose }: {
   const [str, setStr] = useState(String(item.stack_size))
   const n = parseInt(str, 10)
   const valid = Number.isFinite(n) && n >= 1
+  const reserveReduction = Boolean(item.is_reserve && valid && n < item.stack_size)
 
   return (
     <div className="border-t border-border/50 px-3 py-3 bg-surface-1/60 rounded-b-lg space-y-3">
@@ -2978,6 +3088,12 @@ function StackEditor({ item, busy, run, isOnline, onClose }: {
             quantity writes to the database immediately but won't appear in-game
             until the player relogs.
           </span>
+        </div>
+      )}
+      {item.is_reserve && (
+        <div className="text-[11px] text-warning flex items-start gap-1.5">
+          <Icon name="ShieldAlert" size={11} className="mt-0.5 shrink-0" />
+          <span>Reserve quantities cannot be reduced directly. Use guarded Recover Reserve so no hidden rows remain stranded.</span>
         </div>
       )}
       <div className="flex items-end gap-2">
@@ -2994,10 +3110,10 @@ function StackEditor({ item, busy, run, isOnline, onClose }: {
         <button
           type="button"
           className="btn-primary text-xs"
-          disabled={busy || !valid}
+          disabled={busy || !valid || reserveReduction}
           onClick={() => {
             if (!valid) return
-            void (async () => { if (await run(() => setItemStack(item.id, n), 'Save')) onClose() })()
+            void (async () => { if (await run(() => setItemStack(item.id, n, item.stack_size), 'Save')) onClose() })()
           }}
         >
           <Icon name="Save" size={12} /> Save

--- a/webui/src/pages/workspaces/PlayersCommunity.tsx
+++ b/webui/src/pages/workspaces/PlayersCommunity.tsx
@@ -1,0 +1,11 @@
+import { ChatCommandsCard } from '../gameplay/ChatCommandsCard'
+import { WelcomeBackCard } from '../gameplay/WelcomeBackCard'
+
+export function PlayersCommunity() {
+  return (
+    <div className="space-y-4">
+      <ChatCommandsCard />
+      <WelcomeBackCard />
+    </div>
+  )
+}

--- a/webui/src/pages/workspaces/PlayersWorkspace.tsx
+++ b/webui/src/pages/workspaces/PlayersWorkspace.tsx
@@ -3,19 +3,26 @@ import { SharedInventoryExplorer } from '../../components/inventory/SharedInvent
 import { WorkspaceLayout, type WorkspaceTab } from '../../components/platform/WorkspaceLayout'
 import { getWorkspace } from '../../platform/workspaces'
 import { useSearch } from '../../router'
+import { PlayersCommunity } from './PlayersCommunity'
 
 const TABS: readonly WorkspaceTab[] = [
   { id: 'admin', label: 'Player admin', to: '/players?view=admin', icon: 'Users' },
   { id: 'inventory', label: 'Inventory', to: '/players?view=inventory', icon: 'PackageSearch' },
+  { id: 'community', label: 'Community tools', to: '/players?view=community', icon: 'MessageSquare' },
 ]
 
 export default function PlayersWorkspace() {
-  const view = new URLSearchParams(useSearch()).get('view') === 'inventory' ? 'inventory' : 'admin'
+  const requestedView = new URLSearchParams(useSearch()).get('view')
+  const view = requestedView === 'inventory' || requestedView === 'community'
+    ? requestedView
+    : 'admin'
   return (
     <WorkspaceLayout workspace={getWorkspace('players')} tabs={TABS} activeTab={view}>
       {view === 'inventory'
         ? <SharedInventoryExplorer entityTypes={['player']} />
-        : <PlayersTab />}
+        : view === 'community'
+          ? <PlayersCommunity />
+          : <PlayersTab />}
     </WorkspaceLayout>
   )
 }

--- a/webui/src/platform/workspaces.ts
+++ b/webui/src/platform/workspaces.ts
@@ -136,6 +136,8 @@ export const FEATURE_PLACEMENTS: readonly FeaturePlacement[] = [
   { currentFeature: 'Experimental Lab', currentRoutes: ['/experimental'], destination: 'Server Management / Experimental Lab', workspaceId: 'settings', disposition: 'remain' },
   { currentFeature: 'Gameplay Overview', currentRoutes: ['/gameplay?view=overview'], destination: 'Gameplay Admin / Overview', workspaceId: 'home', disposition: 'remain' },
   { currentFeature: 'Gameplay Players', currentRoutes: ['/players', '/gameplay?view=players'], destination: 'Gameplay Admin / Players', workspaceId: 'players', disposition: 'move' },
+  { currentFeature: 'In-game chat commands and shared teleport destinations', currentRoutes: ['/gameplay?view=overview'], destination: 'Gameplay Admin / Players / Community tools', workspaceId: 'players', disposition: 'move' },
+  { currentFeature: 'Welcome Back packages', currentRoutes: ['/gameplay?view=overview'], destination: 'Gameplay Admin / Players / Community tools', workspaceId: 'players', disposition: 'move' },
   { currentFeature: 'Gameplay Bases', currentRoutes: ['/bases', '/gameplay?view=bases'], destination: 'Gameplay Admin / Bases', workspaceId: 'bases', disposition: 'move' },
   { currentFeature: 'Gameplay Storage', currentRoutes: ['/gameplay?view=storage'], destination: 'Shared Inventory Explorer in Players, Bases, Vehicles, and Economy', workspaceId: 'players', disposition: 'merge' },
   { currentFeature: 'Gameplay Blueprints', currentRoutes: ['/gameplay?view=blueprints'], destination: 'Gameplay Admin / Bases / Blueprints', workspaceId: 'bases', disposition: 'move' },

--- a/webui/tests/commandDeck.test.tsx
+++ b/webui/tests/commandDeck.test.tsx
@@ -46,6 +46,9 @@ describe('Command Deck destinations', () => {
   it('searches available task descriptions and requires every search word', () => {
     const routes = getDeckDestinations({ local: true, windows: true, canAccessOwnerSurfaces: true })
     expect(searchDeck(routes, 'give ammo').map(item => item.to)).toEqual(['/players'])
+    expect(searchDeck(routes, 'chat commands').map(item => item.to)).toEqual(['/players'])
+    expect(searchDeck(routes, 'welcome back').map(item => item.to)).toEqual(['/players'])
+    expect(searchDeck(routes, 'shared teleport destinations').map(item => item.to)).toEqual(['/players'])
     expect(searchDeck(routes, 'backup').map(item => item.to)).toEqual(['/database'])
     expect(searchDeck(routes, 'nonexistent')).toEqual([])
     expect(new Set(routes.map(item => item.to)).size).toBe(routes.length)

--- a/webui/tests/inventoryWorkspaces.test.tsx
+++ b/webui/tests/inventoryWorkspaces.test.tsx
@@ -11,6 +11,14 @@ vi.mock('../src/pages/gameplay/PlayersTab', () => ({
   PlayersTab: () => <div>Player admin fixture</div>,
 }))
 
+vi.mock('../src/pages/gameplay/ChatCommandsCard', () => ({
+  ChatCommandsCard: () => <div>In-game commands fixture</div>,
+}))
+
+vi.mock('../src/pages/gameplay/WelcomeBackCard', () => ({
+  WelcomeBackCard: () => <div>Welcome back fixture</div>,
+}))
+
 vi.mock('../src/pages/gameplay/BasesTab', () => ({
   BasesTab: () => <div>Bases fixture</div>,
 }))
@@ -40,17 +48,25 @@ afterEach(() => {
 })
 
 describe('inventory workspace embedding', () => {
-  it('preserves Player admin as default and adds the shared player inventory view', () => {
+  it('preserves Player admin as default and exposes every Players workspace view', () => {
     window.history.replaceState(null, '', '/players')
     const view = render(<BrowserRouter><PlayersWorkspace /></BrowserRouter>)
     expect(screen.getByText('Player admin fixture')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Player admin' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('link', { name: 'Community tools' })).toHaveAttribute('href', '/players?view=community')
 
     view.unmount()
     window.history.replaceState(null, '', '/players?view=inventory')
-    render(<BrowserRouter><PlayersWorkspace /></BrowserRouter>)
+    const inventory = render(<BrowserRouter><PlayersWorkspace /></BrowserRouter>)
     expect(screen.getByText('Inventory fixture: player')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Inventory' })).toHaveAttribute('aria-current', 'page')
+
+    inventory.unmount()
+    window.history.replaceState(null, '', '/players?view=community')
+    render(<BrowserRouter><PlayersWorkspace /></BrowserRouter>)
+    expect(screen.getByText('In-game commands fixture')).toBeInTheDocument()
+    expect(screen.getByText('Welcome back fixture')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Community tools' })).toHaveAttribute('aria-current', 'page')
   })
 
   it('limits the Bases inventory view to proven storage containers', () => {

--- a/webui/tests/playerAmmoEditor.test.tsx
+++ b/webui/tests/playerAmmoEditor.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getPlayerDetail, setWeaponAmmo, type Player } from '../src/api/gameplay'
+import { getPlayerDetail, getReserveRecovery, setWeaponAmmo, type Player } from '../src/api/gameplay'
 import { InventorySection } from '../src/pages/gameplay/players/sections'
 import { COMMAND_DECK_KEY } from '../src/hooks/useCommandDeck'
 
 vi.mock('../src/api/gameplay', async importOriginal => ({
   ...await importOriginal<typeof import('../src/api/gameplay')>(),
   getPlayerDetail: vi.fn(),
+  getReserveRecovery: vi.fn(),
   setWeaponAmmo: vi.fn(),
 }))
 
@@ -27,6 +28,14 @@ beforeEach(() => {
     }],
   })
   vi.mocked(setWeaponAmmo).mockResolvedValue({ ok: true, message: 'Ammo saved.' })
+  vi.mocked(getReserveRecovery).mockResolvedValue({
+    source: 'live', available: false, blocked_reason: 'Reserve is empty.',
+    pawn_id: 42, controller_id: 100, online_status: 'Offline',
+    reserve_inventory_id: 216, backpack_inventory_id: 205,
+    item_rows: 0, item_units: 0, required_volume: 0, used_volume: 10,
+    max_slots: 50, used_slots: 2, max_volume: 1000, revision: 'a'.repeat(64),
+    items: [], rollback: null,
+  })
 })
 
 afterEach(() => {

--- a/webui/tests/playerReserveRecovery.test.tsx
+++ b/webui/tests/playerReserveRecovery.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getPlayerDetail, getReserveRecovery, recoverReserve, rollbackReserve,
+  type Player, type ReserveRecoveryPreview,
+} from '../src/api/gameplay'
+import { InventorySection } from '../src/pages/gameplay/players/sections'
+
+vi.mock('../src/api/gameplay', async importOriginal => ({
+  ...await importOriginal<typeof import('../src/api/gameplay')>(),
+  getPlayerDetail: vi.fn(),
+  getReserveRecovery: vi.fn(),
+  recoverReserve: vi.fn(),
+  rollbackReserve: vi.fn(),
+}))
+
+const player: Player = {
+  id: 42, account_id: 99, controller_id: 100, name: 'Test player',
+  class: '', map: '', faction_id: 0, faction_name: '', online_status: 'Offline',
+}
+
+const preview: ReserveRecoveryPreview = {
+  source: 'live', available: true, blocked_reason: '',
+  pawn_id: 42, controller_id: 100, online_status: 'Offline',
+  reserve_inventory_id: 216, backpack_inventory_id: 205,
+  item_rows: 1, item_units: 6, required_volume: 12, used_volume: 10,
+  max_slots: 50, used_slots: 2, max_volume: 1000, revision: 'a'.repeat(64),
+  items: [{
+    item_id: 301, template_id: 'CopperBar', name: 'Copper Bar', stack_size: 6, quality: 0,
+    source_position: 4, destination_position: 0, unit_volume: 2, total_volume: 12,
+  }],
+  rollback: null,
+}
+
+beforeEach(() => {
+  vi.mocked(getPlayerDetail).mockResolvedValue({
+    source: 'live', specs: [], currency: [],
+    inventory: [{
+      id: 301, template_id: 'CopperBar', name: 'Copper Bar', stack_size: 6, quality: 0,
+      durability: 'N/A', max_durability: 'N/A', water_amount: 'N/A', water_type: '',
+      current_ammo: 'N/A', inventory_id: 216, inventory_type: 33, is_reserve: true,
+    }],
+  })
+  vi.mocked(getReserveRecovery).mockResolvedValue(preview)
+  vi.mocked(recoverReserve).mockResolvedValue({ ok: true, message: 'Recovered Reserve.' })
+  vi.mocked(rollbackReserve).mockResolvedValue({ ok: true, message: 'Rolled back Reserve.' })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function renderInventory() {
+  render(<InventorySection player={player} canWrite demo={false} refreshKey={0} flash={vi.fn()} onChanged={vi.fn()} />)
+}
+
+describe('Reserve recovery inventory controls', () => {
+  it('labels every Reserve row and disables direct deletion', async () => {
+    renderInventory()
+    const reserveBadge = await screen.findByText('Reserve · protected')
+    expect(screen.getByTitle(/Reserve items cannot be deleted directly/)).toBeDisabled()
+    fireEvent.click(reserveBadge.closest('.player-inventory-item')!.querySelector('[role="button"]')!)
+    expect(screen.getByText(/Reserve quantities cannot be reduced directly/)).toBeInTheDocument()
+    const stack = screen.getByRole('spinbutton', { name: 'Stack quantity' })
+    fireEvent.change(stack, { target: { value: '5' } })
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('requires typed acknowledgement before applying the exact preview revision', async () => {
+    renderInventory()
+    expect(await screen.findByText(/Reserve 4 → Backpack 0/)).toBeInTheDocument()
+    const button = screen.getByRole('button', { name: /Recover Reserve to Backpack/ })
+    expect(button).toBeDisabled()
+    fireEvent.change(screen.getByRole('textbox', { name: 'Reserve recovery confirmation' }), { target: { value: 'RECOVER' } })
+    expect(button).toBeEnabled()
+    fireEvent.click(button)
+    await waitFor(() => expect(recoverReserve).toHaveBeenCalledExactlyOnceWith(42, 100, 'a'.repeat(64)))
+  })
+
+  it('offers only exact persisted rollback and requires a second typed acknowledgement', async () => {
+    vi.mocked(getReserveRecovery).mockResolvedValue({
+      ...preview, available: false, blocked_reason: 'Reserve is empty.',
+      item_rows: 0, item_units: 0, items: [],
+      rollback: { recovery_id: 'b'.repeat(32), item_rows: 1, created_at: '2026-01-01T00:00:00Z' },
+    })
+    renderInventory()
+    const button = await screen.findByRole('button', { name: /Roll back recovery/ })
+    expect(button).toBeDisabled()
+    fireEvent.change(screen.getByRole('textbox', { name: 'Reserve rollback confirmation' }), { target: { value: 'ROLLBACK' } })
+    fireEvent.click(button)
+    await waitFor(() => expect(rollbackReserve).toHaveBeenCalledExactlyOnceWith(42, 100, 'b'.repeat(32)))
+  })
+})

--- a/webui/tests/workspaceManifest.test.ts
+++ b/webui/tests/workspaceManifest.test.ts
@@ -57,6 +57,30 @@ describe('workspace manifest', () => {
     }
   })
 
+  it('maps every Classic Players and Inventory surface into Command Deck', () => {
+    const playerPlacements = FEATURE_PLACEMENTS.filter(item => item.workspaceId === 'players')
+    expect(playerPlacements).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        currentFeature: 'Gameplay Players',
+        currentRoutes: ['/players', '/gameplay?view=players'],
+      }),
+      expect.objectContaining({
+        currentFeature: 'Gameplay Storage',
+        currentRoutes: ['/gameplay?view=storage'],
+      }),
+      expect.objectContaining({
+        currentFeature: 'In-game chat commands and shared teleport destinations',
+        currentRoutes: ['/gameplay?view=overview'],
+        destination: 'Gameplay Admin / Players / Community tools',
+      }),
+      expect.objectContaining({
+        currentFeature: 'Welcome Back packages',
+        currentRoutes: ['/gameplay?view=overview'],
+        destination: 'Gameplay Admin / Players / Community tools',
+      }),
+    ]))
+  })
+
   it('keeps every route module lazy and preserves the current permission matrix', () => {
     for (const route of LEGACY_ROUTE_MANIFEST) expect(route.load).toBeTypeOf('function')
 


### PR DESCRIPTION
Delivers the Players & Inventory release item (one delivery category):

- **Command Deck Players & Inventory parity** — community tools + player-management surfaces reach parity with Classic.
- **Guarded Reserve recovery** — offline-only, with verified fresh backup, exact capacity check, single changed-state-guarded transaction, readback, and retained rollback.
- **Reserve delete protection** — protects Reserve items from direct deletion, quantity reduction, and live Clean Inventory.
- **VehicleDeletion refactor** — generalizes the verified-safety-backup into a shared `Invoke-DuneVerifiedSafetyBackup` helper; original vehicle-delete behavior preserved via a thin wrapper.

Full pwsh Pester (1461 passed) and webui Vitest (621 passed) suites green locally, including the Reserve destructive-path guards.