### PR TITLE
Hyper-V-aware VM lifecycle control for self-hosted servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ here cover everything those tags shipped.
   exact rows and Backpack positions, requires the player to be Offline, verifies
   a fresh local backup and exact slot/volume capacity, moves rows intact in one
   changed-state-guarded transaction, reads them back, and retains exact rollback.
+- Added an explicit **Hyper-V VM lifecycle** Settings control for Self-Hosted
+  servers. It transactionally enables the VM's Operating System Shutdown
+  integration and `AutomaticStopAction=ShutDown`, installs a bounded Alpine
+  OpenRC battlegroup shutdown/boot-recovery hook, reports durable results, and
+  can restore the recorded host and guest state.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ guarded controls in one native Windows app.
 - Administer players, bases, storage, blueprints, Landsraad, and the Exchange.
 - Run Duke's native Market Bot with formula or market-follow pricing.
 - Manage one local VM or a separate Hyper-V host over LAN.
+- Reconcile graceful Hyper-V host shutdown with bounded Alpine battlegroup
+  shutdown and boot recovery, with operator-visible status and rollback.
 - Use the responsive full Browser Portal from a phone, tablet, or PC with
   optional host-managed Owner and Admin accounts.
 - Use Tailscale Funnel and the Browser Portal for new remote setups. v15 keeps
@@ -345,8 +347,8 @@ guarded World Restart testing.
 ![Unconfigured v15 Settings including the disabled Legacy Cloudflare section](docs/img/settings.png)
 
 Updates, installation, themes, warnings, Remote Device Access, Browser Portal
-accounts, Hyper-V over LAN, Public IP/DDNS, browser ping, and host-local
-preferences.
+accounts, Hyper-V over LAN, Hyper-V VM lifecycle, Public IP/DDNS, browser ping,
+and host-local preferences.
 </details>
 
 <details>

--- a/app/data/platform-route-policies.json
+++ b/app/data/platform-route-policies.json
@@ -78,7 +78,8 @@
     "http POST /api/gameplay/players/journey/wipe": "destructive",
     "http POST /api/gameplay/players/wipe-codex": "destructive",
     "http DELETE /api/gameplay/item-packages": "reversible-write",
-    "http DELETE /api/setup/hyperv-lan/credential": "reversible-write"
+    "http DELETE /api/setup/hyperv-lan/credential": "reversible-write",
+    "http DELETE /api/setup/hyperv-lifecycle": "reversible-write"
     ,"http POST /api/gameplay/vehicles/delete": "destructive"
     ,"http POST /api/gameplay/vehicles/names": "transactional-write"
     ,"http POST /api/gameplay/vehicles/deletions": "reversible-write"
@@ -179,7 +180,7 @@
     { "source": "RemoteAccess.ps1", "capabilityId": "settings.connectivity", "routeCount": 6, "sha256": "60f71a9c7a4b8b5eda4633ca337ed6b5dfbcdcfc1deaf0008c32f28df8669820" },
     { "source": "RestartSchedule.ps1", "capabilityId": "operation.maintenance", "routeCount": 4, "sha256": "377236ac8359ec7828642c234f07c127e9e2f7c4930b77eadcf0ab19f0201568" },
     { "source": "ServiceMode.ps1", "capabilityId": "operation.runtime", "routeCount": 2, "sha256": "5d5217dd5fca38e176da024ad005d571995b7e3430707609350656942b2fe3b9" },
-    { "source": "Setup.ps1", "capabilityId": "settings.setup", "routeCount": 11, "sha256": "c0fed70bfe378372fe315534a9598e6203b3b4c22b65a16070186cd296cac73c" },
+    { "source": "Setup.ps1", "capabilityId": "settings.setup", "routeCount": 14, "sha256": "955be1424b4c624c8a92e0e9ba82b2978dcdebccb6740a5626c92532608edeeb" },
     { "source": "Shutdown.ps1", "capabilityId": "host.lifecycle", "routeCount": 1, "sha256": "35a9d26192452ee7131cb3541e69cfcd242208f7db855c47e3a4998194797f4f" },
     { "source": "Sietch.ps1", "capabilityId": "operation.topology", "routeCount": 2, "sha256": "c8d97b8e6b93456bbb9eb3eb8a3a77cde95186a15891d5c8e135790e65b73ad6" },
     { "source": "SoloMode.ps1", "capabilityId": "host.solo", "routeCount": 25, "sha256": "8e96bd291775b67ec769d6ffaff3a31b055babc57014cf755ca96fddf0c1640e" },

--- a/app/resources/remote-scripts/dune-hyperv-guest-recovery-install.sh
+++ b/app/resources/remote-scripts/dune-hyperv-guest-recovery-install.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
-# Install Hyper-V guest recovery for dynamic-memory hot-add and KVP health.
+# Reconcile DST's Hyper-V guest recovery and optional VM lifecycle integration.
 
 set -u
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 export PATH
 
+ACTION="${DUNE_HYPERV_ACTION:-recovery}"
 MEMORY_ROOT="${DUNE_HYPERV_MEMORY_ROOT:-/sys/devices/system/memory}"
 BOOT_HOOK="${DUNE_HYPERV_BOOT_HOOK:-/etc/local.d/dune-hyperv-memory-online.start}"
 LOG="${DUNE_HYPERV_LOG:-/var/log/dune-hyperv-guest-recovery.log}"
@@ -14,33 +15,174 @@ PGREP="${DUNE_HYPERV_PGREP:-pgrep}"
 KVP_SERVICE="${DUNE_HYPERV_KVP_SERVICE:-hv_kvp_daemon}"
 KVP_PROCESS="${DUNE_HYPERV_KVP_PROCESS:-hv_kvp_daemon}"
 FORCE_KVP_RESTART="${DUNE_HYPERV_FORCE_KVP_RESTART:-0}"
+VMBUS_ROOT="${DUNE_HYPERV_VMBUS_ROOT:-/sys/bus/vmbus/devices}"
+HV_UTILS_ROOT="${DUNE_HYPERV_HV_UTILS_ROOT:-/sys/module/hv_utils}"
+HV_SHUTDOWN_GUID="0e0b6031-5213-4934-818b-38d90ced39db"
+LIFECYCLE_BIN="${DUNE_HYPERV_LIFECYCLE_BIN:-/usr/local/sbin/dune-hyperv-lifecycle}"
+LIFECYCLE_SERVICE="${DUNE_HYPERV_LIFECYCLE_SERVICE:-/etc/init.d/dune-hyperv-lifecycle}"
+LIFECYCLE_NAME="${DUNE_HYPERV_LIFECYCLE_NAME:-dune-hyperv-lifecycle}"
+LIFECYCLE_STATE_DIR="${DUNE_HYPERV_LIFECYCLE_STATE_DIR:-/var/lib/dune-hyperv-lifecycle}"
+LIFECYCLE_STATE="${DUNE_HYPERV_LIFECYCLE_STATE:-$LIFECYCLE_STATE_DIR/state}"
+LIFECYCLE_BACKUP_DIR="${DUNE_HYPERV_LIFECYCLE_BACKUP_DIR:-/var/lib/dune-hyperv-lifecycle-backup}"
+LIFECYCLE_META="${DUNE_HYPERV_LIFECYCLE_META:-$LIFECYCLE_BACKUP_DIR/install.meta}"
+K3S_BIN="${DUNE_HYPERV_K3S_BIN:-/usr/local/bin/k3s}"
+K3S_SERVICE="${DUNE_HYPERV_K3S_SERVICE:-/etc/init.d/k3s}"
+BG_BIN="${DUNE_HYPERV_BG_BIN:-/home/dune/.dune/bin/battlegroup}"
+TIMEOUT="${DUNE_HYPERV_TIMEOUT:-timeout}"
+STOP_TIMEOUT="${DUNE_HYPERV_STOP_TIMEOUT:-300}"
+START_TIMEOUT="${DUNE_HYPERV_START_TIMEOUT:-900}"
 TXN="$$"
 BOOT_STAGE="${BOOT_HOOK}.new.${TXN}"
+BIN_STAGE="${LIFECYCLE_BIN}.new.${TXN}"
+SERVICE_STAGE="${LIFECYCLE_SERVICE}.new.${TXN}"
+META_STAGE="${LIFECYCLE_META}.new.${TXN}"
+TXN_DIR="${DUNE_HYPERV_TXN_DIR:-/run/dune-hyperv-lifecycle-${TXN}}"
+INITIAL_START_SENTINEL="${LIFECYCLE_STATE_DIR}/.initial-install"
+MUTATION_STARTED=0
+TXN_CREATED=0
+SENTINEL_CREATED=0
+HAD_BIN=0
+HAD_SERVICE=0
+HAD_STATE=0
+HAD_RUNLEVEL=0
+PRIOR_SERVICE_STARTED=0
+HAD_META=0
 
 ts() { date "+%Y-%m-%d %H:%M:%S"; }
 log() { echo "[$(ts)] $*" >> "$LOG" 2>/dev/null || true; }
+bool() { if "$@"; then printf true; else printf false; fi; }
+
+cleanup_transaction() {
+    rm -f "$BOOT_STAGE" "$BIN_STAGE" "$SERVICE_STAGE" "$META_STAGE"
+    if [ "$SENTINEL_CREATED" -eq 1 ]; then rm -f "$INITIAL_START_SENTINEL"; fi
+    if [ "$TXN_CREATED" -eq 1 ]; then rm -rf "$TXN_DIR"; fi
+}
+
+runlevel_has_lifecycle() {
+    "$RC_UPDATE" show default 2>/dev/null |
+        grep -Eq "(^|[[:space:]])${LIFECYCLE_NAME}([[:space:]]|$)"
+}
+
+service_started() {
+    "$RC_SERVICE" "$LIFECYCLE_NAME" status >/dev/null 2>&1
+}
+
+restore_transaction() {
+    log "Hyper-V lifecycle reconciliation failed; restoring prior guest state"
+    if [ "$PRIOR_SERVICE_STARTED" -eq 0 ]; then
+        "$RC_SERVICE" "$LIFECYCLE_NAME" zap >/dev/null 2>&1 || true
+    fi
+    if [ "$HAD_BIN" -eq 1 ]; then
+        cp -p "$TXN_DIR/bin" "$LIFECYCLE_BIN" || log "rollback warning: failed to restore lifecycle executable"
+    else
+        rm -f "$LIFECYCLE_BIN"
+    fi
+    if [ "$HAD_SERVICE" -eq 1 ]; then
+        cp -p "$TXN_DIR/service" "$LIFECYCLE_SERVICE" || log "rollback warning: failed to restore OpenRC service"
+    else
+        rm -f "$LIFECYCLE_SERVICE"
+    fi
+    if [ "$HAD_STATE" -eq 1 ]; then
+        mkdir -p "$(dirname "$LIFECYCLE_STATE")" 2>/dev/null || true
+        cp -p "$TXN_DIR/state" "$LIFECYCLE_STATE" || log "rollback warning: failed to restore lifecycle state"
+    else
+        rm -f "$LIFECYCLE_STATE"
+    fi
+    if [ "$HAD_RUNLEVEL" -eq 1 ]; then
+        "$RC_UPDATE" add "$LIFECYCLE_NAME" default >/dev/null 2>&1 ||
+            log "rollback warning: failed to restore OpenRC runlevel"
+    else
+        "$RC_UPDATE" del "$LIFECYCLE_NAME" default >/dev/null 2>&1 || true
+    fi
+    if [ "$PRIOR_SERVICE_STARTED" -eq 1 ] && [ "$HAD_SERVICE" -eq 1 ]; then
+        "$RC_SERVICE" "$LIFECYCLE_NAME" start >/dev/null 2>&1 ||
+            log "rollback warning: failed to restart prior lifecycle service"
+    fi
+    if [ "$HAD_META" -eq 0 ]; then
+        rm -rf "$LIFECYCLE_BACKUP_DIR"
+    fi
+}
+
 fail() {
-    rm -f "$BOOT_STAGE"
-    log "$*"
+    _message="$*"
+    log "$_message"
+    if [ "$MUTATION_STARTED" -eq 1 ]; then restore_transaction; fi
+    cleanup_transaction
     echo DUNE_HYPERV_GUEST_RECOVERY_FAILED
     exit 1
 }
 
