### PR TITLE
Fix Pages release metadata race

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -16,11 +16,6 @@ on:
       - "CHANGELOG.md"
       - "docs/img/**"
       - ".github/workflows/deploy-site.yml"
-  # The site reads the latest release at BUILD time. A release merge lands on
-  # main (touching CHANGELOG.md) before `gh release create` runs, so the push
-  # deploy alone always publishes the previous version and the site stays stale
-  # until someone dispatches a manual run — this bit v13.3.0 and v13.8.0.
-  #
   # This trigger was previously removed because the release run collided with
   # the in-flight CHANGELOG push run and the github-pages environment rejected
   # the second deploy. The concurrency block below now cancels the in-flight run
@@ -68,6 +63,7 @@ jobs:
         working-directory: site
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DST_RELEASE_EVENT: ${{ github.event_name == 'release' && toJSON(github.event.release) || '' }}
         run: npm run build
 
       - name: Upload Pages artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ here cover everything those tags shipped.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Pages release-metadata race by using the release event payload during builds.
+
 ## [15.0.5] - 2026-09-10
 
 ### Fixed

--- a/site/README.md
+++ b/site/README.md
@@ -5,7 +5,7 @@ Marketing + docs site for the Dune Server Tool. Built with **Astro 7 + React-fre
 This site lives inside the main `DST-DuneServerTool` repo so that:
 
 - Screenshots in `../docs/img/` and the canonical `../CHANGELOG.md` are pulled in at build time — no duplication, the site always reflects what's in the repo.
-- The download button auto-resolves to the latest `DuneServerSetup.exe` via the GitHub Releases API at build time, so a new release picks up the link without a code change.
+- The download button uses the triggering stable release payload for release-triggered Pages builds, avoiding the GitHub API's eventual-consistency window; push and manual builds retain the latest-release API fallback.
 
 ## Local dev
 

--- a/site/package.json
+++ b/site/package.json
@@ -13,7 +13,8 @@
     "preview": "astro preview",
     "check": "astro check",
     "test:changelog": "node --experimental-strip-types scripts/check-changelog.mts",
-    "test:testing": "node --experimental-strip-types scripts/check-testing.mts"
+    "test:testing": "node --experimental-strip-types scripts/check-testing.mts",
+    "test:release": "node --experimental-strip-types scripts/check-release.mts"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.10",

--- a/site/scripts/check-release.mts
+++ b/site/scripts/check-release.mts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import {
+  getLatestRelease,
+  releaseFromEvent,
+  type ReleaseEvent,
+} from "../src/lib/release.ts";
+
+const stableEvent: ReleaseEvent = {
+  tag_name: "v15.0.5",
+  html_url: "https://github.com/coastal-ms/DST-DuneServerTool/releases/tag/v15.0.5",
+  published_at: "2026-09-10T04:00:00Z",
+  prerelease: false,
+  assets: [
+    {
+      name: "DuneServerSetup.exe",
+      browser_download_url:
+        "https://github.com/coastal-ms/DST-DuneServerTool/releases/download/v15.0.5/DuneServerSetup.exe",
+    },
+  ],
+};
+
+const originalEventName = process.env.GITHUB_EVENT_NAME;
+const originalReleaseEvent = process.env.DST_RELEASE_EVENT;
+const originalFetch = globalThis.fetch;
+
+process.env.GITHUB_EVENT_NAME = "release";
+process.env.DST_RELEASE_EVENT = JSON.stringify(stableEvent);
+let fetchCalled = false;
+globalThis.fetch = async () => {
+  fetchCalled = true;
+  throw new Error("stable release builds must not fetch /releases/latest");
+};
+
+assert.deepEqual(await getLatestRelease(), {
+  tag: "v15.0.5",
+  version: "15.0.5",
+  htmlUrl: stableEvent.html_url,
+  installerUrl: stableEvent.assets?.[0].browser_download_url,
+  publishedAt: stableEvent.published_at,
+});
+assert.equal(fetchCalled, false);
+
+assert.equal(
+  releaseFromEvent({
+    ...stableEvent,
+    tag_name: "v15.0.5-test1",
+    prerelease: true,
+  }),
+  null,
+);
+
+process.env.GITHUB_EVENT_NAME = "push";
+delete process.env.DST_RELEASE_EVENT;
+globalThis.fetch = async () =>
+  new Response(
+    JSON.stringify({
+      tag_name: "v15.0.4",
+      html_url:
+        "https://github.com/coastal-ms/DST-DuneServerTool/releases/tag/v15.0.4",
+      published_at: "2026-09-09T04:00:00Z",
+      assets: [
+        {
+          name: "DuneServerSetup.exe",
+          browser_download_url:
+            "https://github.com/coastal-ms/DST-DuneServerTool/releases/download/v15.0.4/DuneServerSetup.exe",
+        },
+      ],
+    }),
+  );
+
+assert.deepEqual(await getLatestRelease(), {
+  tag: "v15.0.4",
+  version: "15.0.4",
+  htmlUrl:
+    "https://github.com/coastal-ms/DST-DuneServerTool/releases/tag/v15.0.4",
+  installerUrl:
+    "https://github.com/coastal-ms/DST-DuneServerTool/releases/download/v15.0.4/DuneServerSetup.exe",
+  publishedAt: "2026-09-09T04:00:00Z",
+});
+
+if (originalEventName === undefined) delete process.env.GITHUB_EVENT_NAME;
+else process.env.GITHUB_EVENT_NAME = originalEventName;
+if (originalReleaseEvent === undefined) delete process.env.DST_RELEASE_EVENT;
+else process.env.DST_RELEASE_EVENT = originalReleaseEvent;
+globalThis.fetch = originalFetch;
+
+console.log("Release resolution checks passed.");

