### PR TITLE
v15.0.4: fix guarded Reserve recovery

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -93,7 +93,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.3"
+      placeholder: "v15.0.4"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.4] - 2026-09-10
+
+### Fixed
+
+- Fixed Hidden Reserve safety previews rejecting a valid Offline player because
+  database result rows were wrapped twice. Reserve protection and independent
+  recovery readback now use the same row-mapping contract as player inventory.
+- Reserve recovery and rollback retain exact player, database, inventory,
+  capacity, backup and changed-state checks. Rollback also binds the original
+  character/account identity; older records without that proof remain blocked.
+  Refreshing or switching players clears stale recovery previews and
+  acknowledgements.
+
 ## [15.0.3] - 2026-09-09
 
 ### Added

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -166,7 +166,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 Write-DuneStartupLog 'Console presentation initialized'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.3'
+$script:DuneToolVersion = '15.0.4'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.3',
+    [string]$Version = '15.0.4',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.3</Version>
+    <Version>15.0.4</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.3"
+#define MyAppVersion "15.0.4"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"

--- a/app/server/lib/ReserveRecovery.ps1
+++ b/app/server/lib/ReserveRecovery.ps1
@@ -94,14 +94,20 @@ WHERE inv.actor_id = $PawnId::bigint
     if (-not $result.ok) {
         return @{ ok = $false; error = "Reserve inventory could not be checked. $($result.error)" }
     }
-    $rows = @(ConvertTo-DuneRowMaps -Result $result)
+    $rows = ConvertTo-DuneRowMaps -Result $result
     if ($rows.Count -ne 1) {
         return @{ ok = $false; error = 'Reserve inventory could not be checked exactly.' }
     }
+    $itemRows = 0L
+    $itemUnits = 0L
+    if (-not [long]::TryParse([string]$rows[0]['item_rows'], [ref]$itemRows) -or $itemRows -lt 0 -or
+        -not [long]::TryParse([string]$rows[0]['item_units'], [ref]$itemUnits) -or $itemUnits -lt 0) {
+        return @{ ok = $false; error = 'Reserve inventory counts could not be proven.' }
+    }
     return @{
         ok = $true
-        item_rows = [long](ConvertTo-DuneInt $rows[0]['item_rows'])
-        item_units = [long](ConvertTo-DuneInt $rows[0]['item_units'])
+        item_rows = $itemRows
+        item_units = $itemUnits
     }
 }
 