-[ -d "$MEMORY_ROOT" ] || {
-    echo DUNE_HYPERV_GUEST_RECOVERY_NOT_APPLICABLE
-    exit 0
+on_interrupt() {
+    log "Hyper-V guest recovery installer interrupted"
+    if [ "$MUTATION_STARTED" -eq 1 ]; then restore_transaction; fi
+    cleanup_transaction
+    exit 1
 }
-[ -w "$MEMORY_ROOT/auto_online_blocks" ] ||
-    fail "memory hot-add policy is not writable: $MEMORY_ROOT/auto_online_blocks"
+trap on_interrupt HUP INT TERM
+
+shutdown_channel_present() {
+    [ -d "$VMBUS_ROOT" ] || return 1
+    for _class in "$VMBUS_ROOT"/*/class_id; do
+        [ -r "$_class" ] || continue
+        _id=$(tr -d '{}[:space:]' < "$_class" 2>/dev/null | tr 'A-F' 'a-f')
+        [ "$_id" = "$HV_SHUTDOWN_GUID" ] && return 0
+    done
+    return 1
+}
+
+hv_utils_present() {
+    [ -d "$HV_UTILS_ROOT" ] && return 0
+    grep -Eq '^hv_utils[[:space:]]' /proc/modules 2>/dev/null
+}
+
+state_value() {
+    _key="$1"
+    [ -r "$LIFECYCLE_STATE" ] || return 0
+    sed -n "s/^${_key}=//p" "$LIFECYCLE_STATE" 2>/dev/null | tail -n 1
+}
+
+lifecycle_managed() {
+    [ -r "$LIFECYCLE_BIN" ] &&
+        grep -Fq 'DUNE_HYPERV_LIFECYCLE_MANAGED=1' "$LIFECYCLE_BIN" 2>/dev/null &&
+        [ -r "$LIFECYCLE_SERVICE" ] &&
+        grep -Fq 'DUNE_HYPERV_LIFECYCLE_MANAGED=1' "$LIFECYCLE_SERVICE" 2>/dev/null
+}
+
+emit_lifecycle_status() {
+    _supported=false
+    _driver=false
+    _channel=false
+    _installed=false
+    _runlevel=false
+    _service=false
+    hv_utils_present && _driver=true
+    shutdown_channel_present && _channel=true
+    [ "$_driver" = true ] && [ "$_channel" = true ] && _supported=true
+    lifecycle_managed && _installed=true
+    runlevel_has_lifecycle && _runlevel=true
+    service_started && _service=true
+    printf 'DUNE_HYPERV_LIFECYCLE_STATUS supported=%s hv_utils=%s shutdown_channel=%s installed=%s runlevel=%s service_started=%s desired=%s last_shutdown_result=%s last_shutdown_phase=%s last_shutdown_at=%s last_start_result=%s last_start_phase=%s last_start_at=%s\n' \
+        "$_supported" "$_driver" "$_channel" "$_installed" "$_runlevel" "$_service" \
+        "$(state_value DESIRED)" "$(state_value LAST_SHUTDOWN_RESULT)" \
+        "$(state_value LAST_SHUTDOWN_PHASE)" "$(state_value LAST_SHUTDOWN_AT)" \
+        "$(state_value LAST_START_RESULT)" "$(state_value LAST_START_PHASE)" \
+        "$(state_value LAST_START_AT)"
+}
 
 online_memory() {
+    [ -d "$MEMORY_ROOT" ] || {
+        echo DUNE_HYPERV_GUEST_RECOVERY_NOT_APPLICABLE
+        exit 0
+    }
+    [ -w "$MEMORY_ROOT/auto_online_blocks" ] ||
+        fail "memory hot-add policy is not writable: $MEMORY_ROOT/auto_online_blocks"
     printf '%s\n' online > "$MEMORY_ROOT/auto_online_blocks" ||
         fail "failed to enable automatic memory onlining"
-    for state in "$MEMORY_ROOT"/memory*/state; do
-        [ -f "$state" ] || continue
-        if [ "$(cat "$state" 2>/dev/null)" = offline ]; then
-            printf '%s\n' online > "$state" ||
-                fail "failed to online memory block: $state"
+    for _state in "$MEMORY_ROOT"/memory*/state; do
+        [ -f "$_state" ] || continue
+        if [ "$(cat "$_state" 2>/dev/null)" = offline ]; then
+            printf '%s\n' online > "$_state" ||
+                fail "failed to online memory block: $_state"
         fi
     done
 }
@@ -50,27 +192,21 @@ kvp_running() {
 }
 
 ensure_kvp() {
-    if [ "$FORCE_KVP_RESTART" = 1 ] ||
-       ! kvp_running; then
+    if [ "$FORCE_KVP_RESTART" = 1 ] || ! kvp_running; then
         "$RC_SERVICE" "$KVP_SERVICE" restart >/dev/null 2>&1 ||
             fail "failed to restart $KVP_SERVICE"
     fi
-    wait_count=0
+    _wait=0
     while ! kvp_running; do
-        wait_count=$((wait_count + 1))
-        [ "$wait_count" -lt 6 ] ||
-            fail "$KVP_PROCESS is still absent after service restart"
+        _wait=$((_wait + 1))
+        [ "$_wait" -lt 6 ] || fail "$KVP_PROCESS is still absent after service restart"
         sleep 1
     done
-    kvp_running ||
-        fail "$KVP_PROCESS is still absent after service restart"
 }
 
-online_memory
-ensure_kvp
-
-mkdir -p "$(dirname "$BOOT_HOOK")" || fail "failed to create boot-hook directory"
-if ! cat > "$BOOT_STAGE" <<'HOOKEOF'
+install_memory_hook() {
+    mkdir -p "$(dirname "$BOOT_HOOK")" || fail "failed to create boot-hook directory"
+    if ! cat > "$BOOT_STAGE" <<'HOOKEOF'
 #!/bin/sh
 set -eu
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
@@ -90,25 +226,471 @@ if ! pgrep -f '(^|/)hv_kvp_daemon([[:space:]]|$)' >/dev/null 2>&1; then
     rc-service hv_kvp_daemon restart >/dev/null 2>&1 || true
 fi
 HOOKEOF
-then
-    fail "failed to stage Hyper-V boot hook"
-fi
-chmod 0755 "$BOOT_STAGE" || fail "failed to make boot hook executable"
-mv -f "$BOOT_STAGE" "$BOOT_HOOK" || fail "failed to publish boot hook"
-"$RC_UPDATE" add local default >/dev/null 2>&1 ||
-    fail "failed to enable the OpenRC local service"
-
-offline=0
-for state in "$MEMORY_ROOT"/memory*/state; do
-    [ -f "$state" ] || continue
-    if [ "$(cat "$state" 2>/dev/null)" = offline ]; then
-        offline=$((offline + 1))
+    then
+        fail "failed to stage Hyper-V memory boot hook"
     fi
-done
-[ "$(cat "$MEMORY_ROOT/auto_online_blocks" 2>/dev/null)" = online ] ||
-    fail "automatic memory onlining did not persist"
-[ "$offline" -eq 0 ] || fail "$offline memory block(s) remain offline"
-[ -x "$BOOT_HOOK" ] || fail "boot hook is missing or not executable"
+    chmod 0755 "$BOOT_STAGE" || fail "failed to make memory boot hook executable"
+    mv -f "$BOOT_STAGE" "$BOOT_HOOK" || fail "failed to publish memory boot hook"
+    "$RC_UPDATE" add local default >/dev/null 2>&1 ||
+        fail "failed to enable the OpenRC local service"
+}
 
-log "Hyper-V guest recovery reconciled: auto_online=online offline=0 kvp=running"
-echo "DUNE_HYPERV_GUEST_RECOVERY_OK auto_online=online offline=0 kvp=running"
+reconcile_recovery() {
+    online_memory
+    ensure_kvp
+    install_memory_hook
+    _offline=0
+    for _state in "$MEMORY_ROOT"/memory*/state; do
+        [ -f "$_state" ] || continue
+        if [ "$(cat "$_state" 2>/dev/null)" = offline ]; then
+            _offline=$((_offline + 1))
+        fi
+    done
+    [ "$(cat "$MEMORY_ROOT/auto_online_blocks" 2>/dev/null)" = online ] ||
+        fail "automatic memory onlining did not persist"
+    [ "$_offline" -eq 0 ] || fail "$_offline memory block(s) remain offline"
+    [ -x "$BOOT_HOOK" ] || fail "memory boot hook is missing or not executable"
+    log "Hyper-V guest recovery reconciled: auto_online=online offline=0 kvp=running"
+    echo "DUNE_HYPERV_GUEST_RECOVERY_OK auto_online=online offline=0 kvp=running"
+}
+
+stage_lifecycle_files() {
+    mkdir -p "$(dirname "$LIFECYCLE_BIN")" "$(dirname "$LIFECYCLE_SERVICE")" ||
+        fail "failed to create lifecycle directories"
+    if ! cat > "$BIN_STAGE" <<'LIFEEOF'
+#!/bin/sh
+# DUNE_HYPERV_LIFECYCLE_MANAGED=1
+set -u
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+export PATH
+
+ACTION="${1:-status}"
+K3S="${DUNE_HYPERV_K3S_BIN:-/usr/local/bin/k3s}"
+BG_BIN="${DUNE_HYPERV_BG_BIN:-/home/dune/.dune/bin/battlegroup}"
+STATE_DIR="${DUNE_HYPERV_LIFECYCLE_STATE_DIR:-/var/lib/dune-hyperv-lifecycle}"
+STATE="${DUNE_HYPERV_LIFECYCLE_STATE:-$STATE_DIR/state}"
+LOG="${DUNE_HYPERV_LOG:-/var/log/dune-hyperv-guest-recovery.log}"
+TIMEOUT="${DUNE_HYPERV_TIMEOUT:-timeout}"
+STOP_TIMEOUT="${DUNE_HYPERV_STOP_TIMEOUT:-300}"
+START_TIMEOUT="${DUNE_HYPERV_START_TIMEOUT:-900}"
+
+now() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] lifecycle: $*" >> "$LOG" 2>/dev/null || true; }
+safe_value() { printf '%s' "$1" | tr -cd 'A-Za-z0-9_.:+-'; }
+
+get_state() {
+    _key="$1"
+    [ -r "$STATE" ] || return 0
+    sed -n "s/^${_key}=//p" "$STATE" 2>/dev/null | tail -n 1
+}
+
+set_state() {
+    _key="$1"
+    _value=$(safe_value "$2")
+    mkdir -p "$STATE_DIR" || return 1
+    _tmp="${STATE}.new.$$"
+    if [ -r "$STATE" ]; then
+        sed "/^${_key}=/d" "$STATE" > "$_tmp" || { rm -f "$_tmp"; return 1; }
+    else
+        : > "$_tmp" || return 1
+    fi
+    printf '%s=%s\n' "$_key" "$_value" >> "$_tmp" || { rm -f "$_tmp"; return 1; }
+    chmod 0600 "$_tmp" || { rm -f "$_tmp"; return 1; }
+    mv -f "$_tmp" "$STATE"
+}
+
+set_result() {
+    _which="$1"
+    _result="$2"
+    _phase="$3"
+    set_state "LAST_${_which}_RESULT" "$_result" &&
+        set_state "LAST_${_which}_PHASE" "$_phase" &&
+        set_state "LAST_${_which}_AT" "$(now)"
+}
+
+pod_rows() {
+    "$K3S" kubectl get pods -A --no-headers \
+        -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,READY:.status.containerStatuses[*].ready,PHASE:.status.phase \
+        2>/dev/null
+}
+
+active_bg_count() {
+    _rows=$(pod_rows) || return 1
+    printf '%s\n' "$_rows" |
+        awk '$2 ~ /(-sg-|-mq-|-sgw-|-tr-|-bgd-)/ && $4 != "Succeeded" && $4 != "Failed" { count++ } END { print count+0 }'
+}
+
+wait_pods_gone() {
+    while :; do
+        _count=$(active_bg_count) || return 1
+        [ "${_count:-0}" -gt 0 ] 2>/dev/null || return 0
+        sleep 2
+    done
+}
+
+k3s_ready() {
+    "$K3S" kubectl get --raw=/readyz 2>/dev/null | grep -qx ok
+}
+
+db_ready() {
+    _rows=$(pod_rows | awk '$2 ~ /(-db-|postgres|^pg-|-pg-)/ && $2 !~ /(dump|backup|fb-|migration|util|mon|pghero)/ && $4 !~ /(Succeeded|Failed)/ {print}')
+    [ -n "$_rows" ] || return 1
+    printf '%s\n' "$_rows" | awk '
+        {
+            n=split($3, ready, ",")
+            for (i=1; i<=n; i++) if (ready[i] != "true") exit 1
+            if ($4 != "Running") exit 1
+        }
+        END { if (NR == 0) exit 1 }'
+}
+
+operators_ready() {
+    _rows=$("$K3S" kubectl get pods -n funcom-operators --no-headers \
+        -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,PHASE:.status.phase 2>/dev/null)
+    [ -n "$_rows" ] || return 1
+    printf '%s\n' "$_rows" | awk '
+        {
+            n=split($2, ready, ",")
+            for (i=1; i<=n; i++) if (ready[i] != "true") exit 1
+            if ($3 != "Running") exit 1
+        }
+        END { if (NR == 0) exit 1 }'
+}
+
+webhook_ready() {
+    "$K3S" kubectl -n funcom-operators get endpoints battlegroupoperator-webhook-svc \
+        -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null |
+        grep -Eq '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
+}
+
+bg_ready() {
+    _row=$("$K3S" kubectl get battlegroups -A \
+        -o jsonpath='{range .items[0]}{.status.phase}{"|"}{.status.database.phase}{"|"}{.status.utilities.serverGateway.phase}{"|"}{.status.utilities.director.phase}{"|"}{range .status.servers[*]}{.phase}:{.ready},{end}{end}' \
+        2>/dev/null)
+    [ -n "$_row" ] || return 1
+    _head=${_row%%|*}; _rest=${_row#*|}
+    _db=${_rest%%|*}; _rest=${_rest#*|}
+    _gw=${_rest%%|*}; _rest=${_rest#*|}
+    _director=${_rest%%|*}; _servers=${_rest#*|}
+    [ "$_head" = Healthy ] && [ "$_db" = Healthy ] &&
+        [ "$_gw" = Running ] && [ "$_director" = Ready ] || return 1
+    [ -n "$_servers" ] || return 1
+    printf '%s' "$_servers" | tr ',' '\n' |
+        awk -F: 'NF == 2 { seen=1; if ($1 != "Running" || $2 != "true") exit 1 } END { if (!seen) exit 1 }'
+}
+
+wait_for() {
+    _phase="$1"
+    shift
+    set_state LAST_START_PHASE "$_phase" || return 1
+    while ! "$@"; do sleep 2; done
+}
+
+stop_worker() {
+    set_state LAST_SHUTDOWN_PHASE battlegroup-stop || exit 1
+    "$BG_BIN" stop >> "$LOG" 2>&1 || exit 2
+    set_state LAST_SHUTDOWN_PHASE pod-drain || exit 1
+    wait_pods_gone
+}
+
+start_worker() {
+    if bg_ready; then exit 0; fi
+    wait_for k3s-api k3s_ready || exit 1
+    wait_for database db_ready || exit 1
+    wait_for operators operators_ready || exit 1
+    wait_for webhook webhook_ready || exit 1
+    set_state LAST_START_PHASE battlegroup-start || exit 1
+    "$BG_BIN" start >> "$LOG" 2>&1 || exit 2
+    wait_for battlegroup-ready bg_ready
+}
+
+case "$ACTION" in
+    stop)
+        _active=$(active_bg_count)
+        _detect_rc=$?
+        if [ "$_detect_rc" -ne 0 ]; then
+            set_state DESIRED running || exit 1
+            set_result SHUTDOWN running detect-unavailable || exit 1
+            log "battlegroup state could not be read; conservatively attempting shutdown and preserving boot recovery"
+        elif [ "${_active:-0}" -gt 0 ] 2>/dev/null; then
+            set_state DESIRED running || exit 1
+            set_result SHUTDOWN running detect || exit 1
+        else
+            set_state DESIRED stopped || exit 1
+            set_result SHUTDOWN skipped battlegroup-stopped || exit 1
+            log "battlegroup already stopped; no boot restore requested"
+            exit 0
+        fi
+        if [ "$(get_state DESIRED)" = running ]; then
+            if "$TIMEOUT" "$STOP_TIMEOUT" "$0" stop-worker; then
+                set_result SHUTDOWN ok complete || exit 1
+                log "graceful battlegroup shutdown completed"
+            else
+                _rc=$?
+                set_result SHUTDOWN failed "timeout-or-exit-${_rc}" || true
+                log "graceful battlegroup shutdown failed or timed out (exit $_rc); allowing OpenRC shutdown to continue"
+            fi
+        fi
+        exit 0
+        ;;
+    stop-worker)
+        stop_worker
+        ;;
+    start)
+        if [ "$(get_state DESIRED)" != running ]; then
+            set_result START skipped desired-stopped || exit 1
+            log "boot reconciliation skipped because battlegroup was intentionally stopped"
+            exit 0
+        fi
+        set_result START running detect || exit 1
+        if "$TIMEOUT" "$START_TIMEOUT" "$0" start-worker; then
+            set_result START ok complete || exit 1
+            log "boot reconciliation completed; battlegroup healthy"
+        else
+            _rc=$?
+            set_result START failed "timeout-or-exit-${_rc}" || true
+            log "boot reconciliation failed or timed out (exit $_rc)"
+        fi
+        exit 0
+        ;;
+    start-worker)
+        start_worker
+        ;;
+    status)
+        printf 'desired=%s last_shutdown_result=%s last_shutdown_phase=%s last_shutdown_at=%s last_start_result=%s last_start_phase=%s last_start_at=%s\n' \
+            "$(get_state DESIRED)" "$(get_state LAST_SHUTDOWN_RESULT)" \
+            "$(get_state LAST_SHUTDOWN_PHASE)" "$(get_state LAST_SHUTDOWN_AT)" \
+            "$(get_state LAST_START_RESULT)" "$(get_state LAST_START_PHASE)" \
+            "$(get_state LAST_START_AT)"
+        ;;
+    *)
+        echo "unsupported lifecycle action: $ACTION" >&2
+        exit 64
+        ;;
+esac
+LIFEEOF
+    then
+        fail "failed to stage Hyper-V lifecycle executable"
+    fi
+
+    if ! cat > "$SERVICE_STAGE" <<SERVICEEOF
+#!/sbin/openrc-run
+# DUNE_HYPERV_LIFECYCLE_MANAGED=1
+description="Dune Hyper-V guest lifecycle reconciliation"
+command="$LIFECYCLE_BIN"
+
+depend() {
+    need k3s
+    after localmount
+}
+
+start() {
+    ebegin "Reconciling Dune battlegroup after VM boot"
+    if [ -f "$INITIAL_START_SENTINEL" ]; then
+        rm -f "$INITIAL_START_SENTINEL"
+    else
+        "\$command" start
+    fi
+    eend 0
+}
+
+stop() {
+    ebegin "Stopping Dune battlegroup before VM shutdown"
+    "\$command" stop
+    eend 0
+}
+SERVICEEOF
+    then
+        fail "failed to stage Hyper-V lifecycle OpenRC service"
+    fi
+    chmod 0755 "$BIN_STAGE" "$SERVICE_STAGE" ||
+        fail "failed to make lifecycle files executable"
+    sh -n "$BIN_STAGE" >/dev/null 2>&1 ||
+        fail "staged lifecycle executable failed shell syntax validation"
+    sh -n "$SERVICE_STAGE" >/dev/null 2>&1 ||
+        fail "staged lifecycle service failed shell syntax validation"
+}
+
+snapshot_transaction() {
+    mkdir "$TXN_DIR" || fail "failed to create exclusive lifecycle transaction directory"
+    TXN_CREATED=1
+    chmod 0700 "$TXN_DIR" || fail "failed to protect lifecycle transaction directory"
+    if [ -f "$LIFECYCLE_BIN" ]; then cp -p "$LIFECYCLE_BIN" "$TXN_DIR/bin" || fail "failed to snapshot lifecycle executable"; HAD_BIN=1; fi
+    if [ -f "$LIFECYCLE_SERVICE" ]; then cp -p "$LIFECYCLE_SERVICE" "$TXN_DIR/service" || fail "failed to snapshot lifecycle service"; HAD_SERVICE=1; fi
+    if [ -f "$LIFECYCLE_STATE" ]; then cp -p "$LIFECYCLE_STATE" "$TXN_DIR/state" || fail "failed to snapshot lifecycle state"; HAD_STATE=1; fi
+    [ -f "$LIFECYCLE_META" ] && HAD_META=1
+    runlevel_has_lifecycle && HAD_RUNLEVEL=1
+    service_started && PRIOR_SERVICE_STARTED=1
+}
+
+save_original_state() {
+    [ -f "$LIFECYCLE_META" ] && return 0
+    mkdir -p "$LIFECYCLE_BACKUP_DIR" || fail "failed to create lifecycle backup directory"
+    if [ "$HAD_BIN" -eq 1 ]; then cp -p "$TXN_DIR/bin" "$LIFECYCLE_BACKUP_DIR/original.bin" || fail "failed to preserve original lifecycle executable"; fi
+    if [ "$HAD_SERVICE" -eq 1 ]; then cp -p "$TXN_DIR/service" "$LIFECYCLE_BACKUP_DIR/original.service" || fail "failed to preserve original lifecycle service"; fi
+    if [ "$HAD_STATE" -eq 1 ]; then cp -p "$TXN_DIR/state" "$LIFECYCLE_BACKUP_DIR/original.state" || fail "failed to preserve original lifecycle state"; fi
+    cat > "$META_STAGE" <<METAEOF
+HAD_BIN=$HAD_BIN
+HAD_SERVICE=$HAD_SERVICE
+HAD_STATE=$HAD_STATE
+HAD_RUNLEVEL=$HAD_RUNLEVEL
+PRIOR_SERVICE_STARTED=$PRIOR_SERVICE_STARTED
+METAEOF
+    chmod 0600 "$META_STAGE" || fail "failed to protect lifecycle install metadata"
+    mv -f "$META_STAGE" "$LIFECYCLE_META" || fail "failed to publish lifecycle install metadata"
+    chmod 0700 "$LIFECYCLE_BACKUP_DIR" || fail "failed to protect lifecycle backup directory"
+}
+
+install_metadata_valid() {
+    [ -r "$LIFECYCLE_META" ] || return 1
+    for _key in HAD_BIN HAD_SERVICE HAD_STATE HAD_RUNLEVEL PRIOR_SERVICE_STARTED; do
+        _value=$(sed -n "s/^${_key}=//p" "$LIFECYCLE_META" 2>/dev/null | tail -n 1)
+        [ "$_value" = 0 ] || [ "$_value" = 1 ] || return 1
+    done
+    [ "$(meta_value HAD_BIN)" -eq 0 ] || [ -f "$LIFECYCLE_BACKUP_DIR/original.bin" ] || return 1
+    [ "$(meta_value HAD_SERVICE)" -eq 0 ] || [ -f "$LIFECYCLE_BACKUP_DIR/original.service" ] || return 1
+    [ "$(meta_value HAD_STATE)" -eq 0 ] || [ -f "$LIFECYCLE_BACKUP_DIR/original.state" ] || return 1
+}
+
+initial_desired_state() {
+    if ! _rows=$("$K3S_BIN" kubectl get pods -A --no-headers \
+        -o custom-columns=NAME:.metadata.name,PHASE:.status.phase 2>/dev/null); then
+        return 1
+    fi
+    _count=$(printf '%s\n' "$_rows" |
+        awk '$1 ~ /(-sg-|-mq-|-sgw-|-tr-|-bgd-)/ && $2 != "Succeeded" && $2 != "Failed" { count++ } END { print count+0 }')
+    if [ "${_count:-0}" -gt 0 ] 2>/dev/null; then printf running; else printf stopped; fi
+}
+
+install_lifecycle() {
+    shutdown_channel_present || fail "Hyper-V shutdown VMBus channel is unavailable"
+    hv_utils_present || fail "hv_utils is unavailable"
+    [ -x "$K3S_BIN" ] || fail "required command missing: $K3S_BIN"
+    [ -x "$K3S_SERVICE" ] || fail "required OpenRC service missing: $K3S_SERVICE"
+    [ -x "$BG_BIN" ] || fail "required command missing: $BG_BIN"
+    command -v "$TIMEOUT" >/dev/null 2>&1 || fail "required command missing: $TIMEOUT"
+    for _required in awk grep sed tail tr; do command -v "$_required" >/dev/null 2>&1 || fail "required command missing: $_required"; done
+    if [ -f "$LIFECYCLE_META" ]; then
+        install_metadata_valid || fail "lifecycle install metadata or original backups are invalid"
+    fi
+
+    stage_lifecycle_files
+    snapshot_transaction
+    MUTATION_STARTED=1
+    save_original_state
+
+    mkdir -p "$LIFECYCLE_STATE_DIR" || fail "failed to create lifecycle state directory"
+    if [ ! -f "$LIFECYCLE_STATE" ]; then
+        _desired=$(initial_desired_state) ||
+            fail "failed to inspect the current battlegroup state"
+        printf 'DESIRED=%s\n' "$_desired" > "$LIFECYCLE_STATE" ||
+            fail "failed to initialize lifecycle state"
+        chmod 0600 "$LIFECYCLE_STATE" || fail "failed to protect lifecycle state"
+    fi
+    mv -f "$BIN_STAGE" "$LIFECYCLE_BIN" || fail "failed to publish lifecycle executable"
+    mv -f "$SERVICE_STAGE" "$LIFECYCLE_SERVICE" || fail "failed to publish lifecycle OpenRC service"
+    "$RC_UPDATE" add "$LIFECYCLE_NAME" default >/dev/null 2>&1 ||
+        fail "failed to enable lifecycle OpenRC service"
+    runlevel_has_lifecycle || fail "lifecycle service missing from default OpenRC runlevel"
+    if ! service_started; then
+        : > "$INITIAL_START_SENTINEL" || fail "failed to stage initial OpenRC start sentinel"
+        SENTINEL_CREATED=1
+        if ! "$RC_SERVICE" "$LIFECYCLE_NAME" start >/dev/null 2>&1; then
+            rm -f "$INITIAL_START_SENTINEL"
+            SENTINEL_CREATED=0
+            fail "failed to start lifecycle OpenRC service"
+        fi
+        rm -f "$INITIAL_START_SENTINEL"
+        SENTINEL_CREATED=0
+    fi
+    service_started || fail "lifecycle OpenRC service did not remain started"
+    lifecycle_managed || fail "lifecycle files failed managed-artifact readback"
+
+    MUTATION_STARTED=0
+    cleanup_transaction
+    log "Hyper-V lifecycle reconciled"
+    emit_lifecycle_status
+}
+
+meta_value() {
+    _key="$1"
+    [ -r "$LIFECYCLE_META" ] || return 0
+    sed -n "s/^${_key}=//p" "$LIFECYCLE_META" | tail -n 1
+}
+
+uninstall_lifecycle() {
+    [ -r "$LIFECYCLE_META" ] || {
+        lifecycle_managed || {
+            echo DUNE_HYPERV_LIFECYCLE_UNINSTALL_OK changed=false
+            exit 0
+        }
+        fail "lifecycle install metadata is missing; refusing to guess rollback state"
+    }
+
+    _had_bin=$(meta_value HAD_BIN)
+    _had_service=$(meta_value HAD_SERVICE)
+    _had_state=$(meta_value HAD_STATE)
+    _had_runlevel=$(meta_value HAD_RUNLEVEL)
+    _prior_started=$(meta_value PRIOR_SERVICE_STARTED)
+    for _value in "$_had_bin" "$_had_service" "$_had_state" "$_had_runlevel" "$_prior_started"; do
+        [ "$_value" = 0 ] || [ "$_value" = 1 ] ||
+            fail "invalid lifecycle install metadata"
+    done
+
+    snapshot_transaction
+    MUTATION_STARTED=1
+    "$RC_SERVICE" "$LIFECYCLE_NAME" zap >/dev/null 2>&1 || true
+    "$RC_UPDATE" del "$LIFECYCLE_NAME" default >/dev/null 2>&1 || true
+
+    if [ "$_had_bin" -eq 1 ]; then
+        [ -f "$LIFECYCLE_BACKUP_DIR/original.bin" ] || fail "original lifecycle executable backup is missing"
+        cp -p "$LIFECYCLE_BACKUP_DIR/original.bin" "$LIFECYCLE_BIN" || fail "failed to restore original lifecycle executable"
+    else
+        rm -f "$LIFECYCLE_BIN"
+    fi
+    if [ "$_had_service" -eq 1 ]; then
+        [ -f "$LIFECYCLE_BACKUP_DIR/original.service" ] || fail "original lifecycle service backup is missing"
+        cp -p "$LIFECYCLE_BACKUP_DIR/original.service" "$LIFECYCLE_SERVICE" || fail "failed to restore original lifecycle service"
+    else
+        rm -f "$LIFECYCLE_SERVICE"
+    fi
+    if [ "$_had_state" -eq 1 ]; then
+        [ -f "$LIFECYCLE_BACKUP_DIR/original.state" ] || fail "original lifecycle state backup is missing"
+        mkdir -p "$(dirname "$LIFECYCLE_STATE")" || fail "failed to restore original lifecycle state directory"
+        cp -p "$LIFECYCLE_BACKUP_DIR/original.state" "$LIFECYCLE_STATE" || fail "failed to restore original lifecycle state"
+    else
+        rm -f "$LIFECYCLE_STATE"
+        rmdir "$LIFECYCLE_STATE_DIR" >/dev/null 2>&1 || true
+    fi
+    if [ "$_had_runlevel" -eq 1 ]; then
+        "$RC_UPDATE" add "$LIFECYCLE_NAME" default >/dev/null 2>&1 ||
+            fail "failed to restore original lifecycle runlevel"
+    fi
+    if [ "$_prior_started" -eq 1 ] && [ "$_had_service" -eq 1 ]; then
+        "$RC_SERVICE" "$LIFECYCLE_NAME" start >/dev/null 2>&1 ||
+            fail "failed to restart original lifecycle service"
+    fi
+    rm -rf "$LIFECYCLE_BACKUP_DIR"
+    MUTATION_STARTED=0
+    cleanup_transaction
+    log "Hyper-V lifecycle integration uninstalled"
+    echo DUNE_HYPERV_LIFECYCLE_UNINSTALL_OK changed=true
+}
+
+case "$ACTION" in
+    recovery)
+        reconcile_recovery
+        ;;
+    lifecycle-status)
+        emit_lifecycle_status
+        ;;
+    lifecycle-install)
+        install_lifecycle
+        ;;
+    lifecycle-uninstall)
+        uninstall_lifecycle
+        ;;
+    *)
+        fail "unsupported Hyper-V guest recovery action: $ACTION"
+        ;;
+esac

