### PR TITLE
Release v15.0.5 updater verification fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -93,7 +93,7 @@ body:
     attributes:
       label: Tool version
       description: Shown in the bottom-left of the web portal sidebar (status bar) and in the CLI menu header.
-      placeholder: "v15.0.4"
+      placeholder: "v15.0.5"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+## [15.0.5] - 2026-09-10
+
 ### Fixed
 
 - Stable installers delivered through the Test channel mirror now verify against

--- a/app/DuneServer.ps1
+++ b/app/DuneServer.ps1
@@ -166,7 +166,7 @@ public static extern bool IsIconic(System.IntPtr hWnd);
 Write-DuneStartupLog 'Console presentation initialized'
 
 # Version (one of the 5 sync'd constants; see persistent-notes.md)
-$script:DuneToolVersion = '15.0.4'
+$script:DuneToolVersion = '15.0.5'
 # Artifact identity defaults for source/dev runs. Build-Exe.ps1 replaces these
 # four declarations only in its generated compilation input, so the resulting
 # executable carries immutable identity without changing tracked version stamps.

--- a/app/build/Build-Exe.ps1
+++ b/app/build/Build-Exe.ps1
@@ -33,7 +33,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Version = '15.0.4',
+    [string]$Version = '15.0.5',
     [string]$BuildCommit = '',
     [string]$BuildTag = '',
     [switch]$Prerelease,

--- a/app/build/Verify-ReleaseArtifact.ps1
+++ b/app/build/Verify-ReleaseArtifact.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)][string]$ExecutablePath,
-    [Parameter(Mandatory)][string]$ExpectedTag,
+    [Parameter(Mandatory)][AllowEmptyString()][string]$ExpectedTag,
     [Parameter(Mandatory)][string]$ExpectedCommit,
     [switch]$ExpectedPrerelease
 )

--- a/app/desktop/DuneShell/DuneShell.csproj
+++ b/app/desktop/DuneShell/DuneShell.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>DuneShell</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <Version>15.0.4</Version>
+    <Version>15.0.5</Version>
     <Product>Dune Server Tool</Product>
     <AssemblyTitle>Dune Server Tool</AssemblyTitle>
     <!-- Self-contained single-file publish so the shell ships as one EXE that

--- a/app/installer/DuneServer.iss
+++ b/app/installer/DuneServer.iss
@@ -16,7 +16,7 @@
 ;                 -> NOT touched by install or uninstall (preserves user config)
 
 #define MyAppName        "Dune Server Tool"
-#define MyAppVersion "15.0.4"
+#define MyAppVersion "15.0.5"
 #define MyAppNumericVersion Copy(MyAppVersion, 1, Pos("-", MyAppVersion + "-") - 1) + ".0"
 #define MyAppPublisher   "Dune Awakening Self-Hosted Tool"
 #define MyAppURL         "https://github.com/coastal-ms/DST-DuneServerTool"

