### PR TITLE
Fix stable mirror updater verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- Stable installers delivered through the Test channel mirror now verify against
+  their embedded stable build tag instead of incorrectly reporting an update
+  failure. Genuine test builds retain exact test-tag and commit verification.
+
 ## [15.0.4] - 2026-09-10
 
 ### Fixed

--- a/app/server/routes/Update.ps1
+++ b/app/server/routes/Update.ps1
@@ -174,7 +174,7 @@ function Get-DuneReleases {
 function Test-DuneStableMirrorLabel {
     param($Release)
     $text = "$($Release.name)`n$($Release.releaseNotes)"
-    return ($text -match '(?i)\b(?:test|stable)(?:[-\s]+channel)?[-\s]+mirror\b')
+    return ($text -match '(?i)\b(?:test|stable|pre-?release)(?:[-\s]+channel)?[-\s]+mirror\b')
 }
 
 function Test-DuneStableMirrorRelease {
@@ -404,6 +404,25 @@ function Get-DuneReleaseExpectedCommit {
     $target = ([string]$Release.targetCommit).Trim().ToLowerInvariant()
     if ($target -match '^[0-9a-f]{40}$') { return $target }
     return Get-DuneReleaseCommitSha -Tag ([string]$Release.tag)
+}
+
+function Get-DuneReleaseExpectedTag {
+    param([Parameter(Mandatory)]$Release)
+    if (-not $Release.isPrerelease -or -not (Test-DuneStableMirrorLabel -Release $Release)) {
+        return [string]$Release.tag
+    }
+
+    $stable = Get-DuneLatestRelease
+    if (-not (Test-DuneStableMirrorRelease -Release $Release -StableRelease $stable)) {
+        throw 'The selected stable mirror does not match the current stable release identity.'
+    }
+    # A release-list mirror tag is not necessarily the embedded build tag.
+    # Only byte-identical installers share the stable identity; separately
+    # built test artifacts keep their own exact tag, even at the same commit.
+    $releaseHash = Get-DuneUpdateExpectedSha256 -Digest ([string]$Release.assetDigest)
+    $stableHash = Get-DuneUpdateExpectedSha256 -Digest ([string]$stable.assetDigest)
+    if ($releaseHash -eq $stableHash) { return [string]$stable.tag }
+    return [string]$Release.tag
 }
 
 function Get-DuneSelectedReleaseIdentity {
@@ -821,6 +840,7 @@ Register-DuneRoute -Method POST -Path '/api/update/install' -Handler {
 
         $safeTag = ($rel.tag -replace '[^A-Za-z0-9._-]','_')
         try {
+            $expectedTag = Get-DuneReleaseExpectedTag -Release $rel
             $updateDir = Get-DuneProtectedUpdateDirectory
             $dest = Save-DuneVerifiedUpdateAsset -Release $rel -Directory $updateDir
             $resolvedReleaseCommit = if ([string]$identity.expectedCommit) {
@@ -873,7 +893,6 @@ Register-DuneRoute -Method POST -Path '/api/update/install' -Handler {
         $innoLogPath = Join-Path $updateDir ("inno-$safeTag-$launchId.log")
         $resultPath = Join-Path $updateDir ("update-result-$safeTag-$launchId.json")
         $installedExe = Join-Path $script:AppDir 'DuneServer.exe'
-        $expectedTag = [string]$rel.tag
         $expectedCommit = [string]$resolvedReleaseCommit
         # Arguments are selected only from these constants after strict mode/source
         # validation above. No request value is ever interpolated as executable code.

--- a/tests/UpdateChannel.Tests.ps1
+++ b/tests/UpdateChannel.Tests.ps1
@@ -82,6 +82,12 @@ Describe 'Get-DunePreReleaseList filtering' {
         $tags | Should -Not -Contain 'v12.9.6-test0'
         $tags | Should -Not -Contain 'v12.9.7-draft'
     }
+    It 'recognizes the silent prerelease mirror wording used by stable publication' {
+        Test-DuneStableMirrorLabel -Release ([pscustomobject]@{
+            name='v15.0.4-test1'
+            releaseNotes='Silent prerelease mirror of v15.0.4. Uses the exact verified stable installer artifact.'
+        }) | Should -BeTrue
+    }
     It 'shows only a fresh stable mirror when it identifies the current stable commit' {
         function global:Get-DuneReleases {
             param([switch]$Force)
@@ -229,7 +235,10 @@ Describe 'Get-DuneSelectedRelease channel resolution' {
         (Get-DuneSelectedRelease).tag | Should -Be 'v15.0.0-test10'
     }
 
-    It 'keeps a fresh v15 stable client on the stable identity during mirror rollover' {
+    It 'keeps a fresh v15 stable client on the stable identity during <MirrorNotes> rollover' -ForEach @(
+        @{ MirrorNotes='Stable channel mirror' }
+        @{ MirrorNotes='Silent prerelease mirror of v15.0.0. Uses the exact verified stable installer artifact.' }
+    ) {
         $script:DuneToolVersion = '15.0.0'
         function global:Get-DuneUpdateChannel { 'test' }
         function global:Read-DuneConfigRaw { @{} }
@@ -243,10 +252,11 @@ Describe 'Get-DuneSelectedRelease channel resolution' {
                 assetUrl='https://x/stable.exe'; assetName='DuneServerSetup.exe'
             }
         }
+        $script:MirrorNotes = $MirrorNotes
         function global:Get-DuneReleases {
             param([switch]$Force)
             @(
-                [pscustomobject]@{ tag='v15.0.0-test10'; name='Stable channel mirror'; releaseNotes='same stable commit'; targetCommit='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/fresh-mirror.exe' }
+                [pscustomobject]@{ tag='v15.0.0-test10'; name='v15.0.0-test10'; releaseNotes=$script:MirrorNotes; targetCommit='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/fresh-mirror.exe' }
                 [pscustomobject]@{ tag='v15.0.0-test1'; name='Stable channel mirror'; releaseNotes='old immutable mirror'; targetCommit='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; isPrerelease=$true; isDraft=$false; assetUrl='https://x/old-mirror.exe' }
             )
         }

--- a/tests/UpdateSecurity.Tests.ps1
+++ b/tests/UpdateSecurity.Tests.ps1
@@ -22,6 +22,35 @@ BeforeAll {
             [Text.Encoding]::UTF8.GetString($Response.OutputStream.ToArray()) | ConvertFrom-Json
         }
     }
+
+    function global:Invoke-TestUpdateVerification {
+        param([string]$ScriptPath, $InstalledIdentity)
+        $tokens = $null
+        $errors = $null
+        $ast = [Management.Automation.Language.Parser]::ParseFile(
+            $ScriptPath, [ref]$tokens, [ref]$errors
+        )
+        $errors | Should -BeNullOrEmpty
+        $saveResult = $ast.Find({
+            param($node)
+            $node -is [Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -eq 'Save-DuneUpdateResult'
+        }, $true)
+        $verification = $ast.Find({
+            param($node)
+            $node -is [Management.Automation.Language.TryStatementAst] -and
+                $node.Body.Statements[0].Extent.Text -eq '$actualInstalledExe = Resolve-DuneInstalledExecutablePath'
+        }, $true)
+        $saveResult | Should -Not -BeNullOrEmpty
+        $verification | Should -Not -BeNullOrEmpty
+
+        # Execute only the generated verification/result block, never the
+        # process shutdown, installer, registry lookup, or failure dialog.
+        function Resolve-DuneInstalledExecutablePath { 'test-installed.exe' }
+        function Get-DuneInstalledBuildIdentity { param($Path) $InstalledIdentity }
+        function Show-DuneUpdateFailure { param($Title, $Message) }
+        & ([scriptblock]::Create($saveResult.Extent.Text + "`n" + $verification.Extent.Text))
+    }
 }
 
 Describe 'Protected updater download seam' {
@@ -33,6 +62,104 @@ Describe 'Protected updater download seam' {
         Mock Invoke-WebRequest {
             $script:DownloadCalls++
             [IO.File]::WriteAllBytes($OutFile, $script:Payload)
+        }
+    }
+
+    Describe 'Updater installed artifact identity' {
+        BeforeEach {
+            $script:StableCommit = '7ea6b333cefdc20ac2ae347a6bf19fd9ae61409e'
+            $script:StableRelease = [pscustomobject]@{
+                tag='v15.0.4'; name='v15.0.4'; releaseNotes=''
+                targetCommit=$script:StableCommit; isPrerelease=$false
+                assetUrl='https://example.test/stable.exe'
+                assetDigest=('sha256:' + ('a' * 64))
+            }
+            Mock Get-DuneLatestRelease { $script:StableRelease }
+            Mock Get-DuneSelectedRelease { $script:SelectedRelease }
+            Mock Get-DuneLock { [Threading.SemaphoreSlim]::new(1, 1) }
+            Mock Get-DuneDecoupleNotice { @{ Needed=$false } }
+            Mock Get-DuneUpdateChannel {
+                if ($script:SelectedRelease.isPrerelease) { 'test' } else { 'stable' }
+            }
+            Mock Get-DuneUpdateRunningBuildInfo {
+                @{ runningIsPrerelease=$false; installedTag='v15.0.3'; buildCommit=('c' * 40) }
+            }
+            Mock Get-DuneProtectedUpdateDirectory { $TestDrive }
+            Mock Save-DuneVerifiedUpdateAsset {
+                $path = Join-Path $TestDrive 'verified-installer.exe'
+                [IO.File]::WriteAllText($path, 'installer')
+                return $path
+            }
+            Mock Start-Process {}
+            Mock Write-Host {}
+            $script:DuneToolVersion = '15.0.3'
+            $script:AppDir = $TestDrive
+        }
+
+        It '<Scenario>' -ForEach @(
+            @{ Scenario='verifies a stable release against its stable tag'; Tag='v15.0.4'; Notes=''; SameAsset=$true; InstalledTag='v15.0.4'; ExpectedTag='v15.0.4'; Success=$true }
+            @{ Scenario='verifies an ordinary test build against its exact test tag'; Tag='v15.0.4-test1'; Notes='Test candidate'; SameAsset=$false; InstalledTag='v15.0.4-test1'; ExpectedTag='v15.0.4-test1'; Success=$true }
+            @{ Scenario='verifies the v15.0.4 silent mirror against the stable artifact tag'; Tag='v15.0.4-test1'; Notes='Silent prerelease mirror of v15.0.4. Uses the exact verified stable installer artifact.'; SameAsset=$true; InstalledTag='v15.0.4'; ExpectedTag='v15.0.4'; Success=$true }
+            @{ Scenario='verifies an older mirror label against the stable artifact tag'; Tag='v15.0.4-test10'; Notes='Stable channel mirror'; SameAsset=$true; InstalledTag='v15.0.4'; ExpectedTag='v15.0.4'; Success=$true }
+            @{ Scenario='keeps a separately built mirror on its own test identity'; Tag='v15.0.4-test1'; Notes='Stable channel mirror'; SameAsset=$false; InstalledTag='v15.0.4-test1'; ExpectedTag='v15.0.4-test1'; Success=$true }
+            @{ Scenario='rejects a test tag when the stable artifact was expected'; Tag='v15.0.4'; Notes=''; SameAsset=$true; InstalledTag='v15.0.4-test1'; ExpectedTag='v15.0.4'; Success=$false }
+            @{ Scenario='rejects a stable tag when a genuine test artifact was expected'; Tag='v15.0.4-test1'; Notes='Test candidate'; SameAsset=$false; InstalledTag='v15.0.4'; ExpectedTag='v15.0.4-test1'; Success=$false }
+            @{ Scenario='rejects the mirror tag when its shared stable artifact was expected'; Tag='v15.0.4-test1'; Notes='Silent prerelease mirror of v15.0.4.'; SameAsset=$true; InstalledTag='v15.0.4-test1'; ExpectedTag='v15.0.4'; Success=$false }
+            @{ Scenario='still rejects the wrong commit for a shared stable artifact'; Tag='v15.0.4-test1'; Notes='Silent prerelease mirror of v15.0.4.'; SameAsset=$true; InstalledTag='v15.0.4'; ExpectedTag='v15.0.4'; Success=$false; WrongCommit=$true }
+            @{ Scenario='still requires embedded build metadata for a shared stable artifact'; Tag='v15.0.4-test1'; Notes='Silent prerelease mirror of v15.0.4.'; SameAsset=$true; InstalledTag='v15.0.4'; ExpectedTag='v15.0.4'; Success=$false; MissingMetadata=$true }
+        ) {
+            $script:SelectedRelease = [pscustomobject]@{
+                tag=$Tag; name=$Tag; releaseNotes=$Notes
+                targetCommit=$script:StableCommit; isPrerelease=($Tag -ne 'v15.0.4')
+                assetUrl='https://example.test/selected.exe'
+                assetDigest=if ($SameAsset) { $script:StableRelease.assetDigest } else { 'sha256:' + ('b' * 64) }
+            }
+            $request = [pscustomobject]@{ QueryString=@{} }
+            $response = New-UpdateSecurityResponse
+            & $script:UpdateInstallHandler $request $response @{} @{ mode='silent'; source='banner' }
+            $response.StatusCode | Should -Be 200
+            (Read-UpdateSecurityResponse $response).toVersion | Should -Be ($Tag -replace '^v','')
+            Assert-MockCalled Save-DuneVerifiedUpdateAsset -Times 1 -Exactly -ParameterFilter { $Release.tag -eq $Tag }
+            $scripts = @(Get-ChildItem $TestDrive -Filter 'DuneRelaunch-*.ps1')
+            $scripts.Count | Should -Be 1
+            Invoke-TestUpdateVerification -ScriptPath $scripts[0].FullName -InstalledIdentity @{
+                present=(-not $MissingMetadata)
+                tag=$InstalledTag
+                commit=if ($WrongCommit) { 'd' * 40 } else { $script:StableCommit }
+            }
+            $results = @(Get-ChildItem $TestDrive -Filter 'update-result-*.json')
+            $results.Count | Should -Be 1
+            $result = Get-Content -LiteralPath $results[0].FullName -Raw | ConvertFrom-Json
+            $result.expectedTag | Should -Be $ExpectedTag
+            $result.expectedCommit | Should -Be $script:StableCommit
+            $result.actualTag | Should -Be $InstalledTag
+            $result.success | Should -Be $Success
+            if (-not $Success) { $result.message | Should -Match 'Installed identity mismatch' }
+        }
+
+        It 'does not launch a mirror with <Problem>' -ForEach @(
+            @{ Problem='a different stable core'; Field='tag'; Value='v15.0.5'; ErrorPattern='*does not match*' }
+            @{ Problem='a different stable commit'; Field='targetCommit'; Value=('b' * 40); ErrorPattern='*does not match*' }
+            @{ Problem='a missing stable digest'; Field='assetDigest'; Value=''; ErrorPattern='*valid GitHub SHA-256*' }
+            @{ Problem='an invalid stable digest'; Field='assetDigest'; Value='sha256:invalid'; ErrorPattern='*valid GitHub SHA-256*' }
+            @{ Problem='an unavailable stable release'; Field='unavailable'; Value=$null; ErrorPattern='*does not match*' }
+        ) {
+            $script:SelectedRelease = [pscustomobject]@{
+                tag='v15.0.4-test1'; name='v15.0.4-test1'
+                releaseNotes='Silent prerelease mirror of v15.0.4.'
+                targetCommit=$script:StableCommit; isPrerelease=$true
+                assetUrl='https://example.test/mirror.exe'; assetDigest=$script:StableRelease.assetDigest
+            }
+            if ($Field -eq 'unavailable') { $script:StableRelease = $null }
+            else { $script:StableRelease.$Field = $Value }
+            $response = New-UpdateSecurityResponse
+            & $script:UpdateInstallHandler ([pscustomobject]@{ QueryString=@{} }) $response @{} @{
+                mode='interactive'; source='settings'
+            }
+            $response.StatusCode | Should -Be 502
+            (Read-UpdateSecurityResponse $response).error | Should -BeLike $ErrorPattern
+            Assert-MockCalled Save-DuneVerifiedUpdateAsset -Times 0 -Exactly
+            Assert-MockCalled Start-Process -Times 0 -Exactly
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes false post-install verification failures when the Test channel serves a silent mirror of the stable installer. Stable mirrors now resolve and verify against the embedded stable tag only when core version, immutable commit, and installer SHA-256 all match; genuine test builds keep exact test-tag verification.

## Related issue

N/A

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (menu option removed/renamed, config key changed, etc.)
- [ ] Docs only
- [ ] Chore / CI / refactor

## Testing

- [x] `Parse-validated` the script (no syntax errors)
- [ ] PSScriptAnalyzer is clean (`Invoke-ScriptAnalyzer -Path .\dune-server.ps1`)
- [ ] Ran end-to-end against a real Dune server VM
- [x] Tested affected menu option(s): stable/test channel update identity resolution and generated verifier execution

`tests\Run-Tests.ps1 -Path @('.\tests\UpdateChannel.Tests.ps1', '.\tests\UpdateSecurity.Tests.ps1')` — 82/82 passed.

## Changelog

- [x] I added an entry to `CHANGELOG.md` under `[Unreleased]`

## Screenshots / output

Regression coverage includes the exact v15.0.4-test1 mirror case: stable and mirror releases share commit `7ea6b333cefdc20ac2ae347a6bf19fd9ae61409e` and installer SHA-256 `249FDA871345D306AFB164C234BE23F920F103AA110A2CB0E5428F7DE6A11E9E`, so the installed stable artifact is verified as `v15.0.4` rather than incorrectly requiring `v15.0.4-test1`.