--- a/app/resources/remote-scripts/dune-hyperv-guest-recovery-install.sh
+++ b/app/resources/remote-scripts/dune-hyperv-guest-recovery-install.sh
@@ -372,8 +372,12 @@ bg_ready() {
     _db=${_rest%%|*}; _rest=${_rest#*|}
     _gw=${_rest%%|*}; _rest=${_rest#*|}
     _director=${_rest%%|*}; _servers=${_rest#*|}
-    [ "$_head" = Healthy ] && [ "$_db" = Healthy ] &&
-        [ "$_gw" = Running ] && [ "$_director" = Ready ] || return 1
+    case "$_head" in
+        Healthy|Running) ;;
+        *) return 1 ;;
+    esac
+    [ "$_db" = Healthy ] && [ "$_gw" = Running ] &&
+        [ "$_director" = Ready ] || return 1
     [ -n "$_servers" ] || return 1
     printf '%s' "$_servers" | tr ',' '\n' |
         awk -F: 'NF == 2 { seen=1; if ($1 != "Running" || $2 != "true") exit 1 } END { if (!seen) exit 1 }'

--- a/app/server/lib/HyperVGuestRecovery.ps1
+++ b/app/server/lib/HyperVGuestRecovery.ps1
@@ -6,6 +6,8 @@ $script:DuneHyperVGuestRecoveryLastSuccess = [datetime]::MinValue
 $script:DuneHyperVGuestRecoveryLastKvpRestart = [datetime]::MinValue
 $script:DuneHyperVGuestRecoveryRetrySeconds = 60
 $script:DuneHyperVGuestRecoveryKvpStateKey = '__cache:hyperv-guest-kvp-restart'
+$script:DuneHyperVShutdownComponentId = [guid]'9f8233ac-be49-4c79-8ee3-e7e1985b2077'
+$script:DuneHyperVLifecycleVmName = 'dune-awakening'
 
 function Get-DuneSharedKvpRestartTime {
     $table = $null
@@ -104,6 +106,379 @@ function Get-DuneHyperVGuestRecoveryInstallerPath {
     return $null
 }
 
+function Invoke-DuneHyperVGuestRecoveryScript {
+    param(
+        [Parameter(Mandatory)][string]$Ip,
+        [ValidateSet('recovery','lifecycle-status','lifecycle-install','lifecycle-uninstall')]
+        [string]$Action = 'recovery',
+        [switch]$ForceKvp,
+        [int]$TimeoutSec = 30
+    )
+    if (-not (Test-DuneValidVmIpv4 -Ip $Ip)) {
+        throw 'A valid VM IPv4 address is required.'
+    }
+    $installer = Get-DuneHyperVGuestRecoveryInstallerPath
+    if (-not $installer) { throw 'Hyper-V guest recovery installer is missing.' }
+    if (-not (Get-Command Invoke-V6Ssh -ErrorAction SilentlyContinue)) {
+        throw 'SSH helper is unavailable.'
+    }
+
+    $raw = [IO.File]::ReadAllText($installer)
+    $lf = $raw -replace "`r`n", "`n" -replace "`r", "`n"
+    $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($lf))
+    $envArgs = @("DUNE_HYPERV_ACTION=$Action")
+    if ($ForceKvp.IsPresent) { $envArgs += 'DUNE_HYPERV_FORCE_KVP_RESTART=1' }
+    $remoteCommand = "base64 -d | sudo -n env $($envArgs -join ' ') sh"
+    $out = Invoke-V6Ssh -Ip $Ip -Cmd $remoteCommand `
+        -StdinData $b64 -TimeoutSec $TimeoutSec
+    return (($out -join "`n").Trim())
+}
+
+function ConvertFrom-DuneHyperVLifecycleStatus {
+    param([string]$Text)
+    if ($Text -notmatch 'DUNE_HYPERV_LIFECYCLE_STATUS') {
+        throw "Guest lifecycle status did not report a valid result: $Text"
+    }
+    $values = @{}
+    foreach ($match in [regex]::Matches($Text, '(?<key>[a-z_]+)=(?<value>[^\s]*)')) {
+        $values[$match.Groups['key'].Value] = $match.Groups['value'].Value
+    }
+    $asBool = {
+        param([string]$Key)
+        return ($values.ContainsKey($Key) -and $values[$Key] -eq 'true')
+    }
+    return @{
+        supported          = & $asBool 'supported'
+        hvUtils            = & $asBool 'hv_utils'
+        shutdownChannel    = & $asBool 'shutdown_channel'
+        installed          = & $asBool 'installed'
+        runlevel            = & $asBool 'runlevel'
+        serviceStarted      = & $asBool 'service_started'
+        desired             = if ($values.ContainsKey('desired')) { $values.desired } else { '' }
+        lastShutdownResult  = if ($values.ContainsKey('last_shutdown_result')) { $values.last_shutdown_result } else { '' }
+        lastShutdownPhase   = if ($values.ContainsKey('last_shutdown_phase')) { $values.last_shutdown_phase } else { '' }
+        lastShutdownAt      = if ($values.ContainsKey('last_shutdown_at')) { $values.last_shutdown_at } else { '' }
+        lastStartResult     = if ($values.ContainsKey('last_start_result')) { $values.last_start_result } else { '' }
+        lastStartPhase      = if ($values.ContainsKey('last_start_phase')) { $values.last_start_phase } else { '' }
+        lastStartAt         = if ($values.ContainsKey('last_start_at')) { $values.last_start_at } else { '' }
+    }
+}
+
+function Get-DuneHyperVLifecycleStatePath {
+    Join-Path $env:APPDATA 'DuneServer\hyperv-lifecycle-state.json'
+}
+
+function Read-DuneHyperVLifecycleState {
+    $path = Get-DuneHyperVLifecycleStatePath
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { return $null }
+    try {
+        return (Get-Content -LiteralPath $path -Raw -ErrorAction Stop |
+            ConvertFrom-Json -ErrorAction Stop)
+    } catch {
+        throw "Hyper-V lifecycle rollback state is unreadable: $($_.Exception.Message)"
+    }
+}
+
+function Save-DuneHyperVLifecycleState {
+    param([Parameter(Mandatory)][hashtable]$State)
+    $path = Get-DuneHyperVLifecycleStatePath
+    $dir = Split-Path -Parent $path
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force -ErrorAction Stop | Out-Null
+    }
+    $tmp = "$path.new.$PID"
+    try {
+        $json = $State | ConvertTo-Json -Depth 5
+        [IO.File]::WriteAllText($tmp, $json, [Text.UTF8Encoding]::new($false))
+        Move-Item -LiteralPath $tmp -Destination $path -Force -ErrorAction Stop
+    } finally {
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Remove-DuneHyperVLifecycleState {
+    $path = Get-DuneHyperVLifecycleStatePath
+    if (Test-Path -LiteralPath $path -PathType Leaf) {
+        Remove-Item -LiteralPath $path -Force -ErrorAction Stop
+    }
+}
+
+function Get-DuneHyperVLifecycleHostSnapshot {
+    $hv = Get-DuneHyperVSplat
+    $vm = Get-VM -Name $script:DuneHyperVLifecycleVmName @hv -ErrorAction Stop
+    $services = @(Get-VMIntegrationService -VMName $script:DuneHyperVLifecycleVmName @hv -ErrorAction Stop)
+    $shutdown = $services | Where-Object {
+        $componentId = ("$($_.Id)" -split '\\')[-1]
+        try { ([guid]$componentId) -eq $script:DuneHyperVShutdownComponentId } catch { $false }
+    } | Select-Object -First 1
+    if (-not $shutdown) {
+        throw "Hyper-V did not expose Operating System Shutdown identity $($script:DuneHyperVShutdownComponentId) for '$($script:DuneHyperVLifecycleVmName)'."
+    }
+    return @{
+        Hv                    = $hv
+        Vm                    = $vm
+        ShutdownService       = $shutdown
+        HostIdentity          = Get-DuneVmHostIdentity
+        VmId                  = "$($vm.Id)"
+        AutomaticStopAction   = "$($vm.AutomaticStopAction)"
+        ShutdownEnabled       = [bool]$shutdown.Enabled
+    }
+}
+
+function Test-DuneHyperVLifecycleStateIdentity {
+    param($State, [hashtable]$HostSnapshot)
+    if (-not $State) { return $false }
+    return (
+        [int]$State.schema -eq 1 -and
+        [string]$State.hostIdentity -eq [string]$HostSnapshot.HostIdentity -and
+        [string]$State.vmId -eq [string]$HostSnapshot.VmId
+    )
+}
+
+function Get-DuneHyperVLifecycleGuestIp {
+    param([hashtable]$HostSnapshot)
+    if ("$($HostSnapshot.Vm.State)" -ne 'Running') { return '' }
+    $hv = $HostSnapshot.Hv
+    $ip = (Get-VMNetworkAdapter -VMName $script:DuneHyperVLifecycleVmName `
+        @hv -ErrorAction Stop).IPAddresses |
+        Where-Object { $_ -match '^\d+\.\d+\.\d+\.\d+$' } |
+        Select-Object -First 1
+    if ($null -ne $ip) { return [string]$ip }
+    return ''
+}
+
+function Get-DuneHyperVLifecycleStatus {
+    $hostSnapshot = Get-DuneHyperVLifecycleHostSnapshot
+    $ip = Get-DuneHyperVLifecycleGuestIp -HostSnapshot $hostSnapshot
+    $guest = @{
+        reachable = $false
+        supported = $false
+        reason = if ($ip) { 'Guest lifecycle status has not been checked.' } else { 'VM is not running or has no Hyper-V IPv4 address.' }
+    }
+    if ($ip) {
+        try {
+            $guestText = Invoke-DuneHyperVGuestRecoveryScript -Ip $ip `
+                -Action lifecycle-status -TimeoutSec 15
+            $guest = ConvertFrom-DuneHyperVLifecycleStatus -Text $guestText
+            $guest.reachable = $true
+            $guest.reason = if ($guest.supported) { '' } else {
+                'The Alpine guest does not expose both hv_utils and the Hyper-V shutdown VMBus channel.'
+            }
+        } catch {
+            $guest = @{ reachable = $false; supported = $false; reason = $_.Exception.Message }
+        }
+    }
+    $saved = $null
+    $savedError = ''
+    try { $saved = Read-DuneHyperVLifecycleState } catch { $savedError = $_.Exception.Message }
+    $stateMatches = if ($saved) {
+        Test-DuneHyperVLifecycleStateIdentity -State $saved -HostSnapshot $hostSnapshot
+    } else { $false }
+    return @{
+        ok = $true
+        host = @{
+            identity = $hostSnapshot.HostIdentity
+            vmId = $hostSnapshot.VmId
+            vmName = $script:DuneHyperVLifecycleVmName
+            vmState = "$($hostSnapshot.Vm.State)"
+            shutdownServiceId = "$($script:DuneHyperVShutdownComponentId)"
+            shutdownEnabled = $hostSnapshot.ShutdownEnabled
+            automaticStopAction = $hostSnapshot.AutomaticStopAction
+            compliant = ($hostSnapshot.ShutdownEnabled -and
+                $hostSnapshot.AutomaticStopAction -eq 'ShutDown')
+        }
+        guest = $guest
+        rollbackStatePresent = [bool]$saved
+        rollbackStateMatches = $stateMatches
+        rollbackStateError = $savedError
+        configured = (
+            $hostSnapshot.ShutdownEnabled -and
+            $hostSnapshot.AutomaticStopAction -eq 'ShutDown' -and
+            [bool]$guest.reachable -and [bool]$guest.supported -and
+            [bool]$guest.installed -and [bool]$guest.runlevel -and
+            [bool]$guest.serviceStarted
+        )
+        ip = $ip
+    }
+}
+
+function Set-DuneHyperVLifecycleHostValues {
+    param(
+        [Parameter(Mandatory)][hashtable]$HostSnapshot,
+        [Parameter(Mandatory)][bool]$ShutdownEnabled,
+        [Parameter(Mandatory)][string]$AutomaticStopAction
+    )
+    if ([bool]$HostSnapshot.ShutdownService.Enabled -ne $ShutdownEnabled) {
+        if ($ShutdownEnabled) {
+            Enable-VMIntegrationService `
+                -VMIntegrationService $HostSnapshot.ShutdownService `
+                -Confirm:$false -ErrorAction Stop | Out-Null
+        } else {
+            Disable-VMIntegrationService `
+                -VMIntegrationService $HostSnapshot.ShutdownService `
+                -Confirm:$false -ErrorAction Stop | Out-Null
+        }
+    }
+    if ([string]$HostSnapshot.AutomaticStopAction -ne $AutomaticStopAction) {
+        $hv = $HostSnapshot.Hv
+        Set-VM -Name $script:DuneHyperVLifecycleVmName `
+            @hv -AutomaticStopAction $AutomaticStopAction `
+            -Confirm:$false -ErrorAction Stop | Out-Null
+    }
+    $readback = Get-DuneHyperVLifecycleHostSnapshot
+    if ($readback.ShutdownEnabled -ne $ShutdownEnabled -or
+        $readback.AutomaticStopAction -ne $AutomaticStopAction) {
+        throw 'Hyper-V lifecycle host settings failed exact readback.'
+    }
+    return $readback
+}
+
+function Invoke-DuneHyperVLifecycleReconcile {
+    param([switch]$InsideLock)
+    if (-not $InsideLock.IsPresent -and
+        (Get-Command Invoke-WithDuneLock -ErrorAction SilentlyContinue)) {
+        return Invoke-WithDuneLock -Name 'hyperv-lifecycle' -TimeoutSec 120 -Script {
+            Invoke-DuneHyperVLifecycleReconcile -InsideLock
+        }
+    }
+
+    $before = Get-DuneHyperVLifecycleStatus
+    if (-not $before.ip) { throw 'The VM must be running with a Hyper-V IPv4 address before lifecycle reconciliation.' }
+    if (-not $before.guest.reachable) { throw "The Alpine guest is unreachable: $($before.guest.reason)" }
+    if (-not $before.guest.supported) { throw $before.guest.reason }
+
+    $hostSnapshot = Get-DuneHyperVLifecycleHostSnapshot
+    $saved = Read-DuneHyperVLifecycleState
+    $createdState = $false
+    if ($saved -and -not (Test-DuneHyperVLifecycleStateIdentity -State $saved -HostSnapshot $hostSnapshot)) {
+        throw 'Saved Hyper-V lifecycle rollback state belongs to a different host or VM. Remove or correct that state before reconciling.'
+    }
+    if (-not $saved) {
+        Save-DuneHyperVLifecycleState -State @{
+            schema = 1
+            hostIdentity = $hostSnapshot.HostIdentity
+            vmId = $hostSnapshot.VmId
+            priorShutdownEnabled = $hostSnapshot.ShutdownEnabled
+            priorAutomaticStopAction = $hostSnapshot.AutomaticStopAction
+            recordedAt = [datetime]::UtcNow.ToString('o')
+        }
+        $saved = Read-DuneHyperVLifecycleState
+        $createdState = $true
+    }
+
+    $guestWasInstalled = [bool]$before.guest.installed
+    $guestInstalled = $false
+    try {
+        $guestText = Invoke-DuneHyperVGuestRecoveryScript -Ip $before.ip `
+            -Action lifecycle-install -TimeoutSec 120
+        if ($guestText -notmatch 'DUNE_HYPERV_LIFECYCLE_STATUS' -or
+            $guestText -notmatch 'installed=true' -or
+            $guestText -notmatch 'runlevel=true' -or
+            $guestText -notmatch 'service_started=true') {
+            throw "Guest lifecycle installation failed exact readback: $guestText"
+        }
+        $guestInstalled = $true
+        [void](Set-DuneHyperVLifecycleHostValues -HostSnapshot $hostSnapshot `
+            -ShutdownEnabled $true -AutomaticStopAction 'ShutDown')
+        $result = Get-DuneHyperVLifecycleStatus
+        if (-not $result.configured) { throw 'Lifecycle reconciliation completed without a compliant final status.' }
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "Hyper-V VM lifecycle reconciled for $($result.host.identity)"
+        }
+        return $result
+    } catch {
+        $primary = $_.Exception.Message
+        $rollbackErrors = [System.Collections.Generic.List[string]]::new()
+        try {
+            [void](Set-DuneHyperVLifecycleHostValues -HostSnapshot (Get-DuneHyperVLifecycleHostSnapshot) `
+                -ShutdownEnabled ([bool]$hostSnapshot.ShutdownEnabled) `
+                -AutomaticStopAction ([string]$hostSnapshot.AutomaticStopAction))
+        } catch { $rollbackErrors.Add("host: $($_.Exception.Message)") }
+        if ($guestInstalled -and -not $guestWasInstalled) {
+            try {
+                $undo = Invoke-DuneHyperVGuestRecoveryScript -Ip $before.ip `
+                    -Action lifecycle-uninstall -TimeoutSec 45
+                if ($undo -notmatch 'DUNE_HYPERV_LIFECYCLE_UNINSTALL_OK') {
+                    throw "unexpected uninstall result: $undo"
+                }
+            } catch { $rollbackErrors.Add("guest: $($_.Exception.Message)") }
+        }
+        if ($createdState -and $rollbackErrors.Count -eq 0) {
+            try { Remove-DuneHyperVLifecycleState } catch {
+                $rollbackErrors.Add("state: $($_.Exception.Message)")
+            }
+        }
+        $suffix = if ($rollbackErrors.Count) {
+            " Rollback errors: $($rollbackErrors -join '; ')"
+        } else { '' }
+        throw "Hyper-V lifecycle reconciliation failed: $primary.$suffix"
+    }
+}
+
+function Remove-DuneHyperVLifecycle {
+    param([switch]$InsideLock)
+    if (-not $InsideLock.IsPresent -and
+        (Get-Command Invoke-WithDuneLock -ErrorAction SilentlyContinue)) {
+        return Invoke-WithDuneLock -Name 'hyperv-lifecycle' -TimeoutSec 90 -Script {
+            Remove-DuneHyperVLifecycle -InsideLock
+        }
+    }
+
+    $status = Get-DuneHyperVLifecycleStatus
+    $hostSnapshot = Get-DuneHyperVLifecycleHostSnapshot
+    $saved = Read-DuneHyperVLifecycleState
+    if (-not $saved) {
+        if (-not $status.guest.installed -and -not $status.host.compliant) {
+            return $status
+        }
+        throw 'Lifecycle rollback state is missing; refusing to guess original Hyper-V settings.'
+    }
+    if (-not (Test-DuneHyperVLifecycleStateIdentity -State $saved -HostSnapshot $hostSnapshot)) {
+        throw 'Lifecycle rollback state belongs to a different host or VM; refusing to change either system.'
+    }
+    if (-not $status.ip) { throw 'The VM must be running to remove its lifecycle integration safely.' }
+
+    $guestWasInstalled = [bool]$status.guest.installed
+    $guestRemoved = $false
+    try {
+        if ($guestWasInstalled) {
+            $guestText = Invoke-DuneHyperVGuestRecoveryScript -Ip $status.ip `
+                -Action lifecycle-uninstall -TimeoutSec 45
+            if ($guestText -notmatch 'DUNE_HYPERV_LIFECYCLE_UNINSTALL_OK') {
+                throw "Guest lifecycle uninstall failed exact readback: $guestText"
+            }
+            $guestRemoved = $true
+        }
+        [void](Set-DuneHyperVLifecycleHostValues -HostSnapshot $hostSnapshot `
+            -ShutdownEnabled ([bool]$saved.priorShutdownEnabled) `
+            -AutomaticStopAction ([string]$saved.priorAutomaticStopAction))
+        Remove-DuneHyperVLifecycleState
+        if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
+            Write-DuneLog "Hyper-V VM lifecycle integration removed for $($hostSnapshot.HostIdentity)"
+        }
+        return Get-DuneHyperVLifecycleStatus
+    } catch {
+        $primary = $_.Exception.Message
+        $compensationErrors = [System.Collections.Generic.List[string]]::new()
+        try {
+            [void](Set-DuneHyperVLifecycleHostValues `
+                -HostSnapshot (Get-DuneHyperVLifecycleHostSnapshot) `
+                -ShutdownEnabled ([bool]$hostSnapshot.ShutdownEnabled) `
+                -AutomaticStopAction ([string]$hostSnapshot.AutomaticStopAction))
+        } catch { $compensationErrors.Add("host: $($_.Exception.Message)") }
+        if ($guestRemoved) {
+            try {
+                [void](Invoke-DuneHyperVGuestRecoveryScript -Ip $status.ip `
+                    -Action lifecycle-install -TimeoutSec 120)
+            } catch { $compensationErrors.Add("guest: $($_.Exception.Message)") }
+        }
+        $suffix = if ($compensationErrors.Count) {
+            " Compensation errors: $($compensationErrors -join '; ')"
+        } else { '' }
+        throw "Hyper-V lifecycle uninstall failed: $primary.$suffix"
+    }
+}
+
 function Invoke-DuneHyperVGuestRecovery {
     param(
         [Parameter(Mandatory)][string]$Ip,
@@ -143,25 +518,9 @@ function Invoke-DuneHyperVGuestRecovery {
         $script:DuneHyperVGuestRecoveryLastAttempt = $now
     }
 
-    $installer = Get-DuneHyperVGuestRecoveryInstallerPath
-    if (-not $installer) {
-        return @{ ok = $false; skipped = $true; reason = 'installer-missing' }
-    }
-    if (-not (Get-Command Invoke-V6Ssh -ErrorAction SilentlyContinue)) {
-        return @{ ok = $false; skipped = $true; reason = 'ssh-helper-missing' }
-    }
     try {
-        $raw = [IO.File]::ReadAllText($installer)
-        $lf = $raw -replace "`r`n", "`n" -replace "`r", "`n"
-        $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($lf))
-        $remoteCommand = if ($ForceKvp.IsPresent) {
-            'base64 -d | sudo -n env DUNE_HYPERV_FORCE_KVP_RESTART=1 sh'
-        } else {
-            'base64 -d | sudo -n sh'
-        }
-        $out = Invoke-V6Ssh -Ip $Ip -Cmd $remoteCommand `
-            -StdinData $b64 -TimeoutSec 30
-        $text = ($out -join "`n").Trim()
+        $text = Invoke-DuneHyperVGuestRecoveryScript -Ip $Ip `
+            -Action recovery -ForceKvp:$ForceKvp -TimeoutSec 30
         if ($text -notmatch 'DUNE_HYPERV_GUEST_RECOVERY_(OK|NOT_APPLICABLE)') {
             throw "VM recovery installer did not report success: $text"
         }
@@ -172,6 +531,9 @@ function Invoke-DuneHyperVGuestRecovery {
         }
         return @{ ok = $true; cached = $false; output = $text }
     } catch {
+        if ($_.Exception.Message -eq 'Hyper-V guest recovery installer is missing.') {
+            return @{ ok = $false; skipped = $true; reason = 'installer-missing' }
+        }
         if (Get-Command Write-DuneLog -ErrorAction SilentlyContinue) {
             Write-DuneLog "Hyper-V guest recovery failed for $Ip`: $($_.Exception.Message)" 'WARN'
         }

--- a/app/server/routes/Setup.ps1
+++ b/app/server/routes/Setup.ps1
@@ -26,6 +26,35 @@ Register-DuneRoute -Method GET -Path '/api/setup/hyperv-lan' -LocalOnly -Handler
     }
 }
 
