### PR TITLE
test: fail closed on Pester discovery and container errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- The PowerShell test runner now fails on Pester discovery, parse, and
+  setup/teardown errors or empty discovery instead of reporting false success.
+  Valid filtered and skipped test runs remain supported.
+
 ## [15.0.4] - 2026-09-10
 
 ### Fixed

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,10 @@ pwsh -NoProfile -File tests\Run-Tests.ps1 -Path tests\Schema.Tests.ps1
 pwsh -NoProfile -File tests\Run-Tests.ps1 -Tag Rmq
 ```
 
+The server runner exits nonzero for test, setup/teardown, discovery, or parse
+failures, and when no tests are discovered. Discovered tests that are skipped or
+excluded by a tag filter (`NotRun`) remain valid, including a filter matching none.
+
 ### WebUI only
 
 ```pwsh
@@ -57,6 +61,8 @@ cd webui ; npm install
 - `HyperVSplat.Tests.ps1` — `Get-DuneHyperVComputerName`/`Get-DuneHyperVSplat` routing (local stays credential-free; LAN attaches `-Credential` only for a matching saved credential) and the "never silently fall back to the current Windows identity" guarantee: `Get-DuneHyperVSplat` throws an actionable error instead when LAN mode is on but no matching credential is saved.
 - `_TestHelpers.ps1` — shared `Import-DstLib` (promotes lib functions to global so Pester `It` blocks see them) + `Register-DstStubs` (HTTP server shims).
 - `Run-Tests.ps1` — Pester runner wrapper.
+- `TestRunner.Tests.ps1` — isolated runner exit-code fixtures for discovery, parse,
+  teardown and assertion failures, empty discovery, and valid filtered/skipped runs.
 
 **Webui side** (`webui/tests/`):
 

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -50,9 +50,22 @@ if ($Tag) { $config.Filter.Tag = $Tag }
 
 $result = Invoke-Pester -Configuration $config
 
