### PR TITLE
Complete Hyper-V lifecycle acceptance fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ here cover everything those tags shipped.
   integration and `AutomaticStopAction=ShutDown`, installs a bounded Alpine
   OpenRC battlegroup shutdown/boot-recovery hook, reports durable results, and
   can restore the recorded host and guest state.
+- Restored **Stop VM Only** under **Commands > VM & Power**. It sends only a
+  graceful Hyper-V guest shutdown request, allowing the reconciled lifecycle
+  hook to stop a running battlegroup first; it never escalates to Hyper-V
+  `TurnOff` or `Save`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ here cover everything those tags shipped.
 - Protected Reserve items from direct deletion, quantity reduction, and live
   Clean Inventory so hidden remaining rows cannot keep base recycling blocked.
 
+### Fixed
+
+- Hyper-V lifecycle boot recovery now recognizes the current Funcom ready tuple
+  (`Running`, database `Ready`, gateway/director `Healthy`) as complete while
+  still requiring every reported game server to be `Running` and ready.
+
 ## [15.0.2] - 2026-09-09
 
 ### Added

--- a/app/resources/remote-scripts/dune-hyperv-guest-recovery-install.sh
+++ b/app/resources/remote-scripts/dune-hyperv-guest-recovery-install.sh
@@ -376,8 +376,18 @@ bg_ready() {
         Healthy|Running) ;;
         *) return 1 ;;
     esac
-    [ "$_db" = Healthy ] && [ "$_gw" = Running ] &&
-        [ "$_director" = Ready ] || return 1
+    case "$_db" in
+        Healthy|Ready) ;;
+        *) return 1 ;;
+    esac
+    case "$_gw" in
+        Healthy|Running) ;;
+        *) return 1 ;;
+    esac
+    case "$_director" in
+        Healthy|Ready) ;;
+        *) return 1 ;;
+    esac
     [ -n "$_servers" ] || return 1
     printf '%s' "$_servers" | tr ',' '\n' |
         awk -F: 'NF == 2 { seen=1; if ($1 != "Running" || $2 != "true") exit 1 } END { if (!seen) exit 1 }'