+# Hyper-V VM lifecycle is deliberately separate from passive VM status polling:
+# GET is read-only, while reconcile/remove are explicit host-local actions.
+Register-DuneRoute -Method GET -Path '/api/setup/hyperv-lifecycle' -LocalOnly -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Write-DuneJson -Response $res -Body (Get-DuneHyperVLifecycleStatus)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+Register-DuneRoute -Method POST -Path '/api/setup/hyperv-lifecycle/reconcile' -LocalOnly -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Write-DuneJson -Response $res -Body (Invoke-DuneHyperVLifecycleReconcile)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
+Register-DuneRoute -Method DELETE -Path '/api/setup/hyperv-lifecycle' -LocalOnly -Handler {
+    param($req, $res, $routeParams, $body)
+    try {
+        Write-DuneJson -Response $res -Body (Remove-DuneHyperVLifecycle)
+    } catch {
+        Write-DuneError -Response $res -Status 500 -Message $_.Exception.Message
+    }
+}
+
 # Save the Hyper-V-over-LAN settings. This is the routing toggle: mode='lan' +
 # a host IP points every Hyper-V call at the remote host; mode='local' (or the
 # checkbox unchecked) restores today's local behavior and fully bypasses the

--- a/docs/hyperv-vm-lifecycle.md
+++ b/docs/hyperv-vm-lifecycle.md
@@ -29,7 +29,10 @@ The guest lifecycle service:
 - records shutdown failure durably but releases OpenRC after 300 seconds;
 - restarts only when the battlegroup was running before shutdown;
 - waits for the k3s API, database pods, operators, webhook endpoints, and the
