### PR TITLE
Release v15.0.3 — Players & Inventory and Hyper-V VM lifecycle

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -93,7 +93,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.2"
+      placeholder: "v15.0.3"
     validations:
       required: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,6 +81,13 @@ jobs:
           $v = (Get-Module PSScriptAnalyzer).Version
           Write-Host "PSScriptAnalyzer $v ready."
 
+          # The Actions pwsh wrapper appends `exit $LASTEXITCODE`, so a
+          # non-zero code left behind by nuget.exe in the fallback path
+          # would fail this step even though the import above succeeded.
+          # Import-Module uses -ErrorAction Stop, so reaching this line
+          # means the module really is loaded; make that the exit code.
+          exit 0
+
       - name: Parse-validate dune-server.ps1
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,6 @@ here cover everything those tags shipped.
 
 - Protected Reserve items from direct deletion, quantity reduction, and live
   Clean Inventory so hidden remaining rows cannot keep base recycling blocked.
-- Replaced an environment-specific example address in the test suite with a
-  documentation placeholder.
 
 ## [15.0.2] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.3] - 2026-09-09
+
 ### Added
 
-- Added **Players > Community tools** to Command Deck, exposing the existing
-  in-game chat command controls, shared `!tp` destinations, and Welcome Back
-  packages while retaining their opt-in defaults and existing safeguards.
+- Brought Command Deck's Players and Inventory workspaces to parity with
+  Classic, including **Players > Community tools** with the existing in-game
+  chat command controls, shared `!tp` destinations, and Welcome Back packages,
+  all keeping their opt-in defaults and existing safeguards.
 - Added guarded hidden-Reserve recovery to Player Inventory. DST previews the
   exact rows and Backpack positions, requires the player to be Offline, verifies
   a fresh local backup and exact slot/volume capacity, moves rows intact in one
@@ -32,6 +35,8 @@ here cover everything those tags shipped.
 
 - Protected Reserve items from direct deletion, quantity reduction, and live
   Clean Inventory so hidden remaining rows cannot keep base recycling blocked.
+- Replaced an environment-specific example address in the test suite with a
+  documentation placeholder.
 
 ## [15.0.2] - 2026-09-09
 

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -166,7 +166,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 Write-DuneStartupLog 'Console presentation initialized'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.2'
+$script:DuneToolVersion = '15.0.3'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.2',
+    [string]$Version = '15.0.3',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.2</Version>
+    <Version>15.0.3</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.2"
+#define MyAppVersion "15.0.3"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.2"
+$script:ToolVersion = "15.0.3"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a


### PR DESCRIPTION
## Summary

Prepares the **v15.0.3** release metadata. Metadata only — no product code changes, no tag, no final release build, no publish.

- Bumps the five canonical version stamps from `15.0.2` to `15.0.3`.
- Writes the dated `## [15.0.3] - 2026-09-09` changelog entry covering the complete v15.0.3 scope.
- Refreshes the bug-report template version placeholder to `v15.0.3`.

## Related issues

Refs #826, #828, #829

## Release scope

v15.0.3 is a transitional release that ships more than one delivery category. The one-category process applies to **future** release planning and does not retroactively rescope this in-flight release.

**#826 — Players & Inventory** (merged, `d10abf4b`)

- **Added** — Command Deck Players and Inventory parity with Classic, including **Players > Community tools** (in-game chat command controls, shared `!tp` destinations, Welcome Back packages), all keeping their opt-in defaults and existing safeguards.
- **Added** — Guarded hidden-Reserve recovery in Player Inventory: exact row/Backpack-position preview, Offline-only, verified fresh local backup, exact slot/volume capacity check, single changed-state-guarded transaction, readback, retained rollback.
- **Changed** — Reserve items protected from direct deletion, quantity reduction, and live Clean Inventory.

**#828 — Hyper-V-aware VM lifecycle** (merged, `989b0995`)

- **Added** — An explicit **Hyper-V VM lifecycle** Settings control for Self-Hosted servers: transactionally enables the VM's Operating System Shutdown integration and `AutomaticStopAction=ShutDown`, installs a bounded Alpine OpenRC battlegroup shutdown/boot-recovery hook, reports durable results, and can restore the recorded host and guest state.

The changelog wording is taken from #828's own reviewed entry so the published notes match what was reviewed.

**#829 — test-suite placeholder** (merged, `b066ef6e`)

Replaced an environment-specific example address in the test suite with a documentation placeholder. Deliberately **not** in the public changelog: it is completion/privacy work rather than a user-facing feature, and the public `CHANGELOG.md` is kept feature-only per commit `0d19036e` ("chore: keep v15.0.2 changelog feature-only"). It stays documented here and in git history.

## Ordering gate

#828 has cleared acceptance, merged into `main`, and this PR has been rebased onto that merge. Pre-merge acceptance candidates intentionally combine the reviewed PR commits for installation and testing. The final `v15.0.3` tag, final installer rebuild, and publication occur only after this PR merges.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (menu option removed/renamed, config key changed, etc.)
- [ ] Docs only
- [x] Chore / CI / refactor

## Version stamps (all five verified at 15.0.3)

| File | Line |
| --- | --- |
| `dune-server.ps1` | `$script:ToolVersion = "15.0.3"` |
| `app/DuneServer.ps1` | `$script:DuneToolVersion = '15.0.3'` |
| `app/build/Build-Exe.ps1` | `[string]$Version = '15.0.3'` |
| `app/installer/DuneServer.iss` | `#define MyAppVersion "15.0.3"` |
| `app/desktop/DuneShell/DuneShell.csproj` | `<Version>15.0.3</Version>` |

Plus `.github/ISSUE_TEMPLATE/bug_report.yml` placeholder `v15.0.3`.

A repo-wide search confirms no `15.0.2` remains outside historical `CHANGELOG.md` entries.

## Testing

- `npm run test:changelog` (site) — **Changelog transformation checks passed.**
- Rendered site changelog headings verified via `getChangelog()`: `[Unreleased]`, `[15.0.3] - 2026-09-09`, `[15.0.2]`, `[15.0.1]`, `[15.0.0]`, `Earlier releases` — the four-release site limit still behaves correctly with the new entry.
- `.github/ISSUE_TEMPLATE/bug_report.yml` parses as valid YAML; `tool_version` placeholder reads `v15.0.3`.
- No changelog link-reference entry added — matches existing practice (15.0.1 and 15.0.2 have none).
- Pre-push scan: no secrets, no IP literals, no local-only file patterns in the diff.

## Changelog

- [x] `CHANGELOG.md` updated (dated `[15.0.3]` entry with three Added items and one Changed item; a fresh empty `[Unreleased]` heading remains, matching the state after the v15.0.2 release)

## Not done in this PR

Merge, final tag, final installer rebuild, and release publication are deliberately out of scope. Acceptance candidates are built separately from the reviewed PR commits before merge.