@@ -149,7 +155,7 @@ backpack_items AS (
 ),
 snapshot AS (
     SELECT jsonb_build_object(
-        'player', COALESCE((SELECT to_jsonb(p) FROM exact_player p), '{}'::jsonb),
+        'player', COALESCE((SELECT to_jsonb(p) FROM exact_player p WHERE (SELECT count(*) FROM exact_player) = 1), '{}'::jsonb),
         'reserve', COALESCE((SELECT jsonb_agg(to_jsonb(r) ORDER BY r.id) FROM reserve_rows r), '[]'::jsonb),
         'reserve_items', COALESCE((SELECT jsonb_agg(item) FROM reserve_items), '[]'::jsonb),
         'backpack', COALESCE((SELECT jsonb_agg(to_jsonb(b) ORDER BY b.id) FROM backpack_rows b), '[]'::jsonb),
@@ -157,7 +163,10 @@ snapshot AS (
     ) AS value
 )
 SELECT (SELECT count(*) FROM exact_player)::text AS player_count,
-       COALESCE((SELECT online_status::text FROM exact_player), '') AS online_status,
+       COALESCE((SELECT online_status::text FROM exact_player WHERE (SELECT count(*) FROM exact_player) = 1), '') AS online_status,
+       COALESCE((SELECT md5(jsonb_build_array(p.id, p.account_id, p.player_pawn_id, p.player_controller_id)::text)
+                 FROM exact_player p
+                 WHERE (SELECT count(*) FROM exact_player) = 1 AND p.id > 0 AND p.account_id > 0), '') AS player_identity_revision,
        (SELECT count(*) FROM reserve_rows)::text AS reserve_count,
        (SELECT count(*) FROM backpack_rows)::text AS backpack_count,
        COALESCE((SELECT to_jsonb(r)::text FROM reserve_rows r ORDER BY r.id LIMIT 1), '{}') AS reserve_inventory,
@@ -187,7 +196,8 @@ function Get-DuneReserveSnapshot {
     $result = Invoke-DuneSqlQuery -Ip $Ip -Sql (Get-DuneReserveSnapshotSql -PawnId $PawnId -ControllerId $ControllerId) `
         -ReadOnly $true -MaxRows 1 -TimeoutSec 30
     if (-not $result.ok) { return @{ ok = $false; error = $result.error } }
-    $rows = @(ConvertTo-DuneRowMaps -Result $result)
+    # ConvertTo-DuneRowMaps already returns a non-enumerated array of row maps.
+    $rows = ConvertTo-DuneRowMaps -Result $result
     if ($rows.Count -ne 1) { return @{ ok = $false; error = 'Reserve snapshot did not return exactly one result.' } }
     $row = $rows[0]
     try {
@@ -196,6 +206,7 @@ function Get-DuneReserveSnapshot {
             database_scope = [string]$scope.key
             player_count = [int](ConvertTo-DuneInt $row['player_count'])
             online_status = [string]$row['online_status']
+            player_identity_revision = [string]$row['player_identity_revision']
             reserve_count = [int](ConvertTo-DuneInt $row['reserve_count'])
             backpack_count = [int](ConvertTo-DuneInt $row['backpack_count'])
             reserve_inventory = ConvertFrom-DuneReserveJson -Value ([string]$row['reserve_inventory']) -Fallback ([pscustomobject]@{})
@@ -263,8 +274,10 @@ function ConvertTo-DuneReservePreview {
         rollback = $null
         database_scope = [string]$Snapshot.database_scope
         snapshot_revision = [string]$Snapshot.snapshot_revision
+        player_identity_revision = [string]$Snapshot.player_identity_revision
     }
     if ($Snapshot.player_count -ne 1) { $preview.blocked_reason = 'The exact pawn/controller pair no longer identifies one player.'; return $preview }
+    if ([string]$Snapshot.player_identity_revision -notmatch '^[a-f0-9]{32}$') { $preview.blocked_reason = 'The exact character and account identity could not be proven.'; return $preview }
     if ([string]$Snapshot.online_status -cne 'Offline') { $preview.blocked_reason = 'The player must be Offline before Reserve recovery.'; return $preview }
     if ($Snapshot.reserve_count -ne 1) { $preview.blocked_reason = 'DST requires exactly one Reserve inventory with the proven type and component identity.'; return $preview }
     if ($Snapshot.backpack_count -ne 1) { $preview.blocked_reason = 'DST requires exactly one pawn-owned Backpack inventory.'; return $preview }
@@ -290,6 +303,11 @@ function ConvertTo-DuneReservePreview {
     try {
         $active = Get-DuneReserveActiveRollback -PawnId $PawnId -DatabaseScope $Snapshot.database_scope
         if ($active) {
+            if ([long]$active.controller_id -ne $ControllerId -or
+                [string]$active.player_identity_revision -cne [string]$Snapshot.player_identity_revision) {
+                $preview.blocked_reason = 'The prior recovery has no matching character/account proof. Its rollback cannot be used for this identity.'
+                return $preview
+            }
             $preview.rollback = @{
                 recovery_id = [string]$active.recovery_id
                 item_rows = @($active.items).Count
@@ -425,13 +443,6 @@ DECLARE
 BEGIN
     PERFORM 1 FROM dune.encrypted_player_state
      WHERE player_pawn_id = $([long]$Preview.pawn_id)::bigint FOR UPDATE;
-    IF NOT EXISTS (
-        SELECT 1 FROM dune.player_state
-        WHERE player_pawn_id = $([long]$Preview.pawn_id)::bigint
-          AND player_controller_id = $([long]$Preview.controller_id)::bigint
-          AND online_status::text = 'Offline'
-    ) THEN RAISE EXCEPTION 'player identity or Offline state changed'; END IF;
-
     PERFORM 1 FROM dune.inventories
      WHERE id IN ($([long]$Preview.reserve_inventory_id)::bigint, $([long]$Preview.backpack_inventory_id)::bigint)
      ORDER BY id FOR UPDATE;
@@ -444,7 +455,10 @@ BEGIN
      ORDER BY id FOR UPDATE;
 
     SELECT snapshot_revision INTO actual_revision
-    FROM ($snapshotSql) current_snapshot;
+    FROM ($snapshotSql) current_snapshot
+    WHERE player_count = '1' AND online_status = 'Offline'
+      AND player_identity_revision = '$([string]$Preview.player_identity_revision)';
+    IF actual_revision IS NULL THEN RAISE EXCEPTION 'player identity or Offline state changed'; END IF;
     IF actual_revision IS DISTINCT FROM '$([string]$Preview.snapshot_revision)' THEN
         RAISE EXCEPTION 'Reserve or Backpack changed after preview';
     END IF;
@@ -508,7 +522,7 @@ ORDER BY i.id;
 "@
     $result = Invoke-DuneSqlQuery -Ip $Ip -Sql $sql -ReadOnly $true -MaxRows @($Entry.items).Count -TimeoutSec 20
     if (-not $result.ok) { return @{ ok = $false; error = $result.error } }
-    $actual = @(ConvertTo-DuneRowMaps -Result $result)
+    $actual = ConvertTo-DuneRowMaps -Result $result
     if ($actual.Count -ne @($Entry.items).Count) { return @{ ok = $false; error = 'Moved item count did not read back exactly.' } }
     foreach ($expected in @($Entry.items)) {
         $row = @($actual | Where-Object { [long]$_['item_id'] -eq [long]$expected.item_id })
@@ -546,6 +560,7 @@ function Invoke-DuneReserveRecovery {
         database_scope = $preview.database_scope
         preview_revision = $preview.revision
         snapshot_revision = $preview.snapshot_revision
+        player_identity_revision = $preview.player_identity_revision
         reserve_inventory_id = $preview.reserve_inventory_id
         backpack_inventory_id = $preview.backpack_inventory_id
         backup_path = $backup.path
@@ -592,6 +607,10 @@ function Invoke-DuneReserveRecovery {
 
 function Get-DuneReserveRollbackSql {
     param([Parameter(Mandatory)]$Entry)
+    if ([string]$Entry.player_identity_revision -notmatch '^[a-f0-9]{32}$') {
+        throw 'The recovery record has no proven character/account identity. Nothing was restored.'
+    }
+    $snapshotSql = (Get-DuneReserveSnapshotSql -PawnId ([long]$Entry.pawn_id) -ControllerId ([long]$Entry.controller_id)).Trim().TrimEnd(';')
     $values = @($Entry.items | ForEach-Object {
         "($([long]$_.item_id)::bigint,$([int]$_.source_position)::integer,$([int]$_.destination_position)::integer,'$([string]$_.invariant_revision)'::text)"
     }) -join ",`n        "
@@ -604,12 +623,6 @@ DECLARE restored_count integer;
 BEGIN
     PERFORM 1 FROM dune.encrypted_player_state
      WHERE player_pawn_id = $([long]$Entry.pawn_id)::bigint FOR UPDATE;
-    IF NOT EXISTS (
-        SELECT 1 FROM dune.player_state
-        WHERE player_pawn_id = $([long]$Entry.pawn_id)::bigint
-          AND player_controller_id = $([long]$Entry.controller_id)::bigint
-          AND online_status::text = 'Offline'
-    ) THEN RAISE EXCEPTION 'player identity or Offline state changed'; END IF;
     PERFORM 1 FROM dune.inventories
      WHERE id IN ($([long]$Entry.reserve_inventory_id)::bigint, $([long]$Entry.backpack_inventory_id)::bigint)
      ORDER BY id FOR UPDATE;
@@ -620,6 +633,12 @@ BEGIN
     PERFORM 1 FROM dune.items
      WHERE inventory_id IN ($([long]$Entry.reserve_inventory_id)::bigint, $([long]$Entry.backpack_inventory_id)::bigint)
      ORDER BY id FOR UPDATE;
+    IF NOT EXISTS (
+        SELECT 1 FROM ($snapshotSql) current_snapshot
+        WHERE player_count = '1' AND online_status = 'Offline'
+          AND player_identity_revision = '$([string]$Entry.player_identity_revision)'
+          AND reserve_count = '1' AND backpack_count = '1'
+    ) THEN RAISE EXCEPTION 'player identity, Offline state or inventory identity changed'; END IF;
     IF NOT EXISTS (
         SELECT 1 FROM dune.inventories inv
         JOIN dune.actor_inventories ai
@@ -689,6 +708,19 @@ function Invoke-DuneReserveRecoveryRollback {
     })
     if ($matches.Count -ne 1) { return @{ ok = $false; error = 'No exact active rollback record matches this player and database.' } }
     $entry = $matches[0]
+    if ([string]$entry.player_identity_revision -notmatch '^[a-f0-9]{32}$') {
+        return @{ ok = $false; error = 'The recovery record has no proven character/account identity. Nothing was restored.' }
+    }
+    $snapshot = Get-DuneReserveSnapshot -Ip $Ip -PawnId $PawnId -ControllerId $ControllerId
+    if (-not $snapshot.ok) { return $snapshot }
+    if ($snapshot.database_scope -cne [string]$entry.database_scope -or $snapshot.player_count -ne 1 -or
+        $snapshot.online_status -cne 'Offline' -or
+        $snapshot.player_identity_revision -cne [string]$entry.player_identity_revision -or
+        $snapshot.reserve_count -ne 1 -or $snapshot.backpack_count -ne 1 -or
+        [long]$snapshot.reserve_inventory.id -ne [long]$entry.reserve_inventory_id -or
+        [long]$snapshot.backpack_inventory.id -ne [long]$entry.backpack_inventory_id) {
+        return @{ ok = $false; error = 'The exact player, Offline state, database or inventory identity changed. Nothing was restored.' }
+    }
     $backup = Invoke-DuneVerifiedSafetyBackup -Ip $Ip -StemPrefix 'dst-reserve-rollback' -ProofLabel 'DST_RESERVE_BACKUP'
     if (-not $backup.ok) { return @{ ok = $false; error = "Rollback stopped because $($backup.error)" } }
     if ($backup.database_scope -cne [string]$entry.database_scope) {

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.3"
+$script:ToolVersion = "15.0.4"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/ReserveRecovery.Postgres.Tests.ps1
+++ b/tests/ReserveRecovery.Postgres.Tests.ps1
@@ -20,6 +20,16 @@ BeforeAll {
         $result.ok | Should -BeTrue
         return (ConvertTo-DuneRowMaps -Result $result)[0]['inventory_id']
     }
+    function Remove-ReserveFixtureSchema {
+        if (-not $script:ReserveFixtureOwnsSchema) { return }
+        $cleanup = Invoke-ReserveFixtureSql 'SET client_min_messages = warning; DROP SCHEMA dune CASCADE;'
+        if (-not $cleanup.ok) { throw $cleanup.error }
+        $script:ReserveFixtureOwnsSchema = $false
+        $probe = Invoke-ReserveFixtureSql "SELECT to_regnamespace('dune') IS NULL AS empty;"
+        if (-not $probe.ok -or (ConvertTo-DuneRowMaps -Result $probe)[0]['empty'] -ne 't') {
+            throw 'Reserve fixture schema cleanup could not be verified.'
+        }
+    }
 }
 
 AfterAll {
@@ -31,14 +41,21 @@ Describe 'Reserve disposable PostgreSQL transactions' -Skip:(
     -not $env:DST_TEST_POSTGRES_PSQL -or -not $env:DST_TEST_POSTGRES_DATABASE
 ) {
     BeforeEach {
+        $script:ReserveFixtureOwnsSchema = $false
         $script:DuneReserveRecoveryStateFile = Join-Path $TestDrive 'postgres-state.json'
         Remove-Item -LiteralPath $script:DuneReserveRecoveryStateFile -Force -ErrorAction SilentlyContinue
         $probe = Invoke-ReserveFixtureSql 'SELECT current_database() AS database;'
         $probe.ok | Should -BeTrue
         (ConvertTo-DuneRowMaps -Result $probe)[0]['database'] | Should -BeExactly $env:DST_TEST_POSTGRES_DATABASE
+        $existing = Invoke-ReserveFixtureSql "SELECT to_regnamespace('dune') IS NULL AS empty;"
+        if (-not $existing.ok -or (ConvertTo-DuneRowMaps -Result $existing)[0]['empty'] -ne 't') {
+            throw 'Reserve fixture schema must be absent before running destructive tests.'
+        }
+        $created = Invoke-ReserveFixtureSql 'CREATE SCHEMA dune;'
+        if (-not $created.ok) { throw $created.error }
+        # AfterEach also runs when the remaining setup or a test assertion fails.
+        $script:ReserveFixtureOwnsSchema = $true
         $setup = Invoke-ReserveFixtureSql @'
-DROP SCHEMA IF EXISTS dune CASCADE;
-CREATE SCHEMA dune;
 CREATE TABLE dune.encrypted_player_state (
     id bigint PRIMARY KEY, account_id bigint, player_pawn_id bigint,
     player_controller_id bigint, online_status text
@@ -63,6 +80,9 @@ INSERT INTO dune.items VALUES (301,216,4,'CopperBar',6,0,2,'{}'),(201,205,1,'Cop
         Mock Get-DuneVehicleHostScope { @{ key = ('b' * 64) } }
         Mock Invoke-DuneSqlQuery { param($Sql) Invoke-ReserveFixtureSql $Sql }
         Mock Invoke-DuneVerifiedSafetyBackup { @{ ok = $true; path = 'synthetic'; bytes = 2048; database_scope = ('b' * 64) } }
+    }
+    AfterEach {
+        Remove-ReserveFixtureSchema
     }
 
     It 'executes the exact snapshot, guarded move, independent readback and guarded rollback' {
@@ -145,5 +165,15 @@ INSERT INTO dune.items VALUES (301,216,4,'CopperBar',6,0,2,'{}'),(201,205,1,'Cop
         $rollback.error | Should -Match 'transaction made no changes'
         Get-ReserveFixtureLocation | Should -Be '205'
         (Read-DuneReserveRecoveryState).entries[0].status | Should -Be 'moved'
+    }
+}
+
+Describe 'Reserve fixture isolation postcondition' -Skip:(
+    -not $env:DST_TEST_POSTGRES_PSQL -or -not $env:DST_TEST_POSTGRES_DATABASE
+) {
+    It 'leaves no Reserve schema for subsequent PostgreSQL suites' {
+        $probe = Invoke-ReserveFixtureSql "SELECT to_regnamespace('dune') IS NULL AS empty;"
+        $probe.ok | Should -BeTrue
+        (ConvertTo-DuneRowMaps -Result $probe)[0]['empty'] | Should -Be 't'
     }
 }

--- a/tests/ReserveRecovery.Postgres.Tests.ps1
+++ b/tests/ReserveRecovery.Postgres.Tests.ps1
@@ -1,0 +1,149 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    . (Join-Path $PSScriptRoot '_PostgresFixture.ps1')
+    Import-DstLib 'Database.ps1'
+    Import-DstLib 'Gameplay.ps1'
+    Import-DstLib 'ReserveRecovery.ps1'
+    function global:Get-DuneVehicleHostScope { throw 'Test must mock Get-DuneVehicleHostScope.' }
+    function global:Invoke-DuneVerifiedSafetyBackup { throw 'Test must mock Invoke-DuneVerifiedSafetyBackup.' }
+
+    function Invoke-ReserveFixtureSql {
+        param([string]$Sql)
+        $path = Join-Path $TestDrive "$([guid]::NewGuid().ToString('N')).sql"
+        [IO.File]::WriteAllText($path, $Sql)
+        $execution = Invoke-TestPostgresFile -SqlPath $path
+        if ($execution.ExitCode -ne 0) { return @{ ok = $false; error = $execution.Error } }
+        return ConvertFrom-DunePsqlCsv -Output $execution.Output -MaxRows 5000
+    }
+    function Get-ReserveFixtureLocation {
+        $result = Invoke-ReserveFixtureSql 'SELECT inventory_id::text FROM dune.items WHERE id = 301;'
+        $result.ok | Should -BeTrue
+        return (ConvertTo-DuneRowMaps -Result $result)[0]['inventory_id']
+    }
+}
+
+AfterAll {
+    Remove-Item function:global:Get-DuneVehicleHostScope -ErrorAction SilentlyContinue
+    Remove-Item function:global:Invoke-DuneVerifiedSafetyBackup -ErrorAction SilentlyContinue
+}
+
+Describe 'Reserve disposable PostgreSQL transactions' -Skip:(
+    -not $env:DST_TEST_POSTGRES_PSQL -or -not $env:DST_TEST_POSTGRES_DATABASE
+) {
+    BeforeEach {
+        $script:DuneReserveRecoveryStateFile = Join-Path $TestDrive 'postgres-state.json'
+        Remove-Item -LiteralPath $script:DuneReserveRecoveryStateFile -Force -ErrorAction SilentlyContinue
+        $probe = Invoke-ReserveFixtureSql 'SELECT current_database() AS database;'
+        $probe.ok | Should -BeTrue
+        (ConvertTo-DuneRowMaps -Result $probe)[0]['database'] | Should -BeExactly $env:DST_TEST_POSTGRES_DATABASE
+        $setup = Invoke-ReserveFixtureSql @'
+DROP SCHEMA IF EXISTS dune CASCADE;
+CREATE SCHEMA dune;
+CREATE TABLE dune.encrypted_player_state (
+    id bigint PRIMARY KEY, account_id bigint, player_pawn_id bigint,
+    player_controller_id bigint, online_status text
+);
+CREATE VIEW dune.player_state AS SELECT * FROM dune.encrypted_player_state;
+CREATE TABLE dune.inventories (
+    id bigint PRIMARY KEY, actor_id bigint, inventory_type integer,
+    max_item_count integer, max_item_volume numeric
+);
+CREATE TABLE dune.actor_inventories (inventory_id bigint, component_name_hash bigint);
+CREATE TABLE dune.items (
+    id bigint PRIMARY KEY, inventory_id bigint REFERENCES dune.inventories(id),
+    position_index integer, template_id text, stack_size bigint, quality_level integer,
+    volume_override numeric, stats jsonb
+);
+INSERT INTO dune.encrypted_player_state VALUES (1,99,42,43,'Offline');
+INSERT INTO dune.inventories VALUES (216,42,33,50,1000),(205,42,0,10,100);
+INSERT INTO dune.actor_inventories VALUES (216,-689927216);
+INSERT INTO dune.items VALUES (301,216,4,'CopperBar',6,0,2,'{}'),(201,205,1,'CopperBar',2,0,1,'{}');
+'@
+        $setup.ok | Should -BeTrue
+        Mock Get-DuneVehicleHostScope { @{ key = ('b' * 64) } }
+        Mock Invoke-DuneSqlQuery { param($Sql) Invoke-ReserveFixtureSql $Sql }
+        Mock Invoke-DuneVerifiedSafetyBackup { @{ ok = $true; path = 'synthetic'; bytes = 2048; database_scope = ('b' * 64) } }
+    }
+
+    It 'executes the exact snapshot, guarded move, independent readback and guarded rollback' {
+        $preview = Get-DuneReserveRecoveryPreview -Ip fixture -PawnId 42 -ControllerId 43
+        $preview.available | Should -BeTrue
+        $preview.items.Count | Should -Be 1
+        $move = Invoke-DuneReserveRecovery -Ip fixture -PawnId 42 -ControllerId 43 -Revision $preview.revision
+        $move.ok | Should -BeTrue -Because $move.error
+        Get-ReserveFixtureLocation | Should -Be '205'
+        $empty = Get-DuneReserveRecoveryPreview -Ip fixture -PawnId 42 -ControllerId 43
+        $empty.available | Should -BeFalse
+        $empty.rollback.recovery_id | Should -Be $move.recovery_id
+        $rollback = Invoke-DuneReserveRecoveryRollback -Ip fixture -PawnId 42 -ControllerId 43 -RecoveryId $move.recovery_id
+        $rollback.ok | Should -BeTrue -Because $rollback.error
+        Get-ReserveFixtureLocation | Should -Be '216'
+        (Read-DuneReserveRecoveryState).history[0].status | Should -Be 'rolled_back'
+    }
+
+    It 'fails closed on <Case> without making up a matching identity' -TestCases @(
+        @{ Case = 'stale controller'; Change = 'UPDATE dune.encrypted_player_state SET player_controller_id=44;' }
+        @{ Case = 'ambiguous exact pair'; Change = "INSERT INTO dune.encrypted_player_state VALUES (2,100,42,43,'Offline');" }
+        @{ Case = 'missing account'; Change = 'UPDATE dune.encrypted_player_state SET account_id=NULL;' }
+        @{ Case = 'online player'; Change = "UPDATE dune.encrypted_player_state SET online_status='Online';" }
+        @{ Case = 'multiple Reserve inventories'; Change = 'INSERT INTO dune.inventories VALUES (217,42,33,50,1000); INSERT INTO dune.actor_inventories VALUES (217,-689927216);' }
+        @{ Case = 'multiple Backpacks'; Change = 'INSERT INTO dune.inventories VALUES (206,42,0,10,100);' }
+    ) {
+        param($Case, $Change)
+        (Invoke-ReserveFixtureSql $Change).ok | Should -BeTrue
+        $preview = Get-DuneReserveRecoveryPreview -Ip fixture -PawnId 42 -ControllerId 43
+        $preview.ok | Should -BeTrue
+        $preview.available | Should -BeFalse
+        $preview.blocked_reason | Should -Not -BeNullOrEmpty
+        Get-ReserveFixtureLocation | Should -Be '216'
+        Should -Invoke Invoke-DuneVerifiedSafetyBackup -Times 0
+    }
+
+    It 'rejects a snapshot revision after its account identity changes' {
+        $preview = Get-DuneReserveRecoveryPreview -Ip fixture -PawnId 42 -ControllerId 43
+        (Invoke-ReserveFixtureSql 'UPDATE dune.encrypted_player_state SET account_id=100;').ok | Should -BeTrue
+        $move = Invoke-DuneReserveRecovery -Ip fixture -PawnId 42 -ControllerId 43 -Revision $preview.revision
+        $move.error | Should -Match 'changed'
+        Get-ReserveFixtureLocation | Should -Be '216'
+        Should -Invoke Invoke-DuneVerifiedSafetyBackup -Times 0
+    }
+
+    It 'rolls the transaction back if <Case> after backup' -TestCases @(
+        @{ Case = 'the player logs in'; Change = "UPDATE dune.encrypted_player_state SET online_status='Online';" }
+        @{ Case = 'the account changes'; Change = 'UPDATE dune.encrypted_player_state SET account_id=100;' }
+        @{ Case = 'the exact pair becomes ambiguous'; Change = "INSERT INTO dune.encrypted_player_state VALUES (2,100,42,43,'Offline');" }
+        @{ Case = 'an item changes'; Change = 'UPDATE dune.items SET stack_size=7 WHERE id=301;' }
+    ) {
+        param($Case, $Change)
+        $preview = Get-DuneReserveRecoveryPreview -Ip fixture -PawnId 42 -ControllerId 43
+        Mock Invoke-DuneVerifiedSafetyBackup {
+            (Invoke-ReserveFixtureSql $Change).ok | Should -BeTrue
+            return @{ ok = $true; path = 'synthetic'; bytes = 2048; database_scope = ('b' * 64) }
+        }
+        $move = Invoke-DuneReserveRecovery -Ip fixture -PawnId 42 -ControllerId 43 -Revision $preview.revision
+        $move.ok | Should -BeFalse
+        $move.error | Should -Match 'transaction rolled back'
+        Get-ReserveFixtureLocation | Should -Be '216'
+        (Read-DuneReserveRecoveryState).entries[0].status | Should -Be 'failed'
+    }
+
+    It 'refuses rollback if <Case> after the rollback backup' -TestCases @(
+        @{ Case = 'the account changes'; Change = 'UPDATE dune.encrypted_player_state SET account_id=100;' }
+        @{ Case = 'the exact pair becomes ambiguous'; Change = "INSERT INTO dune.encrypted_player_state VALUES (2,100,42,43,'Offline');" }
+        @{ Case = 'a recovered item changes'; Change = 'UPDATE dune.items SET stack_size=7 WHERE id=301;' }
+    ) {
+        param($Case, $Change)
+        $preview = Get-DuneReserveRecoveryPreview -Ip fixture -PawnId 42 -ControllerId 43
+        $move = Invoke-DuneReserveRecovery -Ip fixture -PawnId 42 -ControllerId 43 -Revision $preview.revision
+        $move.ok | Should -BeTrue
+        Mock Invoke-DuneVerifiedSafetyBackup {
+            (Invoke-ReserveFixtureSql $Change).ok | Should -BeTrue
+            return @{ ok = $true; path = 'synthetic'; bytes = 2048; database_scope = ('b' * 64) }
+        }
+        $rollback = Invoke-DuneReserveRecoveryRollback -Ip fixture -PawnId 42 -ControllerId 43 -RecoveryId $move.recovery_id
+        $rollback.ok | Should -BeFalse
+        $rollback.error | Should -Match 'transaction made no changes'
+        Get-ReserveFixtureLocation | Should -Be '205'
+        (Read-DuneReserveRecoveryState).entries[0].status | Should -Be 'moved'
+    }
+}

--- a/tests/ReserveRecovery.Tests.ps1
+++ b/tests/ReserveRecovery.Tests.ps1
@@ -1,18 +1,44 @@
 BeforeAll {
     . (Join-Path $PSScriptRoot '_TestHelpers.ps1')
+    Import-DstLib 'Database.ps1'
     Import-DstLib 'Gameplay.ps1'
+    Import-DstLib 'GameplayPlayers.ps1'
     Import-DstLib 'ReserveRecovery.ps1'
-    function global:Invoke-DuneSqlQuery { throw 'Test must mock Invoke-DuneSqlQuery.' }
-    function global:ConvertTo-DuneRowMaps { param($Result) return @($Result.rows) }
+    function global:Get-DuneVehicleHostScope { throw 'Test must mock Get-DuneVehicleHostScope.' }
     function global:Invoke-DuneVerifiedSafetyBackup { throw 'Test must mock Invoke-DuneVerifiedSafetyBackup.' }
 }
 
 AfterAll {
     Remove-Item function:global:Invoke-DuneSqlQuery -ErrorAction SilentlyContinue
-    Remove-Item function:global:ConvertTo-DuneRowMaps -ErrorAction SilentlyContinue
+    Remove-Item function:global:Get-DuneVehicleHostScope -ErrorAction SilentlyContinue
     Remove-Item function:global:Invoke-DuneVerifiedSafetyBackup -ErrorAction SilentlyContinue
     Remove-Item function:global:New-TestReserveItem -ErrorAction SilentlyContinue
     Remove-Item function:global:New-TestReserveSnapshot -ErrorAction SilentlyContinue
+    Remove-Item function:global:ConvertTo-TestReserveSqlResult -ErrorAction SilentlyContinue
+    Remove-Item function:global:New-TestReserveSnapshotResult -ErrorAction SilentlyContinue
+}
+
+function global:ConvertTo-TestReserveSqlResult {
+    param([object[]]$Rows)
+    $csv = @($Rows | ForEach-Object { [pscustomobject]$_ } | ConvertTo-Csv -NoTypeInformation) -join "`n"
+    return ConvertFrom-DunePsqlCsv -Output $csv -MaxRows 100
+}
+
+function global:New-TestReserveSnapshotResult {
+    param([int]$PlayerCount = 1)
+    $snapshot = New-TestReserveSnapshot
+    $row = [ordered]@{
+        player_count = $PlayerCount
+        online_status = 'Offline'
+        reserve_count = 1
+        backpack_count = 1
+        snapshot_revision = $snapshot.snapshot_revision
+        player_identity_revision = $snapshot.player_identity_revision
+    }
+    foreach ($key in @('reserve_inventory', 'backpack_inventory', 'reserve_items', 'backpack_items')) {
+        $row[$key] = ConvertTo-Json -InputObject $snapshot[$key] -Depth 10 -Compress
+    }
+    return ConvertTo-TestReserveSqlResult -Rows @($row)
 }
 
 function global:New-TestReserveItem {
@@ -48,6 +74,7 @@ function global:New-TestReserveSnapshot {
         reserve_items = @($ReserveItems)
         backpack_items = @($BackpackItems)
         snapshot_revision = ('c' * 32)
+        player_identity_revision = ('e' * 32)
     }
 }
 
@@ -58,7 +85,7 @@ Describe 'Reserve identity and destructive guards' -Tag 'Pure' {
             param($Sql, $ReadOnly)
             $script:reserveSql = $Sql
             $ReadOnly | Should -BeTrue
-            return @{ ok = $true; rows = @(@{ item_rows = '2'; item_units = '9' }) }
+            return ConvertTo-TestReserveSqlResult -Rows @(@{ item_rows = '2'; item_units = '9' })
         }
         $result = Test-DunePlayerReserveItems -Ip 'fixture' -PawnId 42
         $result.ok | Should -BeTrue
@@ -68,9 +95,106 @@ Describe 'Reserve identity and destructive guards' -Tag 'Pure' {
         $script:reserveSql | Should -Match 'inv\.actor_id = 42::bigint'
     }
 
+    }
+
+    Describe 'Reserve production row conversion boundary' -Tag 'Pure' {
+        BeforeEach {
+            $script:DuneReserveRecoveryStateFile = Join-Path $TestDrive 'reserve-state.json'
+            Mock Get-DuneVehicleHostScope { @{ key = ('b' * 64) } }
+        }
+
+        It 'loads inventory and a usable preview from the same exact freshly read roster identity' {
+            Mock Invoke-DuneSqlQuery {
+                param($Sql)
+                if ($Sql -eq $script:DunePlayersListSql) {
+                    return ConvertTo-TestReserveSqlResult -Rows @(@{
+                        id = 42; account_id = 99; controller_id = 43; name = 'Test player'
+                        class = ''; map = ''; faction_id = 0; faction_name = ''; online_status = 'Offline'
+                    })
+                }
+                if ($Sql -match '^WITH exact_player') {
+                    $Sql | Should -Match 'ps\.player_pawn_id = 42::bigint'
+                    $Sql | Should -Match 'ps\.player_controller_id = 43::bigint'
+                    return New-TestReserveSnapshotResult
+                }
+                if ($Sql -match 'FROM dune.items i') {
+                    return ConvertTo-TestReserveSqlResult -Rows @(@{
+                        id = 301; template_id = 'CopperBar'; stack_size = 6; quality_level = 0
+                        inventory_id = 216; inventory_type = 33; is_reserve = 't'
+                    })
+                }
+                return @{ ok = $true; columns = @(); rows = @() }
+            }
+            $roster = Get-DunePlayersLive -Ip fixture
+            $player = ($roster | ConvertTo-Json -Depth 8 | ConvertFrom-Json).players[0]
+            $detail = Get-DunePlayerDetailLive -Ip fixture -PawnId $player.id -ControllerId $player.controller_id
+            $detail.inventory[0].is_reserve | Should -BeTrue
+            $snapshot = Get-DuneReserveSnapshot -Ip fixture -PawnId $player.id -ControllerId $player.controller_id
+            $snapshot.player_count | Should -Be 1
+            $preview = Get-DuneReserveRecoveryPreview -Ip fixture -PawnId $player.id -ControllerId $player.controller_id
+            $preview.available | Should -BeTrue
+            $preview.pawn_id | Should -Be 42
+            $preview.controller_id | Should -Be 43
+        }
+
+        It 'rejects an unproven exact pair with player count <Count>' -TestCases @(
+            @{ Count = 0 }, @{ Count = 2 }
+        ) {
+            param($Count)
+            Mock Invoke-DuneSqlQuery { New-TestReserveSnapshotResult -PlayerCount $Count }
+            $preview = Get-DuneReserveRecoveryPreview -Ip fixture -PawnId 42 -ControllerId 43
+            $preview.available | Should -BeFalse
+            $preview.blocked_reason | Should -Match 'exact pawn/controller pair'
+        }
+
+        It 'rejects zero or multiple snapshot result rows rather than treating an outer array as one row' -TestCases @(
+            @{ Count = 0 }, @{ Count = 2 }
+        ) {
+            param($Count)
+            Mock Invoke-DuneSqlQuery {
+                $result = New-TestReserveSnapshotResult
+                if ($Count -eq 0) { $result.rows = @() } else { $result.rows = @($result.rows[0], $result.rows[0]) }
+                return $result
+            }
+            $snapshot = Get-DuneReserveSnapshot -Ip fixture -PawnId 42 -ControllerId 43
+            $snapshot.ok | Should -BeFalse
+            $snapshot.error | Should -Match 'exactly one result'
+        }
+
+        It 'reads back all moved rows through the real mapper and confirms Reserve is empty' -TestCases @(
+            @{ Count = 1 }, @{ Count = 2 }
+        ) {
+            param($Count)
+            $items = @(1..$Count | ForEach-Object {
+                @{ item_id = 300 + $_; destination_position = $_ - 1; invariant_revision = ('a' * 32) }
+            })
+            Mock Invoke-DuneSqlQuery {
+                param($Sql)
+                if ($Sql -match 'AS item_rows') {
+                    return ConvertTo-TestReserveSqlResult -Rows @(@{ item_rows = 0; item_units = 0 })
+                }
+                return ConvertTo-TestReserveSqlResult -Rows @($items | ForEach-Object {
+                    @{ item_id = $_.item_id; inventory_id = 205; position_index = $_.destination_position; invariant_revision = $_.invariant_revision }
+                })
+            }
+            $result = Test-DuneReserveMovedReadback -Ip fixture -Entry @{
+                pawn_id = 42; backpack_inventory_id = 205; items = $items
+            }
+            $result.ok | Should -BeTrue
+        }
+    }
+
+Describe 'Reserve inspection failure' -Tag 'Pure' {
     It 'fails closed when Reserve cannot be inspected' {
         Mock Invoke-DuneSqlQuery { @{ ok = $false; error = 'unavailable' } }
         (Test-DunePlayerReserveItems -Ip 'fixture' -PawnId 42).ok | Should -BeFalse
+    }
+
+    It 'does not interpret missing counts as an empty Reserve' {
+        Mock Invoke-DuneSqlQuery { ConvertTo-TestReserveSqlResult -Rows @(@{ unexpected = 'value' }) }
+        $result = Test-DunePlayerReserveItems -Ip fixture -PawnId 42
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'counts could not be proven'
     }
 }
 
@@ -95,6 +219,13 @@ Describe 'Reserve recovery preview' -Tag 'Pure' {
         $preview = ConvertTo-DuneReservePreview -Snapshot (New-TestReserveSnapshot -Status Online) -PawnId 42 -ControllerId 43
         $preview.available | Should -BeFalse
         $preview.blocked_reason | Should -Match 'Offline'
+    }
+
+    It 'blocks an unproven character/account identity even with one matching pair' {
+        $snapshot = New-TestReserveSnapshot
+        $snapshot.player_identity_revision = ''
+        (ConvertTo-DuneReservePreview -Snapshot $snapshot -PawnId 42 -ControllerId 43).blocked_reason |
+            Should -Match 'character and account identity'
     }
 
     It 'fails closed when an item volume is neither overridden nor catalogued' {
@@ -142,6 +273,20 @@ Describe 'Guarded Reserve move and rollback' -Tag 'Pure' {
         Should -Invoke Invoke-DuneSqlQuery -Times 0
     }
 
+    It 'rejects a preview revision from another database scope' {
+        $revision = Get-DuneReserveBoundRevision -DatabaseScope ('f' * 64) -SnapshotRevision ('c' * 32)
+        (Invoke-DuneReserveRecovery -Ip fixture -PawnId 42 -ControllerId 43 -Revision $revision).ok | Should -BeFalse
+        Should -Invoke Invoke-DuneVerifiedSafetyBackup -Times 0
+        Should -Invoke Invoke-DuneSqlQuery -Times 0
+    }
+
+    It 'stops when the backup proves a different database' {
+        Mock Invoke-DuneVerifiedSafetyBackup { @{ ok = $true; database_scope = ('f' * 64) } }
+        $result = Invoke-DuneReserveRecovery -Ip fixture -PawnId 42 -ControllerId 43 -Revision $script:preview.revision
+        $result.error | Should -Match 'database scope changed'
+        Should -Invoke Invoke-DuneSqlQuery -Times 0
+    }
+
     It 'persists an exact before-image before one guarded transaction and readback' {
         $script:writeSql = ''
         Mock Invoke-DuneSqlQuery {
@@ -157,10 +302,13 @@ Describe 'Guarded Reserve move and rollback' -Tag 'Pure' {
         $state.entries.Count | Should -Be 1
         $state.entries[0].items[0].before_image.inventory_id | Should -Be 216
         $state.entries[0].backup_bytes | Should -Be 2048
+        $state.entries[0].player_identity_revision | Should -Be ('e' * 32)
         $script:writeSql | Should -Match 'player identity or Offline state changed'
         $script:writeSql | Should -Match 'Reserve or Backpack changed after preview'
         $script:writeSql | Should -Match 'Reserve did not become empty'
         $script:writeSql | Should -Match 'Reserve move readback failed'
+        $script:writeSql | Should -Match "player_count = '1' AND online_status = 'Offline'"
+        $script:writeSql | Should -Match "player_identity_revision = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'"
         $script:writeSql | Should -Not -Match 'delete_item|base_backup_recycle'
     }
 
@@ -175,12 +323,184 @@ Describe 'Guarded Reserve move and rollback' -Tag 'Pure' {
     It 'generates a changed-state rollback that restores only inventory and position' {
         $entry = [pscustomobject]@{
             pawn_id = 42; controller_id = 43; reserve_inventory_id = 216; backpack_inventory_id = 205
+            player_identity_revision = ('e' * 32)
             items = @($script:preview.items)
         }
         $sql = Get-DuneReserveRollbackSql -Entry $entry
         $sql | Should -Match 'Reserve changed after recovery'
         $sql | Should -Match 'recovered rows changed after recovery'
+        $sql | Should -Match "player_count = '1' AND online_status = 'Offline'"
+        $sql | Should -Match "reserve_count = '1' AND backpack_count = '1'"
         $sql | Should -Match 'SET inventory_id = 216::bigint,\s+position_index = plan\.source_position'
         $sql | Should -Not -Match 'delete_item|base_backup_recycle'
+    }
+}
+
+Describe 'Reserve rollback identity binding' -Tag 'Pure' {
+    BeforeEach {
+        $script:DuneReserveRecoveryStateFile = Join-Path $TestDrive 'rollback-state.json'
+        $script:entry = @{
+            recovery_id = ('a' * 32); pawn_id = 42; controller_id = 43
+            database_scope = ('b' * 64); player_identity_revision = ('e' * 32)
+            reserve_inventory_id = 216; backpack_inventory_id = 205
+            items = @(); status = 'moved'
+        }
+        $state = New-DuneReserveRecoveryState
+        $state.entries = @($script:entry)
+        Save-DuneReserveRecoveryState -State $state
+        $script:rollbackSnapshot = New-TestReserveSnapshot -ReserveItems @()
+        Mock Get-DuneVehicleHostScope { @{ key = ('b' * 64) } }
+        Mock Get-DuneReserveSnapshot { $script:rollbackSnapshot }
+        Mock Invoke-DuneVerifiedSafetyBackup { @{ ok = $true; database_scope = ('b' * 64); path = 'fixture'; bytes = 2048 } }
+        Mock Invoke-DuneSqlQuery { @{ ok = $true } }
+    }
+
+    It 'fails closed before backup for <Case>' -TestCases @(
+        @{ Case = 'missing pair'; Field = 'player_count'; Value = 0 }
+        @{ Case = 'ambiguous pair'; Field = 'player_count'; Value = 2 }
+        @{ Case = 'changed account or character'; Field = 'player_identity_revision'; Value = ('f' * 32) }
+        @{ Case = 'changed database'; Field = 'database_scope'; Value = ('f' * 64) }
+        @{ Case = 'online player'; Field = 'online_status'; Value = 'Online' }
+        @{ Case = 'ambiguous Reserve'; Field = 'reserve_count'; Value = 2 }
+        @{ Case = 'ambiguous Backpack'; Field = 'backpack_count'; Value = 2 }
+    ) {
+        param($Case, $Field, $Value)
+        $script:rollbackSnapshot[$Field] = $Value
+        $result = Invoke-DuneReserveRecoveryRollback -Ip fixture -PawnId 42 -ControllerId 43 -RecoveryId ('a' * 32)
+        $result.ok | Should -BeFalse
+        $result.error | Should -Match 'identity changed'
+        Should -Invoke Invoke-DuneVerifiedSafetyBackup -Times 0
+        Should -Invoke Invoke-DuneSqlQuery -Times 0
+    }
+
+    It 'rejects a stale controller or a recovery from another database' -TestCases @(
+        @{ Controller = 44; Scope = ('b' * 64) }
+        @{ Controller = 43; Scope = ('f' * 64) }
+    ) {
+        param($Controller, $Scope)
+        Mock Get-DuneVehicleHostScope { @{ key = $Scope } }
+        $result = Invoke-DuneReserveRecoveryRollback -Ip fixture -PawnId 42 -ControllerId $Controller -RecoveryId ('a' * 32)
+        $result.error | Should -Match 'No exact active rollback'
+        Should -Invoke Invoke-DuneVerifiedSafetyBackup -Times 0
+        Should -Invoke Invoke-DuneSqlQuery -Times 0
+    }
+
+    It 'does not invent identity proof for older recovery records' {
+        $state = Read-DuneReserveRecoveryState
+        $state.entries[0].player_identity_revision = ''
+        Save-DuneReserveRecoveryState -State $state
+        $result = Invoke-DuneReserveRecoveryRollback -Ip fixture -PawnId 42 -ControllerId 43 -RecoveryId ('a' * 32)
+        $result.error | Should -Match 'no proven character/account identity'
+        Should -Invoke Invoke-DuneVerifiedSafetyBackup -Times 0
+    }
+
+    It 'does not offer a prior rollback for a reassigned character/account' {
+        $script:rollbackSnapshot.player_identity_revision = ('f' * 32)
+        $preview = ConvertTo-DuneReservePreview -Snapshot $script:rollbackSnapshot -PawnId 42 -ControllerId 43
+        $preview.rollback | Should -BeNullOrEmpty
+        $preview.blocked_reason | Should -Match 'no matching character/account proof'
+    }
+}
+
+Describe 'Reserve route serialization and guarded flow' -Tag 'Pure' {
+    BeforeAll {
+        . (Join-Path (Get-DstRepoRoot) 'app\server\HttpServer.ps1')
+        function Invoke-TestReserveRoute {
+            param([string]$Method = 'GET', [string]$Suffix = '', $Body, [long]$Controller = 43)
+            $query = [Collections.Specialized.NameValueCollection]::new()
+            $query.Add('pawn', '42')
+            $query.Add('controller', [string]$Controller)
+            $request = [pscustomobject]@{ QueryString = $query }
+            $response = [pscustomobject]@{
+                StatusCode = 0; ContentType = ''; ContentLength64 = 0L; Headers = @{}
+                OutputStream = [IO.MemoryStream]::new()
+            }
+
+            $route = $script:DuneRoutes | Where-Object {
+                $_.Method -eq $Method -and $_.Path -eq "/api/gameplay/players/reserve-recovery$Suffix"
+            }
+            & $route.Handler $request $response @{} $Body
+            return @{
+                status = $response.StatusCode
+                body = ([Text.Encoding]::UTF8.GetString($response.OutputStream.ToArray()) | ConvertFrom-Json)
+            }
+        }
+    }
+
+    BeforeEach {
+        $script:DuneReserveRecoveryStateFile = Join-Path $TestDrive 'route-state.json'
+        Remove-Item -LiteralPath $script:DuneReserveRecoveryStateFile -Force -ErrorAction SilentlyContinue
+        $script:DuneRoutes = [Collections.Generic.List[object]]::new()
+        . (Join-Path (Get-DstRepoRoot) 'app\server\routes\Gameplay.ps1')
+        . (Join-Path (Get-DstRepoRoot) 'app\server\routes\GameplayPlayers.ps1')
+        Mock Get-DuneDbContext { @{ ok = $true; ip = 'fixture' } }
+        Mock Get-DuneVehicleHostScope { @{ key = ('b' * 64) } }
+        Mock Invoke-DuneVerifiedSafetyBackup { @{ ok = $true; database_scope = ('b' * 64); bytes = 2048; path = 'fixture' } }
+        $script:moved = $false
+        Mock Invoke-DuneSqlQuery {
+            param($Sql, $ReadOnly)
+            if (-not $ReadOnly) {
+                $Sql | Should -Match 'BEGIN;'
+                $Sql | Should -Match "player_count = '1' AND online_status = 'Offline'"
+                $script:moved = $true
+                return @{ ok = $true; columns = @(); rows = @() }
+            }
+            if ($Sql -match '^WITH exact_player') {
+                $count = if ($Sql -match 'ps\.player_controller_id = 43::bigint') { 1 } else { 0 }
+                return New-TestReserveSnapshotResult -PlayerCount $count
+            }
+            if ($Sql -match 'AS item_rows') {
+                return ConvertTo-TestReserveSqlResult -Rows @(@{ item_rows = 0; item_units = 0 })
+            }
+            return ConvertTo-TestReserveSqlResult -Rows @(@{
+                item_id = 301; inventory_id = 205; position_index = 0; invariant_revision = ('a' * 32)
+            })
+        }
+    }
+
+    It 'serializes a real usable preview and applies its exact identity through backup, move, readback and rollback' {
+        $preview = Invoke-TestReserveRoute
+        $preview.status | Should -Be 200
+        $preview.body.available | Should -BeTrue
+        $preview.body.pawn_id | Should -Be 42
+        $preview.body.controller_id | Should -Be 43
+        $preview.body.PSObject.Properties.Name | Should -Not -Contain 'player_identity_revision'
+        $write = Invoke-TestReserveRoute -Method POST -Body (
+            '{"pawn_id":42,"controller_id":43,"revision":"' + $preview.body.revision + '"}' | ConvertFrom-Json
+        )
+        $write.status | Should -Be 200
+        $write.body.ok | Should -BeTrue
+        $script:moved | Should -BeTrue
+        $recoveryId = $write.body.result.recovery_id
+        (Read-DuneReserveRecoveryState).entries[0].status | Should -Be 'moved'
+        $rollback = Invoke-TestReserveRoute -Method POST -Suffix '/rollback' -Body @{
+            pawn_id = 42; controller_id = 43; recovery_id = $recoveryId
+        }
+        $rollback.status | Should -Be 200
+        (Read-DuneReserveRecoveryState).entries.Count | Should -Be 0
+        (Read-DuneReserveRecoveryState).history[0].status | Should -Be 'rolled_back'
+        Should -Invoke Invoke-DuneVerifiedSafetyBackup -Times 2
+    }
+
+    It 'preserves a blocked preview and rejects a cross-account or stale controller before backup' -TestCases @(
+        @{ Controller = 99 }, @{ Controller = 44 }
+    ) {
+        param($Controller)
+        $preview = Invoke-TestReserveRoute -Controller $Controller
+        $preview.status | Should -Be 200
+        $preview.body.available | Should -BeFalse
+        $preview.body.blocked_reason | Should -Match 'exact pawn/controller pair'
+        $write = Invoke-TestReserveRoute -Method POST -Body @{
+            pawn_id = 42; controller_id = $Controller; revision = ('a' * 64)
+        }
+        $write.status | Should -Be 503
+        $script:moved | Should -BeFalse
+        Should -Invoke Invoke-DuneVerifiedSafetyBackup -Times 0
+    }
+
+    It 'rejects missing identity fields at the write route boundary' {
+        $write = Invoke-TestReserveRoute -Method POST -Body @{ pawn_id = 42; revision = ('a' * 64) }
+        $write.status | Should -Be 400
+        Should -Invoke Invoke-DuneSqlQuery -Times 0
     }
 }

--- a/webui/src/pages/gameplay/players/sections.tsx
+++ b/webui/src/pages/gameplay/players/sections.tsx
@@ -2786,13 +2786,14 @@ export function InventorySection({ player, canWrite, demo, refreshKey, flash, on
 
   useEffect(() => {
     let alive = true
-    if (demo) { setReserve(null); setReserveErr(null); return () => { alive = false } }
+    setReserve(null)
+    if (demo) { setReserveErr(null); return () => { alive = false } }
     setReserveErr(null)
     getReserveRecovery(player.id, player.controller_id)
       .then(r => { if (alive) setReserve(r) })
       .catch(e => { if (alive) setReserveErr(e instanceof Error ? e.message : String(e)) })
     return () => { alive = false }
-  }, [player.id, player.controller_id, demo, refreshKey, tick])
+  }, [player.id, player.controller_id, player.account_id, player.online_status, demo, refreshKey, tick])
 
   const groups = useMemo(() => {
     const inv = detail?.inventory ?? []
@@ -2860,7 +2861,7 @@ function ReserveRecoveryCard({ preview, error, canWrite, busy, player, run }: {
   run: (fn: () => Promise<{ message: string }>, label: string) => Promise<boolean>
 }) {
   const [ack, setAck] = useState('')
-  useEffect(() => { setAck('') }, [preview?.revision, preview?.rollback?.recovery_id])
+  useEffect(() => { setAck('') }, [preview?.revision, preview?.rollback?.recovery_id, player.id, player.controller_id, player.account_id])
   if (error) {
     return <div className="rounded-lg border border-danger/40 bg-danger/5 px-3 py-2 text-xs text-danger" role="alert">
       Reserve safety preview unavailable: {error}
@@ -2869,6 +2870,10 @@ function ReserveRecoveryCard({ preview, error, canWrite, busy, player, run }: {
   if (!preview) {
     return <div className="rounded-lg border border-border bg-surface-2 px-3 py-2 text-xs text-text-dim">Checking Reserve safety…</div>
   }
+  if (preview.pawn_id !== player.id || preview.controller_id !== player.controller_id) {
+    return <ErrorBox msg="Reserve preview does not match the selected player. Refresh inventory before continuing." />
+  }
+  const writable = canWrite && player.online_status === 'Offline' && preview.online_status === 'Offline'
   const recoveryAck = ack === 'RECOVER'
   const rollbackAck = ack === 'ROLLBACK'
   const afterVolume = preview.used_volume + preview.required_volume
@@ -2912,8 +2917,8 @@ function ReserveRecoveryCard({ preview, error, canWrite, busy, player, run }: {
             <input className="mt-1 w-full max-w-48 font-mono bg-surface-2 border border-border rounded px-2 py-1"
               value={ack} onChange={e => setAck(e.target.value)} disabled={busy} aria-label="Reserve recovery confirmation" />
           </label>
-          <button className="btn-danger text-xs" disabled={!canWrite || busy || !recoveryAck}
-            onClick={() => void run(() => recoverReserve(player.id, player.controller_id, preview.revision), 'Recover Reserve')}>
+          <button className="btn-danger text-xs" disabled={!writable || busy || !recoveryAck}
+            onClick={() => void run(() => recoverReserve(preview.pawn_id, preview.controller_id, preview.revision), 'Recover Reserve')}>
             <Icon name="ArchiveRestore" size={12} /> Recover Reserve to Backpack
           </button>
         </div>
@@ -2926,8 +2931,8 @@ function ReserveRecoveryCard({ preview, error, canWrite, busy, player, run }: {
             <input className="mt-1 w-full max-w-48 font-mono bg-surface-2 border border-border rounded px-2 py-1"
               value={ack} onChange={e => setAck(e.target.value)} disabled={busy} aria-label="Reserve rollback confirmation" />
           </label>
-          <button className="btn-danger text-xs" disabled={!canWrite || busy || !rollbackAck}
-            onClick={() => void run(() => rollbackReserve(player.id, player.controller_id, preview.rollback!.recovery_id), 'Rollback Reserve recovery')}>
+          <button className="btn-danger text-xs" disabled={!writable || busy || !rollbackAck}
+            onClick={() => void run(() => rollbackReserve(preview.pawn_id, preview.controller_id, preview.rollback!.recovery_id), 'Rollback Reserve recovery')}>
             <Icon name="Undo2" size={12} /> Roll back recovery
           </button>
         </div>

--- a/webui/tests/api/gameplay.test.ts
+++ b/webui/tests/api/gameplay.test.ts
@@ -50,6 +50,25 @@ function last(): FetchCall {
   return calls[calls.length - 1]!
 }
 
+describe('Reserve exact identity transport', () => {
+  it('uses the same pawn/controller pair for preview, recovery and rollback without account substitution', async () => {
+    const player: gp.Player = {
+      id: 42, controller_id: 43, account_id: 99, name: 'Test player',
+      class: '', map: '', faction_id: 0, faction_name: '', online_status: 'Offline',
+    }
+    await gp.getPlayerDetail(player.id, player.controller_id)
+    expect(last().url).toBe('/api/gameplay/players/detail?pawn=42&controller=43')
+    await gp.getReserveRecovery(player.id, player.controller_id)
+    expect(last().url).toBe('/api/gameplay/players/reserve-recovery?pawn=42&controller=43')
+    await gp.recoverReserve(player.id, player.controller_id, 'a'.repeat(64))
+    expect(last().url).toBe('/api/gameplay/players/reserve-recovery')
+    expect(last().body).toEqual({ pawn_id: 42, controller_id: 43, revision: 'a'.repeat(64) })
+    await gp.rollbackReserve(player.id, player.controller_id, 'b'.repeat(32))
+    expect(last().url).toBe('/api/gameplay/players/reserve-recovery/rollback')
+    expect(last().body).toEqual({ pawn_id: 42, controller_id: 43, recovery_id: 'b'.repeat(32) })
+  })
+})
+
 describe('Phase A — currency / progression writes', () => {
   it('builds the bounded shared inventory query', async () => {
     await gp.getSharedInventory({

--- a/webui/tests/playerReserveRecovery.test.tsx
+++ b/webui/tests/playerReserveRecovery.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   getPlayerDetail, getReserveRecovery, recoverReserve, rollbackReserve,
@@ -77,6 +77,65 @@ describe('Reserve recovery inventory controls', () => {
     expect(button).toBeEnabled()
     fireEvent.click(button)
     await waitFor(() => expect(recoverReserve).toHaveBeenCalledExactlyOnceWith(42, 100, 'a'.repeat(64)))
+  })
+
+  it('shows truthful blocked identity evidence even when protected inventory loads', async () => {
+    vi.mocked(getReserveRecovery).mockResolvedValue({
+      ...preview, available: false, blocked_reason: 'The exact pawn/controller pair no longer identifies one player.',
+    })
+    renderInventory()
+    expect(await screen.findByText('Reserve · protected')).toBeInTheDocument()
+    expect(await screen.findByText(/exact pawn\/controller pair/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Recover Reserve to Backpack/ })).not.toBeInTheDocument()
+    expect(recoverReserve).not.toHaveBeenCalled()
+  })
+
+  it('discards a prior acknowledgement while refreshing and requires a new one even for the same revision', async () => {
+    renderInventory()
+    await screen.findByRole('button', { name: /Recover Reserve to Backpack/ })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Reserve recovery confirmation' }), { target: { value: 'RECOVER' } })
+    let finish!: (value: ReserveRecoveryPreview) => void
+    vi.mocked(getReserveRecovery).mockImplementationOnce(() => new Promise(resolve => { finish = resolve }))
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh inventory' }))
+    expect(await screen.findByText('Checking Reserve safety…')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Recover Reserve to Backpack/ })).not.toBeInTheDocument()
+    await act(async () => { finish(preview) })
+    expect(await screen.findByRole('button', { name: /Recover Reserve to Backpack/ })).toBeDisabled()
+  })
+
+  it('does not pair an earlier player preview with the current selection', async () => {
+    vi.mocked(getReserveRecovery).mockResolvedValue({ ...preview, controller_id: 101 })
+    renderInventory()
+    expect(await screen.findByText(/Reserve preview does not match the selected player/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Recover Reserve to Backpack/ })).not.toBeInTheDocument()
+  })
+
+  it('keeps both writes unavailable when current player status is not Offline', async () => {
+    vi.mocked(getReserveRecovery).mockResolvedValue({
+      ...preview,
+      rollback: { recovery_id: 'b'.repeat(32), item_rows: 1, created_at: '2026-01-01T00:00:00Z' },
+    })
+    render(<InventorySection player={{ ...player, online_status: 'Online' }} canWrite demo={false} refreshKey={0} flash={vi.fn()} onChanged={vi.fn()} />)
+    await screen.findByRole('button', { name: /Recover Reserve to Backpack/ })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Reserve recovery confirmation' }), { target: { value: 'RECOVER' } })
+    expect(screen.getByRole('button', { name: /Recover Reserve to Backpack/ })).toBeDisabled()
+    fireEvent.change(screen.getByRole('textbox', { name: 'Reserve rollback confirmation' }), { target: { value: 'ROLLBACK' } })
+    expect(screen.getByRole('button', { name: /Roll back recovery/ })).toBeDisabled()
+  })
+
+  it('does not restore a stale preview after the selection changes', async () => {
+    let finishOld!: (value: ReserveRecoveryPreview) => void
+    vi.mocked(getReserveRecovery).mockImplementationOnce(() => new Promise(resolve => { finishOld = resolve }))
+    const props = { canWrite: true, demo: false, refreshKey: 0, flash: vi.fn(), onChanged: vi.fn() }
+    const { rerender } = render(<InventorySection {...props} player={player} />)
+    await waitFor(() => expect(getReserveRecovery).toHaveBeenCalledWith(42, 100))
+    vi.mocked(getReserveRecovery).mockResolvedValue({ ...preview, pawn_id: 44, controller_id: 102, revision: 'c'.repeat(64) })
+    rerender(<InventorySection {...props} player={{ ...player, id: 44, controller_id: 102 }} />)
+    await screen.findByRole('button', { name: /Recover Reserve to Backpack/ })
+    await act(async () => { finishOld(preview) })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Reserve recovery confirmation' }), { target: { value: 'RECOVER' } })
+    fireEvent.click(screen.getByRole('button', { name: /Recover Reserve to Backpack/ }))
+    await waitFor(() => expect(recoverReserve).toHaveBeenCalledExactlyOnceWith(44, 102, 'c'.repeat(64)))
   })
 
   it('offers only exact persisted rollback and requires a second typed acknowledgement', async () => {


### PR DESCRIPTION
## Summary

Fix Hidden Reserve recovery rejecting a valid Offline player. `ConvertTo-DuneRowMaps` already returns a non-enumerated array; wrapping it again nested the result and turned a valid `player_count` into zero. Use the existing row contract for preview, Reserve protection and independent readback without changing pawn/controller resolution.

Keep the exact Offline/player/database/inventory, revision, capacity, backup, transaction and readback safeguards. Bind rollback to the original character/account identity and reject missing legacy proof. Clear stale UI previews and acknowledgements when refreshing or switching players. Align all five version stamps and the bug-report placeholder to 15.0.4.

## Related issue

N/A

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs only
- [ ] Chore / CI / refactor

## Testing

- [x] Parse-validated changed PowerShell and ran error-level PSScriptAnalyzer on Reserve recovery.
- [x] 52 Reserve regressions passed, including 15 real PostgreSQL synthetic transaction cases covering exact move/rollback and changed-state failures. Both Pester containers passed with zero failures or skips.
- [x] Adjacent player/inventory backend suites passed, including the existing PostgreSQL inventory integration cases.
- [x] 94 Players/Inventory WebUI/API tests, targeted ESLint and WebUI production build passed.
- [x] Secret scan and existing public-boundary guard passed.
- [ ] Ran end-to-end against a real Dune server VM.

## Changelog

- [x] Added a dated 15.0.4 section to `CHANGELOG.md`.

## Screenshots / output

N/A