-  established battlegroup readiness fields, with a 900-second bound; and
+  established battlegroup readiness fields, with a 900-second bound. The
+  top-level Funcom phase may be `Running` (current) or `Healthy` (legacy), but
+  database, gateway, director, and every game server must still report their
+  healthy/ready states; and
 - records startup success, failure, or skip state for the Settings status view.
 
 Reconcile snapshots original host and guest state before mutation. Removal

--- a/docs/hyperv-vm-lifecycle.md
+++ b/docs/hyperv-vm-lifecycle.md
@@ -1,0 +1,90 @@
+# Hyper-V VM lifecycle
+
+DST can reconcile a Self-Hosted `dune-awakening` VM so Windows host shutdown
+requests a graceful guest shutdown and Alpine preserves the Funcom battlegroup's
+prior running state across the boot.
+
+The feature is opt-in under **Settings > Hyper-V VM lifecycle**. Reading status
+does not change the host or guest.
+
+## Safety boundary
+
+Reconcile changes only:
+
+- the VM's Hyper-V **Operating System Shutdown** integration enabled state,
+  selected by its stable integration-service GUID; and
+- the VM's **Automatic Stop Action**, set to `ShutDown`.
+
+DST does not change Automatic Start Action, dynamic memory, checkpoints, VSS,
+file-copy, KVP host settings, VM networking, or other VM configuration.
+Alpine's kernel `hv_utils` shutdown support and the shutdown VMBus channel must
+both be present before any lifecycle change is allowed. DST does not install or
+enable `hv_fcopy_daemon` or `hv_vss_daemon`.
+
+The guest lifecycle service:
+
+- depends on OpenRC `k3s`, so its stop hook runs before k3s stops;
+- uses `/home/dune/.dune/bin/battlegroup stop` and waits for the established
+  Funcom battlegroup pod set to drain;
+- records shutdown failure durably but releases OpenRC after 300 seconds;
+- restarts only when the battlegroup was running before shutdown;
+- waits for the k3s API, database pods, operators, webhook endpoints, and the
+  established battlegroup readiness fields, with a 900-second bound; and
+- records startup success, failure, or skip state for the Settings status view.
+
+Reconcile snapshots original host and guest state before mutation. Removal
+requires that snapshot to match the current host and VM identity; DST refuses to
+guess if the snapshot is missing, unreadable, or belongs to another VM.
+
+## Disposable-VM acceptance plan
+
+Run this plan only on an isolated Hyper-V host and a disposable clone of the
+supported Alpine/Funcom VM. Do not use a production server.
+
+1. Record the disposable VM ID, Automatic Start Action, Automatic Stop Action,
+   all integration-service enabled states, memory settings, network adapters,
+   checkpoints, and current battlegroup readiness.
+2. With lifecycle integration absent, open Settings and refresh status. Confirm
+   this read-only action changes none of the recorded host or guest values.
+3. Disable Operating System Shutdown and set Automatic Stop Action to `Save`.
+   Reconcile from Settings. Confirm only Operating System Shutdown becomes
+   enabled and Automatic Stop Action becomes `ShutDown`; all unrelated values
+   must match the baseline exactly.
+4. Confirm the guest reports `hv_utils=true`, `shutdown_channel=true`,
+   `installed=true`, `runlevel=true`, and `service_started=true`. Confirm the
+   generated OpenRC service declares `need k3s`.
+5. With a healthy battlegroup running, request a normal Windows host shutdown.
+   Confirm the guest records `DESIRED=running`, invokes the product
+   `battlegroup stop` path, drains the established Funcom pods, and powers off
+   before the 300-second bound.
+6. Boot the host and VM. Confirm k3s becomes ready before battlegroup recovery,
+   the database and operators become ready before webhook and battlegroup
+   startup, and Settings reports a successful durable startup result.
+7. Stop the battlegroup intentionally, then repeat host shutdown and boot.
+   Confirm the guest records `DESIRED=stopped` and does not restart it.
+8. In a second disposable run, force pod drain to exceed 300 seconds. Confirm
+   the durable shutdown result is failed, OpenRC continues host shutdown, and
+   Windows is never blocked indefinitely.
+9. Force each reconciliation failure point in turn: guest staging, OpenRC
+   runlevel update, guest readback, Hyper-V integration enable, Automatic Stop
+   Action update, and host readback. Confirm the pre-test host and guest state
+   is restored or that the error explicitly reports any compensation failure.
+10. Force each removal failure point in turn. Confirm DST either restores the
+    original host and guest state or compensates back to the fully configured
+    lifecycle state; no mixed host/guest state may be reported as success.
+11. Change the disposable VM ID or target host after reconciliation. Confirm
+    removal and further reconciliation fail closed without changing either
+    system.
+12. Remove lifecycle integration normally. Confirm the original Operating
+    System Shutdown enabled state, Automatic Stop Action, guest files, OpenRC
+    runlevel membership, service state, and any pre-existing same-path files
+    are restored exactly.
+13. Compare the final full Hyper-V inventory to step 1. Aside from values
+    deliberately restored to their baseline, there must be no difference.
+
+## References
+
+- [Microsoft Hyper-V integration services](https://learn.microsoft.com/windows-server/virtualization/hyper-v/integration-services)
+- [Linux `hv_utils` implementation](https://github.com/torvalds/linux/blob/master/drivers/hv/hv_util.c)
+- [Alpine `hvtools` package contents](https://pkgs.alpinelinux.org/contents?branch=edge&name=hvtools&arch=x86_64&repo=community)
+- [OpenRC service script guide](https://github.com/OpenRC/openrc/blob/master/service-script-guide.md)

--- a/tests/HyperVGuestRecovery.Tests.ps1
+++ b/tests/HyperVGuestRecovery.Tests.ps1
@@ -497,7 +497,7 @@ Describe 'Hyper-V guest recovery POSIX installer' {
         $source | Should -Not -Match 'rc-update\s+add\s+hv_(fcopy|vss)_daemon'
     }
 
-    It 'installs idempotently, records bounded stop failure, and uninstalls cleanly' {
+    It 'accepts Running readiness only with healthy subcomponents and preserves lifecycle rollback' {
         $bash = Get-Command bash -ErrorAction SilentlyContinue
         if (-not $bash) { Set-ItResult -Skipped -Because 'bash is unavailable'; return }
 
@@ -571,6 +571,52 @@ esac
             $LASTEXITCODE | Should -Be 0
             ($second -join "`n") | Should -Match 'service_started=true'
 
+            $systemTimeout = (& $bash.Source -lc 'command -v timeout').Trim()
+            $bgRow = Join-Path $root 'battlegroup-row'
+            Set-Content $k3s @"
+#!/bin/sh
+case "`$*" in
+  *"get battlegroups -A"*) cat '$rootPosix/battlegroup-row' ;;
+  *"get --raw=/readyz"*) printf 'ok\n' ;;
+  *"get pods -n funcom-operators"*) printf 'battlegroup-controller true Running\n' ;;
+  *"get endpoints"*) printf '10.0.0.2' ;;
+  *"get pods -A"*) printf 'default dune-db-0 true Running\ndefault dune-sg-0 true Running\n' ;;
+  *) exit 1 ;;
+esac
+"@ -NoNewline
+            Set-Content $timeout @"
+#!/bin/sh
+shift
+exec '$systemTimeout' 1 "`$@"
+"@ -NoNewline
+            & $bash.Source -lc "chmod +x '$rootPosix/fake-bin/k3s' '$rootPosix/fake-bin/timeout'"
+            Set-Content (Join-Path $stateDir 'state') 'DESIRED=running'
+
+            foreach ($phase in @('Healthy', 'Running')) {
+                Set-Content $bgRow "$phase|Healthy|Running|Ready|Running:true,"
+                & $bash.Source $env:DUNE_HYPERV_LIFECYCLE_BIN start
+                $LASTEXITCODE | Should -Be 0
+                $state = Get-Content (Join-Path $stateDir 'state') -Raw
+                $state | Should -Match 'LAST_START_RESULT=ok'
+                $state | Should -Match 'LAST_START_PHASE=complete'
+            }
+
+            @(
+                'Starting|Healthy|Running|Ready|Running:true,',
+                'Running|Operation|Running|Ready|Running:true,',
+                'Running|Healthy|Starting|Ready|Running:true,',
+                'Running|Healthy|Running|Starting|Running:true,',
+                'Running|Healthy|Running|Ready|Running:false,'
+            ) | ForEach-Object {
+                Set-Content $bgRow $_
+                & $bash.Source $env:DUNE_HYPERV_LIFECYCLE_BIN start
+                $LASTEXITCODE | Should -Be 0
+                $state = Get-Content (Join-Path $stateDir 'state') -Raw
+                $state | Should -Match 'LAST_START_RESULT=failed'
+            }
+
+            Set-Content $timeout "#!/bin/sh`nexit 124`n" -NoNewline
+            & $bash.Source -lc "chmod +x '$rootPosix/fake-bin/timeout'"
             $env:DUNE_HYPERV_ACTION = $null
             & $bash.Source $env:DUNE_HYPERV_LIFECYCLE_BIN stop
             $LASTEXITCODE | Should -Be 0

