### PR TITLE
docs(p34): replace real example IP with documentation placeholders

### DIFF
--- a/docs/troubleshooting-p34.md
+++ b/docs/troubleshooting-p34.md
@@ -88,7 +88,7 @@ P34s for you while outside players connect fine.
   route -p add <PUBLIC_IP> mask 255.255.255.255 <VM_LAN_IP>
   ```
 
-  Example: `route -p add 67.55.18.153 mask 255.255.255.255 192.168.68.62`.
+  Example: `route -p add 203.0.113.10 mask 255.255.255.255 192.168.1.50`.
   `-p` makes it survive reboots; undo with `route delete <PUBLIC_IP>`. This works
   because the server VM already answers on its public IP. A **console**
   (PlayStation/Xbox) can't take a local route — it must connect by the server's


### PR DESCRIPTION
Replaces a concrete public/LAN IP pair in the P34 troubleshooting guide's `route -p add` example with reserved documentation ranges (RFC5737 `203.0.113.10` and RFC1918 `192.168.1.50`), matching the placeholder convention used in the surrounding code block. Privacy hygiene only; no behavior change.