--- a/site/src/lib/release.ts
+++ b/site/src/lib/release.ts
@@ -10,6 +10,14 @@ export interface LatestRelease {
   publishedAt: string | null;
 }
 
+export interface ReleaseEvent {
+  tag_name?: string;
+  html_url?: string;
+  published_at?: string | null;
+  prerelease?: boolean;
+  assets?: Array<{ name?: string; browser_download_url?: string }>;
+}
+
 const REPO = "coastal-ms/DST-DuneServerTool";
 const FALLBACK: LatestRelease = {
   tag: "latest",
@@ -19,7 +27,38 @@ const FALLBACK: LatestRelease = {
   publishedAt: null,
 };
 
+export function releaseFromEvent(event: ReleaseEvent): LatestRelease | null {
+  if (event.prerelease || !event.tag_name) return null;
+
+  return {
+    tag: event.tag_name,
+    version: event.tag_name.replace(/^v/, ""),
+    htmlUrl: event.html_url ?? `https://github.com/${REPO}/releases`,
+    installerUrl:
+      event.assets?.find(
+        (asset) =>
+          asset.name === "DuneServerSetup.exe" &&
+          Boolean(asset.browser_download_url),
+      )?.browser_download_url ?? null,
+    publishedAt: event.published_at ?? null,
+  };
+}
+
 export async function getLatestRelease(): Promise<LatestRelease> {
+  if (process.env.GITHUB_EVENT_NAME === "release") {
+    const serializedEvent = process.env.DST_RELEASE_EVENT;
+    if (serializedEvent) {
+      try {
+        const release = releaseFromEvent(
+          JSON.parse(serializedEvent) as ReleaseEvent,
+        );
+        if (release) return release;
+      } catch (err) {
+        console.warn("[release] event payload parse failed:", err);
+      }
+    }
+  }
+
   try {
     const headers: Record<string, string> = {
       Accept: "application/vnd.github+json",


### PR DESCRIPTION
## Summary

Makes release-triggered Pages builds use the triggering stable release payload instead of racing GitHub's eventually consistent `/releases/latest` endpoint. Push and manual builds retain the existing API fallback, while prerelease events remain excluded.

## Related issue

N/A

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (menu option removed/renamed, config key changed, etc.)
- [ ] Docs only
- [ ] Chore / CI / refactor

## Testing

- [x] `Parse-validated` the script (no syntax errors)
- [ ] PSScriptAnalyzer is clean (`Invoke-ScriptAnalyzer -Path .\dune-server.ps1`)
- [ ] Ran end-to-end against a real Dune server VM
- [x] Tested affected menu option(s): release-event metadata resolution and fallback site builds

Validated with `npm run test:release`, `npm run test:testing`, `npm run test:changelog`, `npm run check`, and a production site build using a v15.0.5 release payload.

## Changelog

- [ ] I added an entry to `CHANGELOG.md` under `[Unreleased]`

## Screenshots / output

The regression covers a stable release event resolving v15.0.5 without calling `/releases/latest`, plus prerelease and non-release fallback boundaries.