--- a/tests/HyperVGuestRecovery.Tests.ps1
+++ b/tests/HyperVGuestRecovery.Tests.ps1
@@ -9,11 +9,21 @@ BeforeAll {
         param($Name, $TimeoutSec, $Script)
         return & $Script
     }
+    function global:Get-DuneHyperVSplat { @{} }
+    function global:Get-VM { param($Name, $ComputerName, $Credential, $ErrorAction) }
+    function global:Get-VMIntegrationService { param($VMName, $ComputerName, $Credential, $ErrorAction) }
+    function global:Get-VMNetworkAdapter { param($VMName, $ComputerName, $Credential, $ErrorAction) }
+    function global:Enable-VMIntegrationService { param($VMIntegrationService, $Confirm, $ErrorAction) }
+    function global:Disable-VMIntegrationService { param($VMIntegrationService, $Confirm, $ErrorAction) }
+    function global:Set-VM { param($Name, $ComputerName, $Credential, $AutomaticStopAction, $Confirm, $ErrorAction) }
 }
 
 AfterAll {
     Remove-Item function:global:Invoke-V6Ssh -ErrorAction SilentlyContinue
     Remove-Item function:global:Invoke-WithDuneLock -ErrorAction SilentlyContinue
+    'Get-DuneHyperVSplat','Get-VM','Get-VMIntegrationService','Get-VMNetworkAdapter',
+    'Enable-VMIntegrationService','Disable-VMIntegrationService','Set-VM' |
+        ForEach-Object { Remove-Item "function:global:$_" -ErrorAction SilentlyContinue }
 }
 
 Describe 'Hyper-V guest recovery backend' -Tag 'Pure' {
@@ -42,7 +52,7 @@ Describe 'Hyper-V guest recovery backend' -Tag 'Pure' {
             param($Ip, $Cmd, $TimeoutSec, $StdinData)
             $decoded = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($StdinData))
             $decoded | Should -Not -Match "`r"
-            $Cmd | Should -Be 'base64 -d | sudo -n sh'
+            $Cmd | Should -Be 'base64 -d | sudo -n env DUNE_HYPERV_ACTION=recovery sh'
             return @('DUNE_HYPERV_GUEST_RECOVERY_OK auto_online=online offline=0 kvp=running')
         }
 
@@ -143,6 +153,247 @@ Describe 'Hyper-V guest recovery backend' -Tag 'Pure' {
             $script:DuneConfigFile = $priorConfig
         }
     }
+
+    It 'selects Operating System Shutdown by stable GUID and preserves LAN splats' {
+        $credential = [pscredential]::new('test', (ConvertTo-SecureString 'test' -AsPlainText -Force))
+        Mock Get-DuneHyperVSplat { @{ ComputerName = '192.168.1.50'; Credential = $credential } }
+        Mock Get-DuneVmHostIdentity { 'lan:192.168.1.50' }
+        Mock Get-VM {
+            [pscustomobject]@{
+                Id = [guid]'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+                State = 'Running'
+                AutomaticStopAction = 'Save'
+            }
+        }
+        Mock Get-VMIntegrationService {
+            @(
+                [pscustomobject]@{ Id = 'Microsoft:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\84EAAE65-2F2E-45F5-9BB5-0E857DC8EB47'; Name = 'Battement'; Enabled = $true },
+                [pscustomobject]@{ Id = 'Microsoft:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\9F8233AC-BE49-4C79-8EE3-E7E1985B2077'; Name = 'Fermeture'; Enabled = $false }
+            )
+        }
+
+        $snapshot = Get-DuneHyperVLifecycleHostSnapshot
+
+        $snapshot.ShutdownService.Name | Should -Be 'Fermeture'
+        $snapshot.ShutdownEnabled | Should -BeFalse
+        Should -Invoke Get-VM -Times 1 -Exactly -ParameterFilter {
+            $ComputerName -eq '192.168.1.50' -and $Credential.UserName -eq 'test'
+        }
+        Should -Invoke Get-VMIntegrationService -Times 1 -Exactly -ParameterFilter {
+            $ComputerName -eq '192.168.1.50' -and $Credential.UserName -eq 'test'
+        }
+    }
+
+    It 'changes only shutdown integration and Automatic Stop Action with exact readback' {
+        $shutdown = [pscustomobject]@{
+            Id = 'Microsoft:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\9F8233AC-BE49-4C79-8EE3-E7E1985B2077'
+            Enabled = $false
+        }
+        $before = @{
+            Hv = @{ ComputerName = '192.168.1.50' }
+            ShutdownService = $shutdown
+            AutomaticStopAction = 'Save'
+        }
+        Mock Enable-VMIntegrationService {}
+        Mock Disable-VMIntegrationService {}
+        Mock Set-VM {}
+        Mock Get-DuneHyperVLifecycleHostSnapshot {
+            @{ ShutdownEnabled = $true; AutomaticStopAction = 'ShutDown' }
+        }
+
+        $after = Set-DuneHyperVLifecycleHostValues -HostSnapshot $before `
+            -ShutdownEnabled $true -AutomaticStopAction ShutDown
+
+        $after.ShutdownEnabled | Should -BeTrue
+        Should -Invoke Enable-VMIntegrationService -Times 1 -Exactly -ParameterFilter {
+            $VMIntegrationService -eq $shutdown
+        }
+        Should -Invoke Disable-VMIntegrationService -Times 0
+        Should -Invoke Set-VM -Times 1 -Exactly -ParameterFilter {
+            $Name -eq 'dune-awakening' -and
+            $ComputerName -eq '192.168.1.50' -and
+            $AutomaticStopAction -eq 'ShutDown'
+        }
+    }
+
+    It 'rejects rollback state for a different host or VM' {
+        $hostSnapshot = @{
+            HostIdentity = 'local:host-a'
+            VmId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+        }
+        Test-DuneHyperVLifecycleStateIdentity -State ([pscustomobject]@{
+            schema = 1
+            hostIdentity = 'local:host-b'
+            vmId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+        }) -HostSnapshot $hostSnapshot | Should -BeFalse
+        Test-DuneHyperVLifecycleStateIdentity -State ([pscustomobject]@{
+            schema = 1
+            hostIdentity = 'local:host-a'
+            vmId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+        }) -HostSnapshot $hostSnapshot | Should -BeFalse
+    }
+
+    It 'parses durable lifecycle results without trusting arbitrary prose' {
+        $parsed = ConvertFrom-DuneHyperVLifecycleStatus -Text @'
+noise before marker
+DUNE_HYPERV_LIFECYCLE_STATUS supported=true hv_utils=true shutdown_channel=true installed=true runlevel=true service_started=true desired=running last_shutdown_result=failed last_shutdown_phase=timeout-or-exit-124 last_shutdown_at=2026-03-12T00:00:00Z last_start_result=ok last_start_phase=complete last_start_at=2026-03-12T00:05:00Z
+'@
+        $parsed.supported | Should -BeTrue
+        $parsed.lastShutdownResult | Should -Be 'failed'
+        $parsed.lastShutdownPhase | Should -Be 'timeout-or-exit-124'
+        { ConvertFrom-DuneHyperVLifecycleStatus -Text 'supported=true' } |
+            Should -Throw '*did not report a valid result*'
+    }
+
+    It 'restores host values and removes a newly installed guest hook when reconcile fails' {
+        $script:testLifecycleState = $null
+        $status = @{
+            ip = '192.168.23.219'
+            guest = @{ reachable = $true; supported = $true; installed = $false }
+        }
+        $hostSnapshot = @{
+            HostIdentity = 'local:test-host'
+            VmId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+            Hv = @{}
+            ShutdownService = [pscustomobject]@{ Enabled = $false }
+            ShutdownEnabled = $false
+            AutomaticStopAction = 'Save'
+        }
+        Mock Get-DuneHyperVLifecycleStatus { $status }
+        Mock Get-DuneHyperVLifecycleHostSnapshot { $hostSnapshot }
+        Mock Read-DuneHyperVLifecycleState { $script:testLifecycleState }
+        Mock Save-DuneHyperVLifecycleState {
+            $script:testLifecycleState = [pscustomobject]@{
+                schema = 1
+                hostIdentity = 'local:test-host'
+                vmId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+                priorShutdownEnabled = $false
+                priorAutomaticStopAction = 'Save'
+            }
+        }
+        Mock Remove-DuneHyperVLifecycleState { $script:testLifecycleState = $null }
+        Mock Invoke-DuneHyperVGuestRecoveryScript {
+            if ($Action -eq 'lifecycle-install') {
+                return 'DUNE_HYPERV_LIFECYCLE_STATUS installed=true runlevel=true service_started=true'
+            }
+            if ($Action -eq 'lifecycle-uninstall') {
+                return 'DUNE_HYPERV_LIFECYCLE_UNINSTALL_OK changed=true'
+            }
+        }
+        Mock Set-DuneHyperVLifecycleHostValues {
+            if ($ShutdownEnabled -and $AutomaticStopAction -eq 'ShutDown') {
+                throw 'simulated host apply failure'
+            }
+            return $hostSnapshot
+        }
+
+        { Invoke-DuneHyperVLifecycleReconcile -InsideLock } |
+            Should -Throw '*simulated host apply failure*'
+
+        Should -Invoke Invoke-DuneHyperVGuestRecoveryScript -Times 1 -Exactly -ParameterFilter {
+            $Action -eq 'lifecycle-uninstall'
+        }
+        Should -Invoke Set-DuneHyperVLifecycleHostValues -Times 1 -Exactly -ParameterFilter {
+            -not $ShutdownEnabled -and $AutomaticStopAction -eq 'Save'
+        }
+        Should -Invoke Remove-DuneHyperVLifecycleState -Times 1 -Exactly
+    }
+
+    It 'preserves configured host values when a repeat reconcile fails' {
+        $script:testHostApplyCalls = 0
+        $status = @{
+            ip = '192.168.23.219'
+            guest = @{ reachable = $true; supported = $true; installed = $true }
+        }
+        $hostSnapshot = @{
+            HostIdentity = 'local:test-host'
+            VmId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+            ShutdownEnabled = $true
+            AutomaticStopAction = 'ShutDown'
+        }
+        Mock Get-DuneHyperVLifecycleStatus { $status }
+        Mock Get-DuneHyperVLifecycleHostSnapshot { $hostSnapshot }
+        Mock Read-DuneHyperVLifecycleState {
+            [pscustomobject]@{
+                schema = 1
+                hostIdentity = 'local:test-host'
+                vmId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+                priorShutdownEnabled = $false
+                priorAutomaticStopAction = 'Save'
+            }
+        }
+        Mock Invoke-DuneHyperVGuestRecoveryScript {
+            'DUNE_HYPERV_LIFECYCLE_STATUS installed=true runlevel=true service_started=true'
+        }
+        Mock Set-DuneHyperVLifecycleHostValues {
+            $script:testHostApplyCalls++
+            if ($script:testHostApplyCalls -eq 1) { throw 'simulated repeat apply failure' }
+            return $hostSnapshot
+        }
+        Mock Remove-DuneHyperVLifecycleState {}
+
+        { Invoke-DuneHyperVLifecycleReconcile -InsideLock } |
+            Should -Throw '*simulated repeat apply failure*'
+
+        Should -Invoke Set-DuneHyperVLifecycleHostValues -Times 2 -Exactly -ParameterFilter {
+            $ShutdownEnabled -and $AutomaticStopAction -eq 'ShutDown'
+        }
+        Should -Invoke Invoke-DuneHyperVGuestRecoveryScript -Times 0 -ParameterFilter {
+            $Action -eq 'lifecycle-uninstall'
+        }
+        Should -Invoke Remove-DuneHyperVLifecycleState -Times 0
+    }
+
+    It 'compensates back to fully configured state when uninstall host restore fails' {
+        $status = @{
+            ip = '192.168.23.219'
+            host = @{ compliant = $true }
+            guest = @{ installed = $true }
+        }
+        $hostSnapshot = @{
+            HostIdentity = 'local:test-host'
+            VmId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+            ShutdownEnabled = $true
+            AutomaticStopAction = 'TurnOff'
+        }
+        Mock Get-DuneHyperVLifecycleStatus { $status }
+        Mock Get-DuneHyperVLifecycleHostSnapshot { $hostSnapshot }
+        Mock Read-DuneHyperVLifecycleState {
+            [pscustomobject]@{
+                schema = 1
+                hostIdentity = 'local:test-host'
+                vmId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+                priorShutdownEnabled = $false
+                priorAutomaticStopAction = 'Save'
+            }
+        }
+        Mock Remove-DuneHyperVLifecycleState {}
+        Mock Invoke-DuneHyperVGuestRecoveryScript {
+            if ($Action -eq 'lifecycle-uninstall') {
+                return 'DUNE_HYPERV_LIFECYCLE_UNINSTALL_OK changed=true'
+            }
+            if ($Action -eq 'lifecycle-install') {
+                return 'DUNE_HYPERV_LIFECYCLE_STATUS installed=true runlevel=true service_started=true'
+            }
+        }
+        Mock Set-DuneHyperVLifecycleHostValues {
+            if (-not $ShutdownEnabled -and $AutomaticStopAction -eq 'Save') {
+                throw 'simulated host restore failure'
+            }
+            return $hostSnapshot
+        }
+
+        { Remove-DuneHyperVLifecycle -InsideLock } |
+            Should -Throw '*simulated host restore failure*'
+
+        Should -Invoke Set-DuneHyperVLifecycleHostValues -Times 1 -Exactly -ParameterFilter {
+            $ShutdownEnabled -and $AutomaticStopAction -eq 'TurnOff'
+        }
+        Should -Invoke Invoke-DuneHyperVGuestRecoveryScript -Times 1 -Exactly -ParameterFilter {
+            $Action -eq 'lifecycle-install'
+        }
+        Should -Invoke Remove-DuneHyperVLifecycleState -Times 0
+    }
 }
 
 Describe 'Hyper-V guest recovery POSIX installer' {
@@ -228,5 +479,132 @@ Describe 'Hyper-V guest recovery POSIX installer' {
             "Invoke-DuneHyperVGuestRecoveryInstall -Ip `$ip -Phase 'pre-reboot-start'",
             'Invoke-DuneHyperVGuestRecoveryInstall -Ip $ip -Phase "pre-$cmdName"'
         ) | ForEach-Object { $launcher | Should -Match ([regex]::Escape($_)) }