-if ($result.FailedCount -gt 0) {
+if ($null -eq $result) {
     Write-Host ""
-    Write-Host "$($result.FailedCount) test(s) failed." -ForegroundColor Red
+    Write-Host "Pester did not return a test result." -ForegroundColor Red
+    exit 1
+}
+# The aggregate result includes discovery/container and setup/teardown failures;
+# FailedCount only counts failed tests.
+if ($result.Result -ne 'Passed') {
+    Write-Host ""
+    Write-Host "Pester result: $($result.Result). $($result.FailedCount) test(s), $($result.FailedBlocksCount) block(s), $($result.FailedContainersCount) container(s) failed." -ForegroundColor Red
+    exit 1
+}
+# TotalCount includes filtered NotRun tests and skipped tests.
+if ($result.TotalCount -le 0) {
+    Write-Host ""
+    Write-Host "No tests were discovered. Check the test paths and definitions." -ForegroundColor Red
     exit 1
 }
 Write-Host ""

--- a/tests/TestRunner.Tests.ps1
+++ b/tests/TestRunner.Tests.ps1
@@ -1,0 +1,113 @@
+BeforeAll {
+    $script:runnerPath = Join-Path $PSScriptRoot 'Run-Tests.ps1'
+
+    function Invoke-TestRunnerFixture {
+        param([string]$Content, [string]$Tag, [switch]$WithPassingFile)
+
+        $fixtureRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $fixtureRoot | Out-Null
+        Set-Content -LiteralPath (Join-Path $fixtureRoot 'Fixture.Tests.ps1') -Value $Content
+        if ($WithPassingFile) {
+            Set-Content -LiteralPath (Join-Path $fixtureRoot 'Passing.Tests.ps1') -Value @'
+Describe 'Passing sibling' {
+    It 'passes independently' { $true | Should -BeTrue }
+}
+'@
+        }
+        $arguments = @{}
+        if ($Tag) { $arguments.Tag = $Tag }
+        # Isolate the runner's exit statement and Pester state from this suite.
+        $output = & pwsh -NoProfile -File $script:runnerPath -Path $fixtureRoot @arguments 2>&1
+        $exitCode = $LASTEXITCODE
+        [pscustomobject]@{
+            ExitCode = $exitCode
+            Output = ($output -join "`n") -replace '\x1b\[[0-9;]*m', ''
+        }
+    }
+}
+
+Describe 'Pester runner exit contract' -Tag 'TestRunner' {
+    It 'fails for <Name> even when a sibling passes and FailedCount is zero' -ForEach @(
+        @{
+            Name = 'a discovery exception'
+            Content = "throw 'fixture discovery failure'"
+            Diagnostic = 'Container failed: 1'
+        }
+        @{
+            Name = 'a parse error'
+            Content = "Describe 'broken syntax' {"
+            Diagnostic = 'Container failed: 1'
+        }
+        @{
+            Name = 'a discovery exception after registering a test'
+            Content = @'
+Describe 'Partially discovered' {
+    It 'was registered before the error' { $true | Should -BeTrue }
+}
+throw 'fixture late discovery failure'
+'@
+            Diagnostic = 'Container failed: 1'
+        }
+        @{
+            Name = 'an AfterAll failure'
+            Content = @'
+Describe 'Failed teardown' {
+    It 'passes before teardown' { $true | Should -BeTrue }
+    AfterAll { throw 'fixture teardown failure' }
+}
+'@
+            Diagnostic = 'BeforeAll \\ AfterAll failed: 1'
+        }
+    ) {
+        $run = Invoke-TestRunnerFixture -Content $Content -WithPassingFile
+        $run.Output | Should -Match 'Tests Passed: [1-9]\d*, Failed: 0'
+        $run.Output | Should -Match $Diagnostic
+        $run.ExitCode | Should -Be 1
+        $run.Output | Should -Not -Match 'All \d+ tests passed\.'
+    }
+
+    It 'fails when no tests are discovered (tag: <Tag>)' -ForEach @(
+        @{ Tag = '' }
+        @{ Tag = 'Missing' }
+    ) {
+        $run = Invoke-TestRunnerFixture -Content '# No test definitions.' -Tag $Tag
+        $run.ExitCode | Should -Be 1
+        $run.Output | Should -Match 'No tests were discovered'
+        $run.Output | Should -Not -Match 'All \d+ tests passed\.'
+    }
+
+    It 'still fails for an ordinary assertion failure' {
+        $run = Invoke-TestRunnerFixture -Content @'
+Describe 'Failed assertion' {
+    It 'fails' { $false | Should -BeTrue }
+}
+'@
+        $run.ExitCode | Should -Be 1
+        $run.Output | Should -Match 'Tests Passed: 0, Failed: 1'
+    }
+
+    It 'preserves successful execution with <ExpectedPassed> passed and <ExpectedNotRun> NotRun' -ForEach @(
+        @{ Tag = ''; ExpectedPassed = 2; ExpectedNotRun = 0 }
+        @{ Tag = 'Selected'; ExpectedPassed = 1; ExpectedNotRun = 1 }
+        @{ Tag = 'Missing'; ExpectedPassed = 0; ExpectedNotRun = 2 }
+    ) {
+        $run = Invoke-TestRunnerFixture -Tag $Tag -Content @'
+Describe 'Filterable tests' {
+    It 'matches' -Tag 'Selected' { $true | Should -BeTrue }
+    It 'does not match' -Tag 'Unselected' { $true | Should -BeTrue }
+}
+'@
+        $run.ExitCode | Should -Be 0
+        $run.Output | Should -Match "Tests Passed: $ExpectedPassed, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: $ExpectedNotRun"
+    }
+
+    It 'allows a discovered suite whose tests are explicitly skipped' {
+        $run = Invoke-TestRunnerFixture -Content @'
+Describe 'Skipped suite' -Skip {
+    It 'does not execute' { throw 'must remain skipped' }
+}
+'@
+        $run.ExitCode | Should -Be 0
+        $run.Output | Should -Match 'Tests Passed: 0, Failed: 0, Skipped: 1'
+    }
+}


### PR DESCRIPTION
## Summary

Pester's `FailedCount` counts failed tests, not discovery/container or setup/teardown errors. The runner could therefore print success and exit 0 while Pester's aggregate `Result` was `Failed`, including when another file passed. This is a repository runner defect: CI accepts Pester 5+ and invokes this same wrapper.

Require a returned, aggregate `Passed` result and nonzero `TotalCount`; otherwise exit 1 and report failure counts or empty discovery. `TotalCount` includes skipped and filtered `NotRun` tests, so valid filters (including matching no tests) and skipped suites still exit 0. Successful targeted-suite output is unchanged. No product/runtime behavior or dependencies change.

## Related issue

N/A - focused test-runner correction.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (menu option removed/renamed, config key changed, etc.)
- [ ] Docs only
- [x] Chore / CI / refactor

## Testing

Audited Pester 5.7.1: aggregate `Result` combines `FailedCount`, `FailedBlocksCount`, and `FailedContainersCount`; `TotalCount` retains `NotRun` tests.

One Pester suite creates disposable fixtures and invokes the real runner in separate PowerShell processes. Coverage includes early and late discovery exceptions, parse errors, teardown failures beside a passing file, empty discovery with/without tags, assertion failures, normal/partial/fully filtered runs, and skipped suites.

Before the fix, six regression cases incorrectly returned exit 0; five compatibility cases passed. After the fix:

```powershell
& .\tests\Run-Tests.ps1 -Path .\tests\TestRunner.Tests.ps1,.\tests\Schema.Tests.ps1,.\tests\Rmq.Tests.ps1
```

33 passed, 0 failed, exit 0: 11 runner regression cases plus the same 22 Schema/mocked-RMQ tests that passed before the change.

- [x] `Parse-validated` the changed PowerShell scripts through execution
- [ ] PSScriptAnalyzer is clean (`Invoke-ScriptAnalyzer -Path .\dune-server.ps1`) - not run; entrypoint unchanged
- [ ] Ran end-to-end against a real Dune server VM - not applicable
- [ ] Tested affected menu option(s) - not applicable

## Changelog

- [x] I added an entry to `CHANGELOG.md` under `[Unreleased]`

## Screenshots / output

No UI changes. Staged and commit-scoped secret scans, outgoing public-boundary guard, and diff whitespace checks passed.