--- a/dune-server.ps1
+++ b/dune-server.ps1
@@ -21,7 +21,7 @@ param(
 # Wraps the original battlegroup.ps1 menu and adds extra tools
 # ============================================================
 
-$script:ToolVersion = "15.0.4"
+$script:ToolVersion = "15.0.5"
 
 # Cold-boot readiness budgets (seconds). A fresh battlegroup's FIRST boot can
 # take 10-30 min: k3s + funcom-operators initialize, metrics-server restarts a

--- a/tests/ReleaseArtifact.Tests.ps1
+++ b/tests/ReleaseArtifact.Tests.ps1
@@ -1,0 +1,153 @@
+BeforeAll {
+    $repo = Split-Path $PSScriptRoot -Parent
+    $sourceVerifier = Join-Path $repo 'app\build\Verify-ReleaseArtifact.ps1'
+    $fixture = Join-Path $TestDrive 'verifier'
+    New-Item -ItemType Directory -Path $fixture | Out-Null
+    $script:verifier = Join-Path $fixture 'Verify-ReleaseArtifact.ps1'
+    Copy-Item -LiteralPath $sourceVerifier -Destination $script:verifier
+    Copy-Item -LiteralPath (Join-Path $repo 'app\build\BuildHelpers.ps1') `
+        -Destination (Join-Path $fixture 'BuildHelpers.ps1')
+
+    # Replace only executable extraction; exercise the real script binder and matcher.
+    Add-Content -LiteralPath (Join-Path $fixture 'BuildHelpers.ps1') -Value @'
+
+function Get-DuneExecutableBuildMetadata {
+    param([Parameter(Mandatory)][string]$ExecutablePath)
+    Get-Content -LiteralPath $ExecutablePath -Raw | ConvertFrom-Json
+}
+'@
+}
+
+Describe 'Release artifact verifier entrypoint' {
+    BeforeEach {
+        $script:metadataPath = Join-Path $TestDrive 'candidate metadata.json'
+        $script:metadata = @{
+            present = $true
+            valid = $true
+            tag = ''
+            commit = 'a' * 40
+            prerelease = $false
+        }
+        $script:arguments = @{
+            ExecutablePath = $script:metadataPath
+            ExpectedTag = ''
+            ExpectedCommit = 'a' * 40
+            ExpectedPrerelease = $false
+        }
+        Mock Write-Host {}
+    }
+
+    It 'keeps all identity parameters mandatory, including an explicitly empty tag' {
+        $command = Get-Command -Name $script:verifier
+        foreach ($name in @('ExecutablePath', 'ExpectedTag', 'ExpectedCommit')) {
+            $parameter = $command.Parameters[$name]
+            $parameter | Should -Not -BeNullOrEmpty
+            @($parameter.Attributes | Where-Object {
+                $_ -is [Management.Automation.ParameterAttribute] -and $_.Mandatory
+            }).Count | Should -Be 1
+        }
+        @($command.Parameters['ExpectedTag'].Attributes | Where-Object {
+            $_ -is [Management.Automation.AllowEmptyStringAttribute]
+        }).Count | Should -Be 1
+    }
+
+    It 'forwards the executable path and exact identity for <Scenario>' -ForEach @(
+        @{ Scenario = 'an untagged stable candidate'; Tag = ''; Prerelease = $false }
+        @{ Scenario = 'an untagged prerelease candidate'; Tag = ''; Prerelease = $true }
+        @{ Scenario = 'a final stable release'; Tag = 'v15.0.5'; Prerelease = $false }
+        @{ Scenario = 'a final prerelease'; Tag = 'v15.0.5-test1'; Prerelease = $true }
+    ) {
+        $script:metadata.tag = $Tag
+        $script:metadata.prerelease = $Prerelease
+        $script:arguments.ExpectedTag = $Tag
+        $script:arguments.ExpectedPrerelease = $Prerelease
+        $script:metadata | ConvertTo-Json | Set-Content -LiteralPath $script:metadataPath
+
+        & $script:verifier @script:arguments
+
+        Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
+            $Object -ceq "Verified built DuneServer.exe identity: tag=$Tag, commit=$('a' * 40), prerelease=$Prerelease"
+        }
+    }
+
+    It 'fails closed for <Scenario>' -ForEach @(
+        @{ Scenario = 'an empty embedded tag when a final tag is required'; ActualTag = ''; ExpectedTag = 'v15.0.5' }
+        @{ Scenario = 'the wrong final tag'; ActualTag = 'v15.0.4'; ExpectedTag = 'v15.0.5' }
+        @{ Scenario = 'a final tag with different casing'; ActualTag = 'V15.0.5'; ExpectedTag = 'v15.0.5' }
+        @{ Scenario = 'a tagged artifact presented as an untagged candidate'; ActualTag = 'v15.0.5'; ExpectedTag = '' }
+    ) {
+        $script:metadata.tag = $ActualTag
+        $script:arguments.ExpectedTag = $ExpectedTag
+        $script:metadata | ConvertTo-Json | Set-Content -LiteralPath $script:metadataPath
+
+        { & $script:verifier @script:arguments } | Should -Throw '*identity mismatch*'
+
+        Should -Invoke Write-Host -Times 0 -Exactly
+    }
+
+    It 'rejects a wrong commit for <Scenario>' -ForEach @(
+        @{ Scenario = 'an untagged candidate'; Tag = '' }
+        @{ Scenario = 'a final release'; Tag = 'v15.0.5' }
+    ) {
+        $script:metadata.tag = $Tag
+        $script:metadata.commit = 'b' * 40
+        $script:arguments.ExpectedTag = $Tag
+        $script:metadata | ConvertTo-Json | Set-Content -LiteralPath $script:metadataPath
+
+        { & $script:verifier @script:arguments } | Should -Throw '*identity mismatch*'
+
+        Should -Invoke Write-Host -Times 0 -Exactly
+    }
+
+    It 'rejects incomplete embedded metadata for <Scenario>' -ForEach @(
+        @{ Scenario = 'an untagged candidate'; Tag = ''; Field = 'present' }
+        @{ Scenario = 'a malformed untagged candidate'; Tag = ''; Field = 'valid' }
+        @{ Scenario = 'a final release'; Tag = 'v15.0.5'; Field = 'present' }
+        @{ Scenario = 'a malformed final release'; Tag = 'v15.0.5'; Field = 'valid' }
+    ) {
+        $script:metadata.tag = $Tag
+        $script:metadata[$Field] = $false
+        $script:arguments.ExpectedTag = $Tag
+        $script:metadata | ConvertTo-Json | Set-Content -LiteralPath $script:metadataPath
+
+        { & $script:verifier @script:arguments } | Should -Throw '*identity mismatch*'
+
+        Should -Invoke Write-Host -Times 0 -Exactly
+    }
+
+    It 'still requires the full immutable commit for a final release' {
+        $script:metadata.tag = 'v15.0.5'
+        $script:metadata.commit = 'a' * 12
+        $script:arguments.ExpectedTag = 'v15.0.5'
+        $script:arguments.ExpectedCommit = 'a' * 12
+        $script:metadata | ConvertTo-Json | Set-Content -LiteralPath $script:metadataPath
+
+        { & $script:verifier @script:arguments } | Should -Throw '*full 40-character Git commit id*'
+
+        Should -Invoke Write-Host -Times 0 -Exactly
+    }
+
+    It 'rejects an incorrect candidate prerelease flag' {
+        $script:metadata.prerelease = $true
+        $script:metadata | ConvertTo-Json | Set-Content -LiteralPath $script:metadataPath
+
+        { & $script:verifier @script:arguments } | Should -Throw '*identity mismatch*'
+
+        Should -Invoke Write-Host -Times 0 -Exactly
+    }
+
+    It 'preserves tag and prerelease consistency for <Tag>' -ForEach @(
+        @{ Tag = 'v15.0.5'; Prerelease = $true; ExpectedError = '*must not use -Prerelease*' }
+        @{ Tag = 'v15.0.5-test1'; Prerelease = $false; ExpectedError = '*requires -Prerelease*' }
+    ) {
+        $script:metadata.tag = $Tag
+        $script:metadata.prerelease = $Prerelease
+        $script:arguments.ExpectedTag = $Tag
+        $script:arguments.ExpectedPrerelease = $Prerelease
+        $script:metadata | ConvertTo-Json | Set-Content -LiteralPath $script:metadataPath
+
+        { & $script:verifier @script:arguments } | Should -Throw $ExpectedError
+
+        Should -Invoke Write-Host -Times 0 -Exactly
+    }
+}


### PR DESCRIPTION
## Summary

Prepares v15.0.5 with the accepted stable-mirror updater verification fix and the narrowly scoped verifier correction required for untagged candidate builds. Final tagged-release verification remains strict.

## Related issue

N/A

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (menu option removed/renamed, config key changed, etc.)
- [ ] Docs only
- [ ] Chore / CI / refactor

## Testing

- [x] `Parse-validated` the script (no syntax errors)
- [ ] PSScriptAnalyzer is clean (`Invoke-ScriptAnalyzer -Path .\dune-server.ps1`)
- [x] Ran end-to-end against a real Dune server VM
- [x] Tested affected menu option(s): v15.0.5 candidate installation and Solo inventory display

- Updater-focused suite: 82/82 passed
- Release verifier suite: 49/49 passed
- Complete installer build completed with all required stages
- Accepted candidate commit: `6df3bfdab164dd5f6ff6b445fbb69331a112f803`
- Accepted installer SHA-256: `0FCEE1CF6608E76101E79BAC18A25877EE773877D773542AB39080EDA0EF12CB`

## Changelog

- [x] I added an entry to `CHANGELOG.md` under `[Unreleased]`

## Screenshots / output

Coastal installed and accepted the exact candidate. The accepted run also showed Literjon correctly in Solo inventory, so no speculative Literjon code change is included.