+    }
+
+    It 'uses hv_utils in-kernel shutdown support without enabling unrelated daemons' {
+        $source = Get-Content `
+            (Join-Path (Get-DstRepoRoot) 'app\resources\remote-scripts\dune-hyperv-guest-recovery-install.sh') -Raw
+
+        $source | Should -Match '/sys/module/hv_utils'
+        $source | Should -Match '0e0b6031-5213-4934-818b-38d90ced39db'
+        $source | Should -Match 'need k3s'
+        $source | Should -Match '\.initial-install'
+        $source | Should -Match '/run/dune-hyperv-lifecycle-'
+        $source | Should -Not -Match '/tmp/dune-hyperv-lifecycle-'
+        $source | Should -Match 'mkdir "\$TXN_DIR"'
+        $source | Should -Match 'start_worker\(\)[\s\S]*wait_for k3s-api k3s_ready[\s\S]*wait_for database db_ready[\s\S]*wait_for operators operators_ready[\s\S]*wait_for webhook webhook_ready[\s\S]*"\$BG_BIN" start[\s\S]*wait_for battlegroup-ready bg_ready'
+        $source | Should -Not -Match 'rc-service\s+hv_(fcopy|vss)_daemon'
+        $source | Should -Not -Match 'rc-update\s+add\s+hv_(fcopy|vss)_daemon'
+    }
+
+    It 'installs idempotently, records bounded stop failure, and uninstalls cleanly' {
+        $bash = Get-Command bash -ErrorAction SilentlyContinue
+        if (-not $bash) { Set-ItResult -Skipped -Because 'bash is unavailable'; return }
+
+        $root = Join-Path $TestDrive 'lifecycle-guest'
+        $bin = Join-Path $root 'fake-bin'
+        $vmbus = Join-Path $root 'vmbus\shutdown'
+        $hvUtils = Join-Path $root 'hv_utils'
+        $stateDir = Join-Path $root 'state'
+        $backupDir = Join-Path $root 'backup'
+        New-Item -ItemType Directory -Path $bin, $vmbus, $hvUtils, $stateDir, $backupDir -Force | Out-Null
+        Set-Content (Join-Path $vmbus 'class_id') '{0E0B6031-5213-4934-818B-38D90CED39DB}' -NoNewline
+        $rootPosix = (& $bash.Source -lc "cygpath -u '$($root -replace '\\','/')'").Trim()
+
+        $runlevel = Join-Path $root 'runlevel'
+        $started = Join-Path $root 'started'
+        $k3s = Join-Path $bin 'k3s'
+        $bg = Join-Path $bin 'battlegroup'
+        $timeout = Join-Path $bin 'timeout'
+        $rcService = Join-Path $bin 'rc-service'
+        $rcUpdate = Join-Path $bin 'rc-update'
+        Set-Content $k3s "#!/bin/sh`nprintf 'default dune-sg-0 true Running\n'`n" -NoNewline
+        Set-Content $bg "#!/bin/sh`nexit 0`n" -NoNewline
+        Set-Content $timeout "#!/bin/sh`nexit 124`n" -NoNewline
+        Set-Content $rcService @"
+#!/bin/sh
+case "`$2" in
+  status) test -f '$rootPosix/started' ;;
+  start) touch '$rootPosix/started' ;;
+  zap) rm -f '$rootPosix/started' ;;
+esac
+"@ -NoNewline
+        Set-Content $rcUpdate @"
+#!/bin/sh
+case "`$1" in
+  show) test -f '$rootPosix/runlevel' && printf ' dune-hyperv-lifecycle\n' ;;
+  add) touch '$rootPosix/runlevel' ;;
+  del) rm -f '$rootPosix/runlevel' ;;
+esac
+"@ -NoNewline
+        & $bash.Source -lc "chmod +x '$rootPosix/fake-bin/k3s' '$rootPosix/fake-bin/battlegroup' '$rootPosix/fake-bin/timeout' '$rootPosix/fake-bin/rc-service' '$rootPosix/fake-bin/rc-update'"
+
+        $env:DUNE_HYPERV_ACTION = 'lifecycle-install'
+        $env:DUNE_HYPERV_VMBUS_ROOT = "$rootPosix/vmbus"
+        $env:DUNE_HYPERV_HV_UTILS_ROOT = "$rootPosix/hv_utils"
+        $env:DUNE_HYPERV_LIFECYCLE_BIN = "$rootPosix/sbin/dune-hyperv-lifecycle"
+        $env:DUNE_HYPERV_LIFECYCLE_SERVICE = "$rootPosix/init.d/dune-hyperv-lifecycle"
+        $env:DUNE_HYPERV_LIFECYCLE_STATE_DIR = "$rootPosix/state"
+        $env:DUNE_HYPERV_LIFECYCLE_STATE = "$rootPosix/state/state"
+        $env:DUNE_HYPERV_LIFECYCLE_BACKUP_DIR = "$rootPosix/backup"
+        $env:DUNE_HYPERV_LIFECYCLE_META = "$rootPosix/backup/install.meta"
+        $env:DUNE_HYPERV_K3S_BIN = "$rootPosix/fake-bin/k3s"
+        $env:DUNE_HYPERV_K3S_SERVICE = "$rootPosix/fake-bin/k3s-service"
+        $env:DUNE_HYPERV_BG_BIN = "$rootPosix/fake-bin/battlegroup"
+        $env:DUNE_HYPERV_TIMEOUT = "$rootPosix/fake-bin/timeout"
+        $env:DUNE_HYPERV_RC_SERVICE = "$rootPosix/fake-bin/rc-service"
+        $env:DUNE_HYPERV_RC_UPDATE = "$rootPosix/fake-bin/rc-update"
+        $env:DUNE_HYPERV_LOG = "$rootPosix/lifecycle.log"
+        $env:DUNE_HYPERV_TXN_DIR = "$rootPosix/txn"
+        Set-Content (Join-Path $bin 'k3s-service') '#!/bin/sh' -NoNewline
+        & $bash.Source -lc "chmod +x '$env:DUNE_HYPERV_K3S_SERVICE'"
+
+        try {
+            $installer = Join-Path (Get-DstRepoRoot) 'app\resources\remote-scripts\dune-hyperv-guest-recovery-install.sh'
+            $first = & $bash.Source $installer
+            $diagnostic = if (Test-Path (Join-Path $root 'lifecycle.log')) {
+                Get-Content (Join-Path $root 'lifecycle.log') -Raw
+            } else { '' }
+            $LASTEXITCODE | Should -Be 0 -Because "$($first -join "`n")`n$diagnostic"
+            ($first -join "`n") | Should -Match 'installed=true'
+            $second = & $bash.Source $installer
+            $LASTEXITCODE | Should -Be 0
+            ($second -join "`n") | Should -Match 'service_started=true'
+
+            $env:DUNE_HYPERV_ACTION = $null
+            & $bash.Source $env:DUNE_HYPERV_LIFECYCLE_BIN stop
+            $LASTEXITCODE | Should -Be 0
+            $state = Get-Content (Join-Path $stateDir 'state') -Raw
+            $state | Should -Match 'DESIRED=running'
+            $state | Should -Match 'LAST_SHUTDOWN_RESULT=failed'
+            $state | Should -Match 'LAST_SHUTDOWN_PHASE=timeout-or-exit-124'
+
+            $env:DUNE_HYPERV_ACTION = 'lifecycle-uninstall'
+            $removed = & $bash.Source $installer
+            $LASTEXITCODE | Should -Be 0
+            ($removed -join "`n") | Should -Match 'DUNE_HYPERV_LIFECYCLE_UNINSTALL_OK changed=true'
+            Test-Path (Join-Path $root 'sbin\dune-hyperv-lifecycle') | Should -BeFalse
+            Test-Path (Join-Path $root 'init.d\dune-hyperv-lifecycle') | Should -BeFalse
+
+            Set-Content $k3s "#!/bin/sh`nexit 1`n" -NoNewline
+            & $bash.Source -lc "chmod +x '$rootPosix/fake-bin/k3s'"
+            $env:DUNE_HYPERV_ACTION = 'lifecycle-install'
+            $failed = & $bash.Source $installer
+            $LASTEXITCODE | Should -Be 1
+            ($failed -join "`n") | Should -Match 'DUNE_HYPERV_GUEST_RECOVERY_FAILED'
+            Test-Path (Join-Path $root 'sbin\dune-hyperv-lifecycle') | Should -BeFalse
+            Test-Path (Join-Path $root 'init.d\dune-hyperv-lifecycle') | Should -BeFalse
+            Test-Path $runlevel | Should -BeFalse
+        } finally {
+            @(
+                'DUNE_HYPERV_ACTION','DUNE_HYPERV_VMBUS_ROOT','DUNE_HYPERV_HV_UTILS_ROOT',
+                'DUNE_HYPERV_LIFECYCLE_BIN','DUNE_HYPERV_LIFECYCLE_SERVICE',
+                'DUNE_HYPERV_LIFECYCLE_STATE_DIR','DUNE_HYPERV_LIFECYCLE_STATE',
+                'DUNE_HYPERV_LIFECYCLE_BACKUP_DIR','DUNE_HYPERV_LIFECYCLE_META',
+                'DUNE_HYPERV_K3S_BIN','DUNE_HYPERV_K3S_SERVICE','DUNE_HYPERV_BG_BIN',
+                'DUNE_HYPERV_TIMEOUT','DUNE_HYPERV_RC_SERVICE','DUNE_HYPERV_RC_UPDATE',
+                'DUNE_HYPERV_LOG','DUNE_HYPERV_TXN_DIR'
+            ) | ForEach-Object { Remove-Item "Env:$_" -ErrorAction SilentlyContinue }
+        }
     }
 }