--- a/app/server/lib/Commands.ps1
+++ b/app/server/lib/Commands.ps1
@@ -15,6 +15,7 @@
 $script:DuneCommands = @(
     @{ Section='VM'; Key='a';  Name='initial-setup';   Mode='Console'; Requires='none';    DisabledWhen='core-pods-running'; Desc='Run the initial VM setup wizard' }
     @{ Section='VM'; Key='c';  Name='start-vm';        Label='Start VM Only';      Mode='InApp';   Requires='exists';  DisabledWhen='vm-running';  Desc='Power on the VM only (no battlegroup) - use this to run an update without launching the game servers' }
+    @{ Section='VM'; Key='b';  Name='stop-vm';         Label='Stop VM Only';       Mode='InApp';   Requires='running'; Desc='Request a graceful Hyper-V guest shutdown without running Stop All; reconciled VM lifecycle stops a running battlegroup first, and DST will not hard-power-off the VM' }
     @{ Section='VM'; Key='d';  Name='startup';         Label='Start All';          Mode='Console'; Requires='exists';  DisabledWhen='bg-running';  Desc='Power on VM, start battlegroup, wait for maps Ready' }
     @{ Section='VM'; Key='e';  Name='shutdown';        Label='Stop All';           Mode='Console'; Requires='running'; Desc='Stop the battlegroup (if running) and power off the VM' }
     @{ Section='VM'; Key='f';  Name='reboot';          Label='Reboot All';         Mode='Console'; Requires='running'; Desc='Stop battlegroup, reboot VM, start battlegroup' }
@@ -165,7 +166,7 @@ function Get-DuneCommandOrderFile {
 
 function Get-DuneDefaultCommandLayout {
     $priority = @{
-        'start'    = 0; 'start-vm'   = 0; 'startup' = 0
+        'start'    = 0; 'start-vm'   = 0; 'startup' = 0; 'stop-vm' = 0
         'reboot'   = 1; 'shutdown'   = 1; 'stop'    = 1
     }
     $sorted = @(

--- a/app/server/routes/Commands.ps1
+++ b/app/server/routes/Commands.ps1
@@ -138,6 +138,7 @@ Register-DuneRoute -Method POST -Path '/api/commands/run/{name}' -Handler {
 
     $disruptiveActions = @{
         shutdown = 'stopping the battlegroup and powering off the VM'
+        'stop-vm' = 'gracefully shutting down the VM and its running battlegroup'
         reboot = 'rebooting the VM and battlegroup'
         restart = 'restarting the battlegroup'
         stop = 'stopping the battlegroup'

--- a/docs/hyperv-vm-lifecycle.md
+++ b/docs/hyperv-vm-lifecycle.md
@@ -31,8 +31,9 @@ The guest lifecycle service:
 - waits for the k3s API, database pods, operators, webhook endpoints, and the
   established battlegroup readiness fields, with a 900-second bound. The
   top-level Funcom phase may be `Running` (current) or `Healthy` (legacy), but
-  database, gateway, director, and every game server must still report their
-  healthy/ready states; and
+  database must be `Ready` or `Healthy`, gateway must be `Healthy` or `Running`,
+  director must be `Healthy` or `Ready`, and every reported game server must be
+  `Running` with `ready=true`; and
 - records startup success, failure, or skip state for the Settings status view.
 
 Reconcile snapshots original host and guest state before mutation. Removal

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -735,14 +735,16 @@ function Get-VmInfo {
 # Issue Stop-VM as a background job, render a live MM:SS counter while the VM
 # transitions to Off, and escalate to a hard power-off (-TurnOff) if the
 # graceful shutdown stalls past $GracefulSec. Throws if the VM never reaches
-# Off within $TotalSec. Returns elapsed seconds on success.
+# Off within $TotalSec. GracefulOnly suppresses escalation for lifecycle-aware
+# callers. Returns elapsed seconds on success.
 function Stop-VmWithEscalation {
     param(
         [Parameter(Mandatory)][string]$Name,
         [string]$Label = "Stopping VM",
         [string]$EstimateText,
         [int]$GracefulSec = 90,
-        [int]$TotalSec = 240
+        [int]$TotalSec = 240,
+        [switch]$GracefulOnly
     )
     $start = Get-Date
     $jobs = @()
@@ -768,7 +770,7 @@ function Stop-VmWithEscalation {
             $vm = Get-VM -Name $Name @hvSplat -ErrorAction SilentlyContinue
             if (-not $vm -or $vm.State -eq 'Off') { break }
             $elapsed = [int]((Get-Date) - $start).TotalSeconds
-            if (-not $escalated -and $elapsed -ge $GracefulSec) {
+            if (-not $GracefulOnly -and -not $escalated -and $elapsed -ge $GracefulSec) {
                 Complete-WaitCounter -Message "Graceful shutdown still running after $(Format-Duration $elapsed) (state: $($vm.State)) - escalating to hard power-off." -Color Yellow
                 $jobs += Start-Job -ScriptBlock {
                     param($n, $cn, $credLibPath)
@@ -786,7 +788,8 @@ function Stop-VmWithEscalation {
                 $escalated = $true
             }
             if ($elapsed -ge $TotalSec) {
-                throw "VM '$Name' did not reach Off state within $(Format-Duration $elapsed) (last state: $($vm.State))."
+                $safety = if ($GracefulOnly) { ' DST did not attempt a hard power-off.' } else { '' }
+                throw "VM '$Name' did not reach Off state within $(Format-Duration $elapsed) (last state: $($vm.State)).$safety"
             }
             Write-WaitCounter -Start $start -Label "$Label (state: $($vm.State))..." -EstimateText $EstimateText
             Start-Sleep -Seconds 2
@@ -1816,14 +1819,12 @@ while ($true) {
             Write-Host "VM '$vmName' is already off." -ForegroundColor Green
             continue
         }
-        # Use the same graceful-then-hard-power-off escalation as Stop All
-        # instead of a bare Stop-VM -Force: the Alpine guest does not always honor
-        # the Hyper-V integration shutdown request, and a plain Stop-VM then writes
-        # an error (and on an already-off VM throws outright), flashing the InApp
-        # window shut before it can be read.
+        # The reconciled lifecycle hook has a 300-second guest-side bound. Wait
+        # through that bound, but never bypass it with Hyper-V TurnOff.
         $estVmStop = Format-PhaseEstimate 'vm-stop'
         try {
-            $vmStopSec = Stop-VmWithEscalation -Name $vmName -Label "Stopping VM" -EstimateText $estVmStop
+            $vmStopSec = Stop-VmWithEscalation -Name $vmName -Label "Stopping VM" `
+                -EstimateText $estVmStop -TotalSec 330 -GracefulOnly
             Save-PhaseTiming 'vm-stop' $vmStopSec
             Complete-WaitCounter -Message "VM stopped in $(Format-Duration $vmStopSec)." -Color Green
         } catch {

--- a/tests/CommandOrchestration.Tests.ps1
+++ b/tests/CommandOrchestration.Tests.ps1
@@ -37,6 +37,27 @@ Describe 'One-shot command orchestration' -Tag 'Commands' {
             $availability.available | Should -BeTrue
         }
 
+        It 'restores Stop VM Only as a guarded graceful Hyper-V shutdown' {
+            $command = Get-DuneCommandByName -Name 'stop-vm'
+            $command.Label | Should -Be 'Stop VM Only'
+            $command.Section | Should -Be 'VM'
+            $command.Requires | Should -Be 'running'
+            $command.DisabledWhen | Should -BeNullOrEmpty
+            $command.Desc | Should -Match 'graceful Hyper-V guest shutdown'
+            $command.Desc | Should -Match 'will not hard-power-off'
+
+            $availability = Get-DuneCommandAvailability -Command $command -State @{
+                vmExists=$true; vmRunning=$true; bgState='running'; worldRestartActive=$false
+            }
+            $availability.available | Should -BeTrue
+
+            $route = Get-Content (Join-Path $PSScriptRoot '..\app\server\routes\Commands.ps1') -Raw
+            $route | Should -Match "'stop-vm'\s*=\s*'gracefully shutting down the VM and its running battlegroup'"
+
+            $categories = Get-Content (Join-Path $PSScriptRoot '..\webui\src\pages\commands\categories.ts') -Raw
+            $categories | Should -Match "commands:\s*\[[^\]]*'stop-vm'[^\]]*\]"
+        }
+
         It 'blocks shells and browser admin surfaces during maintenance' {
             foreach ($name in @('open-file-browser', 'open-director', 'shell-vm', 'shell-pod', 'ssh')) {
                 $command = Get-DuneCommandByName -Name $name
@@ -65,6 +86,17 @@ Describe 'One-shot command orchestration' -Tag 'Commands' {
     It 'does not hold Reboot All on a fixed post-reboot operator settle' {
         $script:entry | Should -Match "Invoke-OnDemandPartitionClear -Ip \`$ip -DelaySec 0 -Phase 'post-reboot' -Mode cron -Fast"
         $script:entry | Should -Not -Match "Invoke-OnDemandPartitionClear -Ip \`$ip -DelaySec 45 -Phase 'post-reboot'"
+    }
+
+    It 'keeps Stop VM Only on graceful shutdown without hard-power-off escalation' {
+        $start = $script:entry.IndexOf('if ($cmdName -eq "stop-vm")')
+        $end = $script:entry.IndexOf('if ($cmdName -eq "startup")', $start)
+        $handler = $script:entry.Substring($start, $end - $start)
+
+        $handler | Should -Match 'Stop-VmWithEscalation[\s\S]*-TotalSec 330 -GracefulOnly'
+        $handler | Should -Not -Match 'Stop-VM[^\r\n]*-(TurnOff|Save)\b'
+        $script:entry | Should -Match 'if \(-not \$GracefulOnly -and -not \$escalated'
+        $script:entry | Should -Match "if \(\`$GracefulOnly\) \{ ' DST did not attempt a hard power-off\.' \}"
     }
 
     It 'passes explicit conservative and manual partition-heal modes' {

--- a/tests/HyperVGuestRecovery.Tests.ps1
+++ b/tests/HyperVGuestRecovery.Tests.ps1
@@ -592,8 +592,11 @@ exec '$systemTimeout' 1 "`$@"
             & $bash.Source -lc "chmod +x '$rootPosix/fake-bin/k3s' '$rootPosix/fake-bin/timeout'"
             Set-Content (Join-Path $stateDir 'state') 'DESIRED=running'
 
-            foreach ($phase in @('Healthy', 'Running')) {
-                Set-Content $bgRow "$phase|Healthy|Running|Ready|Running:true,"
+            @(
+                'Running|Ready|Healthy|Healthy|Running:true,Running:true,',
+                'Healthy|Healthy|Running|Ready|Running:true,'
+            ) | ForEach-Object {
+                Set-Content $bgRow $_
                 & $bash.Source $env:DUNE_HYPERV_LIFECYCLE_BIN start
                 $LASTEXITCODE | Should -Be 0
                 $state = Get-Content (Join-Path $stateDir 'state') -Raw
@@ -602,11 +605,13 @@ exec '$systemTimeout' 1 "`$@"
             }
 
             @(
-                'Starting|Healthy|Running|Ready|Running:true,',
-                'Running|Operation|Running|Ready|Running:true,',
-                'Running|Healthy|Starting|Ready|Running:true,',
-                'Running|Healthy|Running|Starting|Running:true,',
-                'Running|Healthy|Running|Ready|Running:false,'
+                'Starting|Ready|Healthy|Healthy|Running:true,',
+                'Running|Operation|Healthy|Healthy|Running:true,',
+                'Running|Ready|Ready|Healthy|Running:true,',
+                'Running|Ready|Healthy|Starting|Running:true,',
+                'Running|Ready|Healthy|Healthy|Starting:true,',
+                'Running|Ready|Healthy|Healthy|Running:false,',
+                'Running|Ready|Healthy|Healthy|'
             ) | ForEach-Object {
                 Set-Content $bgRow $_
                 & $bash.Source $env:DUNE_HYPERV_LIFECYCLE_BIN start

--- a/webui/src/pages/commands/categories.ts
+++ b/webui/src/pages/commands/categories.ts
@@ -4,7 +4,7 @@ export const COMMAND_CATEGORIES = [
   { id: 'battlegroup', label: 'Battlegroup', icon: 'Activity', description: 'Start, stop, update, and maintain the game servers.',
     commands: ['start', 'restart', 'stop', 'update', 'fix-on-demand-maps'] },
   { id: 'vm', label: 'VM & Power', icon: 'HardDrive', description: 'VM setup, power, and memory. All-server actions also affect the battlegroup.',
-    commands: ['initial-setup', 'start-vm', 'startup', 'shutdown', 'reboot', 'enable-experimental-swap'] },
+    commands: ['initial-setup', 'start-vm', 'stop-vm', 'startup', 'shutdown', 'reboot', 'enable-experimental-swap'] },
   { id: 'configuration', label: 'Configuration', icon: 'Settings', description: 'Apply INIs and open battlegroup or Director configuration.',
     commands: ['apply-inis', 'edit', 'edit-advanced', 'open-director'] },
   { id: 'network', label: 'Network & Access', icon: 'Network', description: 'Connection addresses, VM credentials, and SSH keys.',

--- a/webui/tests/commandCategories.test.ts
+++ b/webui/tests/commandCategories.test.ts
@@ -12,7 +12,7 @@ describe('Command purpose categories', () => {
     expect(catalog.length).toBeGreaterThan(20)
     expect([...categorized].sort()).toEqual([...catalog].sort())
     expect(new Set(categorized).size).toBe(categorized.length)
-    expect(COMMAND_CATEGORIES.every(category => category.commands.length >= 2 && category.commands.length <= 6)).toBe(true)
+    expect(COMMAND_CATEGORIES.every(category => category.commands.length >= 2 && category.commands.length <= 7)).toBe(true)
   })
   it.each([['VM', 'vm'], ['Battlegroup', 'battlegroup'], ['Tools', 'tools']])('keeps future %s commands reachable', (section, expected) => {
     const command: Command = { name: 'future-operation', section, label: '', key: '', mode: 'Console', requires: 'none', desc: '', available: true, reason: '', external: false }


### PR DESCRIPTION
## Summary
- restore the existing `stop-vm` command to **Commands > VM & Power** after #828 made Hyper-V guest shutdown battlegroup-aware
- route it through the existing disruptive-action player confirmation and keep it local-only
- reuse the existing CLI shutdown path in graceful-only mode, allowing 330 seconds for the bounded 300-second guest hook and never escalating to Hyper-V `TurnOff` or `Save`
- retain existing hard-off escalation for **Stop All** and **Reboot All**
- accept the live Funcom ready tuple: battlegroup `Running`, database `Ready`, gateway/director `Healthy`, and every server `Running` with `ready=true`
- retain proven legacy phase equivalents while rejecting invalid or empty subordinate readiness

## Validation
- 55 Pester tests: Hyper-V lifecycle, platform contracts, and command orchestration
- 44 Pester tests: shutdown, player guard, command orchestration, and local-only access
- 20 Vitest tests: command categories and Commands workbench
- WebUI lint
- shell and PowerShell parser checks plus `git diff --check`
- gitleaks, prohibited local-only path scan, and public-boundary checks

Follow-up to #828 from live disposable-VM acceptance. No release build or publication was performed.