--- a/tests/HyperVGuestRecovery.Tests.ps1
+++ b/tests/HyperVGuestRecovery.Tests.ps1
@@ -248,7 +248,7 @@ DUNE_HYPERV_LIFECYCLE_STATUS supported=true hv_utils=true shutdown_channel=true 
     It 'restores host values and removes a newly installed guest hook when reconcile fails' {
         $script:testLifecycleState = $null
         $status = @{
-            ip = '192.168.23.219'
+            ip = '192.168.1.219'
             guest = @{ reachable = $true; supported = $true; installed = $false }
         }
         $hostSnapshot = @{
@@ -302,7 +302,7 @@ DUNE_HYPERV_LIFECYCLE_STATUS supported=true hv_utils=true shutdown_channel=true 
     It 'preserves configured host values when a repeat reconcile fails' {
         $script:testHostApplyCalls = 0
         $status = @{
-            ip = '192.168.23.219'
+            ip = '192.168.1.219'
             guest = @{ reachable = $true; supported = $true; installed = $true }
         }
         $hostSnapshot = @{
@@ -346,7 +346,7 @@ DUNE_HYPERV_LIFECYCLE_STATUS supported=true hv_utils=true shutdown_channel=true 
 
     It 'compensates back to fully configured state when uninstall host restore fails' {
         $status = @{
-            ip = '192.168.23.219'
+            ip = '192.168.1.219'
             host = @{ compliant = $true }
             guest = @{ installed = $true }
         }

--- a/tests/PlatformContracts.Tests.ps1
+++ b/tests/PlatformContracts.Tests.ps1
@@ -283,6 +283,19 @@ Describe 'Complete route classification' {
             Should -Be 'operation.diagnostics.manage'
         @($script:DuneRoutes | Where-Object Path -eq '/api/status').Classification.capabilityId |
             Should -Be 'platform.status'
+        $lifecycleRoutes = @($script:DuneRoutes | Where-Object {
+            $_.Path -like '/api/setup/hyperv-lifecycle*'
+        })
+        $lifecycleRoutes.Count | Should -Be 3
+        @($lifecycleRoutes | Where-Object { -not $_.LocalOnly }).Count | Should -Be 0
+        @($lifecycleRoutes | Where-Object { $_.Classification.capabilityId -ne 'settings.setup' }).Count |
+            Should -Be 0
+        @($lifecycleRoutes | Where-Object Method -eq 'GET').Classification.lifecycle |
+            Should -Be 'read'
+        @($lifecycleRoutes | Where-Object Method -eq 'POST').Classification.lifecycle |
+            Should -Be 'transactional-write'
+        @($lifecycleRoutes | Where-Object Method -eq 'DELETE').Classification.lifecycle |
+            Should -Be 'reversible-write'
     }
 
     It 'matches the actual startup registrations and keeps the Pods cleanup reachable' {

--- a/tests/PlatformContracts.Tests.ps1
+++ b/tests/PlatformContracts.Tests.ps1
@@ -170,7 +170,7 @@ Describe 'Complete route classification' {
     It 'classifies the exact registered HTTP and WebSocket inventory' {
         $records = @(Get-PlatformRouteRecords)
         $manifest = Get-DuneRoutePolicyManifest
-        $records.Count | Should -Be 371
+        $records.Count | Should -Be 374
         $sources = @($records.SourceFile | Sort-Object -Unique)
         @($manifest.groups.source | Sort-Object) | Should -Be $sources
 
@@ -334,7 +334,7 @@ $result = @{
         $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
         $resultLine = @($output | Where-Object { [string]$_ -like 'ROUTE_RESULT:*' })[-1]
         $result = ([string]$resultLine).Substring('ROUTE_RESULT:'.Length) | ConvertFrom-Json
-        $result.total | Should -Be 371
+        $result.total | Should -Be 374
         $result.unclassified | Should -Be 0
         $result.incompatible | Should -Be 0
         $result.podsCleanup | Should -Be 1

--- a/webui/src/api/setup.ts
+++ b/webui/src/api/setup.ts
@@ -81,6 +81,54 @@ export function deleteHyperVLanCredential() {
   return api<{ ok: boolean }>('/api/setup/hyperv-lan/credential', { method: 'DELETE' })
 }
 
+export interface HyperVLifecycleGuestStatus {
+  reachable: boolean
+  supported: boolean
+  reason: string
+  hvUtils?: boolean
+  shutdownChannel?: boolean
+  installed?: boolean
+  runlevel?: boolean
+  serviceStarted?: boolean
+  desired?: string
+  lastShutdownResult?: string
+  lastShutdownPhase?: string
+  lastShutdownAt?: string
+  lastStartResult?: string
+  lastStartPhase?: string
+  lastStartAt?: string
+}
+
+export interface HyperVLifecycleStatus {
+  ok: boolean
+  configured: boolean
+  ip: string
+  rollbackStatePresent: boolean
+  rollbackStateMatches: boolean
+  rollbackStateError: string
+  host: {
+    identity: string
+    vmId: string
+    vmName: string
+    vmState: string
+    shutdownServiceId: string
+    shutdownEnabled: boolean
+    automaticStopAction: string
+    compliant: boolean
+  }
+  guest: HyperVLifecycleGuestStatus
+}
+
+export function getHyperVLifecycle() {
+  return api<HyperVLifecycleStatus>('/api/setup/hyperv-lifecycle')
+}
+export function reconcileHyperVLifecycle() {
+  return api<HyperVLifecycleStatus>('/api/setup/hyperv-lifecycle/reconcile', { method: 'POST' })
+}
+export function removeHyperVLifecycle() {
+  return api<HyperVLifecycleStatus>('/api/setup/hyperv-lifecycle', { method: 'DELETE' })
+}
+
 // Remote install (VM lives on a headless Hyper-V host). user/password are
 // optional — omit them to use the saved Hyper-V LAN credential for hostIp
 // (set in the Connect step) instead of re-entering it; an explicit value here

--- a/webui/src/pages/Settings.tsx
+++ b/webui/src/pages/Settings.tsx
@@ -11,6 +11,7 @@ import { DashboardAlertsCard } from './settings/DashboardAlertsCard'
 import { PublicIpCard } from './settings/PublicIpCard'
 import { ServerBrowserPingCard } from './settings/ServerBrowserPingCard'
 import { HyperVLanCard } from './settings/HyperVLanCard'
+import { HyperVLifecycleCard } from './settings/HyperVLifecycleCard'
 import { RemoteAccessCard } from './settings/RemoteAccessCard'
 import { MobileAppCard } from './settings/MobileAppCard'
 import { FlsTokenCard } from './settings/FlsTokenCard'
@@ -713,6 +714,8 @@ export function Settings() {
       <SectionErrorBoundary name="Remote Access"><RemoteAccessCard /></SectionErrorBoundary>
 
       <SectionErrorBoundary name="Hyper-V over LAN"><HyperVLanCard /></SectionErrorBoundary>
+
+      <SectionErrorBoundary name="Hyper-V VM lifecycle"><HyperVLifecycleCard /></SectionErrorBoundary>
 
       <SectionErrorBoundary name="Public IP"><PublicIpCard /></SectionErrorBoundary>
 

--- a/webui/src/pages/settings/HyperVLifecycleCard.tsx
+++ b/webui/src/pages/settings/HyperVLifecycleCard.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ApiError } from '../../api/client'
+import {
+  getHyperVLifecycle,
+  reconcileHyperVLifecycle,
+  removeHyperVLifecycle,
+  type HyperVLifecycleStatus,
+} from '../../api/setup'
+import { Icon } from '../../components/Icon'
+import { useCardCollapse } from '../../components/CollapsibleCard'
+
+function resultText(result?: string, phase?: string, at?: string) {
+  if (!result) return 'No result recorded'
+  return [result, phase, at].filter(Boolean).join(' · ')
+}
+
+export function HyperVLifecycleCard() {
+  const { open, setOpen } = useCardCollapse('settings.hyperVLifecycle', false)
+  const [status, setStatus] = useState<HyperVLifecycleStatus | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [working, setWorking] = useState(false)
+  const [confirmRemove, setConfirmRemove] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setStatus(await getHyperVLifecycle())
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { if (open) void load() }, [open, load])
+
+  const reconcile = useCallback(async () => {
+    setWorking(true)
+    setMessage(null)
+    setError(null)
+    try {
+      const next = await reconcileHyperVLifecycle()
+      setStatus(next)
+      setMessage('Hyper-V shutdown and Alpine boot lifecycle reconciled.')
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : String(e))
+    } finally {
+      setWorking(false)
+    }
+  }, [])
+
+  const remove = useCallback(async () => {
+    setWorking(true)
+    setMessage(null)
+    setError(null)
+    try {
+      const next = await removeHyperVLifecycle()
+      setStatus(next)
+      setConfirmRemove(false)
+      setMessage('Lifecycle integration removed and recorded Hyper-V values restored.')
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : String(e))
+    } finally {
+      setWorking(false)
+    }
+  }, [])
+
+  const configured = status?.configured === true
+  const guestReady = status?.guest.reachable && status.guest.supported
+
+  return (
+    <div className="card mb-4" data-section-nav-id="settings.hyperVLifecycle" data-section-nav-label="Hyper-V VM lifecycle">
+      <button
+        type="button"
+        onClick={() => setOpen(value => !value)}
+        aria-expanded={open}
+        data-section-nav-toggle
+        className="w-full flex items-center justify-between gap-3 p-6 text-left"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <Icon name="Power" size={18} className="text-text-muted shrink-0" />
+          <div className="min-w-0">
+            <div className="font-medium">Hyper-V VM lifecycle</div>
+            <div className="text-sm text-text-muted truncate">
+              {configured
+                ? 'Graceful host shutdown and Alpine battlegroup boot recovery are configured.'
+                : 'Protect the Funcom stack when Windows stops or restarts its Hyper-V host.'}
+            </div>
+          </div>
+        </div>
+        <Icon name={open ? 'ChevronUp' : 'ChevronDown'} size={18} className="text-text-muted shrink-0" />
+      </button>
+
+      {open && (
+        <div className="px-6 pb-6 space-y-4">
+          <p className="text-sm text-text-dim">
+            Reconcile enables only Hyper-V Operating System Shutdown and sets this VM&apos;s Automatic Stop Action
+            to <span className="font-mono">ShutDown</span>. The Alpine hook stops the battlegroup before k3s,
+            has a fixed timeout, and restarts only a battlegroup that was running before shutdown.
+          </p>
+
+          {error && (
+            <div className="rounded-lg border border-danger/40 bg-danger/10 p-3 text-sm text-danger flex items-start gap-2">
+              <Icon name="CircleX" size={16} className="mt-0.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+          {message && (
+            <div className="rounded-lg border border-success/40 bg-success/10 p-3 text-sm text-success flex items-start gap-2">
+              <Icon name="CircleCheck" size={16} className="mt-0.5 shrink-0" />
+              <span>{message}</span>
+            </div>
+          )}
+
+          {loading && !status ? (
+            <p className="text-sm text-text-dim italic">Loading…</p>
+          ) : status && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+              <div className="rounded-lg border border-border bg-surface-2 p-3 space-y-1">
+                <div className="font-medium">Windows host</div>
+                <div className="text-text-dim">Target <span className="font-mono text-text">{status.host.identity}</span></div>
+                <div className="text-text-dim">VM <span className="font-mono text-text">{status.host.vmName}</span> · {status.host.vmState}</div>
+                <div className={status.host.shutdownEnabled ? 'text-success' : 'text-warning'}>
+                  Operating System Shutdown: {status.host.shutdownEnabled ? 'enabled' : 'disabled'}
+                </div>
+                <div className={status.host.automaticStopAction === 'ShutDown' ? 'text-success' : 'text-warning'}>
+                  Automatic Stop Action: {status.host.automaticStopAction || 'unknown'}
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-border bg-surface-2 p-3 space-y-1">
+                <div className="font-medium">Alpine guest</div>
+                <div className={guestReady ? 'text-success' : 'text-warning'}>
+                  hv_utils shutdown support: {guestReady ? 'ready' : 'not verified'}
+                </div>
+                <div className={status.guest.installed && status.guest.runlevel && status.guest.serviceStarted ? 'text-success' : 'text-warning'}>
+                  OpenRC lifecycle: {status.guest.installed ? 'installed' : 'not installed'}
+                </div>
+                {status.guest.reason && <div className="text-xs text-warning break-words">{status.guest.reason}</div>}
+                <div className="text-xs text-text-dim">
+                  Last shutdown: {resultText(status.guest.lastShutdownResult, status.guest.lastShutdownPhase, status.guest.lastShutdownAt)}
+                </div>
+                <div className="text-xs text-text-dim">
+                  Last start: {resultText(status.guest.lastStartResult, status.guest.lastStartPhase, status.guest.lastStartAt)}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {status?.rollbackStateError && (
+            <div className="text-sm text-danger">{status.rollbackStateError}</div>
+          )}
+          {status?.rollbackStatePresent && !status.rollbackStateMatches && (
+            <div className="text-sm text-danger">
+              Saved rollback state belongs to a different Hyper-V host or VM. DST will not change either system.
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <button type="button" className="btn-secondary" onClick={() => void load()} disabled={loading || working}>
+              <Icon name={loading ? 'Loader2' : 'RefreshCw'} size={14} className={loading ? 'animate-spin' : ''} />
+              Refresh
+            </button>
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={() => void reconcile()}
+              disabled={loading || working || !status?.guest.reachable || !status.guest.supported || (status.rollbackStatePresent && !status.rollbackStateMatches)}
+            >
+              <Icon name={working ? 'Loader2' : 'ShieldCheck'} size={14} className={working ? 'animate-spin' : ''} />
+              {working ? 'Working…' : 'Reconcile'}
+            </button>
+            {status?.rollbackStatePresent && (
+              !confirmRemove ? (
+                <button type="button" className="btn-secondary" onClick={() => setConfirmRemove(true)} disabled={working}>
+                  Remove lifecycle integration
+                </button>
+              ) : (
+                <>
+                  <button type="button" className="btn-secondary text-danger" onClick={() => void remove()} disabled={working}>
+                    Confirm remove
+                  </button>
+                  <button type="button" className="btn-secondary" onClick={() => setConfirmRemove(false)} disabled={working}>
+                    Cancel
+                  </button>
+                </>
+              )
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/webui/tests/api/hyperVLan.test.ts
+++ b/webui/tests/api/hyperVLan.test.ts
@@ -6,6 +6,9 @@ import {
   deleteHyperVLanCredential,
   getHyperVLanHostResources,
   startHyperVLanInstall,
+  getHyperVLifecycle,
+  reconcileHyperVLifecycle,
+  removeHyperVLifecycle,
 } from '../../src/api/setup'
 
 interface FetchCall {
@@ -45,6 +48,20 @@ describe('Hyper-V LAN credential API', () => {
       url: '/api/setup/hyperv-lan/test',
       method: 'POST',
       body: { hostIp: '192.168.1.50', user: undefined, password: undefined },
+    })
+  })
+
+  describe('Hyper-V VM lifecycle API', () => {
+    it('keeps status read-only and mutations explicit', async () => {
+      await getHyperVLifecycle()
+      await reconcileHyperVLifecycle()
+      await removeHyperVLifecycle()
+
+      expect(calls.slice(-3)).toEqual([
+        { url: '/api/setup/hyperv-lifecycle', method: undefined, body: undefined },
+        { url: '/api/setup/hyperv-lifecycle/reconcile', method: 'POST', body: undefined },
+        { url: '/api/setup/hyperv-lifecycle', method: 'DELETE', body: undefined },
+      ])
     })
   })
 

--- a/webui/tests/components/HyperVLifecycleCard.test.tsx
+++ b/webui/tests/components/HyperVLifecycleCard.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { api } from '../../src/api/client'
+import { HyperVLifecycleCard } from '../../src/pages/settings/HyperVLifecycleCard'
+
+vi.mock('../../src/api/client', () => ({
+  ApiError: class ApiError extends Error {
+    body?: unknown
+  },
+  api: vi.fn(),
+}))
+
+const readyStatus = {
+  ok: true,
+  configured: false,
+  ip: '192.168.23.219',
+  rollbackStatePresent: false,
+  rollbackStateMatches: false,
+  rollbackStateError: '',
+  host: {
+    identity: 'local:test-host',
+    vmId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    vmName: 'dune-awakening',
+    vmState: 'Running',
+    shutdownServiceId: '9f8233ac-be49-4c79-8ee3-e7e1985b2077',
+    shutdownEnabled: false,
+    automaticStopAction: 'Save',
+    compliant: false,
+  },
+  guest: {
+    reachable: true,
+    supported: true,
+    reason: '',
+    hvUtils: true,
+    shutdownChannel: true,
+    installed: false,
+    runlevel: false,
+    serviceStarted: false,
+  },
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.mocked(api).mockImplementation(async (path, init) => {
+    if (path === '/api/setup/hyperv-lifecycle' && !init?.method) return readyStatus
+    if (path === '/api/setup/hyperv-lifecycle/reconcile' && init?.method === 'POST') {
+      return {
+        ...readyStatus,
+        configured: true,
+        rollbackStatePresent: true,
+        rollbackStateMatches: true,
+        host: { ...readyStatus.host, shutdownEnabled: true, automaticStopAction: 'ShutDown', compliant: true },
+        guest: { ...readyStatus.guest, installed: true, runlevel: true, serviceStarted: true },
+      }
+    }
+    if (path === '/api/setup/hyperv-lifecycle' && init?.method === 'DELETE') return readyStatus
+    throw new Error(`Unexpected API call: ${path}`)
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('HyperVLifecycleCard', () => {
+  it('loads passively and reconciles only after an explicit operator action', async () => {
+    const user = userEvent.setup()
+    render(<HyperVLifecycleCard />)
+
+    expect(api).not.toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: /hyper-v vm lifecycle/i }))
+    await screen.findByText(/operating system shutdown: disabled/i)
+    expect(api).toHaveBeenCalledTimes(1)
+    expect(api).toHaveBeenLastCalledWith('/api/setup/hyperv-lifecycle')
+
+    await user.click(screen.getByRole('button', { name: /^reconcile$/i }))
+    await screen.findByText(/lifecycle reconciled/i)
+    await waitFor(() => {
+      expect(api).toHaveBeenCalledWith('/api/setup/hyperv-lifecycle/reconcile', { method: 'POST' })
+    })
+  })
+
+  it('requires an inline confirmation before uninstalling', async () => {
+    vi.mocked(api).mockResolvedValueOnce({
+      ...readyStatus,
+      configured: true,
+      rollbackStatePresent: true,
+      rollbackStateMatches: true,
+      host: { ...readyStatus.host, shutdownEnabled: true, automaticStopAction: 'ShutDown', compliant: true },
+      guest: { ...readyStatus.guest, installed: true, runlevel: true, serviceStarted: true },
+    })
+    const user = userEvent.setup()
+    render(<HyperVLifecycleCard />)
+
+    await user.click(screen.getByRole('button', { name: /hyper-v vm lifecycle/i }))
+    const remove = await screen.findByRole('button', { name: /remove lifecycle integration/i })
+    await user.click(remove)
+    expect(api).toHaveBeenCalledTimes(1)
+    await user.click(screen.getByRole('button', { name: /confirm remove/i }))
+
+    await waitFor(() => {
+      expect(api).toHaveBeenCalledWith('/api/setup/hyperv-lifecycle', { method: 'DELETE' })
+    })
+  })
+})

--- a/webui/tests/components/HyperVLifecycleCard.test.tsx
+++ b/webui/tests/components/HyperVLifecycleCard.test.tsx
@@ -15,7 +15,7 @@ vi.mock('../../src/api/client', () => ({
 const readyStatus = {
   ok: true,
   configured: false,
-  ip: '192.168.23.219',
+  ip: '192.168.1.219',
   rollbackStatePresent: false,
   rollbackStateMatches: false,
   rollbackStateError: '',


### PR DESCRIPTION
Adds a Settings control for Hyper-V VM shutdown/startup lifecycle on self-hosted servers, with guest-recovery support. Full pwsh (HyperVGuestRecovery + PlatformContracts) and webui (hyperVLan + HyperVLifecycleCard) suites pass locally. Non-destructive; isolated to its own category.